### PR TITLE
Restore groupId and version in POM

### DIFF
--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -1,7 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.antlr</groupId>
     <artifactId>antlr4</artifactId>
+    <version>4.5-SNAPSHOT</version>
 
     <name>ANTLR 4 Tool</name>
     <description>The ANTLR 4 grammar compiler.</description>


### PR DESCRIPTION
There are quite a few issues with building via Maven right now; among them, the `tool/pom.xml` is missing `<groupId>` and `<version>` (previously defined by the parent POM that has been removed).