### PR TITLE
Expose grammar options and use in testrig for lexer name

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/Recognizer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Recognizer.java
@@ -69,6 +69,14 @@ public abstract class Recognizer<Symbol, ATNInterpreter extends ATNSimulator> {
 	public abstract String[] getRuleNames();
 
 	/**
+	 * Get a map of the grammar options.
+	 */
+	@NotNull
+	public Map<String,String> getOptions() {
+		throw new UnsupportedOperationException("The current recognizer does not provide an option map");
+	}
+
+	/**
 	 * Get a map from token names to token types.
 	 *
 	 * <p>Used for XPath and tree pattern compilation.</p>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -53,7 +53,9 @@ import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.*;
 import org.antlr.v4.runtime.tree.*;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Iterator;
 import java.util.ArrayList;
 
@@ -229,6 +231,11 @@ public class <parser.name> extends <superClass> {
 	public static final String[] ruleNames = {
 		<parser.ruleNames:{r | "<r>"}; separator=", ", wrap, anchor>
 	};
+	public static final Map\<String,String> options;
+	static {
+		options = new HashMap\<String,String>();
+		<parser.options.keys:{k | options.put("<k>", "<parser.options.(k)>"); }; separator="\n">
+	}
 
 	@Override
 	public String getGrammarFileName() { return "<parser.grammarFileName; format="java-escape">"; }
@@ -238,6 +245,9 @@ public class <parser.name> extends <superClass> {
 
 	@Override
 	public String[] getRuleNames() { return ruleNames; }
+
+	@Override
+	public Map\<String,String> getOptions() { return options; }
 
 	@Override
 	public String getSerializedATN() { return _serializedATN; }
@@ -841,6 +851,8 @@ import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.misc.*;
+import java.util.HashMap;
+import java.util.Map;
 
 <lexer>
 >>
@@ -865,6 +877,11 @@ public class <lexer.name> extends <superClass> {
 	public static final String[] ruleNames = {
 		<lexer.ruleNames:{r | "<r>"}; separator=", ", wrap, anchor>
 	};
+	public static final Map\<String,String> options;
+	static {
+		options = new HashMap\<String,String>();
+		<lexer.options.keys:{k | options.put("<k>", "<lexer.options.(k)>"); }; separator="\n">
+	}
 
 	<namedActions.members>
 
@@ -881,6 +898,9 @@ public class <lexer.name> extends <superClass> {
 
 	@Override
 	public String[] getRuleNames() { return ruleNames; }
+
+	@Override
+	public Map\<String,String> getOptions() { return options; }
 
 	@Override
 	public String getSerializedATN() { return _serializedATN; }

--- a/tool/src/org/antlr/v4/codegen/model/Lexer.java
+++ b/tool/src/org/antlr/v4/codegen/model/Lexer.java
@@ -105,7 +105,10 @@ public class Lexer extends OutputModelObject {
 		}
 		options = new HashMap<String,String>();
 		for (String name : Grammar.lexerOptions) {
-			options.put(name, g.getOptionString(name));
+			String value = g.getOptionString(name);
+			if ( value!=null ) {
+				options.put(name, g.getOptionString(name));
+			}
 		}
 	}
 

--- a/tool/src/org/antlr/v4/codegen/model/Lexer.java
+++ b/tool/src/org/antlr/v4/codegen/model/Lexer.java
@@ -41,6 +41,7 @@ import org.antlr.v4.tool.Rule;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -54,6 +55,7 @@ public class Lexer extends OutputModelObject {
 	public Set<String> ruleNames;
 	public Collection<String> modes;
 	@ModelElement public ActionChunk superClass;
+	public Map<String,String> options;
 
 	@ModelElement public SerializedATN atn;
 	@ModelElement public LinkedHashMap<Rule, RuleActionFunction> actionFuncs =
@@ -100,6 +102,10 @@ public class Lexer extends OutputModelObject {
 		}
 		else {
 			superClass = new DefaultLexerSuperClass();
+		}
+		options = new HashMap<String,String>();
+		for (String name : Grammar.lexerOptions) {
+			options.put(name, g.getOptionString(name));
 		}
 	}
 

--- a/tool/src/org/antlr/v4/codegen/model/Parser.java
+++ b/tool/src/org/antlr/v4/codegen/model/Parser.java
@@ -104,7 +104,10 @@ public class Parser extends OutputModelObject {
 		}
 		options = new HashMap<String,String>();
 		for (String name : Grammar.parserOptions) {
-			options.put(name, g.getOptionString(name));
+			String value = g.getOptionString(name);
+			if ( value!=null ) {
+				options.put(name, g.getOptionString(name));
+			}
 		}
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/Parser.java
+++ b/tool/src/org/antlr/v4/codegen/model/Parser.java
@@ -41,6 +41,7 @@ import org.antlr.v4.tool.Rule;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +53,7 @@ public class Parser extends OutputModelObject {
 	public String grammarFileName;
 	public String grammarName;
 	@ModelElement public ActionChunk superClass;
+	public Map<String,String> options;
 	public Map<String,Integer> tokens;
 	public String[] tokenNames;
 	public Set<String> ruleNames;
@@ -99,6 +101,10 @@ public class Parser extends OutputModelObject {
 		}
 		else {
 			superClass = new DefaultParserSuperClass();
+		}
+		options = new HashMap<String,String>();
+		for (String name : Grammar.parserOptions) {
+			options.put(name, g.getOptionString(name));
 		}
 	}
 }


### PR DESCRIPTION
This is a potential fix for https://github.com/antlr/antlr4/issues/493 .  It exposes the grammar options in the generated Lexer + Parser classes, and uses the exposed tokenVocab option in TestRig as a fallback class name.  It "works for me" in fixing that issue.