### PR TITLE
Lookahead tweaks

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -546,18 +546,23 @@ while ( _alt!=<choice.exitAlt> && _alt!=-1 ) {
 >>
 
 PlusBlock(choice, alts, error) ::= <<
-setState(<choice.blockStartStateNumber>); <! alt block decision !>
-_errHandler.sync(this);
-_alt = getInterpreter().adaptivePredict(_input,<choice.decision>,_ctx);
 do {
+	setState(<choice.blockStartStateNumber>); <! alt block decision !>
+<if(rest(alts))>
+	_errHandler.sync(this);
+	_alt = getInterpreter().adaptivePredict(_input,<choice.startState.decision>,_ctx);
 	switch (_alt) {
 	<alts:{alt|
-case <i><if(!choice.ast.greedy)>+1<endif>:
+case <i>:
 	<alt>
 	break;}; separator="\n">
 	default:
 		<error>
 	}
+<else>
+	<! only one alt, no need for a decision beforehand !>
+	<alts>
+<endif>
 	setState(<choice.loopBackStateNumber>); <! loopback/exit decision !>
 	_errHandler.sync(this);
 	_alt = getInterpreter().adaptivePredict(_input,<choice.decision>,_ctx);

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -494,7 +494,6 @@ do {
 
 LL1PlusBlockSingleAlt(choice, loopExpr, alts, preamble, iteration) ::= <<
 setState(<choice.blockStartStateNumber>); <! alt block decision !>
-_errHandler.sync(this);
 <preamble; separator="\n">
 do {
 	<alts; separator="\n">

--- a/tool/src/org/antlr/v4/analysis/AnalysisPipeline.java
+++ b/tool/src/org/antlr/v4/analysis/AnalysisPipeline.java
@@ -83,15 +83,10 @@ public class AnalysisPipeline {
 		g.decisionLOOK = new ArrayList<IntervalSet[]>(g.atn.getNumberOfDecisions()+1);
 		for (DecisionState s : g.atn.decisionToState) {
             g.tool.log("LL1", "\nDECISION "+s.decision+" in rule "+g.getRule(s.ruleIndex).name);
-			IntervalSet[] look;
-			if ( s.nonGreedy ) { // nongreedy decisions can't be LL(1)
-				look = new IntervalSet[s.getNumberOfTransitions()+1];
-			}
-			else {
-				LL1Analyzer anal = new LL1Analyzer(g.atn);
-				look = anal.getDecisionLookahead(s);
-				g.tool.log("LL1", "look=" + Arrays.toString(look));
-			}
+
+			LL1Analyzer anal = new LL1Analyzer(g.atn);
+			IntervalSet[] look = anal.getDecisionLookahead(s);
+			g.tool.log("LL1", "look=" + Arrays.toString(look));
 
 			assert s.decision + 1 >= g.decisionLOOK.size();
 			Utils.setSize(g.decisionLOOK, s.decision+1);

--- a/tool/src/org/antlr/v4/analysis/AnalysisPipeline.java
+++ b/tool/src/org/antlr/v4/analysis/AnalysisPipeline.java
@@ -97,11 +97,16 @@ public class AnalysisPipeline {
 
 	/** Return whether lookahead sets are disjoint; no lookahead => not disjoint */
 	public static boolean disjoint(IntervalSet[] altLook) {
+		if ( altLook==null ) return false;
 		boolean collision = false;
 		IntervalSet combined = new IntervalSet();
-		if ( altLook==null ) return false;
 		for (IntervalSet look : altLook) {
-			if ( look==null ) return false; // lookahead must've computation failed
+			if ( look==null || look.contains(Token.EPSILON) ) {
+				// lookahead calculation hit a predicate or failed to follow
+				// global context transitions
+				return false;
+			}
+
 			if ( !look.and(combined).isNil() ) {
 				collision = true;
 				break;

--- a/tool/src/org/antlr/v4/codegen/model/Choice.java
+++ b/tool/src/org/antlr/v4/codegen/model/Choice.java
@@ -77,14 +77,16 @@ public abstract class Choice extends RuleElement {
 		return altLook;
 	}
 
-	public TestSetInline addCodeForLookaheadTempVar(IntervalSet look) {
+	public TestSetInline addCodeForLookaheadTempVar(IntervalSet look, boolean requiresPreamble) {
 		List<SrcOp> testOps = factory.getLL1Test(look, ast);
 		TestSetInline expr = Utils.find(testOps, TestSetInline.class);
 		if (expr != null) {
 			Decl d = new TokenTypeDecl(factory, expr.varName);
 			factory.getCurrentRuleFunction().addLocalDecl(d);
-			CaptureNextTokenType nextType = new CaptureNextTokenType(factory,expr.varName);
-			addPreambleOp(nextType);
+			if (requiresPreamble) {
+				CaptureNextTokenType nextType = new CaptureNextTokenType(factory,expr.varName);
+				addPreambleOp(nextType);
+			}
 		}
 		return expr;
 	}

--- a/tool/src/org/antlr/v4/codegen/model/LL1Loop.java
+++ b/tool/src/org/antlr/v4/codegen/model/LL1Loop.java
@@ -60,8 +60,8 @@ public abstract class LL1Loop extends Choice {
 		iteration.add(op);
 	}
 
-	public SrcOp addCodeForLoopLookaheadTempVar(IntervalSet look) {
-		TestSetInline expr = addCodeForLookaheadTempVar(look);
+	public SrcOp addCodeForLoopLookaheadTempVar(IntervalSet look, boolean requiresPreamble) {
+		TestSetInline expr = addCodeForLookaheadTempVar(look, requiresPreamble);
 		if (expr != null) {
 			CaptureNextTokenType nextType = new CaptureNextTokenType(factory, expr.varName);
 			addIterationOp(nextType);

--- a/tool/src/org/antlr/v4/codegen/model/LL1OptionalBlockSingleAlt.java
+++ b/tool/src/org/antlr/v4/codegen/model/LL1OptionalBlockSingleAlt.java
@@ -59,7 +59,7 @@ public class LL1OptionalBlockSingleAlt extends LL1Choice {
 		IntervalSet expecting = look.or(followLook);
 		this.error = getThrowNoViableAlt(factory, blkAST, expecting);
 
-		expr = addCodeForLookaheadTempVar(look);
+		expr = addCodeForLookaheadTempVar(look, true);
 		followExpr = factory.getLL1Test(followLook, blkAST);
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/LL1PlusBlock.java
+++ b/tool/src/org/antlr/v4/codegen/model/LL1PlusBlock.java
@@ -68,7 +68,7 @@ public class LL1PlusBlock extends LL1Loop {
 
 		this.error = getThrowNoViableAlt(factory, plusRoot, all);
 
-		loopExpr = addCodeForLoopLookaheadTempVar(all);
+		loopExpr = addCodeForLoopLookaheadTempVar(all, true);
 
 		loopLabel = gen.getTarget().getLoopLabel(plusRoot);
 		loopCounterVar = gen.getTarget().getLoopCounter(plusRoot);

--- a/tool/src/org/antlr/v4/codegen/model/LL1PlusBlockSingleAlt.java
+++ b/tool/src/org/antlr/v4/codegen/model/LL1PlusBlockSingleAlt.java
@@ -50,6 +50,6 @@ public class LL1PlusBlockSingleAlt extends LL1Loop {
 		IntervalSet[] altLookSets = factory.getGrammar().decisionLOOK.get(decision);
 
 		IntervalSet loopBackLook = altLookSets[0];
-		loopExpr = addCodeForLoopLookaheadTempVar(loopBackLook);
+		loopExpr = addCodeForLoopLookaheadTempVar(loopBackLook, false);
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/LL1StarBlockSingleAlt.java
+++ b/tool/src/org/antlr/v4/codegen/model/LL1StarBlockSingleAlt.java
@@ -49,6 +49,6 @@ public class LL1StarBlockSingleAlt extends LL1Loop {
 		assert altLookSets.length == 2;
 		IntervalSet enterLook = altLookSets[0];
 		IntervalSet exitLook = altLookSets[1];
-		loopExpr = addCodeForLoopLookaheadTempVar(enterLook);
+		loopExpr = addCodeForLoopLookaheadTempVar(enterLook, true);
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/PlusBlock.java
+++ b/tool/src/org/antlr/v4/codegen/model/PlusBlock.java
@@ -38,6 +38,8 @@ import org.antlr.v4.tool.ast.GrammarAST;
 import java.util.List;
 
 public class PlusBlock extends Loop {
+	public PlusBlockStartState startState;
+	public PlusLoopbackState loopbackState;
 	@ModelElement public ThrowNoViableAlt error;
 
 	public PlusBlock(OutputModelFactory factory,
@@ -46,12 +48,12 @@ public class PlusBlock extends Loop {
 	{
 		super(factory, plusRoot, alts);
 
-		PlusBlockStartState blkStart = (PlusBlockStartState)plusRoot.atnState;
-		PlusLoopbackState loop = ((PlusBlockStartState)plusRoot.atnState).loopBackState;
-		stateNumber = blkStart.loopBackState.stateNumber;
-		blockStartStateNumber = blkStart.stateNumber;
-		loopBackStateNumber = loop.stateNumber;
+		startState = (PlusBlockStartState)plusRoot.atnState;
+		loopbackState = ((PlusBlockStartState)plusRoot.atnState).loopBackState;
+		stateNumber = startState.loopBackState.stateNumber;
+		blockStartStateNumber = startState.stateNumber;
+		loopBackStateNumber = loopbackState.stateNumber;
 		this.error = getThrowNoViableAlt(factory, plusRoot, null);
-		decision = loop.decision;
+		decision = loopbackState.decision;
 	}
 }


### PR DESCRIPTION
* Fix code generation for `PlusBlock` to adhere to [the documentation](http://www.antlr.org/api/Java/org/antlr/v4/runtime/atn/ATNState.html). The only reason it worked previously is we never produced a `PlusBlockStartState` in the code generation process containing more than one alternative.
* Remove unnecessary call to `LA(1)` prior to entering an LL(1) positive closure with only one alternative
* Fix LL(1) analysis for non-greedy loops
