### PR TITLE
Report an end position when reporting syntax errors

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/ANTLRErrorListener.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ANTLRErrorListener.java
@@ -30,13 +30,13 @@
 
 package org.antlr.v4.runtime;
 
+import java.util.BitSet;
+
 import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.atn.DecisionInfo;
 import org.antlr.v4.runtime.atn.ParserATNSimulator;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.dfa.DFA;
-
-import java.util.BitSet;
 
 /** How to emit recognition errors. */
 public interface ANTLRErrorListener {
@@ -63,8 +63,10 @@ public interface ANTLRErrorListener {
 	 * 		  started production for the decision.
 	 * @param line
 	 * 		  The line number in the input where the error occurred.
-	 * @param charPositionInLine
+	 * @param startPositionInLine
 	 * 		  The character position within that line where the error occurred.
+	 * @param endPositionInLine
+	 * 		  The character position within that line where the error ended.
 	 * @param msg
 	 * 		  The message to emit.
 	 * @param e
@@ -76,7 +78,8 @@ public interface ANTLRErrorListener {
 	public void syntaxError(Recognizer<?, ?> recognizer,
 							Object offendingSymbol,
 							int line,
-							int charPositionInLine,
+							int startPositionInLine,
+							int endPositionInLine,
 							String msg,
 							RecognitionException e);
 

--- a/runtime/Java/src/org/antlr/v4/runtime/BaseErrorListener.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/BaseErrorListener.java
@@ -29,10 +29,10 @@
  */
 package org.antlr.v4.runtime;
 
+import java.util.BitSet;
+
 import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.dfa.DFA;
-
-import java.util.BitSet;
 
 /**
  * Provides an empty default implementation of {@link ANTLRErrorListener}. The
@@ -46,7 +46,8 @@ public class BaseErrorListener implements ANTLRErrorListener {
 	public void syntaxError(Recognizer<?, ?> recognizer,
 							Object offendingSymbol,
 							int line,
-							int charPositionInLine,
+							int startPositionInLine,
+							int endPositionInLine,
 							String msg,
 							RecognitionException e)
 	{

--- a/runtime/Java/src/org/antlr/v4/runtime/ConsoleErrorListener.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ConsoleErrorListener.java
@@ -55,11 +55,12 @@ public class ConsoleErrorListener extends BaseErrorListener {
 	public void syntaxError(Recognizer<?, ?> recognizer,
 							Object offendingSymbol,
 							int line,
-							int charPositionInLine,
+							int startPositionInLine,
+							int endPositionInLine,
 							String msg,
 							RecognitionException e)
 	{
-		System.err.println("line " + line + ":" + charPositionInLine + " " + msg);
+		System.err.println("line " + line + ":" + startPositionInLine + " " + msg);
 	}
 
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
@@ -29,14 +29,14 @@
  */
 package org.antlr.v4.runtime;
 
+import java.util.ArrayList;
+import java.util.EmptyStackException;
+import java.util.List;
+
 import org.antlr.v4.runtime.atn.LexerATNSimulator;
 import org.antlr.v4.runtime.misc.IntegerStack;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.misc.Pair;
-
-import java.util.ArrayList;
-import java.util.EmptyStackException;
-import java.util.List;
 
 /** A lexer is recognizer that draws input symbols from a character stream.
  *  lexer grammars result in a subclass of this object. A Lexer object
@@ -383,7 +383,7 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 		String msg = "token recognition error at: '"+ getErrorDisplay(text) + "'";
 
 		ANTLRErrorListener listener = getErrorListenerDispatch();
-		listener.syntaxError(this, null, _tokenStartLine, _tokenStartCharPositionInLine, msg, e);
+		listener.syntaxError(this, null, _tokenStartLine, _tokenStartCharPositionInLine, _input.index(), msg, e);
 	}
 
 	public String getErrorDisplay(String s) {

--- a/runtime/Java/src/org/antlr/v4/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Parser.java
@@ -29,6 +29,13 @@
  */
 package org.antlr.v4.runtime;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
 import org.antlr.v4.runtime.atn.ATN;
 import org.antlr.v4.runtime.atn.ATNDeserializationOptions;
 import org.antlr.v4.runtime.atn.ATNDeserializer;
@@ -51,13 +58,6 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.antlr.v4.runtime.tree.Trees;
 import org.antlr.v4.runtime.tree.pattern.ParseTreePattern;
 import org.antlr.v4.runtime.tree.pattern.ParseTreePatternMatcher;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
 
 /** This is all the parsing support code essentially; most of it is error recovery stuff. */
 public abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
@@ -558,7 +558,7 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 		charPositionInLine = offendingToken.getCharPositionInLine();
 
 		ANTLRErrorListener listener = getErrorListenerDispatch();
-		listener.syntaxError(this, offendingToken, line, charPositionInLine, msg, e);
+		listener.syntaxError(this, offendingToken, line, charPositionInLine, charPositionInLine + offendingToken.getText().length(), msg, e);
 	}
 
 	/**

--- a/runtime/Java/src/org/antlr/v4/runtime/ProxyErrorListener.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ProxyErrorListener.java
@@ -29,11 +29,11 @@
  */
 package org.antlr.v4.runtime;
 
-import org.antlr.v4.runtime.atn.ATNConfigSet;
-import org.antlr.v4.runtime.dfa.DFA;
-
 import java.util.BitSet;
 import java.util.Collection;
+
+import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.dfa.DFA;
 
 /**
  * This implementation of {@link ANTLRErrorListener} dispatches all calls to a
@@ -57,12 +57,13 @@ public class ProxyErrorListener implements ANTLRErrorListener {
 	public void syntaxError(Recognizer<?, ?> recognizer,
 							Object offendingSymbol,
 							int line,
-							int charPositionInLine,
+							int startPositionInLine,
+							int endPositionInLine,
 							String msg,
 							RecognitionException e)
 	{
 		for (ANTLRErrorListener listener : delegates) {
-			listener.syntaxError(recognizer, offendingSymbol, line, charPositionInLine, msg, e);
+			listener.syntaxError(recognizer, offendingSymbol, line, startPositionInLine, endPositionInLine, msg, e);
 		}
 	}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/xpath/XPathLexerErrorListener.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/xpath/XPathLexerErrorListener.java
@@ -7,7 +7,7 @@ import org.antlr.v4.runtime.Recognizer;
 public class XPathLexerErrorListener extends BaseErrorListener {
 	@Override
 	public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
-							int line, int charPositionInLine, String msg,
+							int line, int startPositionInLine, int endPositionInLine, String msg,
 							RecognitionException e)
 	{
 	}

--- a/tool/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -1574,7 +1574,7 @@ public class TestPerformance extends BaseTest {
 
 		@Override
 		public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
-								int line, int charPositionInLine,
+								int line, int startPositionInLine, int endPositionInLine,
 								String msg, RecognitionException e)
 		{
 			if (!REPORT_SYNTAX_ERRORS) {
@@ -1583,10 +1583,10 @@ public class TestPerformance extends BaseTest {
 
 			String sourceName = recognizer.getInputStream().getSourceName();
 			if (!sourceName.isEmpty()) {
-				sourceName = String.format("%s:%d:%d: ", sourceName, line, charPositionInLine);
+				sourceName = String.format("%s:%d:%d: ", sourceName, line, startPositionInLine);
 			}
 
-			System.err.println(sourceName+"line "+line+":"+charPositionInLine+" "+msg);
+			System.err.println(sourceName+"line "+line+":"+startPositionInLine+" "+msg);
 		}
 
 	}


### PR DESCRIPTION
Clients often want to report a span position for errors, rather than just a point position. Currently, an end position can be reconstructed from the token length for parser errors, but lexer errors do not have tokens attached. Nonetheless, we do know the ending index of the error, and it is helpful to report it.

For comparison, what I'm currently doing is using a regex to match the `token error at '...'` error message, pull the offending text out, and use the length of that. That's both slow and fragile, so something like this seems like a better approach.

This changes the interface of `ANTLRErrorListener`, so potentially breaks people's subclasses. Ideally, it would be nice to do this without changing the interface, but I don't see an obvious way to do that.