### PR TITLE
Makes TestRig's dialog to save and restore its state

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -64,3 +64,4 @@ YYYY/MM/DD, github id, Full name, email
 2014/10/26, bdkearns, Brian Kearns, bdkearns@gmail.com
 2014/10/27, michaelpj, Michael Peyton Jones, michaelpj@gmail.com
 2015/01/29, TomLottermann, Thomas Lottermann, tomlottermann@gmail.com
+2015/02/15, pavlo, Pavlo Lysov, pavlikus@gmail.com

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/gui/TreeViewer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/gui/TreeViewer.java
@@ -273,7 +273,7 @@ public class TreeViewer extends JComponent {
     private static final String DIALOG_X_PREFS_KEY              = "dialog_x";
     private static final String DIALOG_Y_PREFS_KEY              = "dialog_y";
     private static final String DIALOG_DIVIDER_LOC_PREFS_KEY    = "dialog_divider_location";
-    private static final String DIALOG_VIEWER_SCALE_PREFS_KEY   = "dialog_slider_location";
+    private static final String DIALOG_VIEWER_SCALE_PREFS_KEY   = "dialog_viewer_scale";
 
 	protected static JDialog showInDialog(final TreeViewer viewer) {
 		final JDialog dialog = new JDialog();

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/gui/TreeViewer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/gui/TreeViewer.java
@@ -36,7 +36,6 @@ import org.abego.treelayout.TreeLayout;
 import org.abego.treelayout.util.DefaultConfiguration;
 import org.antlr.v4.runtime.misc.GraphicsSupport;
 import org.antlr.v4.runtime.misc.JFileChooserConfirmOverwrite;
-import org.antlr.v4.runtime.misc.NotNull;
 import org.antlr.v4.runtime.misc.Utils;
 import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.Tree;
@@ -54,8 +53,7 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import java.awt.event.*;
 import java.awt.geom.CubicCurve2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
@@ -68,6 +66,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.prefs.Preferences;
 
 public class TreeViewer extends JComponent {
 	public static final Color LIGHT_RED = new Color(244, 213, 211);
@@ -269,9 +268,18 @@ public class TreeViewer extends JComponent {
 	// ----------------------------------------------------------------------
 
 
+    private static final String DIALOG_WIDTH_PREFS_KEY          = "dialog_width";
+    private static final String DIALOG_HEIGHT_PREFS_KEY         = "dialog_height";
+    private static final String DIALOG_X_PREFS_KEY              = "dialog_x";
+    private static final String DIALOG_Y_PREFS_KEY              = "dialog_y";
+    private static final String DIALOG_DIVIDER_LOC_PREFS_KEY    = "dialog_divider_location";
+    private static final String DIALOG_VIEWER_SCALE_PREFS_KEY   = "dialog_slider_location";
+
 	protected static JDialog showInDialog(final TreeViewer viewer) {
 		final JDialog dialog = new JDialog();
 		dialog.setTitle("Parse Tree Inspector");
+
+        final Preferences prefs = Preferences.userNodeForPackage(TreeViewer.class);
 
 		// Make new content panes
 		final Container mainPane = new JPanel(new BorderLayout(5,5));
@@ -294,15 +302,14 @@ public class TreeViewer extends JComponent {
 			new ActionListener() {
 				@Override
 				public void actionPerformed(ActionEvent e) {
-					dialog.setVisible(false);
-					dialog.dispose();
+                    dialog.dispatchEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSING));
 				}
 			}
 		);
 		wrapper.add(ok);
 
 		// Add an export-to-png button right of the "OK" button
-		JButton png = new JButton("png");
+		JButton png = new JButton("Export as PNG");
 		png.addActionListener(
 			new ActionListener() {
 				@Override
@@ -316,9 +323,12 @@ public class TreeViewer extends JComponent {
 		bottomPanel.add(wrapper, BorderLayout.SOUTH);
 
 		// Add scale slider
-		int sliderValue = (int) ((viewer.getScale()-1.0) * 1000);
-		final JSlider scaleSlider = new JSlider(JSlider.HORIZONTAL,
-										  -999,1000,sliderValue);
+        double lastKnownViewerScale = prefs.getDouble(DIALOG_VIEWER_SCALE_PREFS_KEY, viewer.getScale());
+        viewer.setScale(lastKnownViewerScale);
+
+		int sliderValue = (int) ((lastKnownViewerScale - 1.0) * 1000);
+		final JSlider scaleSlider = new JSlider(JSlider.HORIZONTAL, -999, 1000, sliderValue);
+
 		scaleSlider.addChangeListener(
 			new ChangeListener() {
 				@Override
@@ -362,7 +372,7 @@ public class TreeViewer extends JComponent {
 		treePanel.add(new JScrollPane(tree));
 
 		// Create the pane for both the JTree and the AST
-		JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
+		final JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
 				treePanel, contentPane);
 
 		mainPane.add(splitPane, BorderLayout.CENTER);
@@ -370,14 +380,41 @@ public class TreeViewer extends JComponent {
 		dialog.setContentPane(mainPane);
 
 		// make viz
-		dialog.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-		dialog.setPreferredSize(new Dimension(600, 500));
+        WindowListener exitListener = new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                prefs.putInt(DIALOG_WIDTH_PREFS_KEY, (int) dialog.getSize().getWidth());
+                prefs.putInt(DIALOG_HEIGHT_PREFS_KEY, (int) dialog.getSize().getHeight());
+                prefs.putDouble(DIALOG_X_PREFS_KEY, dialog.getLocationOnScreen().getX());
+                prefs.putDouble(DIALOG_Y_PREFS_KEY, dialog.getLocationOnScreen().getY());
+                prefs.putInt(DIALOG_DIVIDER_LOC_PREFS_KEY, splitPane.getDividerLocation());
+                prefs.putDouble(DIALOG_VIEWER_SCALE_PREFS_KEY, viewer.getScale());
+
+                dialog.setVisible(false);
+                dialog.dispose();
+            }
+        };
+        dialog.addWindowListener(exitListener);
+		dialog.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+
+        int width = prefs.getInt(DIALOG_WIDTH_PREFS_KEY, 600);
+        int height = prefs.getInt(DIALOG_HEIGHT_PREFS_KEY, 500);
+		dialog.setPreferredSize(new Dimension(width, height));
 		dialog.pack();
 
-		// After pack(): set the divider at 1/3 of the frame.
-		splitPane.setDividerLocation(0.33);
+		// After pack(): set the divider at 1/3 (200/600) of the frame.
+        int dividerLocation = prefs.getInt(DIALOG_DIVIDER_LOC_PREFS_KEY, 200);
+		splitPane.setDividerLocation(dividerLocation);
 
-		dialog.setLocationRelativeTo(null);
+        if (prefs.getDouble(DIALOG_X_PREFS_KEY, -1) != -1) {
+            dialog.setLocation(
+                    (int)prefs.getDouble(DIALOG_X_PREFS_KEY, 100),
+                    (int)prefs.getDouble(DIALOG_Y_PREFS_KEY, 100)
+            );
+        }
+        else {
+            dialog.setLocationRelativeTo(null);
+        }
+
 		dialog.setVisible(true);
 		return dialog;
 	}


### PR DESCRIPTION
It changes the TestRig's JDialog to remember its state between launches. When it gets shutdown, it stores the following information using [standard Java Preferences API] (http://docs.oracle.com/javase/8/docs/technotes/guides/preferences/overview.html) and restores them during consequent launch:

* Dialog's width and height
* Dialog's position on screen
* The TreeView component's scale factor
* The placement of the splitpane divider 

