### PR TITLE
Reduce size of _serializedATN

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,9 @@ January 11, 2013
 * Add error 144: multi-character literals are not allowed in lexer sets
 * Error 134 now only applies to rule references in lexer sets
 * Updated error messages (cleanup)
+* Reduce size of _serializedATN by adding 2 to each element: new representation
+  avoids embedded values 0 and 0xFFFF which are common and have multi-byte
+  representations in Java's modified UTF-8
 
 January 10, 2013
 

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
@@ -43,7 +43,7 @@ import java.util.List;
 public abstract class ATNSimulator {
 	public static final int SERIALIZED_VERSION;
 	static {
-		SERIALIZED_VERSION = 1;
+		SERIALIZED_VERSION = 2;
 	}
 
 	/** Must distinguish between missing edge and edge we know leads nowhere */
@@ -99,6 +99,12 @@ public abstract class ATNSimulator {
 	}
 
 	public static ATN deserialize(@NotNull char[] data) {
+		data = data.clone();
+		// don't adjust the first value since that's the version number
+		for (int i = 1; i < data.length; i++) {
+			data[i] = (char)(data[i] - 2);
+		}
+
 		ATN atn = new ATN();
 		List<IntervalSet> sets = new ArrayList<IntervalSet>();
 		int p = 0;


### PR DESCRIPTION
Reduce size of `_serializedATN` by adding 2 to each element: new representation avoids embedded values 0 and 0xFFFF which are common and have multi-byte representations in Java's modified UTF-8
