### PR TITLE
Expose TokenSources from ParserRuleContext and TokenStreamRewriter

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/WrappedSource.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/WrappedSource.java
@@ -1,0 +1,65 @@
+package org.antlr.v4.runtime;
+
+import org.antlr.v4.runtime.misc.NotNull;
+import org.antlr.v4.runtime.misc.Pair;
+
+/**
+ * An abstract base class for {@link TokenSource} wrappers.  It provides
+ * common implementation and utility methods for deriving wrappers.
+ * Tokens subclasses will generally want to use the cloneToken method
+ * to avoid inadvertent changes to source tokens.
+ */
+public abstract class WrappedSource implements TokenSource {
+	protected TokenFactory<?> factory;
+
+	/** Clone an input Token.  Our stream view clones tokens so that the
+	 * original tokens are not modified.  This is particularly important
+	 * to preserve the source Token's index.
+	 * */
+	protected Token cloneToken(Token t) {
+		if (factory != null) {
+			return factory.create(new Pair<TokenSource, CharStream>(this, null), t.getType(), t.getText(), t.getChannel(),
+					-1, -1, getLine(), getCharPositionInLine());
+		} else {
+			return new CommonToken(t);
+		}
+	}
+
+	protected Token createEOF() {
+		// All tokens exhausted.  Return EOF
+		if (factory != null) {
+			return factory.create(new Pair<TokenSource, CharStream>(this, null), Token.EOF, "",
+					Token.DEFAULT_CHANNEL, -1, -1, getLine(), getCharPositionInLine());
+		} else {
+			return new CommonToken(new Pair<TokenSource, CharStream>(this, null), Token.EOF, Token.DEFAULT_CHANNEL,
+					-1, -1);
+		}
+	}
+
+	@Override
+	public int getLine() {
+		// Possible TODO: boolean switch to enable line tracking
+		return -1;
+	}
+
+	@Override
+	public int getCharPositionInLine() {
+		// Possible TODO: boolean switch to enable column tracking
+		return -1;
+	}
+
+	@Override
+	public CharStream getInputStream() {
+		return null;
+	}
+
+	@Override
+	public void setTokenFactory(@NotNull TokenFactory<?> factory) {
+		this.factory = factory;
+	}
+
+	@Override
+	public TokenFactory<?> getTokenFactory() {
+		return factory;
+	}
+}


### PR DESCRIPTION
_Revisision 2_

TL; DR -- Add toSource() methods on ParserRuleContext and TokenStreamRewriter to stream portions of the parse tree and to stream rewrite operations.  I'm using this for a c-preprocessor-like implementation.

This PR adds the following:

1. A new TokenSource abstract class, WrappedSource, that provides common implementations and utilities for wrapper TokenSource implementations.
3. A new toSource() method on ParserRuleContext that returns a ParserRuleContext.ContextSource.  This TokenSource walks the context node for terminal tokens and returns them.
4. Methods on TokenStreamRewriter to accept rewrite operations as Tokens.
5. A new toSource() method on TokenStreamRewriter that combines all of the above to stream rewrites as a TokenSource.

I'm currently using these features in a C-preprocessor-like implementation that makes multiple replacement passes on the tokens underneath different context nodes.  By adding the toSource() methods above, the macro replacement is simplified.  It takes a TokenSource as the input and returns a TokenSource as output, recursing and iterating as many times as needed, each with TokenSource input and output.  Since the individual tree nodes can be streamed as a TokenSource, the replacements can be made in isolated portions of the tree.  The replacement results are collected at the end from the full tree and then passed to a different Lexer/Parser for compiling.

_This PR has a lot of changes, so I'm quite open to suggestions/feedback_