### PR TITLE
Add support for Github based maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <bootclasspath.compile>${bootclasspath.java6}</bootclasspath.compile>
         <bootclasspath.testCompile>${bootclasspath.java6}</bootclasspath.testCompile>
         <antlr.testinprocess>true</antlr.testinprocess>
+        <github.global.server>github</github.global.server>
     </properties>
 
     <mailingLists>
@@ -94,7 +95,15 @@
         <connection>scm:git:git://github.com/antlr/antlr4.git</connection>
         <developerConnection>scm:git:git@github.com:antlr/antlr4.git</developerConnection>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>internal.repo</id>
+            <name>Temporary Staging Repository</name>
+            <url>file://${project.build.directory}/mvn-repo</url>
+        </repository>
+    </distributionManagement>
 
     <profiles>
         <profile>
@@ -193,6 +202,40 @@
                 <artifactId>maven-gpg-plugin</artifactId>
                 <!-- override the version inherited from the parent -->
                 <version>1.4</version>
+            </plugin>
+
+            
+
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.1</version>
+                <configuration>
+                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.9</version>
+                <configuration>
+                    <message>Maven artifacts for ${project.version}</message>
+                    <noJekyll>true</noJekyll>                                 
+                    <outputDirectory>${project.build.directory}/mvn-repo</outputDirectory>
+                    <branch>refs/heads/mvn-repo</branch>                     
+                    <includes><include>**/*</include></includes>
+                    <repositoryName>antlr4</repositoryName>     
+                    <repositoryOwner>antlr</repositoryOwner>
+                    <merge>true</merge>  
+                </configuration>
+                <executions>
+                  <execution>
+                    <goals>
+                      <goal>site</goal>
+                    </goals>
+                    <phase>deploy</phase>
+                  </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Hi, I added support for using Github as a Maven repo as suggested [here (please read me)](http://stackoverflow.com/questions/14013644/hosting-a-maven-repository-on-github).

After you merge the request, you need to do the followings.
#### Adding Github Authentication

Add the following code to your `~/.m2/settings.xml`. The id `github` is used by `<github.global.server>github</github.global.server>` in `pom.xml`. The password is used to commit artifacts to github repository.

```
<settings>
  <servers>
    <server>
      <id>github</id>
      <username>YOUR-USERNAME</username>
      <password>YOUR-PASSWORD</password>
    </server>
  </servers>
</settings>
```
#### Deploy

Run `mvn clean deploy` to deploy artifacts into Github `mvn-repo` branch.
#### Reference the Repo

Users need to add the following code to reference this repo

In Maven

```
<repositories>
    <repository>
        <id>antlr4-mvn-repo</id>
        <url>https://raw.github.com/antlr/antlr4/mvn-repo/</url>
        <snapshots>
            <enabled>true</enabled>
            <updatePolicy>always</updatePolicy>
        </snapshots>
    </repository>
</repositories>
```

In Gradle

```
maven {
    url "https://raw.github.com/antlr/antlr4/mvn-repo/"
}
```
