### PR TITLE
Remove ability to reference enclosing rule by name, in favor of $ctx

### DIFF
--- a/tool/src/org/antlr/v4/tool/Alternative.java
+++ b/tool/src/org/antlr/v4/tool/Alternative.java
@@ -92,7 +92,6 @@ public class Alternative implements AttributeResolver {
         if ( ruleRefs.get(x)!=null ) return true; // rule ref in this alt?
         LabelElementPair anyLabelDef = getAnyLabelDef(x);
         if ( anyLabelDef!=null && anyLabelDef.type==LabelType.RULE_LABEL ) return true;
-		if ( x.equals(rule.name) ) return true; // $r for action in rule r, $r is a dict
 		return false;
 	}
 
@@ -108,9 +107,6 @@ public class Alternative implements AttributeResolver {
 	 */
 	@Override
 	public Attribute resolveToAttribute(String x, String y, ActionAST node) {
-		if ( rule.name.equals(x) ) { // x is this rule?
-			return rule.resolveToAttribute(x, y, node);
-		}
         if ( tokenRefs.get(x)!=null ) { // token ref in this alt?
             return rule.getPredefinedScope(LabelType.TOKEN_LABEL).get(y);
         }
@@ -162,7 +158,6 @@ public class Alternative implements AttributeResolver {
 		if ( anyLabelDef!=null && anyLabelDef.type==LabelType.RULE_LABEL ) {
             return rule.g.getRule(anyLabelDef.element.getText());
         }
-		if ( x.equals(rule.name) ) return rule;
         return null;
     }
 }

--- a/tool/src/org/antlr/v4/tool/Rule.java
+++ b/tool/src/org/antlr/v4/tool/Rule.java
@@ -259,9 +259,6 @@ public class Rule implements AttributeResolver {
 	/** $x.y	Attribute: x is surrounding rule, label ref (in any alts) */
 	@Override
 	public Attribute resolveToAttribute(String x, String y, ActionAST node) {
-		if ( this.name.equals(x) ) { // x is this rule?
-			return resolveToAttribute(y, node);
-		}
 		LabelElementPair anyLabelDef = getAnyLabelDef(x);
 		if ( anyLabelDef!=null ) {
 			if ( anyLabelDef.type==LabelType.RULE_LABEL ) {
@@ -306,7 +303,6 @@ public class Rule implements AttributeResolver {
 	@Override
 	public boolean resolvesToAttributeDict(String x, ActionAST node) {
 		if ( resolvesToToken(x, node) ) return true;
-		if ( x.equals(name) ) return true; // $r for action in rule r, $r is a dict
 		return false;
 	}
 

--- a/tool/test/org/antlr/v4/test/TestActionTranslation.java
+++ b/tool/test/org/antlr/v4/test/TestActionTranslation.java
@@ -119,25 +119,25 @@ public class TestActionTranslation extends BaseTest {
 	}
 
 	@Test public void testArguments() throws Exception {
-		String action = "$x; $a.x";
+		String action = "$x; $ctx.x";
 		String expected = "_localctx.x; _localctx.x";
 		testActions(attributeTemplate, "inline", action, expected);
 	}
 
 	@Test public void testReturnValue() throws Exception {
-		String action = "$x; $a.x";
-		String expected = "_localctx.x; _localctx.x";
+		String action = "$y; $ctx.y";
+		String expected = "_localctx.y; _localctx.y";
 		testActions(attributeTemplate, "inline", action, expected);
 	}
 
 	@Test public void testReturnValueWithNumber() throws Exception {
-		String action = "$a.x1";
+		String action = "$ctx.x1";
 		String expected = "_localctx.x1";
 		testActions(attributeTemplate, "inline", action, expected);
 	}
 
 	@Test public void testReturnValuesCurrentRule() throws Exception {
-		String action = "$y; $a.y;";
+		String action = "$y; $ctx.y;";
 		String expected = "_localctx.y; _localctx.y;";
 		testActions(attributeTemplate, "inline", action, expected);
 	}
@@ -167,11 +167,11 @@ public class TestActionTranslation extends BaseTest {
     }
 
 	@Test public void testRefToTextAttributeForCurrentRule() throws Exception {
-        String action = "$a.text; $text";
+        String action = "$ctx.text; $text";
 
 		// this is the expected translation for all cases
 		String expected =
-			"_input.getText(_localctx.start, _input.LT(-1)); _input.getText(_localctx.start, _input.LT(-1))";
+			"_localctx.text; _input.getText(_localctx.start, _input.LT(-1))";
 
 		testActions(attributeTemplate, "init", action, expected);
 		testActions(attributeTemplate, "inline", action, expected);

--- a/tool/test/org/antlr/v4/test/TestAttributeChecks.java
+++ b/tool/test/org/antlr/v4/test/TestAttributeChecks.java
@@ -78,7 +78,7 @@ public class TestAttributeChecks extends BaseTest {
 		"$x = $y",		"",
 		"$y = $x",		"",
 		"$y.b = 3;",	"",
-		"$a.x = $a.y",	"",
+		"$ctx.x = $ctx.y",	"",
 		"$lab.e",		"",
 		"$lab.text",	"",
 		"$b.e",			"",


### PR DESCRIPTION
Fixes #571
