### PR TITLE
Fix handling of lexer accept positions for zero-length tokens and at EOF

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -200,8 +200,6 @@ public class LexerATNSimulator extends ATNSimulator {
 		if (ds0.isAcceptState) {
 			// allow zero-length tokens
 			captureSimState(prevAccept, input, ds0);
-			// adjust index since the current input character was not yet consumed
-			prevAccept.index--;
 		}
 
 		int t = input.LA(1);
@@ -239,6 +237,14 @@ public class LexerATNSimulator extends ATNSimulator {
 				break;
 			}
 
+			// If this is a consumable input element, make sure to consume before
+			// capturing the accept state so the input index, line, and char
+			// position accurately reflect the state of the interpreter at the
+			// end of the token.
+			if (t != IntStream.EOF) {
+				consume(input);
+			}
+
 			if (target.isAcceptState) {
 				captureSimState(prevAccept, input, target);
 				if (t == IntStream.EOF) {
@@ -246,11 +252,7 @@ public class LexerATNSimulator extends ATNSimulator {
 				}
 			}
 
-			if (t != IntStream.EOF) {
-				consume(input);
-				t = input.LA(1);
-			}
-
+			t = input.LA(1);
 			s = target; // flip; current DFA target becomes new src/from state
 		}
 
@@ -388,9 +390,6 @@ public class LexerATNSimulator extends ATNSimulator {
 		input.seek(index);
 		this.line = line;
 		this.charPositionInLine = charPos;
-		if (input.LA(1) != IntStream.EOF) {
-			consume(input);
-		}
 
 		if (lexerActionExecutor != null && recog != null) {
 			lexerActionExecutor.execute(recog, input, startIndex);


### PR DESCRIPTION
In the beginning (prior to supporting zero-length tokens), the `captureSimState` method was called prior to consuming the final matched character of a token. The input index was recorded directly, but a fixup was later applied in `accept` by calling `consume`. The introduction of support for zero-length tokens resulted in inconsistent state when `captureSimState` was called, so a fixup was applied to the input index for just that case when it occurred. Unfortunately the fixup did not properly handling the `line` and `charPositionInLine` fields.

This pull request makes the following changes.
1. `captureSimState` is called with the input positioned exactly where it should be in all cases.
2. The recorded `index`, `line`, and `charPositionInLine` values can therefore be applied directly with no fixup either when they are recorded or when they are later applied.
