### PR TITLE
add support for $self

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -711,11 +711,13 @@ RulePropertyRef_start(r) ::= "(<ctx(r)>.<r.label>!=null?(<ctx(r)>.<r.label>.star
 RulePropertyRef_stop(r)	 ::= "(<ctx(r)>.<r.label>!=null?(<ctx(r)>.<r.label>.stop):null)"
 RulePropertyRef_text(r)	 ::= "(<ctx(r)>.<r.label>!=null?_input.getText(<ctx(r)>.<r.label>.start,<ctx(r)>.<r.label>.stop):null)"
 RulePropertyRef_ctx(r)	 ::= "<ctx(r)>.<r.label>"
+RulePropertyRef_self(r)	 ::= "this"
 
 ThisRulePropertyRef_start(r) ::= "_localctx.start"
 ThisRulePropertyRef_stop(r)	 ::= "_localctx.stop"
 ThisRulePropertyRef_text(r)	 ::= "_input.getText(_localctx.start, _input.LT(-1))"
 ThisRulePropertyRef_ctx(r)	 ::= "_localctx"
+ThisRulePropertyRef_self(r)	 ::= "this"
 
 NonLocalAttrRef(s)		 ::= "((<s.ruleName; format=\"cap\">Context)getInvokingContext(<s.ruleIndex>)).<s.name>"
 SetNonLocalAttr(s, rhsChunks)	  ::=

--- a/tool/src/org/antlr/v4/codegen/ActionTranslator.java
+++ b/tool/src/org/antlr/v4/codegen/ActionTranslator.java
@@ -30,6 +30,12 @@
 
 package org.antlr.v4.codegen;
 
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.Token;
 import org.antlr.v4.codegen.model.RuleFunction;
@@ -44,12 +50,14 @@ import org.antlr.v4.codegen.model.chunk.QRetValueRef;
 import org.antlr.v4.codegen.model.chunk.RetValueRef;
 import org.antlr.v4.codegen.model.chunk.RulePropertyRef;
 import org.antlr.v4.codegen.model.chunk.RulePropertyRef_ctx;
+import org.antlr.v4.codegen.model.chunk.RulePropertyRef_self;
 import org.antlr.v4.codegen.model.chunk.RulePropertyRef_start;
 import org.antlr.v4.codegen.model.chunk.RulePropertyRef_stop;
 import org.antlr.v4.codegen.model.chunk.RulePropertyRef_text;
 import org.antlr.v4.codegen.model.chunk.SetAttr;
 import org.antlr.v4.codegen.model.chunk.SetNonLocalAttr;
 import org.antlr.v4.codegen.model.chunk.ThisRulePropertyRef_ctx;
+import org.antlr.v4.codegen.model.chunk.ThisRulePropertyRef_self;
 import org.antlr.v4.codegen.model.chunk.ThisRulePropertyRef_start;
 import org.antlr.v4.codegen.model.chunk.ThisRulePropertyRef_stop;
 import org.antlr.v4.codegen.model.chunk.ThisRulePropertyRef_text;
@@ -71,12 +79,6 @@ import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.Rule;
 import org.antlr.v4.tool.ast.ActionAST;
 
-import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /** */
 public class ActionTranslator implements ActionSplitterListener {
 	public static final Map<String, Class<? extends RulePropertyRef>> thisRulePropToModelMap =
@@ -86,6 +88,7 @@ public class ActionTranslator implements ActionSplitterListener {
 		thisRulePropToModelMap.put("stop",  ThisRulePropertyRef_stop.class);
 		thisRulePropToModelMap.put("text",  ThisRulePropertyRef_text.class);
 		thisRulePropToModelMap.put("ctx",   ThisRulePropertyRef_ctx.class);
+		thisRulePropToModelMap.put("self",  ThisRulePropertyRef_self.class);
 	}
 
 	public static final Map<String, Class<? extends RulePropertyRef>> rulePropToModelMap =
@@ -95,6 +98,7 @@ public class ActionTranslator implements ActionSplitterListener {
 		rulePropToModelMap.put("stop",  RulePropertyRef_stop.class);
 		rulePropToModelMap.put("text",  RulePropertyRef_text.class);
 		rulePropToModelMap.put("ctx",   RulePropertyRef_ctx.class);
+		rulePropToModelMap.put("self",  RulePropertyRef_self.class);
 	}
 
 	public static final Map<String, Class<? extends TokenPropertyRef>> tokenPropToModelMap =

--- a/tool/src/org/antlr/v4/codegen/model/chunk/RulePropertyRef_self.java
+++ b/tool/src/org/antlr/v4/codegen/model/chunk/RulePropertyRef_self.java
@@ -1,0 +1,40 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012 Terence Parr
+ *  Copyright (c) 2012 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.antlr.v4.codegen.model.chunk;
+
+import org.antlr.v4.codegen.model.decl.StructDecl;
+
+/** */
+public class RulePropertyRef_self extends RulePropertyRef {
+	public RulePropertyRef_self(StructDecl ctx, String label) {
+		super(ctx, label);
+	}
+}

--- a/tool/src/org/antlr/v4/codegen/model/chunk/ThisRulePropertyRef_self.java
+++ b/tool/src/org/antlr/v4/codegen/model/chunk/ThisRulePropertyRef_self.java
@@ -1,0 +1,40 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012 Terence Parr
+ *  Copyright (c) 2012 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.antlr.v4.codegen.model.chunk;
+
+import org.antlr.v4.codegen.model.decl.StructDecl;
+
+/** */
+public class ThisRulePropertyRef_self extends RulePropertyRef {
+	public ThisRulePropertyRef_self(StructDecl ctx, String label) {
+		super(ctx, label);
+	}
+}

--- a/tool/src/org/antlr/v4/tool/Rule.java
+++ b/tool/src/org/antlr/v4/tool/Rule.java
@@ -55,6 +55,7 @@ public class Rule implements AttributeResolver {
 	public static final AttributeDict predefinedRulePropertiesDict =
 		new AttributeDict(AttributeDict.DictType.PREDEFINED_RULE);
 	static {
+		predefinedRulePropertiesDict.add(new Attribute("self"));
 		predefinedRulePropertiesDict.add(new Attribute("text"));
 		predefinedRulePropertiesDict.add(new Attribute("start"));
 		predefinedRulePropertiesDict.add(new Attribute("stop"));

--- a/tool/test/org/antlr/v4/test/tool/TestDollarSelf.java
+++ b/tool/test/org/antlr/v4/test/tool/TestDollarSelf.java
@@ -1,0 +1,21 @@
+package org.antlr.v4.test.tool;
+
+import static org.junit.Assert.*;
+
+import org.antlr.v4.test.rt.java.BaseTest;
+import org.junit.Test;
+
+public class TestDollarSelf extends BaseTest {
+
+	@Test
+	public void testSimpleCall() throws Exception {
+		String grammar = "grammar T;\n" +
+	                  "a : ID  { System.out.println( $self.getSourceName() ); }\n" +
+	                  "  ;\n" +
+	                  "ID : 'a'..'z'+ ;\n";
+		String found = execParser("T.g4", grammar, "TParser", "TLexer", "a", "x", true);
+		assertTrue(found.indexOf(this.getClass().getSimpleName())>=0);
+		assertNull(this.stderrDuringParse);
+	}
+
+}


### PR DESCRIPTION
Hi,
proposing to add a new $self property, referring to the parser instance.
The purpose is to enable multi target semantic predicates, using a strategy where parser is derived from an abstract parser which implements utility methods.
Currently this is not possible:
- Java and C# method calls do not need 'this', so are easily portable
- Python method calls require 'self'. A way to work around this is to always use 'self', and declare a 'self' member in Java and C# abstract parsers as described in our Wiki
- Javascript method calls require 'this'. This defeats the Python workaround. 
  A TestDollarSelf is provided to illustrate the concept.
  I also validated it with all other targets and will add a multi-target test if agreed.
  All the existing tests pass ok.
