### PR TITLE
ParseTreeVisitor call visit method for children

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/tree/AbstractParseTreeVisitor.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/AbstractParseTreeVisitor.java
@@ -69,7 +69,7 @@ public abstract class AbstractParseTreeVisitor<T> implements ParseTreeVisitor<T>
 			}
 
 			ParseTree c = node.getChild(i);
-			T childResult = c.accept(this);
+			T childResult = visit(c);
 			result = aggregateResult(result, childResult);
 		}
 


### PR DESCRIPTION
Allows subclasses to override visit if they want to be called
for each visit to a child.
