### PR TITLE
Remove comment that was only meant for testing

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -1417,7 +1417,7 @@ public class ParserATNSimulator extends ATNSimulator {
 			if ( c!=null ) {
 				if (!t.isEpsilon() && !closureBusy.add(c)) {
 					// avoid infinite recursion for EOF* and EOF+
-					//continue;
+					continue;
 				}
 
 				int newDepth = depth;


### PR DESCRIPTION
#537 was broken due to a line of code that was commented out for testing.
