### PR TITLE
Add @jcbrinfo as a contributor

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -73,3 +73,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/05/09, lkraz, Luke Krasnoff, luke.krasnoff@gmail.com
 2015/05/12, Pursuit92, Josh Chase, jcjoshuachase@gmail.com
 2015/05/20, peturingi, Pétur Ingi Egilsson, petur@petur.eu
+2015/05/27, jcbrinfo, Jean-Christophe Beaupré, jcbrinfo@users.noreply.github.com


### PR DESCRIPTION
I want to contribute to the antlr/antlr4-python3 project.

Signed-off-by: jcbrinfo <jcbrinfo@users.noreply.github.com>