### PR TITLE
Report unknown rule error in proper file.

### DIFF
--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -480,18 +480,18 @@ public class Tool {
 			@Override
 			public void ruleRef(GrammarAST ref, ActionAST arg) {
 				RuleAST ruleAST = ruleToAST.get(ref.getText());
+				String fileName = ref.getToken().getInputStream().getSourceName();
 				if (Character.isUpperCase(currentRuleName.charAt(0)) &&
 					Character.isLowerCase(ref.getText().charAt(0)))
 				{
 					badref = true;
-					String fileName = ref.getToken().getInputStream().getSourceName();
 					errMgr.grammarError(ErrorType.PARSER_RULE_REF_IN_LEXER_RULE,
 										fileName, ref.getToken(), ref.getText(), currentRuleName);
 				}
 				else if ( ruleAST==null ) {
 					badref = true;
 					errMgr.grammarError(ErrorType.UNDEFINED_RULE_REF,
-										g.fileName, ref.token, ref.getText());
+										fileName, ref.token, ref.getText());
 				}
 			}
 			@Override

--- a/tool/test/org/antlr/v4/test/tool/TestCompositeGrammars.java
+++ b/tool/test/org/antlr/v4/test/tool/TestCompositeGrammars.java
@@ -30,10 +30,13 @@
 
 package org.antlr.v4.test.tool;
 
+import org.antlr.v4.tool.ANTLRMessage;
 import org.antlr.v4.tool.ErrorType;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.GrammarSemanticsMessage;
 import org.junit.Test;
+
+import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -58,6 +61,25 @@ public class TestCompositeGrammars extends BaseTest {
 		writeFile(tmpdir, "M.g4", master);
 		ErrorQueue equeue = antlr("M.g4", false, "-lib", subdir);
 		assertEquals(equeue.size(), 0);
+	}
+
+	@Test public void testErrorInImportedGetsRightFilename() throws Exception {
+		String slave =
+			"parser grammar S;\n" +
+			"a : 'a' | c;\n";
+		mkdir(tmpdir);
+		writeFile(tmpdir, "S.g4", slave);
+		String master =
+			"grammar M;\n" +
+			"import S;\n";
+		writeFile(tmpdir, "M.g4", master);
+		ErrorQueue equeue = antlr("M.g4", false, "-lib", tmpdir);
+		ANTLRMessage msg = equeue.errors.get(0);
+		assertEquals(ErrorType.UNDEFINED_RULE_REF, msg.getErrorType());
+		assertEquals("c", msg.getArgs()[0]);
+		assertEquals(2, msg.line);
+		assertEquals(10, msg.charPosition);
+		assertEquals("S.g4", new File(msg.fileName).getName());
 	}
 
 	@Test public void testImportFileNotSearchedForInOutputDir() throws Exception {


### PR DESCRIPTION
Fixes #823. For the record, there are lots of errors that ask for g.fileName and not `tokenOfErrorLocation.getInputStream().getSourceName()`.