### PR TITLE
Fix issue 196

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -1229,7 +1229,7 @@ public class ParserATNSimulator extends ATNSimulator {
 	{
 		if ( debug ) System.out.println("closure("+config.toString(parser,true)+")");
 
-		if ( !closureBusy.add(config) ) return; // avoid infinite recursion
+		if ( depth != 0 && !closureBusy.add(config) ) return; // avoid infinite recursion
 
 		if ( config.state instanceof RuleStopState ) {
 			// We hit rule end. If we have context info, use it

--- a/tool/test/org/antlr/v4/test/TestSemPredEvalParser.java
+++ b/tool/test/org/antlr/v4/test/TestSemPredEvalParser.java
@@ -77,6 +77,30 @@ public class TestSemPredEvalParser extends BaseTest {
 		assertEquals(expecting, stderrDuringParse);
 	}
 
+	/**
+	 * This is a regression test for antlr/antlr4#196
+	 * "element+ in expression grammar doesn't parse properly"
+	 * https://github.com/antlr/antlr4/issues/196
+	 */
+	@Test public void testAtomWithClosureInTranslatedLRRule() throws Exception {
+		String grammar =
+			"grammar T;\n" +
+			"start : e[0] EOF;\n" +
+			"e[int _p]\n" +
+			"    :   ( 'a'\n" +
+			"        | 'b'+\n" +
+			"        )\n" +
+			"        ( {3 >= $_p}? '+' e[4]\n" +
+			"        )*\n" +
+			"    ;\n";
+
+		String found = execParser("T.g4", grammar, "TParser", "TLexer", "start",
+								  "a+b+a", false);
+		String expecting = "";
+		assertEquals(expecting, found);
+		assertNull(stderrDuringParse);
+	}
+
 	@Test public void testValidateInDFA() throws Exception {
 		String grammar =
 			"grammar T;\n" +


### PR DESCRIPTION
Configs "in context" have special meaning for predicate transitions, so don't add them to closure busy as a visited state or some configs could be improperly eliminated from the closure set (fixes #196)
