### PR TITLE
Revert "enable testing of javascript runtime in browsers"

### DIFF
--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -20,18 +20,6 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
-    	<dependency>
-        	<groupId>org.seleniumhq.selenium</groupId>
-        	<artifactId>selenium-java</artifactId>
-        	<version>2.43.1</version>
-            <scope>test</scope>
-   		</dependency>  
-        <dependency>
-           <groupId>org.eclipse.jetty</groupId>
-           <artifactId>jetty-server</artifactId>
-           <version>8.1.16.v20140903</version>
-           <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>


### PR DESCRIPTION
Reverts antlr/antlr4#731

The dependencies added in #731 are not required for, or used in any way, by the current code base. They should only be added if/when they actually become necessary for testing this project.
