### PR TITLE
Added an export-to-PNG functionality.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -53,4 +53,5 @@ YYYY/MM/DD, github id, Full name, email
 2012/10/10, stephengaito, Stephen Gaito, stephen@percepitsys.co.uk
 2012/11/23, maguro, Alan Cabrera, adc@toolazydogs.com
 2013/01/29, metadave, Dave Parfitt, diparfitt@gmail.com
+2013/03/06, bkiers, Bart Kiers, bkiers@gmail.com
 

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/gui/TreeViewer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/gui/TreeViewer.java
@@ -42,16 +42,9 @@ import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.Tree;
 import org.antlr.v4.runtime.tree.Trees;
 
+import javax.imageio.ImageIO;
 import javax.print.PrintException;
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSlider;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.BasicStroke;
@@ -69,6 +62,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.geom.CubicCurve2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -293,10 +288,43 @@ public class TreeViewer extends JComponent {
 		// Make the scrollpane (containing the viewer) the center component
 		contentPane.add(scrollPane, BorderLayout.CENTER);
 
+        JPanel wrapper = new JPanel(new FlowLayout());
+
+        // Add an export-to-png button left of the "OK" button
+        JButton png = new JButton("png");
+        png.addActionListener(
+            new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    BufferedImage bi = new BufferedImage(viewer.getSize().width,
+                            viewer.getSize().height, BufferedImage.TYPE_INT_ARGB);
+                    Graphics g = bi.createGraphics();
+                    viewer.paint(g);
+                    g.dispose();
+
+                    try{
+                        File pngFile = new File("antlrv4_parse_tree_" +
+                                System.currentTimeMillis() +  ".png");
+                        ImageIO.write(bi, "png", pngFile);
+                        JOptionPane.showMessageDialog(dialog,
+                                "Saved PNG to: " + pngFile.getAbsolutePath());
+                    } catch (Exception ex) {
+                        JOptionPane.showMessageDialog(dialog,
+                                "Could not export to PNG: " + ex.getMessage(),
+                                "Error",
+                                JOptionPane.ERROR_MESSAGE);
+                        ex.printStackTrace();
+                    }
+                }
+            }
+        );
+        wrapper.add(png);
+
 	  	// Add button to bottom
 		JPanel bottomPanel = new JPanel(new BorderLayout(0,0));
 		contentPane.add(bottomPanel, BorderLayout.SOUTH);
-		JButton ok = new JButton("OK");
+
+        JButton ok = new JButton("OK");
 		ok.addActionListener(
 			new ActionListener() {
 				@Override
@@ -306,8 +334,8 @@ public class TreeViewer extends JComponent {
 				}
 			}
 		);
-		JPanel wrapper = new JPanel(new FlowLayout());
 		wrapper.add(ok);
+
 		bottomPanel.add(wrapper, BorderLayout.SOUTH);
 
 		// Add scale slider


### PR DESCRIPTION
Added an export-to-PNG button in the dialog that is launched after invoking org.antlr.v4.runtime.misc.TestRig with the "-gui" parameter. When pressed, a PNG file of the parse tree is created in the present working directory.
