### PR TITLE
Make ANTLR 4 runtime maven artifacts OSGi-ready

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,24 @@
         <bootclasspath.compile>${bootclasspath.java6}</bootclasspath.compile>
         <bootclasspath.testCompile>${bootclasspath.java6}</bootclasspath.testCompile>
         <antlr.testinprocess>true</antlr.testinprocess>
+        <maven-bundle-plugin.version>2.3.7</maven-bundle-plugin.version>
+
+        <!-- Default OSGi metadata - see maven-bundle-plugin configuration -->
+        <osgi.symbolicName>${project.groupId}.${project.artifactId}</osgi.symbolicName>
+        <osgi.failok>false</osgi.failok>
+        <osgi.nouses>false</osgi.nouses>
+        <osgi.versionPolicy>${range;[===,=+);${@}}</osgi.versionPolicy>
+        <osgi.private/>
+        <osgi.import>
+            *
+        </osgi.import>
+        <osgi.export/>
+        <!--
+            antlr4-runtime is main bundle and host to annotations fragment bundle
+            so define symbolic name here to ensure consistent reference in annotation
+            OSGi metadata.
+        -->
+        <antlr4-runtime.symbolicName>${project.groupId}.antlr4-runtime</antlr4-runtime.symbolicName>
     </properties>
 
     <mailingLists>
@@ -135,6 +153,29 @@
     </profiles>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${maven-bundle-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <obrRepository>NONE</obrRepository>
+                        <manifestLocation>${project.build.directory}/META-INF</manifestLocation>
+                        <instructions>
+                            <Bundle-SymbolicName>${osgi.symbolicName}</Bundle-SymbolicName>
+                            <Import-Package>${osgi.import}</Import-Package>
+                            <Export-Package>${osgi.export}</Export-Package>
+                            <Private-Package>${osgi.private}</Private-Package>
+                            <_nouses>${osgi.nouses}</_nouses>
+                            <_versionpolicy>${osgi.versionPolicy}</_versionpolicy>
+                            <_failok>${osgi.failok}</_failok>
+                        </instructions>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -14,9 +14,23 @@
     <name>ANTLR 4 Runtime</name>
     <description>The ANTLR 4 Runtime</description>
 
+    <packaging>bundle</packaging>
+
     <properties>
         <!-- Assumes dot is in the system path, or specified for the build. -->
         <dot.path>dot</dot.path>
+
+        <!-- OSGi metadata -->
+        <osgi.symbolicName>${antlr4-runtime.symbolicName}</osgi.symbolicName>
+
+        <!--
+           org.antlr.v4.runtime.misc is a non-overlapping split package.
+           Since we are treating antlr4-annotations as a fragment,
+           do not try to merge packages into one bundle.
+         -->
+        <osgi.export>
+            org.antlr.v4*;version=${project.version};-split-package:=first
+        </osgi.export>
     </properties>
 
     <dependencies>
@@ -115,6 +129,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/runtime/JavaAnnotations/pom.xml
+++ b/runtime/JavaAnnotations/pom.xml
@@ -14,6 +14,15 @@
     <name>ANTLR 4 Runtime Annotations</name>
     <description>A set of annotations used within the ANTLR 4 Runtime</description>
 
+    <packaging>bundle</packaging>
+
+    <properties>
+        <osgi.export>
+            org.antlr.v4.runtime.misc;version=${project.version}
+        </osgi.export>
+        <osgi.fragmentHost>${antlr4-runtime.symbolicName}</osgi.fragmentHost>
+    </properties>
+
     <build>
         <sourceDirectory>src</sourceDirectory>
         <resources>
@@ -30,6 +39,15 @@
                     <compilerArgs>
                         <compilerArg>-proc:none</compilerArg>
                     </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Fragment-Host>${osgi.fragmentHost}</Fragment-Host>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Added maven-bundle-plugin + metadata configuration to antlr4-runtime and
antlr4-annotations jar manifests to allow antlr4 runtime to be used to
execute parsers in OSGi runtime.

The addition of OSGi metadata as generated by the maven-bundle-plugin (actually it is generated by a tool called [Bnd](http://www.aqute.biz/Code/Bnd)  which is invoked by the plugin) adds to the manifest of *antlr4-runtime* and *antlr4-annotations* manifests as follows (standard jar manifest entries remain and are highlighted in bold):

Firstly antlr4-runtime:

__Manifest-Version: 1.0__
Bnd-LastModified: 1409190229833
__Build-Jdk: 1.7.0_25__
__Built-By: cd01__
Bundle-Description: The ANTLR 4 Runtime
Bundle-DocURL: http://www.antlr.org
Bundle-License: http://www.antlr.org/license.html
Bundle-ManifestVersion: 2
Bundle-Name: ANTLR 4 Runtime
Bundle-SymbolicName: org.antlr.antlr4-runtime
Bundle-Vendor: ANTLR
Bundle-Version: 4.4.0.SNAPSHOT
__Created-By: Apache Maven Bundle Plugin__
Export-Package: org.antlr.v4.runtime;uses:="org.antlr.v4.runtime.dfa,org
 .antlr.v4.runtime.atn,org.antlr.v4.runtime.misc,org.antlr.v4.runtime.tr
 ee,org.antlr.v4.runtime.tree.pattern,org.antlr.v4.runtime.tree.gui,java
 x.print,javax.swing";version="4.4.0.SNAPSHOT",org.antlr.v4.runtime.tree
 .gui;uses:="org.antlr.v4.runtime.tree,org.abego.treelayout,org.antlr.v4
 .runtime.misc,org.abego.treelayout.util,javax.swing,javax.swing.event,j
 avax.swing.tree,javax.swing.filechooser,javax.swing.border,javax.print,
 javax.imageio";version="4.4.0.SNAPSHOT",org.antlr.v4.runtime.tree.xpath
 ;uses:="org.antlr.v4.runtime,org.antlr.v4.runtime.tree,org.antlr.v4.run
 time.dfa,org.antlr.v4.runtime.atn";version="4.4.0.SNAPSHOT",org.antlr.v
 4.runtime.dfa;uses:="org.antlr.v4.runtime.atn,org.antlr.v4.runtime.misc
 ";version="4.4.0.SNAPSHOT",org.antlr.v4.runtime.atn;uses:="org.antlr.v4
 .runtime,org.antlr.v4.runtime.misc,org.antlr.v4.runtime.dfa";version="4
 .4.0.SNAPSHOT",org.antlr.v4.runtime.tree.pattern;uses:="org.antlr.v4.ru
 ntime.misc,org.antlr.v4.runtime.tree,org.antlr.v4.runtime,org.antlr.v4.
 runtime.tree.xpath,org.antlr.v4.runtime.atn";version="4.4.0.SNAPSHOT",o
 rg.antlr.v4.runtime.misc;uses:="javax.swing,javax.imageio,javax.print,j
 avax.print.attribute,org.antlr.v4.runtime,org.antlr.v4.runtime.atn";ver
 sion="4.4.0.SNAPSHOT",org.antlr.v4.runtime.tree;uses:="org.antlr.v4.run
 time,org.antlr.v4.runtime.misc,org.antlr.v4.runtime.tree.gui";version="
 4.4.0.SNAPSHOT"
__Implementation-Title: ANTLR 4 Runtime__
__Implementation-Vendor: ANTLR__
__Implementation-Vendor-Id: org.antlr__
__Implementation-Version: 4.4-SNAPSHOT__
Import-Package: javax.imageio,javax.print,javax.print.attribute,javax.sw
 ing,javax.swing.border,javax.swing.event,javax.swing.filechooser,javax.
 swing.tree,org.abego.treelayout,org.abego.treelayout.util
Tool: Bnd-1.50.0

and secondly antlr4-annotations:

__Manifest-Version: 1.0__
Bnd-LastModified: 1409178802662
__Build-Jdk: 1.7.0_25__
__Built-By: cd01__
Bundle-Description: A set of annotations used within the ANTLR 4 Runtime
Bundle-DocURL: http://www.antlr.org
Bundle-License: http://www.antlr.org/license.html
Bundle-ManifestVersion: 2
Bundle-Name: ANTLR 4 Runtime Annotations
Bundle-SymbolicName: org.antlr.antlr4-annotations
Bundle-Vendor: ANTLR
Bundle-Version: 4.4.0.SNAPSHOT
__Created-By: Apache Maven Bundle Plugin__
Export-Package: org.antlr.v4.runtime.misc;uses:="javax.lang.model.elemen
 t,javax.lang.model.util,javax.tools,javax.lang.model,javax.lang.model.t
 ype,javax.annotation.processing";version="4.4.0.SNAPSHOT"
Fragment-Host: org.antlr.antlr4-runtime
__Implementation-Title: ANTLR 4 Runtime Annotations__
__Implementation-Vendor: ANTLR__
__Implementation-Vendor-Id: org.antlr__
__Implementation-Version: 4.4-SNAPSHOT__
Import-Package: javax.annotation.processing,javax.lang.model,javax.lang.
 model.element,javax.lang.model.type,javax.lang.model.util,javax.tools
Tool: Bnd-1.50.0

*ok, there is a slight difference in that with maven jar plugin you will get **Archiver-Version: Plexus Archiver*** :wink: