### PR TITLE
remove constant word size in *code gen* for inline set testing.

### DIFF
--- a/tool/src/org/antlr/v4/codegen/ParserFactory.java
+++ b/tool/src/org/antlr/v4/codegen/ParserFactory.java
@@ -316,7 +316,7 @@ public class ParserFactory extends DefaultOutputModelFactory {
 
 	@Override
 	public List<SrcOp> getLL1Test(IntervalSet look, GrammarAST blkAST) {
-		return list(new TestSetInline(this, blkAST, look));
+		return list(new TestSetInline(this, blkAST, look, gen.getTarget().getInlineTestSetWordSize()));
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/Target.java
+++ b/tool/src/org/antlr/v4/codegen/Target.java
@@ -405,6 +405,14 @@ public abstract class Target {
 		return Integer.MAX_VALUE;
 	}
 
+	/** How many bits should be used to do inline token type tests? Java assumes
+	 *  a 64-bit word for bitsets.  Must be a valid wordsize for your target like
+	 *  8, 16, 32, 64, etc...
+	 *
+	 *  @since 4.5
+	 */
+	public int getInlineTestSetWordSize() { return 64; }
+
 	public boolean grammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
 		switch (idNode.getParent().getType()) {
 			case ANTLRParser.ASSIGN:

--- a/tool/src/org/antlr/v4/codegen/model/MatchSet.java
+++ b/tool/src/org/antlr/v4/codegen/model/MatchSet.java
@@ -43,7 +43,8 @@ public class MatchSet extends MatchToken {
 	public MatchSet(OutputModelFactory factory, GrammarAST ast) {
 		super(factory, ast);
 		SetTransition st = (SetTransition)ast.atnState.transition(0);
-		expr = new TestSetInline(factory, null, st.set);
+		int wordSize = factory.getGenerator().getTarget().getInlineTestSetWordSize();
+		expr = new TestSetInline(factory, null, st.set, wordSize);
 		Decl d = new TokenTypeDecl(factory, expr.varName);
 		factory.getCurrentRuleFunction().addLocalDecl(d);
 		capture = new CaptureNextTokenType(factory,expr.varName);

--- a/tool/src/org/antlr/v4/codegen/model/TestSetInline.java
+++ b/tool/src/org/antlr/v4/codegen/model/TestSetInline.java
@@ -39,25 +39,29 @@ import java.util.List;
 
 /** */
 public class TestSetInline extends SrcOp {
+	public int bitsetWordSize;
 	public String varName;
 	public Bitset[] bitsets;
 
-	public TestSetInline(OutputModelFactory factory, GrammarAST ast, IntervalSet set) {
+	public TestSetInline(OutputModelFactory factory, GrammarAST ast, IntervalSet set, int wordSize) {
 		super(factory, ast);
-
-		Bitset[] withZeroOffset = createBitsets(factory, set, true);
-		Bitset[] withoutZeroOffset = createBitsets(factory, set, false);
+		bitsetWordSize = wordSize;
+		Bitset[] withZeroOffset = createBitsets(factory, set, wordSize, true);
+		Bitset[] withoutZeroOffset = createBitsets(factory, set, wordSize, false);
 		this.bitsets = withZeroOffset.length <= withoutZeroOffset.length ? withZeroOffset : withoutZeroOffset;
 		this.varName = "_la";
 	}
 
-	private static Bitset[] createBitsets(OutputModelFactory factory, IntervalSet set, boolean useZeroOffset) {
+	private static Bitset[] createBitsets(OutputModelFactory factory,
+										  IntervalSet set,
+										  int wordSize,
+										  boolean useZeroOffset) {
 		List<Bitset> bitsetList = new ArrayList<Bitset>();
 		for (int ttype : set.toArray()) {
 			Bitset current = !bitsetList.isEmpty() ? bitsetList.get(bitsetList.size() - 1) : null;
-			if (current == null || ttype > (current.shift + 63)) {
+			if (current == null || ttype > (current.shift + wordSize-1)) {
 				current = new Bitset();
-				if (useZeroOffset && ttype >= 0 && ttype < 63) {
+				if (useZeroOffset && ttype >= 0 && ttype < wordSize-1) {
 					current.shift = 0;
 				}
 				else {


### PR DESCRIPTION
Fixes #777. Will commit override in antlr/antlr4-javascript repo next.
