### PR TITLE
Relax versioning

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/RuntimeMetaData.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/RuntimeMetaData.java
@@ -164,6 +164,12 @@ public class RuntimeMetaData {
 	 * <em>minor</em> version components.
 	 *
 	 * <p>
+	 * For example, version strings x.y and x.y.z are considered "compatible",
+	 * and this listener will not throw an exception. Likewise, version strings
+	 * x.y-SNAPSHOT and x.y.z are considered "compatible" because the major and
+	 * minor components x.y are the same in each.</p>
+	 *
+	 * <p>
 	 * For the purposes of this listener, version numbers are assumed to have
 	 * the form
 	 * <em>major</em>.<em>minor</em>.<em>patch</em>.<em>revision</em>-<em>suffix</em>,

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -90,6 +90,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class Tool {
 	public static final String VERSION;
 	static {
+		// Assigned in a static{} block to prevent the field from becoming a
+		// compile-time constant
 		VERSION = RuntimeMetaData.VERSION;
 	}
 


### PR DESCRIPTION
- Default version mismatch listener only throws an exception if the major and/or minor versions do not match (ignore patch, revision, and/or suffix values)
- Fixes #634
