### PR TITLE
Add goto to reserved words for java.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -71,3 +71,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/04/29, jszheng, Jinshan Zheng, zheng_js@hotmail.com
 2015/05/08, ViceIce, Michael Kriese, michael.kriese@gmx.de
 2015/05/09, lkraz, Luke Krasnoff, luke.krasnoff@gmail.com
+2015/05/12, Pursuit92, Josh Chase, jcjoshuachase@gmail.com

--- a/tool/src/org/antlr/v4/codegen/JavaTarget.java
+++ b/tool/src/org/antlr/v4/codegen/JavaTarget.java
@@ -50,7 +50,7 @@ public class JavaTarget extends Target {
 	protected static final String[] javaKeywords = {
 		"abstract", "assert", "boolean", "break", "byte", "case", "catch",
 		"char", "class", "const", "continue", "default", "do", "double", "else",
-		"enum", "extends", "false", "final", "finally", "float", "for",
+		"enum", "extends", "false", "final", "finally", "float", "for", "goto",
 		"if", "implements", "import", "instanceof", "int", "interface",
 		"long", "native", "new", "null", "package", "private", "protected",
 		"public", "return", "short", "static", "strictfp", "super", "switch",


### PR DESCRIPTION
Goto isn't in the reserved words, so it doesn't get caught when compiling a grammar that uses it as a rule name.