### PR TITLE
Use visit(c) rather than c.accept(this) in visitChildren

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/tree/AbstractParseTreeVisitor.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/AbstractParseTreeVisitor.java
@@ -69,7 +69,7 @@ public abstract class AbstractParseTreeVisitor<T> implements ParseTreeVisitor<T>
 			}
 
 			ParseTree c = node.getChild(i);
-			T childResult = c.accept(this);
+			T childResult = visit(c);
 			result = aggregateResult(result, childResult);
 		}
 


### PR DESCRIPTION
By default, visitChildren calls `c.accept(this)` for each children `c`
I suggest using`visit(c)` instead so that it's easier to trace what is being visited.
