### PR TITLE
Header file generation support

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -67,3 +67,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/02/15, pavlo, Pavlo Lysov, pavlikus@gmail.com
 2015/03/07, RedTailedHawk, Lawrence Parker, larry@answerrocket.com
 2015/04/03, rljacobson, Robert Jacobson, rljacobson@gmail.com
+2015/04/06, ojakubcik, Ondrej Jakubcik, ojakubcik@gmail.com

--- a/tool/src/org/antlr/v4/codegen/BlankOutputModelFactory.java
+++ b/tool/src/org/antlr/v4/codegen/BlankOutputModelFactory.java
@@ -37,6 +37,7 @@ import org.antlr.v4.codegen.model.Lexer;
 import org.antlr.v4.codegen.model.LexerFile;
 import org.antlr.v4.codegen.model.Parser;
 import org.antlr.v4.codegen.model.ParserFile;
+import org.antlr.v4.codegen.model.ParserHeaderFile;
 import org.antlr.v4.codegen.model.RuleFunction;
 import org.antlr.v4.codegen.model.SrcOp;
 import org.antlr.v4.runtime.misc.IntervalSet;
@@ -51,6 +52,9 @@ import java.util.List;
 public abstract class BlankOutputModelFactory implements OutputModelFactory {
 	@Override
 	public ParserFile parserFile(String fileName) { return null; }
+
+	@Override
+	public ParserHeaderFile parserHeaderFile(String fileName) { return null; }
 
 	@Override
 	public Parser parser(ParserFile file) { return null; }

--- a/tool/src/org/antlr/v4/codegen/CodeGenPipeline.java
+++ b/tool/src/org/antlr/v4/codegen/CodeGenPipeline.java
@@ -70,41 +70,97 @@ public class CodeGenPipeline {
 		int errorCount = g.tool.errMgr.getNumErrors();
 
 		if ( g.isLexer() ) {
-			ST lexer = gen.generateLexer();
-			if (g.tool.errMgr.getNumErrors() == errorCount) {
-				writeRecognizer(lexer, gen);
+			if (gen.getTarget().wantsRecognizerCodeFile()) {
+				ST lexer = gen.generateLexer();
+				if (g.tool.errMgr.getNumErrors() == errorCount) {
+					writeRecognizer(lexer, gen);
+				}
+			}
+
+			if (gen.getTarget().wantsRecognizerHeaderFile()) {
+				ST lexerHeader = gen.generateLexerHeader();
+				if (g.tool.errMgr.getNumErrors() == errorCount) {
+					gen.writeRecognizerHeader(lexerHeader);
+				}
 			}
 		}
 		else {
-			ST parser = gen.generateParser();
-			if (g.tool.errMgr.getNumErrors() == errorCount) {
-				writeRecognizer(parser, gen);
-			}
-			if ( g.tool.gen_listener ) {
-				ST listener = gen.generateListener();
+			if (gen.getTarget().wantsRecognizerCodeFile()) {
+				ST parser = gen.generateParser();
 				if (g.tool.errMgr.getNumErrors() == errorCount) {
-					gen.writeListener(listener);
+					writeRecognizer(parser, gen);
 				}
-				if (gen.getTarget().wantsBaseListener()) {
-					ST baseListener = gen.generateBaseListener();
+			}
+
+			if (gen.getTarget().wantsRecognizerHeaderFile()) {
+				ST parserHeader = gen.generateParserHeader();
+				if (g.tool.errMgr.getNumErrors() == errorCount) {
+					gen.writeRecognizerHeader(parserHeader);
+				}
+			}
+
+			if ( g.tool.gen_listener ) {
+				if (gen.getTarget().wantsListenerCodeFile()) {
+					ST listener = gen.generateListener();
 					if (g.tool.errMgr.getNumErrors() == errorCount) {
-						gen.writeBaseListener(baseListener);
+						gen.writeListener(listener);
+					}
+				}
+
+				if (gen.getTarget().wantsListenerHeaderFile()) {
+					ST listenerHeader = gen.generateListenerHeader();
+					if (g.tool.errMgr.getNumErrors() == errorCount) {
+						gen.writeListenerHeader(listenerHeader);
+					}
+				}
+
+				if (gen.getTarget().wantsBaseListener()) {
+					if (gen.getTarget().wantsBaseListenerCodeFile()) {
+						ST baseListener = gen.generateBaseListener();
+						if (g.tool.errMgr.getNumErrors() == errorCount) {
+							gen.writeBaseListener(baseListener);
+						}
+					}
+
+					if (gen.getTarget().wantsBaseListenerHeaderFile()){
+						ST baseListenerHeader = gen.generateBaseListenerHeader();
+						if (g.tool.errMgr.getNumErrors() == errorCount) {
+							gen.writeBaseListenerHeader(baseListenerHeader);
+						}
 					}
 				}
 			}
 			if ( g.tool.gen_visitor ) {
-				ST visitor = gen.generateVisitor();
-				if (g.tool.errMgr.getNumErrors() == errorCount) {
-					gen.writeVisitor(visitor);
-				}
-				if (gen.getTarget().wantsBaseVisitor()) {
-					ST baseVisitor = gen.generateBaseVisitor();
+				if (gen.getTarget().wantsVisitorCodeFile()) {
+					ST visitor = gen.generateVisitor();
 					if (g.tool.errMgr.getNumErrors() == errorCount) {
-						gen.writeBaseVisitor(baseVisitor);
+						gen.writeVisitor(visitor);
+					}
+				}
+				
+				if (gen.getTarget().wantsVisitorHeaderFile()) {
+					ST visitorHeader = gen.generateVisitorHeader();
+					if (g.tool.errMgr.getNumErrors() == errorCount) {
+						gen.writeVisitorHeader(visitorHeader);
+					}
+				}
+
+				if (gen.getTarget().wantsBaseVisitor()) {
+					if (gen.getTarget().wantsBaseVisitorCodeFile()) {
+						ST baseVisitor = gen.generateBaseVisitor();
+						if (g.tool.errMgr.getNumErrors() == errorCount) {
+							gen.writeBaseVisitor(baseVisitor);
+						}
+					}
+					
+					if (gen.getTarget().wantsBaseVisitorHeaderFile()) {
+						ST baseVisitorHeader = gen.generateBaseVisitorHeader();
+						if (g.tool.errMgr.getNumErrors() == errorCount) {
+							gen.writeBaseVisitorHeader(baseVisitorHeader);
+						}
 					}
 				}
 			}
-			gen.writeHeaderFile();
 		}
 		gen.writeVocabFile();
 	}

--- a/tool/src/org/antlr/v4/codegen/CodeGenerator.java
+++ b/tool/src/org/antlr/v4/codegen/CodeGenerator.java
@@ -203,6 +203,26 @@ public class CodeGenerator {
 	public void writeBaseVisitor(ST outputFileST) {
 		getTarget().genFile(g, outputFileST, getBaseVisitorFileName());
 	}
+	
+	public void writeRecognizerHeader(ST outputFileST) {
+		getTarget().genFile(g, outputFileST, getRecognizerHeaderFileName());
+	}
+
+	public void writeListenerHeader(ST outputFileST) {
+		getTarget().genFile(g, outputFileST, getListenerHeaderFileName());
+	}
+
+	public void writeBaseListenerHeader(ST outputFileST) {
+		getTarget().genFile(g, outputFileST, getBaseListenerHeaderFileName());
+	}
+
+	public void writeVisitorHeader(ST outputFileST) {
+		getTarget().genFile(g, outputFileST, getVisitorHeaderFileName());
+	}
+
+	public void writeBaseVisitorHeader(ST outputFileST) {
+		getTarget().genFile(g, outputFileST, getBaseVisitorHeaderFileName());
+	}
 
 	public void writeVocabFile() {
 		// write out the vocab interchange file; used by antlr,
@@ -289,7 +309,6 @@ public class CodeGenerator {
 
 	public String getRecognizerHeaderFileName() {
 		ST extST = getTemplates().getInstanceOf("headerFileExtension");
-		if ( extST==null ) return null;
 		String recognizerHeaderName = g.getRecognizerName();
 		return recognizerHeaderName+extST.render();
 	}
@@ -297,7 +316,6 @@ public class CodeGenerator {
 	public String getListenerHeaderFileName() {
 		assert g.name != null;
 		ST extST = getTemplates().getInstanceOf("headerFileExtension");
-		if ( extST==null ) return null;
 		String listenerHeaderName = g.name + "Listener";
 		return listenerHeaderName+extST.render();
 	}
@@ -305,7 +323,6 @@ public class CodeGenerator {
 	public String getBaseListenerHeaderFileName() {
 		assert g.name != null;
 		ST extST = getTemplates().getInstanceOf("headerFileExtension");
-		if ( extST==null ) return null;
 		String listenerHeaderName = g.name + "BaseListener";
 		return listenerHeaderName+extST.render();
 	}
@@ -313,7 +330,6 @@ public class CodeGenerator {
 	public String getVisitorHeaderFileName() {
 		assert g.name != null;
 		ST extST = getTemplates().getInstanceOf("headerFileExtension");
-		if ( extST==null ) return null;
 		String visitorHeaderName = g.name + "Visitor";
 		return visitorHeaderName+extST.render();
 	}
@@ -321,7 +337,6 @@ public class CodeGenerator {
 	public String getBaseVisitorHeaderFileName() {
 		assert g.name != null;
 		ST extST = getTemplates().getInstanceOf("headerFileExtension");
-		if ( extST==null ) return null;
 		String visitorHeaderName = g.name + "BaseVisitor";
 		return visitorHeaderName+extST.render();
 	}

--- a/tool/src/org/antlr/v4/codegen/CodeGenerator.java
+++ b/tool/src/org/antlr/v4/codegen/CodeGenerator.java
@@ -145,6 +145,12 @@ public class CodeGenerator {
 	public ST generateBaseListener() { return walk(createController().buildBaseListenerOutputModel()); }
 	public ST generateVisitor() { return walk(createController().buildVisitorOutputModel()); }
 	public ST generateBaseVisitor() { return walk(createController().buildBaseVisitorOutputModel()); }
+	public ST generateLexerHeader() { return walk(createController().buildLexerHeaderOutputModel()); }
+	public ST generateParserHeader() { return walk(createController().buildParserHeaderOutputModel()); }
+	public ST generateListenerHeader() { return walk(createController().buildListenerHeaderOutputModel()); }
+	public ST generateBaseListenerHeader() { return walk(createController().buildBaseListenerHeaderOutputModel()); }
+	public ST generateVisitorHeader() { return walk(createController().buildVisitorHeaderOutputModel()); }
+	public ST generateBaseVisitorHeader() { return walk(createController().buildBaseVisitorHeaderOutputModel()); }
 
 	/** Generate a token vocab file with all the token names/types.  For example:
 	 *  ID=7
@@ -196,17 +202,6 @@ public class CodeGenerator {
 
 	public void writeBaseVisitor(ST outputFileST) {
 		getTarget().genFile(g, outputFileST, getBaseVisitorFileName());
-	}
-
-	public void writeHeaderFile() {
-		String fileName = getHeaderFileName();
-		if ( fileName==null ) return;
-		if ( getTemplates().isDefined("headerFile") ) {
-			ST extST = getTemplates().getInstanceOf("headerFileExtension");
-			ST headerFileST = null;
-			// TODO:  don't hide this header file generation here!
-			getTarget().genRecognizerHeaderFile(g, headerFileST, extST.render(lineWidth));
-		}
 	}
 
 	public void writeVocabFile() {
@@ -281,8 +276,8 @@ public class CodeGenerator {
 	public String getBaseVisitorFileName() {
 		assert g.name != null;
 		ST extST = getTemplates().getInstanceOf("codeFileExtension");
-		String listenerName = g.name + "BaseVisitor";
-		return listenerName+extST.render();
+		String visitorName = g.name + "BaseVisitor";
+		return visitorName+extST.render();
 	}
 
 	/** What is the name of the vocab file generated for this grammar?
@@ -292,11 +287,42 @@ public class CodeGenerator {
 		return g.name+VOCAB_FILE_EXTENSION;
 	}
 
-	public String getHeaderFileName() {
+	public String getRecognizerHeaderFileName() {
 		ST extST = getTemplates().getInstanceOf("headerFileExtension");
 		if ( extST==null ) return null;
-		String recognizerName = g.getRecognizerName();
-		return recognizerName+extST.render();
+		String recognizerHeaderName = g.getRecognizerName();
+		return recognizerHeaderName+extST.render();
 	}
 
+	public String getListenerHeaderFileName() {
+		assert g.name != null;
+		ST extST = getTemplates().getInstanceOf("headerFileExtension");
+		if ( extST==null ) return null;
+		String listenerHeaderName = g.name + "Listener";
+		return listenerHeaderName+extST.render();
+	}
+
+	public String getBaseListenerHeaderFileName() {
+		assert g.name != null;
+		ST extST = getTemplates().getInstanceOf("headerFileExtension");
+		if ( extST==null ) return null;
+		String listenerHeaderName = g.name + "BaseListener";
+		return listenerHeaderName+extST.render();
+	}
+
+	public String getVisitorHeaderFileName() {
+		assert g.name != null;
+		ST extST = getTemplates().getInstanceOf("headerFileExtension");
+		if ( extST==null ) return null;
+		String visitorHeaderName = g.name + "Visitor";
+		return visitorHeaderName+extST.render();
+	}
+	
+	public String getBaseVisitorHeaderFileName() {
+		assert g.name != null;
+		ST extST = getTemplates().getInstanceOf("headerFileExtension");
+		if ( extST==null ) return null;
+		String visitorHeaderName = g.name + "BaseVisitor";
+		return visitorHeaderName+extST.render();
+	}
 }

--- a/tool/src/org/antlr/v4/codegen/CodeGeneratorExtension.java
+++ b/tool/src/org/antlr/v4/codegen/CodeGeneratorExtension.java
@@ -38,6 +38,7 @@ import org.antlr.v4.codegen.model.Lexer;
 import org.antlr.v4.codegen.model.LexerFile;
 import org.antlr.v4.codegen.model.Parser;
 import org.antlr.v4.codegen.model.ParserFile;
+import org.antlr.v4.codegen.model.ParserHeaderFile;
 import org.antlr.v4.codegen.model.RuleFunction;
 import org.antlr.v4.codegen.model.SrcOp;
 import org.antlr.v4.tool.ast.GrammarAST;
@@ -53,6 +54,8 @@ public class CodeGeneratorExtension {
 	}
 
 	public ParserFile parserFile(ParserFile f) { return f; }
+
+	public ParserHeaderFile parserHeaderFile(ParserHeaderFile f) { return f; }
 
 	public Parser parser(Parser p) { return p; }
 

--- a/tool/src/org/antlr/v4/codegen/OutputModelController.java
+++ b/tool/src/org/antlr/v4/codegen/OutputModelController.java
@@ -35,7 +35,9 @@ import org.antlr.v4.analysis.LeftRecursiveRuleAltInfo;
 import org.antlr.v4.codegen.model.Action;
 import org.antlr.v4.codegen.model.AltBlock;
 import org.antlr.v4.codegen.model.BaseListenerFile;
+import org.antlr.v4.codegen.model.BaseListenerHeaderFile;
 import org.antlr.v4.codegen.model.BaseVisitorFile;
+import org.antlr.v4.codegen.model.BaseVisitorHeaderFile;
 import org.antlr.v4.codegen.model.Choice;
 import org.antlr.v4.codegen.model.CodeBlockForAlt;
 import org.antlr.v4.codegen.model.CodeBlockForOuterMostAlt;
@@ -43,16 +45,20 @@ import org.antlr.v4.codegen.model.LabeledOp;
 import org.antlr.v4.codegen.model.LeftRecursiveRuleFunction;
 import org.antlr.v4.codegen.model.Lexer;
 import org.antlr.v4.codegen.model.LexerFile;
+import org.antlr.v4.codegen.model.LexerHeaderFile;
 import org.antlr.v4.codegen.model.ListenerFile;
+import org.antlr.v4.codegen.model.ListenerHeaderFile;
 import org.antlr.v4.codegen.model.OutputModelObject;
 import org.antlr.v4.codegen.model.Parser;
 import org.antlr.v4.codegen.model.ParserFile;
+import org.antlr.v4.codegen.model.ParserHeaderFile;
 import org.antlr.v4.codegen.model.RuleActionFunction;
 import org.antlr.v4.codegen.model.RuleFunction;
 import org.antlr.v4.codegen.model.RuleSempredFunction;
 import org.antlr.v4.codegen.model.SrcOp;
 import org.antlr.v4.codegen.model.StarBlock;
 import org.antlr.v4.codegen.model.VisitorFile;
+import org.antlr.v4.codegen.model.VisitorHeaderFile;
 import org.antlr.v4.codegen.model.decl.CodeBlock;
 import org.antlr.v4.misc.Utils;
 import org.antlr.v4.parse.ANTLRParser;
@@ -112,23 +118,22 @@ public class OutputModelController {
 		CodeGenerator gen = delegate.getGenerator();
 		ParserFile file = parserFile(gen.getRecognizerFileName());
 		setRoot(file);
-		Parser parser = parser(file);
-		file.parser = parser;
+		file.parser = parser(file);
 
 		for (Rule r : g.rules.values()) {
-			buildRuleFunction(parser, r);
+			buildRuleFunction(file.parser, r);
 		}
 
 		return file;
 	}
 
 	public OutputModelObject buildLexerOutputModel() {
+		Grammar g = delegate.getGrammar();
 		CodeGenerator gen = delegate.getGenerator();
 		LexerFile file = lexerFile(gen.getRecognizerFileName());
 		setRoot(file);
 		file.lexer = lexer(file);
 
-		Grammar g = delegate.getGrammar();
 		for (Rule r : g.rules.values()) {
 			buildLexerRuleActions(file.lexer, r);
 		}
@@ -174,6 +179,67 @@ public class OutputModelController {
 
 	public Lexer lexer(LexerFile file) {
 		return new Lexer(delegate, file);
+	}
+
+	/** Header files may contain the actual code, so this is
+	 * essentially the same as above.
+	 */
+	public OutputModelObject buildParserHeaderOutputModel() {
+		Grammar g = delegate.getGrammar();
+		CodeGenerator gen = delegate.getGenerator();
+		ParserHeaderFile file = parserHeaderFile(gen.getRecognizerHeaderFileName());
+		setRoot(file);
+		file.parser = parser(file);
+
+		for (Rule r : g.rules.values()) {
+			buildRuleFunction(file.parser, r);
+		}
+
+		return file;
+	}
+
+	public OutputModelObject buildLexerHeaderOutputModel() {
+		Grammar g = delegate.getGrammar();
+		CodeGenerator gen = delegate.getGenerator();
+		LexerHeaderFile file = lexerHeaderFile(gen.getRecognizerHeaderFileName());
+		setRoot(file);
+		file.lexer = lexer(file);
+
+		for (Rule r : g.rules.values()) {
+			buildLexerRuleActions(file.lexer, r);
+		}
+
+		return file;
+	}
+
+	public OutputModelObject buildListenerHeaderOutputModel() {
+		CodeGenerator gen = delegate.getGenerator();
+		return new ListenerHeaderFile(delegate, gen.getListenerHeaderFileName());
+	}
+
+	public OutputModelObject buildBaseListenerHeaderOutputModel() {
+		CodeGenerator gen = delegate.getGenerator();
+		return new BaseListenerHeaderFile(delegate, gen.getBaseListenerHeaderFileName());
+	}
+
+	public OutputModelObject buildVisitorHeaderOutputModel() {
+		CodeGenerator gen = delegate.getGenerator();
+		return new VisitorHeaderFile(delegate, gen.getVisitorHeaderFileName());
+	}
+
+	public OutputModelObject buildBaseVisitorHeaderOutputModel() {
+		CodeGenerator gen = delegate.getGenerator();
+		return new BaseVisitorHeaderFile(delegate, gen.getBaseVisitorHeaderFileName());
+	}
+
+	public ParserHeaderFile parserHeaderFile(String fileName) {
+		ParserHeaderFile f = delegate.parserHeaderFile(fileName);
+		for (CodeGeneratorExtension ext : extensions) f = ext.parserHeaderFile(f);
+		return f;
+	}
+
+	public LexerHeaderFile lexerHeaderFile(String fileName) {
+		return new LexerHeaderFile(delegate, fileName);
 	}
 
 	/** Create RuleFunction per rule and update sempreds,actions of parser

--- a/tool/src/org/antlr/v4/codegen/OutputModelFactory.java
+++ b/tool/src/org/antlr/v4/codegen/OutputModelFactory.java
@@ -39,6 +39,7 @@ import org.antlr.v4.codegen.model.LexerFile;
 import org.antlr.v4.codegen.model.OutputModelObject;
 import org.antlr.v4.codegen.model.Parser;
 import org.antlr.v4.codegen.model.ParserFile;
+import org.antlr.v4.codegen.model.ParserHeaderFile;
 import org.antlr.v4.codegen.model.RuleFunction;
 import org.antlr.v4.codegen.model.SrcOp;
 import org.antlr.v4.codegen.model.decl.CodeBlock;
@@ -62,6 +63,8 @@ public interface OutputModelFactory {
 	OutputModelController getController();
 
 	ParserFile parserFile(String fileName);
+	
+	ParserHeaderFile parserHeaderFile(String fileName);
 
 	Parser parser(ParserFile file);
 

--- a/tool/src/org/antlr/v4/codegen/Target.java
+++ b/tool/src/org/antlr/v4/codegen/Target.java
@@ -128,13 +128,6 @@ public abstract class Target {
 		getCodeGenerator().write(outputFileST, fileName);
 	}
 
-	protected void genRecognizerHeaderFile(Grammar g,
-										   ST headerFileST,
-										   String extName) // e.g., ".h"
-	{
-		// no header file by default
-	}
-
 	/** Get a meaningful name for a token type useful during code generation.
 	 *  Literals without associated names are converted to the string equivalent
 	 *  of their integer values. Used to generate x==ID and x==34 type comparisons
@@ -523,5 +516,75 @@ public abstract class Target {
 	 */
 	public boolean supportsOverloadedMethods() {
 		return true;
+	}
+
+	/**
+	 * @since 4.5
+	 */
+	public boolean wantsRecognizerCodeFile() {
+		return true;
+	}
+	
+	/**
+	 * @since 4.5
+	 */
+	public boolean wantsRecognizerHeaderFile() {
+		return false;
+	}
+
+	/**
+	 * @since 4.5
+	 */
+	public boolean wantsListerCodeFile() {
+		return true;
+	}
+	
+	/**
+	 * @since 4.5
+	 */
+	public boolean wantsListerHeaderFile() {
+		return false;
+	}
+
+	/**
+	 * @since 4.5
+	 */
+	public boolean wantsBaseListenerCodeFile() {
+		return true;
+	}
+	
+	/**
+	 * @since 4.5
+	 */
+	public boolean wantsBaseListenerHeaderFile() {
+		return false;
+	}
+
+	/**
+	 * @since 4.5
+	 */
+	public boolean wantsVisitorCodeFile() {
+		return true;
+	}
+	
+	/**
+	 * @since 4.5
+	 */
+	public boolean wantsVisitorHeaderFile() {
+		return false;
+	}
+
+	/**
+	 * @since 4.5
+	 */
+	public boolean wantsBaseVisitorCodeFile() {
+		return true;
+	}
+	
+	/**
+	 * @since 4.5
+	 */
+	public boolean wantsBaseVisitorHeaderFile() {
+		return false;
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/Target.java
+++ b/tool/src/org/antlr/v4/codegen/Target.java
@@ -535,14 +535,14 @@ public abstract class Target {
 	/**
 	 * @since 4.5
 	 */
-	public boolean wantsListerCodeFile() {
+	public boolean wantsListenerCodeFile() {
 		return true;
 	}
 	
 	/**
 	 * @since 4.5
 	 */
-	public boolean wantsListerHeaderFile() {
+	public boolean wantsListenerHeaderFile() {
 		return false;
 	}
 

--- a/tool/src/org/antlr/v4/codegen/model/BaseListenerHeaderFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/BaseListenerHeaderFile.java
@@ -1,0 +1,38 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012 Terence Parr
+ *  Copyright (c) 2012 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.antlr.v4.codegen.model;
+
+import org.antlr.v4.codegen.OutputModelFactory;
+
+public class BaseListenerHeaderFile extends BaseListenerFile {
+	public BaseListenerHeaderFile(OutputModelFactory factory, String fileName) {
+		super(factory, fileName);
+	}
+}

--- a/tool/src/org/antlr/v4/codegen/model/BaseVisitorHeaderFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/BaseVisitorHeaderFile.java
@@ -1,0 +1,38 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012 Terence Parr
+ *  Copyright (c) 2012 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.antlr.v4.codegen.model;
+
+import org.antlr.v4.codegen.OutputModelFactory;
+
+public class BaseVisitorHeaderFile extends BaseVisitorFile {
+	public BaseVisitorHeaderFile(OutputModelFactory factory, String fileName) {
+		super(factory, fileName);
+	}
+}

--- a/tool/src/org/antlr/v4/codegen/model/LexerHeaderFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/LexerHeaderFile.java
@@ -1,0 +1,38 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012 Terence Parr
+ *  Copyright (c) 2012 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.antlr.v4.codegen.model;
+
+import org.antlr.v4.codegen.OutputModelFactory;
+
+public class LexerHeaderFile extends LexerFile {
+	public LexerHeaderFile(OutputModelFactory factory, String fileName) {
+		super(factory, fileName);
+	}
+}

--- a/tool/src/org/antlr/v4/codegen/model/ListenerHeaderFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/ListenerHeaderFile.java
@@ -1,0 +1,38 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012 Terence Parr
+ *  Copyright (c) 2012 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.antlr.v4.codegen.model;
+
+import org.antlr.v4.codegen.OutputModelFactory;
+
+public class ListenerHeaderFile extends ListenerFile {
+	public ListenerHeaderFile(OutputModelFactory factory, String fileName) {
+		super(factory, fileName);
+	}
+}

--- a/tool/src/org/antlr/v4/codegen/model/ParserHeaderFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/ParserHeaderFile.java
@@ -1,0 +1,38 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012 Terence Parr
+ *  Copyright (c) 2012 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.antlr.v4.codegen.model;
+
+import org.antlr.v4.codegen.OutputModelFactory;
+
+public class ParserHeaderFile extends ParserFile {
+	public ParserHeaderFile(OutputModelFactory factory, String fileName) {
+		super(factory, fileName);
+	}
+}

--- a/tool/src/org/antlr/v4/codegen/model/VisitorHeaderFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/VisitorHeaderFile.java
@@ -1,0 +1,38 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012 Terence Parr
+ *  Copyright (c) 2012 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.antlr.v4.codegen.model;
+
+import org.antlr.v4.codegen.OutputModelFactory;
+
+public class VisitorHeaderFile extends VisitorFile {
+	public VisitorHeaderFile(OutputModelFactory factory, String fileName) {
+		super(factory, fileName);
+	}
+}


### PR DESCRIPTION
While working on C++ target for ANTLR, I wanted to be able to generate header files for various parts of the generated code. The current infrastructure doesn't seem to be sufficient, so this is my attempt at generating header files using the existing infrastructure.

I'd like to ask you review the code. Java and C# unit tests were fine, other targets are missing some classes - I am quite sure this is not related to my changes. Also, I have signed the contributors agreement.

Please let me know if this should be part of a separate pull request.

Thanks,
Ondrej