### PR TITLE
Generalize options

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -73,7 +73,7 @@ import org.antlr.v4.runtime.tree.ParseTreeListener;
  * This interface defines a complete listener for a parse tree produced by
  * {@link <file.parserName>}.
  */
-public interface <file.grammarName>Listener extends ParseTreeListener {
+<file.factory.grammar.ast.combinedOptions.classModifier; null="public"> interface <file.grammarName>Listener extends ParseTreeListener {
 	<file.listenerNames:{lname |
 /**
  * Enter a parse tree produced by {@link <file.parserName>#<lname>\}.
@@ -105,7 +105,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
  * which can be extended to create a listener which only needs to handle a subset
  * of the available methods.
  */
-public class <file.grammarName>BaseListener implements <file.grammarName>Listener {
+<file.factory.grammar.ast.combinedOptions.classModifier; null="public"> class <file.grammarName>BaseListener implements <file.grammarName>Listener {
 	<file.listenerNames:{lname |
 /**
  * {@inheritDoc\}
@@ -163,7 +163,7 @@ import org.antlr.v4.runtime.tree.ParseTreeVisitor;
  * @param \<T> The return type of the visit operation. Use {@link Void} for
  * operations with no return type.
  */
-public interface <file.grammarName>Visitor\<T> extends ParseTreeVisitor\<T> {
+<file.factory.grammar.ast.combinedOptions.classModifier; null="public"> interface <file.grammarName>Visitor\<T> extends ParseTreeVisitor\<T> {
 	<file.visitorNames:{lname |
 /**
  * Visit a parse tree produced by {@link <file.parserName>#<lname>\}.
@@ -191,7 +191,7 @@ import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
  * @param \<T> The return type of the visit operation. Use {@link Void} for
  * operations with no return type.
  */
-public class <file.grammarName>BaseVisitor\<T> extends AbstractParseTreeVisitor\<T> implements <file.grammarName>Visitor\<T> {
+<file.factory.grammar.ast.combinedOptions.classModifier; null="public"> class <file.grammarName>BaseVisitor\<T> extends AbstractParseTreeVisitor\<T> implements <file.grammarName>Visitor\<T> {
 	<file.visitorNames:{lname |
 /**
  * {@inheritDoc\}
@@ -213,7 +213,7 @@ Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
 
 Parser_(parser, funcs, atn, sempredFuncs, ctor, superClass) ::= <<
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
-public class <parser.name> extends <superClass> {
+<file.factory.grammar.ast.combinedOptions.classModifier; null="public"> class <parser.name> extends <superClass> {
 	protected static final DFA[] _decisionToDFA;
 	protected static final PredictionContextCache _sharedContextCache =
 		new PredictionContextCache();
@@ -843,7 +843,7 @@ import org.antlr.v4.runtime.misc.*;
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
-public class <lexer.name> extends <superClass> {
+<lexerFile.factory.grammar.ast.combinedOptions.classModifier; null="public"> class <lexer.name> extends <superClass> {
 	protected static final DFA[] _decisionToDFA;
 	protected static final PredictionContextCache _sharedContextCache =
 		new PredictionContextCache();

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -365,7 +365,7 @@ public class Tool {
 			lexerAST = transform.extractImplicitLexer(g); // alters g.ast
 			if ( lexerAST!=null ) {
 				if (grammarOptions != null) {
-					lexerAST.cmdLineOptions = grammarOptions;
+					lexerAST.applyCommandLineOptions(grammarOptions);
 				}
 
 				lexerg = new LexerGrammar(this, lexerAST);
@@ -621,7 +621,7 @@ public class Tool {
 					((GrammarRootAST)root).hasErrors = p.getNumberOfSyntaxErrors()>0;
 					assert ((GrammarRootAST)root).tokenStream == tokens;
 					if ( grammarOptions!=null ) {
-						((GrammarRootAST)root).cmdLineOptions = grammarOptions;
+						((GrammarRootAST)root).applyCommandLineOptions(grammarOptions);
 					}
 					return ((GrammarRootAST)root);
 				}

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -134,7 +134,7 @@ public class Tool {
 	public boolean gen_visitor = false;
 	public boolean gen_dependencies = false;
 	public String genPackage = null;
-	public Map<String, String> grammarOptions = null;
+	public Map<String, String> commandLineOptions = new HashMap<String, String>();
 	public boolean warnings_are_errors = false;
 	public boolean longMessages = false;
 
@@ -306,8 +306,7 @@ public class Tool {
 			if ( Grammar.parserOptions.contains(option) ||
 				 Grammar.lexerOptions.contains(option) )
 			{
-				if ( grammarOptions==null ) grammarOptions = new HashMap<String, String>();
-				grammarOptions.put(option, value);
+				commandLineOptions.put(option, value);
 			}
 			else {
 				errMgr.grammarError(ErrorType.ILLEGAL_OPTION,
@@ -364,9 +363,7 @@ public class Tool {
 		{
 			lexerAST = transform.extractImplicitLexer(g); // alters g.ast
 			if ( lexerAST!=null ) {
-				if (grammarOptions != null) {
-					lexerAST.applyCommandLineOptions(grammarOptions);
-				}
+				lexerAST.applyCommandLineOptions(commandLineOptions);
 
 				lexerg = new LexerGrammar(this, lexerAST);
 				lexerg.fileName = g.fileName;
@@ -620,9 +617,7 @@ public class Tool {
 				if ( root instanceof GrammarRootAST) {
 					((GrammarRootAST)root).hasErrors = p.getNumberOfSyntaxErrors()>0;
 					assert ((GrammarRootAST)root).tokenStream == tokens;
-					if ( grammarOptions!=null ) {
-						((GrammarRootAST)root).applyCommandLineOptions(grammarOptions);
-					}
+					((GrammarRootAST)root).applyCommandLineOptions(commandLineOptions);
 					return ((GrammarRootAST)root);
 				}
 			}

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -303,17 +303,8 @@ public class Tool {
 				errMgr.toolError(ErrorType.BAD_OPTION_SET_SYNTAX, arg);
 				return;
 			}
-			if ( Grammar.parserOptions.contains(option) ||
-				 Grammar.lexerOptions.contains(option) )
-			{
-				commandLineOptions.put(option, value);
-			}
-			else {
-				errMgr.grammarError(ErrorType.ILLEGAL_OPTION,
-									null,
-									null,
-									option);
-			}
+
+			commandLineOptions.put(option, value);
 		}
 		else {
 			errMgr.toolError(ErrorType.BAD_OPTION_SET_SYNTAX, arg);

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -223,7 +223,7 @@ public class Tool {
 			String arg = args[i];
 			i++;
 			if ( arg.startsWith("-D") ) { // -Dlanguage=Java syntax
-				handleOptionSetArg(arg);
+				handleOptionSetArg(arg.substring("-D".length()));
 				continue;
 			}
 			if ( arg.charAt(0)!='-' ) { // file name
@@ -295,18 +295,14 @@ public class Tool {
 	}
 
 	protected void handleOptionSetArg(String arg) {
-		int eq = arg.indexOf('=');
-		if ( eq>0 && arg.length()>3 ) {
-			String option = arg.substring("-D".length(), eq);
-			String value = arg.substring(eq+1);
-			if ( value.length()==0 ) {
-				errMgr.toolError(ErrorType.BAD_OPTION_SET_SYNTAX, arg);
-				return;
-			}
+		final String[] pieces = arg.split("=", 2);
+		final boolean hasEqualSign = arg.indexOf('=') > 0;
 
-			commandLineOptions.put(option, value);
-		}
-		else {
+		if (pieces.length == 2) {
+			commandLineOptions.put(pieces[0], pieces[1]);
+		} else if (hasEqualSign) {
+			commandLineOptions.put(pieces[0], "");
+		} else {
 			errMgr.toolError(ErrorType.BAD_OPTION_SET_SYNTAX, arg);
 		}
 	}

--- a/tool/src/org/antlr/v4/tool/ast/GrammarASTWithOptions.java
+++ b/tool/src/org/antlr/v4/tool/ast/GrammarASTWithOptions.java
@@ -34,7 +34,6 @@ import org.antlr.runtime.Token;
 import org.antlr.v4.misc.CharSupport;
 import org.antlr.v4.runtime.misc.NotNull;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/tool/src/org/antlr/v4/tool/ast/GrammarASTWithOptions.java
+++ b/tool/src/org/antlr/v4/tool/ast/GrammarASTWithOptions.java
@@ -39,11 +39,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class GrammarASTWithOptions extends GrammarAST {
-    protected Map<String, GrammarAST> options;
+    protected final Map<String, GrammarAST> options = new HashMap<String, GrammarAST>();
 
 	public GrammarASTWithOptions(GrammarASTWithOptions node) {
 		super(node);
-		this.options = node.options;
+
+		this.options.putAll(node.getOptions());
 	}
 
 	public GrammarASTWithOptions(Token t) { super(t); }
@@ -52,8 +53,7 @@ public abstract class GrammarASTWithOptions extends GrammarAST {
     public GrammarASTWithOptions(int type, Token t, String text) { super(type,t,text); }
 
     public void setOption(String key, GrammarAST node) {
-        if ( options==null ) options = new HashMap<String, GrammarAST>();
-        options.put(key, node);
+        this.options.put(key, node);
     }
 
 	public String getOptionString(String key) {
@@ -88,10 +88,6 @@ public abstract class GrammarASTWithOptions extends GrammarAST {
 
 	@NotNull
 	public Map<String, GrammarAST> getOptions() {
-		if (options == null) {
-			return Collections.emptyMap();
-		}
-
 		return options;
 	}
 }

--- a/tool/src/org/antlr/v4/tool/ast/GrammarRootAST.java
+++ b/tool/src/org/antlr/v4/tool/ast/GrammarRootAST.java
@@ -49,8 +49,9 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 	/** Track stream used to create this tree */
 	@NotNull
 	public final TokenStream tokenStream;
-	public final Map<String, String> combinedOptions; // Merged default, node, and command-line options
 	public String fileName;
+
+	private final HashMap<String, String> commandLineOptions = new HashMap<String, String>();
 
 	public GrammarRootAST(GrammarRootAST node) {
 		super(node);
@@ -58,13 +59,6 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 		this.grammarType = node.grammarType;
 		this.hasErrors = node.hasErrors;
 		this.tokenStream = node.tokenStream;
-
-		this.combinedOptions = new HashMap<String, String>();
-		this.combinedOptions.putAll(defaultOptions);
-
-		for (final String key : this.getOptions().keySet()) {
-			this.combinedOptions.put(key, super.getOptionString(key));
-		}
 	}
 
 	public GrammarRootAST(Token t, TokenStream tokenStream) {
@@ -74,13 +68,6 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 		}
 
 		this.tokenStream = tokenStream;
-
-		this.combinedOptions = new HashMap<String, String>();
-		this.combinedOptions.putAll(defaultOptions);
-
-		for (final String key : this.getOptions().keySet()) {
-			this.combinedOptions.put(key, super.getOptionString(key));
-		}
 	}
 
 	public GrammarRootAST(int type, Token t, TokenStream tokenStream) {
@@ -90,13 +77,6 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 		}
 
 		this.tokenStream = tokenStream;
-
-		this.combinedOptions = new HashMap<String, String>();
-		this.combinedOptions.putAll(defaultOptions);
-
-		for (final String key : this.getOptions().keySet()) {
-			this.combinedOptions.put(key, super.getOptionString(key));
-		}
 	}
 
 	public GrammarRootAST(int type, Token t, String text, TokenStream tokenStream) {
@@ -106,17 +86,10 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 		}
 
 		this.tokenStream = tokenStream;
-
-		this.combinedOptions = new HashMap<String, String>();
-		this.combinedOptions.putAll(defaultOptions);
-
-		for (final String key : this.getOptions().keySet()) {
-			this.combinedOptions.put(key, super.getOptionString(key));
-		}
     }
 
 	public void applyCommandLineOptions(final Map<String, String> cmdLineOptions) {
-		this.combinedOptions.putAll(cmdLineOptions);
+		this.commandLineOptions.putAll(cmdLineOptions);
 	}
 
 	public String getGrammarName() {
@@ -127,7 +100,7 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 
 	@Override
 	public String getOptionString(String key) {
-		return this.combinedOptions.get(key);
+		return this.getCombinedOptions().get(key);
 	}
 
 	@Override
@@ -135,4 +108,17 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 
 	@Override
 	public GrammarRootAST dupNode() { return new GrammarRootAST(this); }
+
+	public Map<String, String> getCombinedOptions() {
+		final HashMap<String, String> combinedOptions = new HashMap<String, String>();
+		combinedOptions.putAll(defaultOptions);
+
+		for (final String key : this.getOptions().keySet()) {
+			combinedOptions.put(key, super.getOptionString(key));
+		}
+
+		combinedOptions.putAll(this.commandLineOptions);
+
+		return combinedOptions;
+	}
 }

--- a/tool/src/org/antlr/v4/tool/ast/GrammarRootAST.java
+++ b/tool/src/org/antlr/v4/tool/ast/GrammarRootAST.java
@@ -49,14 +49,22 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 	/** Track stream used to create this tree */
 	@NotNull
 	public final TokenStream tokenStream;
-	public Map<String, String> cmdLineOptions; // -DsuperClass=T on command line
+	public final Map<String, String> combinedOptions; // Merged default, node, and command-line options
 	public String fileName;
 
 	public GrammarRootAST(GrammarRootAST node) {
 		super(node);
+
 		this.grammarType = node.grammarType;
 		this.hasErrors = node.hasErrors;
 		this.tokenStream = node.tokenStream;
+
+		this.combinedOptions = new HashMap<String, String>();
+		this.combinedOptions.putAll(defaultOptions);
+
+		for (final String key : this.getOptions().keySet()) {
+			this.combinedOptions.put(key, super.getOptionString(key));
+		}
 	}
 
 	public GrammarRootAST(Token t, TokenStream tokenStream) {
@@ -66,6 +74,13 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 		}
 
 		this.tokenStream = tokenStream;
+
+		this.combinedOptions = new HashMap<String, String>();
+		this.combinedOptions.putAll(defaultOptions);
+
+		for (final String key : this.getOptions().keySet()) {
+			this.combinedOptions.put(key, super.getOptionString(key));
+		}
 	}
 
 	public GrammarRootAST(int type, Token t, TokenStream tokenStream) {
@@ -75,6 +90,13 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 		}
 
 		this.tokenStream = tokenStream;
+
+		this.combinedOptions = new HashMap<String, String>();
+		this.combinedOptions.putAll(defaultOptions);
+
+		for (final String key : this.getOptions().keySet()) {
+			this.combinedOptions.put(key, super.getOptionString(key));
+		}
 	}
 
 	public GrammarRootAST(int type, Token t, String text, TokenStream tokenStream) {
@@ -84,7 +106,18 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 		}
 
 		this.tokenStream = tokenStream;
+
+		this.combinedOptions = new HashMap<String, String>();
+		this.combinedOptions.putAll(defaultOptions);
+
+		for (final String key : this.getOptions().keySet()) {
+			this.combinedOptions.put(key, super.getOptionString(key));
+		}
     }
+
+	public void applyCommandLineOptions(final Map<String, String> cmdLineOptions) {
+		this.combinedOptions.putAll(cmdLineOptions);
+	}
 
 	public String getGrammarName() {
 		Tree t = getChild(0);
@@ -94,14 +127,7 @@ public class GrammarRootAST extends GrammarASTWithOptions {
 
 	@Override
 	public String getOptionString(String key) {
-		if ( cmdLineOptions!=null && cmdLineOptions.containsKey(key) ) {
-			return cmdLineOptions.get(key);
-		}
-		String value = super.getOptionString(key);
-		if ( value==null ) {
-			value = defaultOptions.get(key);
-		}
-		return value;
+		return this.combinedOptions.get(key);
 	}
 
 	@Override

--- a/tool/test/org/antlr/v4/test/TestGrammarOptions.java
+++ b/tool/test/org/antlr/v4/test/TestGrammarOptions.java
@@ -27,8 +27,7 @@ public class TestGrammarOptions extends BaseTest {
 		BaseTest.writeFile(this.tmpdir, GRAMMAR_FILE_NAME, GRAMMAR_WITHOUT_OPTIONS);
 		
 		final File grammarFile = new File(this.tmpdir, GRAMMAR_FILE_NAME);
-		
-		GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
+		final GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
 		
 		assertEquals("Java", root.getOptionString("language"));
 	}
@@ -39,8 +38,7 @@ public class TestGrammarOptions extends BaseTest {
 		BaseTest.writeFile(this.tmpdir, GRAMMAR_FILE_NAME, GRAMMAR_WITH_OPTIONS);
 		
 		final File grammarFile = new File(this.tmpdir, GRAMMAR_FILE_NAME);
-		
-		GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
+		final GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
 		
 		assertEquals("Python", root.getOptionString("language"));
 	}
@@ -57,8 +55,7 @@ public class TestGrammarOptions extends BaseTest {
 			BaseTest.writeFile(this.tmpdir, GRAMMAR_FILE_NAME, GRAMMAR_WITHOUT_OPTIONS);
 			
 			final File grammarFile = new File(this.tmpdir, GRAMMAR_FILE_NAME);
-			
-			GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
+			final GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
 			root.applyCommandLineOptions(commandLineOptions);
 			assertEquals("C", root.getOptionString("language"));
 		}
@@ -67,10 +64,31 @@ public class TestGrammarOptions extends BaseTest {
 			BaseTest.writeFile(this.tmpdir, GRAMMAR_FILE_NAME, GRAMMAR_WITH_OPTIONS);
 			
 			final File grammarFile = new File(this.tmpdir, GRAMMAR_FILE_NAME);
-			
-			GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
+			final GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
 			root.applyCommandLineOptions(commandLineOptions);
 			assertEquals("C", root.getOptionString("language"));
 		}
 	}
+	
+	@Test
+	public void testArbitraryGrammarOption() {
+		final String grammar =
+				"grammar T;\n" +
+				"options {color=purple;}" +
+				"a: 'x';";
+
+		this.mkdir(this.tmpdir);
+		BaseTest.writeFile(this.tmpdir, GRAMMAR_FILE_NAME, grammar);
+		
+		final File grammarFile = new File(this.tmpdir, GRAMMAR_FILE_NAME);
+		final GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
+		assertEquals("purple", root.getOptionString("color"));
+		
+		final HashMap<String, String> commandLineOptions = new HashMap<String, String>();
+		commandLineOptions.put("size", "large");
+		
+		root.applyCommandLineOptions(commandLineOptions);
+		assertEquals("large", root.getOptionString("size"));
+	}
+	
 }

--- a/tool/test/org/antlr/v4/test/TestGrammarOptions.java
+++ b/tool/test/org/antlr/v4/test/TestGrammarOptions.java
@@ -1,0 +1,76 @@
+package org.antlr.v4.test;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.HashMap;
+
+import org.antlr.v4.tool.ast.GrammarRootAST;
+import org.junit.Test;
+
+public class TestGrammarOptions extends BaseTest {
+	
+	private static final String GRAMMAR_FILE_NAME = "T.g4";
+	
+	private static final String GRAMMAR_WITHOUT_OPTIONS =
+			"grammar T;\n" +
+			"a: 'x';";
+	
+	private static final String GRAMMAR_WITH_OPTIONS =
+			"grammar T;\n" +
+			"options {language=Python;}" +
+			"a: 'x';";
+
+	@Test
+	public void testDefaultOption() {
+		this.mkdir(this.tmpdir);
+		BaseTest.writeFile(this.tmpdir, GRAMMAR_FILE_NAME, GRAMMAR_WITHOUT_OPTIONS);
+		
+		final File grammarFile = new File(this.tmpdir, GRAMMAR_FILE_NAME);
+		
+		GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
+		
+		assertEquals("Java", root.getOptionString("language"));
+	}
+	
+	@Test
+	public void testGrammarOption() {
+		this.mkdir(this.tmpdir);
+		BaseTest.writeFile(this.tmpdir, GRAMMAR_FILE_NAME, GRAMMAR_WITH_OPTIONS);
+		
+		final File grammarFile = new File(this.tmpdir, GRAMMAR_FILE_NAME);
+		
+		GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
+		
+		assertEquals("Python", root.getOptionString("language"));
+	}
+	
+	@Test
+	public void testCommandLineOption() {
+		
+		final HashMap<String, String> commandLineOptions = new HashMap<String, String>();
+		commandLineOptions.put("language", "C");
+		
+		this.mkdir(this.tmpdir);
+		
+		{
+			BaseTest.writeFile(this.tmpdir, GRAMMAR_FILE_NAME, GRAMMAR_WITHOUT_OPTIONS);
+			
+			final File grammarFile = new File(this.tmpdir, GRAMMAR_FILE_NAME);
+			
+			GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
+			root.applyCommandLineOptions(commandLineOptions);
+			assertEquals("C", root.getOptionString("language"));
+		}
+		
+		{
+			BaseTest.writeFile(this.tmpdir, GRAMMAR_FILE_NAME, GRAMMAR_WITH_OPTIONS);
+			
+			final File grammarFile = new File(this.tmpdir, GRAMMAR_FILE_NAME);
+			
+			GrammarRootAST root = this.newTool().loadGrammar(grammarFile.getAbsolutePath());
+			root.applyCommandLineOptions(commandLineOptions);
+			assertEquals("C", root.getOptionString("language"));
+		}
+	}
+}


### PR DESCRIPTION
This is an alternative to https://github.com/antlr/antlr4/pull/326. As discussed there, another way to go about things would be to have `-D` set arbitrary properties that can be used by templates. This pull request does that by creating a combined pool of options that draws from (in order of increasing precedence) defaults, grammar-level options, and command-line options.

The `-D` flag can now be used to set arbitrary properties. If the given property is a recognized grammar option (e.g. `language`), it will override whatever is in the defaults/grammar definition. If it's not a recognized grammar option, it will still be set and can be read by the template as desired.

Do we think this is the right way to go? If so, I'll add unit tests. If not, I'm open to other suggestions.