### PR TITLE
Fix excess token consumption after `recoverInline`

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/ANTLRErrorStrategy.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ANTLRErrorStrategy.java
@@ -63,6 +63,9 @@ public interface ANTLRErrorStrategy {
 	 * returns the {@link Token} instance which should be treated as the
 	 * successful result of the match.
 	 *
+   * <p>This method handles the consumption of any tokens - the caller should
+	 * <b>not</b> call {@link Parser#consume} after a successful recovery.</p>
+	 *
 	 * <p>Note that the calling code will not report an error if this method
 	 * returns successfully. The error strategy implementation is responsible
 	 * for calling {@link Parser#notifyErrorListeners} as appropriate.</p>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -647,8 +647,9 @@ setState(<m.stateNumber>);
 <capture>
 if ( <if(invert)><m.varName> \<= 0 || <else>!<endif>(<expr>) ) {
 	<if(m.labels)><m.labels:{l | <labelref(l)> = (Token)}><endif>_errHandler.recoverInline(this);
+} else {
+	consume();
 }
-consume();
 >>
 
 Wildcard(w) ::= <<

--- a/tool/test/org/antlr/v4/test/rt/gen/Generator.java
+++ b/tool/test/org/antlr/v4/test/rt/gen/Generator.java
@@ -585,6 +585,10 @@ public class Generator {
 				"aab",
 				"",
 				"line 1:1 extraneous input 'a' expecting {'b', 'c'}\n");
+		file.addParserTest(input, "SingleTokenDeletionConsumption", "T", "a",
+				"aabd",
+				"[@2,2:2='b',<1>,1:2]\n",
+				"line 1:1 extraneous input 'a' expecting {'b', 'c'}\n");
 		file.addParserTest(input, "SingleTokenInsertion", "T", "a",
 				"ac",
 				"",
@@ -596,6 +600,10 @@ public class Generator {
 		file.addParserTest(input, "SingleSetInsertion", "T", "a",
 				"ad",
 				"",
+				"line 1:1 missing {'b', 'c'} at 'd'\n");
+		file.addParserTest(input, "SingleSetInsertionConsumption", "T", "a",
+				"ad",
+				"[@0,0:0='a',<3>,1:0]\n",
 				"line 1:1 missing {'b', 'c'} at 'd'\n");
 		file.addParserTest(input, "ConjuringUpTokenFromSet", "T", "a",
 				"ad",

--- a/tool/test/org/antlr/v4/test/rt/gen/grammars/ParserErrors/SingleSetInsertionConsumption.st
+++ b/tool/test/org/antlr/v4/test/rt/gen/grammars/ParserErrors/SingleSetInsertionConsumption.st
@@ -1,0 +1,3 @@
+grammar <grammarName>;
+set: ('b'|'c') ;
+a: 'a' set 'd' {System.out.println($set.stop);} ;

--- a/tool/test/org/antlr/v4/test/rt/gen/grammars/ParserErrors/SingleTokenDeletionConsumption.st
+++ b/tool/test/org/antlr/v4/test/rt/gen/grammars/ParserErrors/SingleTokenDeletionConsumption.st
@@ -1,0 +1,3 @@
+grammar <grammarName>;
+set: ('b'|'c') ;
+a: 'a' set 'd' {System.out.println($set.stop);} ;

--- a/tool/test/org/antlr/v4/test/rt/java/TestParserErrors.java
+++ b/tool/test/org/antlr/v4/test/rt/java/TestParserErrors.java
@@ -37,6 +37,17 @@ public class TestParserErrors extends BaseTest {
 
 	/* this file and method are generated, any edit will be overwritten by the next generation */
 	@Test
+	public void testSingleTokenDeletionConsumption() throws Exception {
+		String grammar = "grammar T;\n" +
+	                  "set: ('b'|'c') ;\n" +
+	                  "a: 'a' set 'd' {System.out.println($set.stop);} ;";
+		String found = execParser("T.g4", grammar, "TParser", "TLexer", "a", "aabd", false);
+		assertEquals("[@2,2:2='b',<1>,1:2]\n", found);
+		assertEquals("line 1:1 extraneous input 'a' expecting {'b', 'c'}\n", this.stderrDuringParse);
+	}
+
+	/* this file and method are generated, any edit will be overwritten by the next generation */
+	@Test
 	public void testSingleTokenInsertion() throws Exception {
 		String grammar = "grammar T;\n" +
 	                  "a : 'a' 'b' 'c' ;";
@@ -62,6 +73,17 @@ public class TestParserErrors extends BaseTest {
 	                  "a : 'a' ('b'|'c') 'd' ;";
 		String found = execParser("T.g4", grammar, "TParser", "TLexer", "a", "ad", false);
 		assertEquals("", found);
+		assertEquals("line 1:1 missing {'b', 'c'} at 'd'\n", this.stderrDuringParse);
+	}
+
+	/* this file and method are generated, any edit will be overwritten by the next generation */
+	@Test
+	public void testSingleSetInsertionConsumption() throws Exception {
+		String grammar = "grammar T;\n" +
+	                  "set: ('b'|'c') ;\n" +
+	                  "a: 'a' set 'd' {System.out.println($set.stop);} ;";
+		String found = execParser("T.g4", grammar, "TParser", "TLexer", "a", "ad", false);
+		assertEquals("[@0,0:0='a',<3>,1:0]\n", found);
 		assertEquals("line 1:1 missing {'b', 'c'} at 'd'\n", this.stderrDuringParse);
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/antlr/antlr4/issues/795

As discussed, this changes the code generation for `Parser`s so that they only `consume` when they do *not* need to `recoverInline`. I've added tests which fail before the change (in both cases, the `set` rule's final consumed token was `d`), and updated the documentation to warn that `recoverInline` will handle it's own token consumption.

(As a side note, I see that the build and test infrastructure has changed - it would be nice if there was a little bit of documentation about that. It took me a while to figure out the test generator, and I could never get `bild.py` to do what I wanted.) [Edit: parrt adding link to [building ANTLR itself](https://github.com/antlr/antlr4/wiki/How-to-build-ANTLR-itself)]