### PR TITLE
Freshen maven 2

### DIFF
--- a/antlr4-maven-plugin/pom.xml
+++ b/antlr4-maven-plugin/pom.xml
@@ -1,207 +1,286 @@
-<!--
-
- [The "BSD license"]
-
- ANTLR        - Copyright (c) 2005-2010 Terence Parr
- Maven Plugin - Copyright (c) 2009      Jim Idle
-
- All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions
- are met:
- 1. Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
- 2. Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
- 3. The name of the author may not be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
- THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
- INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-  -->
+<!-- [The "BSD license"] ANTLR - Copyright (c) 2005-2010 Terence Parr Maven
+	Plugin - Copyright (c) 2009 Jim Idle All rights reserved. Redistribution
+	and use in source and binary forms, with or without modification, are permitted
+	provided that the following conditions are met: 1. Redistributions of source
+	code must retain the above copyright notice, this list of conditions and
+	the following disclaimer. 2. Redistributions in binary form must reproduce
+	the above copyright notice, this list of conditions and the following disclaimer
+	in the documentation and/or other materials provided with the distribution.
+	3. The name of the author may not be used to endorse or promote products
+	derived from this software without specific prior written permission. THIS
+	SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+	GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+	OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+	DAMAGE. -->
 
 
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr4-master</artifactId>
-        <version>4.4-SNAPSHOT</version>
-    </parent>
+<!-- 	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
+ -->
+	<groupId>org.antlr</groupId>
 
-    <artifactId>antlr4-maven-plugin</artifactId>
-    <packaging>maven-plugin</packaging>
+	<artifactId>antlr4-maven-plugin</artifactId>
+	<version>4.5</version>
+	<packaging>maven-plugin</packaging>
 
-    <name>ANTLR 4 Maven plugin</name>
-    <description>Maven plugin for ANTLR 4 grammars</description>
-    <url>http://www.antlr.org</url>
+	<name>ANTLR 4 Maven plugin</name>
+	<description>Maven plugin for ANTLR 4 grammars</description>
+	<url>http://www.antlr.org</url>
+
+    <organization>
+        <name>ANTLR</name>
+        <url>http://www.antlr.org</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>The BSD License</name>
+            <url>http://www.antlr.org/license.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+	  <developer>
+		  <name>Terence Parr</name>
+		  <url>http://parrt.cs.usfca.edu</url>
+		  <roles>
+			  <role>Project lead - ANTLR</role>
+		  </roles>
+	  </developer>
+
+	  <developer>
+		  <name>Sam Harwell</name>
+		  <url>http://tunnelvisionlabs.com</url>
+		  <roles>
+			  <role>Developer - Coauthor of tool, C# target</role>
+		  </roles>
+	  </developer>
+
+	  <developer>
+		  <name>Eric Vergnaud</name>
+		  <roles>
+			  <role>Developer - JavaScript, C#, Python 2, Python 3</role>
+		  </roles>
+	  </developer>
+
+	  <developer>
+		  <name>Jim Idle</name>
+		  <email>jimi@idle.ws</email>
+		  <url>http://www.linkedin.com/in/jimidle</url>
+		  <roles>
+			  <role>Developer - Maven Plugin</role>
+		  </roles>
+	  </developer>
+    </developers>
+
+    <mailingLists>
+        <mailingList>
+            <name>antlr-discussion</name>
+            <archive>https://groups.google.com/forum/?fromgroups#!forum/antlr-discussion</archive>
+        </mailingList>
+    </mailingLists>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/antlr/antlr4/issues</url>
+    </issueManagement>
+
+    <scm>
+        <url>https://github.com/antlr/antlr4/tree/master</url>
+        <connection>scm:git:git://github.com/antlr/antlr4.git</connection>
+        <developerConnection>scm:git:git@github.com:antlr/antlr4.git</developerConnection>
+      <tag>HEAD</tag>
+  </scm>
 
     <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
-    
-    <!-- Ancilliary information for completeness
-      -->
-    <inceptionYear>2009</inceptionYear>
+		<maven>3.0</maven>
+	</prerequisites>
 
-    <!-- ============================================================================= -->
+	<!-- Ancilliary information for completeness -->
+	<inceptionYear>2009</inceptionYear>
 
-    <!--
+	<!-- ============================================================================= -->
 
-     What are we depedent on for the Mojos to execute? We need the
-     plugin API itself and of course we need the ANTLR Tool and runtime
-     and any of their dependencies, which we inherit. The Tool itself provides
-     us with all the dependencies, so we need only name it here.
-      -->
-    <dependencies>
+	<!-- What are we depedent on for the Mojos to execute? We need the plugin
+		API itself and of course we need the ANTLR Tool and runtime and any of their
+		dependencies, which we inherit. The Tool itself provides us with all the
+		dependencies, so we need only name it here. -->
+	<dependencies>
 
-        <!--
-          The things we need to build the target language recognizer
-          -->
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-            <version>3.0.5</version>
-            <scope>compile</scope>
-        </dependency>
+		<!-- The things we need to build the target language recognizer -->
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>3.0.5</version>
+			<scope>compile</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
-            <version>2.2.1</version>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-project</artifactId>
+			<version>2.2.1</version>
+		</dependency>
 
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-api</artifactId>
-            <version>2.2</version>
-        </dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-compiler-api</artifactId>
+			<version>2.2</version>
+		</dependency>
 
-        <dependency>
-            <groupId>org.sonatype.plexus</groupId>
-            <artifactId>plexus-build-api</artifactId>
-            <version>0.0.7</version>
-        </dependency>
+		<dependency>
+			<groupId>org.sonatype.plexus</groupId>
+			<artifactId>plexus-build-api</artifactId>
+			<version>0.0.7</version>
+		</dependency>
 
-        <!--
-         The version of ANTLR tool that this version of the plugin controls.
-         We have decided that this should be in lockstep with ANTLR itself, other
-         than -1 -2 -3 etc patch releases.
-          -->
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+		<!-- The version of ANTLR tool that this version of the plugin controls.
+			We have decided that this should be in lockstep with ANTLR itself, other
+			than -1 -2 -3 etc patch releases. -->
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr4</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
-        <!--
-          Testing requirements...
-          -->
-        <dependency>
+		<!-- Testing requirements... -->
+		<dependency>
 
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
 
-        </dependency>
+		</dependency>
 
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>1.1</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.maven.shared</groupId>
+			<artifactId>maven-plugin-testing-harness</artifactId>
+			<version>1.1</version>
+			<scope>test</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.2</version>
-            <scope>provided</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+			<version>3.2</version>
+			<scope>provided</scope>
+		</dependency>
 
-    </dependencies>
-    
-    <build>
+	</dependencies>
 
-        <defaultGoal>install</defaultGoal>
-        <resources>
-            <resource>
-                <directory>resources</directory>
-            </resource>
-        </resources>
+	<build>
 
-        <plugins>
+		<defaultGoal>install</defaultGoal>
+		<resources>
+			<resource>
+				<directory>resources</directory>
+			</resource>
+		</resources>
+
+		<plugins>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<!-- see http://jira.codehaus.org/browse/MNG-5346 -->
+					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+				</configuration>
+				<executions>
+					<execution>
+						<id>mojo-descriptor</id>
+						<goals>
+							<goal>descriptor</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>help-goal</id>
+						<goals>
+							<goal>helpmojo</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-site-plugin</artifactId>
+				<version>3.3</version>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-project-info-reports-plugin</artifactId>
+				<version>2.7</version>
+				<configuration>
+					<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+				</configuration>
+			</plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
                 <configuration>
-                    <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <compilerArgs>
+                        <arg>-Xlint</arg>
+                        <arg>-Xlint:-serial</arg>
+                    </compilerArgs>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>help-goal</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.3</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
                 <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
                 </configuration>
             </plugin>
 
-        </plugins>
-
-    </build>
-
-    <reporting>
-        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.16</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <!-- override the version inherited from the parent -->
+                <version>2.2.1</version>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
+                <!-- override the version inherited from the parent -->
+                <version>2.9.1</version>
                 <configuration>
                     <quiet>true</quiet>
                 </configuration>
@@ -209,9 +288,45 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.3</version>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <!-- override the version inherited from the parent -->
+                <version>1.4</version>
             </plugin>
-        </plugins>
-    </reporting>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <!-- override the version inherited from the parent -->
+                <version>2.4.2</version><!--$NO-MVN-MAN-VER$-->
+                <configuration>
+                    <arguments>-Psonatype-oss-release ${release.arguments}</arguments>
+                </configuration>
+            </plugin>
+		</plugins>
+
+	</build>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<version>3.3</version>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.9</version>
+				<configuration>
+					<quiet>true</quiet>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jxr-plugin</artifactId>
+				<version>2.3</version>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>

--- a/antlr4-maven-plugin/pom.xml
+++ b/antlr4-maven-plugin/pom.xml
@@ -35,7 +35,7 @@
 	<groupId>org.antlr</groupId>
 
 	<artifactId>antlr4-maven-plugin</artifactId>
-	<version>4.5</version>
+	<version>4.5-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>ANTLR 4 Maven plugin</name>
@@ -60,7 +60,7 @@
 		  <name>Terence Parr</name>
 		  <url>http://parrt.cs.usfca.edu</url>
 		  <roles>
-			  <role>Project lead - ANTLR</role>
+			  <role>Project lead</role>
 		  </roles>
 	  </developer>
 

--- a/bild.py
+++ b/bild.py
@@ -39,7 +39,7 @@ if not os.path.exists("bilder.py"):
 from bilder import *
 
 BOOTSTRAP_VERSION = "4.4"
-VERSION = "4.5"
+VERSION = "4.5-SNAPSHOT"
 JAVA_TARGET = "."
 PYTHON2_TARGET = "../antlr4-python2"
 PYTHON3_TARGET = "../antlr4-python3"

--- a/pom.xml
+++ b/pom.xml
@@ -32,29 +32,36 @@
     <developers>
 
         <developer>
-            <name>Terence Parr</name>
-            <url>http://antlr.org/wiki/display/~admin/Home</url>
-            <roles>
-                <role>Project lead - ANTLR</role>
-            </roles>
-        </developer>
+     		  <name>Terence Parr</name>
+     		  <url>http://parrt.cs.usfca.edu</url>
+     		  <roles>
+     			  <role>Project lead</role>
+     		  </roles>
+     	  </developer>
 
-        <developer>
-            <name>Sam Harwell</name>
-            <url>http://tunnelvisionlabs.com</url>
-            <roles>
-                <role>Developer</role>
-            </roles>
-        </developer>
+     	  <developer>
+     		  <name>Sam Harwell</name>
+     		  <url>http://tunnelvisionlabs.com</url>
+     		  <roles>
+     			  <role>Developer - Coauthor of tool, C# target</role>
+     		  </roles>
+     	  </developer>
 
-        <developer>
-            <name>Jim Idle</name>
-            <email>jimi@idle.ws</email>
-            <url>http://www.linkedin.com/in/jimidle</url>
-            <roles>
-                <role>Developer - Maven Plugin</role>
-            </roles>
-        </developer>
+     	  <developer>
+     		  <name>Eric Vergnaud</name>
+     		  <roles>
+     			  <role>Developer - JavaScript, C#, Python 2, Python 3</role>
+     		  </roles>
+     	  </developer>
+
+     	  <developer>
+     		  <name>Jim Idle</name>
+     		  <email>jimi@idle.ws</email>
+     		  <url>http://www.linkedin.com/in/jimidle</url>
+     		  <roles>
+     			  <role>Developer - Maven Plugin</role>
+     		  </roles>
+     	  </developer>
 
     </developers>
 


### PR DESCRIPTION
This basically sets the version number to 4.5-SNAPSHOT for pushing to maven central snapshots area: `https://oss.sonatype.org/content/repositories/snapshots`.  to be safe I changed the version within all of the pom.xml files as well as bild.py but we are building things with bild.py only.   We use maven only to do the install/deploy once we have the jars we want. We do this with some [magical commandline stuff](https://github.com/antlr/antlr4/wiki/Deploying-ANTLR-mvn-artifacts). Once we have finalized things than I can change the version to 4.5, create the new jars, and push the release.