### PR TITLE
LookaheadEventInfo now tracks alt taken by decision.

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/AmbiguityInfo.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/AmbiguityInfo.java
@@ -76,6 +76,7 @@ public class AmbiguityInfo extends DecisionEventInfo {
 	 * @param configs The final configuration set identifying the ambiguous
 	 * alternatives for the current input
 	 * @param ambigAlts The set of alternatives in the decision that lead to a valid parse.
+	 *                  The predicted alt is the min(ambigAlts)
 	 * @param input The input token stream
 	 * @param startIndex The start index for the current prediction
 	 * @param stopIndex The index at which the ambiguity was identified during

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LookaheadEventInfo.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LookaheadEventInfo.java
@@ -39,6 +39,13 @@ import org.antlr.v4.runtime.TokenStream;
  * @since 4.3
  */
 public class LookaheadEventInfo extends DecisionEventInfo {
+	/** The alternative chosen by adaptivePredict(), not necessarily
+	 *  the outermost alt shown for a rule; left-recursive rules have
+	 *  user-level alts that differ from the rewritten rule with a (...) block
+	 *  and a (..)* loop.
+	 */
+	public int predictedAlt;
+
 	/**
 	 * Constructs a new instance of the {@link LookaheadEventInfo} class with
 	 * the specified detailed lookahead information.
@@ -56,9 +63,11 @@ public class LookaheadEventInfo extends DecisionEventInfo {
 	 */
 	public LookaheadEventInfo(int decision,
 							  ATNConfigSet configs,
+							  int predictedAlt,
 							  TokenStream input, int startIndex, int stopIndex,
 							  boolean fullCtx)
 	{
 		super(decision, configs, input, startIndex, stopIndex, fullCtx);
+		this.predictedAlt = predictedAlt;
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ProfilingATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ProfilingATNSimulator.java
@@ -94,7 +94,7 @@ public class ProfilingATNSimulator extends ParserATNSimulator {
 			if ( SLL_k > decisions[decision].SLL_MaxLook ) {
 				decisions[decision].SLL_MaxLook = SLL_k;
 				decisions[decision].SLL_MaxLookEvent =
-						new LookaheadEventInfo(decision, null, input, _startIndex, _sllStopIndex, false);
+						new LookaheadEventInfo(decision, null, alt, input, _startIndex, _sllStopIndex, false);
 			}
 
 			if (_llStopIndex >= 0) {
@@ -104,7 +104,7 @@ public class ProfilingATNSimulator extends ParserATNSimulator {
 				if ( LL_k > decisions[decision].LL_MaxLook ) {
 					decisions[decision].LL_MaxLook = LL_k;
 					decisions[decision].LL_MaxLookEvent =
-							new LookaheadEventInfo(decision, null, input, _startIndex, _llStopIndex, true);
+							new LookaheadEventInfo(decision, null, alt, input, _startIndex, _llStopIndex, true);
 				}
 			}
 


### PR DESCRIPTION
This is internal to profiling ATN simulator so hopefully won't mess up binary compatibility with 4.5.