### PR TITLE
Removed extraneous spaces from the alias grun command

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -35,7 +35,7 @@ UNIX
 3. Create aliases for the ANTLR Tool, and TestRig.
 
    $ alias antlr4='java -jar /usr/local/lib/antlr-4.0-complete.jar'
-   $ alias grun  ='java org.antlr.v4.runtime.misc.TestRig'
+   $ alias grun='java org.antlr.v4.runtime.misc.TestRig'
 
 WINDOWS (Thanks to Graham Wideman)
 


### PR DESCRIPTION
Removed spaces from the grun alias so copy and paste people will not get an error.

I mostly just wanted to do a pull request because I've never done one before ;)
