### PR TITLE
Check for nonconforming left-recursive rules.

### DIFF
--- a/tool/src/org/antlr/v4/analysis/LeftRecursiveRuleTransformer.java
+++ b/tool/src/org/antlr/v4/analysis/LeftRecursiveRuleTransformer.java
@@ -93,7 +93,12 @@ public class LeftRecursiveRuleTransformer {
 			if ( !Grammar.isTokenName(r.name) ) {
 				if ( LeftRecursiveRuleAnalyzer.hasImmediateRecursiveRuleRefs(r.ast, r.name) ) {
 					boolean fitsPattern = translateLeftRecursiveRule(ast, (LeftRecursiveRule)r, language);
-					if ( fitsPattern ) leftRecursiveRuleNames.add(r.name);
+					if ( fitsPattern ) {
+						leftRecursiveRuleNames.add(r.name);
+					}
+					else { // better given an error that non-conforming left-recursion exists
+						tool.errMgr.grammarError(ErrorType.NONCONFORMING_LR_RULE, g.fileName, ((GrammarAST)r.ast.getChild(0)).token, r.name);
+					}
 				}
 			}
 		}

--- a/tool/src/org/antlr/v4/parse/GrammarTreeVisitor.g
+++ b/tool/src/org/antlr/v4/parse/GrammarTreeVisitor.g
@@ -79,6 +79,7 @@ package org.antlr.v4.parse;
 import org.antlr.v4.Tool;
 import org.antlr.v4.tool.*;
 import org.antlr.v4.tool.ast.*;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 }
 
@@ -105,8 +106,12 @@ public void visit(GrammarAST t, String ruleName) {
 		Method m = getClass().getMethod(ruleName);
 		m.invoke(this);
 	}
-	catch (Exception e) {
+	catch (Throwable e) {
 		ErrorManager errMgr = getErrorManager();
+		if ( e instanceof InvocationTargetException ) {
+			e = e.getCause();
+		}
+		//e.printStackTrace(System.err);
 		if ( errMgr==null ) {
 			System.err.println("can't find rule "+ruleName+
 							   " or tree structure error: "+t.toStringTree()

--- a/tool/src/org/antlr/v4/semantics/SemanticPipeline.java
+++ b/tool/src/org/antlr/v4/semantics/SemanticPipeline.java
@@ -85,13 +85,14 @@ public class SemanticPipeline {
 		BasicSemanticChecks basics = new BasicSemanticChecks(g, ruleCollector);
 		basics.process();
 
-		// don't continue if we get errors in this basic check
-		//if ( false ) return;
-
 		// TRANSFORM LEFT-RECURSIVE RULES
+		int prevErrors = g.tool.errMgr.getNumErrors();
 		LeftRecursiveRuleTransformer lrtrans =
 			new LeftRecursiveRuleTransformer(g.ast, ruleCollector.rules.values(), g);
 		lrtrans.translateLeftRecursiveRules();
+
+		// don't continue if we got errors during left-recursion elimination
+		if ( g.tool.errMgr.getNumErrors()>prevErrors ) return;
 
 		// STORE RULES IN GRAMMAR
 		for (Rule r : ruleCollector.rules.values()) {

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -956,6 +956,8 @@ public enum ErrorType {
 	 */
 	CHANNELS_BLOCK_IN_COMBINED_GRAMMAR(164, "custom channels are not supported in combined grammars", ErrorSeverity.ERROR),
 
+	NONCONFORMING_LR_RULE(165, "rule <arg> is left recursive but doesn't conform to a pattern ANTLR can handle", ErrorSeverity.ERROR),
+
 	/*
 	 * Backward incompatibility errors
 	 */


### PR DESCRIPTION
We didn't check for left-recursive rules that didn't follow pattern that would lead to error. added unit tests. Passes all tests. Fixes #822, Fixes #855. 