### PR TITLE
Fix spacing in MANIFEST file

### DIFF
--- a/bild.py
+++ b/bild.py
@@ -83,12 +83,12 @@ def mkjar_complete():
     copytree(src="tool/resources", trg="out")  # messages, Java code gen, etc...
     manifest = \
         """Main-Class: org.antlr.v4.Tool
-        Implementation-Vendor: ANTLR
-        Implementation-Title: ANTLR 4 Tool
-        Implementation-Version: %s
-        Built-By: %s
-        Build-Jdk: 1.6
-        Created-By: http://www.bildtool.org
+Implementation-Vendor: ANTLR
+Implementation-Title: ANTLR 4 Tool
+Implementation-Version: %s
+Built-By: %s
+Build-Jdk: 1.6
+Created-By: http://www.bildtool.org
         """ % (VERSION, os.getlogin())
     # unjar required libraries
     unjar("runtime/Java/lib/org.abego.treelayout.core.jar", trgdir="out")
@@ -117,11 +117,11 @@ def mkjar_runtime():
         javac(sp, "out", version="1.6", cp=cp, args=args)
     manifest = \
         """Implementation-Vendor: ANTLR
-        Implementation-Title: ANTLR 4 Runtime
-        Implementation-Version: %s
-        Built-By: %s
-        Build-Jdk: 1.6
-        Created-By: http://www.bildtool.org
+Implementation-Title: ANTLR 4 Runtime
+Implementation-Version: %s
+Built-By: %s
+Build-Jdk: 1.6
+Created-By: http://www.bildtool.org
         """ % (VERSION, os.getlogin())
     jarfile = "dist/antlr4-" + VERSION + ".jar"
     jar(jarfile, srcdir="out/runtime", manifest=manifest)


### PR DESCRIPTION
The manifest files in jars are apparently pretty picky with respect to
spacing and don't like having the spaces in front of the keys. If they
do the file is ignored and jar just generates a blank one, conveniently
leaving out the Main-Class directive making the jar useless. Given the
literal quotes in python the rest of the lines need to be moved over to
avoid adding extra whitespace.