### PR TITLE
Improved deterministic code generation output

### DIFF
--- a/tool/src/org/antlr/v4/codegen/CodeGenerator.java
+++ b/tool/src/org/antlr/v4/codegen/CodeGenerator.java
@@ -40,13 +40,12 @@ import org.antlr.v4.tool.Grammar;
 import org.stringtemplate.v4.AutoIndentWriter;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
-import org.stringtemplate.v4.STGroupFile;
 import org.stringtemplate.v4.STWriter;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Constructor;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** General controller for code gen.  Can instantiate sub generator(s).
@@ -158,7 +157,7 @@ public class CodeGenerator {
 	 */
 	ST getTokenVocabOutput() {
 		ST vocabFileST = new ST(vocabFilePattern);
-		Map<String,Integer> tokens = new HashMap<String,Integer>();
+		Map<String,Integer> tokens = new LinkedHashMap<String,Integer>();
 		// make constants for the token names
 		for (String t : g.tokenNameToTypeMap.keySet()) {
 			int tokenType = g.tokenNameToTypeMap.get(t);
@@ -169,7 +168,7 @@ public class CodeGenerator {
 		vocabFileST.add("tokens", tokens);
 
 		// now dump the strings
-		Map<String,Integer> literals = new HashMap<String,Integer>();
+		Map<String,Integer> literals = new LinkedHashMap<String,Integer>();
 		for (String literal : g.stringLiteralToTypeMap.keySet()) {
 			int tokenType = g.stringLiteralToTypeMap.get(literal);
 			if ( tokenType>=Token.MIN_USER_TOKEN_TYPE) {

--- a/tool/src/org/antlr/v4/codegen/OutputModelWalker.java
+++ b/tool/src/org/antlr/v4/codegen/OutputModelWalker.java
@@ -41,9 +41,9 @@ import org.stringtemplate.v4.compiler.FormalArgument;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -143,7 +143,7 @@ public class OutputModelWalker {
 				}
 				else if ( o instanceof Map ) {
 					Map<?, ?> nestedOmoMap = (Map<?, ?>)o;
-					Map<Object, ST> m = new HashMap<Object, ST>();
+					Map<Object, ST> m = new LinkedHashMap<Object, ST>();
 					for (Map.Entry<?, ?> entry : nestedOmoMap.entrySet()) {
 						ST nestedST = walk((OutputModelObject)entry.getValue());
 //						System.out.println("set ModelElement "+fieldName+"="+nestedST+" in "+templateName);

--- a/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
@@ -68,6 +68,8 @@ import java.util.Set;
 import static org.antlr.v4.parse.ANTLRParser.RULE_REF;
 import static org.antlr.v4.parse.ANTLRParser.TOKEN_REF;
 
+import java.util.LinkedHashSet;
+
 /** */
 public class RuleFunction extends OutputModelObject {
 	public String name;
@@ -207,7 +209,7 @@ public class RuleFunction extends OutputModelObject {
 				}
 			}
 		}
-		Set<Decl> decls = new HashSet<Decl>();
+		Set<Decl> decls = new LinkedHashSet<Decl>();
 		for (GrammarAST t : allRefs) {
 			String refLabelName = t.getText();
 			List<Decl> d = getDeclForAltElement(t,


### PR DESCRIPTION
This change improves upon some of the work in #724.

The most obvious improvements here are:
- For separate lexer and parser grammars, the order in which tokens were written to the **.tokens** file while generating the lexer affected the order in which the token constants appeared in the final generated parser.
- Generated accessor methods in parse tree context classes is now deterministic.
