### PR TITLE
ignore subdirectory "gen"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ nbactions*.xml
 # Generated files
 out/
 doc/
+gen/
 gen3/
 gen4/
 tmp/


### PR DESCRIPTION
Hi,
I just followed the build instructions and found that git wouldn't ignore the generated subdirectory 'gen', so it might be added to .gitignore.
Have fun,
Herbert.
