### PR TITLE
Move TestPerformance.testExpressionGrammar to the runtime test suite

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Index.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Index.stg
@@ -9,6 +9,7 @@ TestFolders ::= [
 	"ParserErrors": [],
 	"ParserExec": [],
 	"ParseTrees": [],
+	"Performance": [],
 	"SemPredEvalLexer": [],
 	"SemPredEvalParser": [],
 	"Sets": []

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Performance/ExpressionGrammar.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Performance/ExpressionGrammar.stg
@@ -1,0 +1,54 @@
+/*
+ * This is a regression test for antlr/antlr4#192 "Poor performance of
+ * expression parsing".
+ * https://github.com/antlr/antlr4/issues/192
+ */
+
+TestType() ::= "Parser"
+
+Options ::= [
+	"Timeout": "60000"
+]
+
+Grammar ::= [
+	"Expr": {<grammar("Expr")>}
+]
+
+InputFragment() ::= <<
+not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or
+    X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or
+not X1 and     X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or
+not X1 and not X2 and     X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or
+not X1 and not X2 and not X3 and     X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or
+not X1 and not X2 and not X3 and not X4 and     X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or
+not X1 and not X2 and not X3 and not X4 and not X5 and     X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or
+not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and     X7 and not X8 and not X9 and not X10 and not X11 and not X12 or
+not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and     X8 and not X9 and not X10 and not X11 and not X12 or
+not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and     X9 and not X10 and not X11 and not X12 or
+not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and     X10 and not X11 and not X12 or
+not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and     X11 and not X12 or
+not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and     X12
+>>
+
+Rule() ::= "program"
+
+Output() ::= ""
+
+Errors() ::= ""
+
+grammar(grammarName) ::= <<
+grammar <grammarName>;
+
+program: expr EOF;
+
+expr
+	: ID
+	| 'not' expr
+	| expr 'and' expr
+	| expr 'or' expr
+	;
+
+ID: [a-zA-Z_][a-zA-Z_0-9]*;
+WS: [ \t\n\r\f]+ -> skip;
+ERROR: .;
+>>

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Performance/ExpressionGrammar_1.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Performance/ExpressionGrammar_1.stg
@@ -1,0 +1,5 @@
+import "ExpressionGrammar.stg"
+
+Input() ::= <<
+<InputFragment()>
+>>

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Performance/ExpressionGrammar_2.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Performance/ExpressionGrammar_2.stg
@@ -1,0 +1,14 @@
+import "ExpressionGrammar.stg"
+
+Input() ::= <<
+<InputFragment()> or
+<InputFragment()> or
+<InputFragment()> or
+<InputFragment()> or
+<InputFragment()> or
+<InputFragment()> or
+<InputFragment()> or
+<InputFragment()> or
+<InputFragment()> or
+<InputFragment()>
+>>

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Performance/Index.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Performance/Index.stg
@@ -1,0 +1,7 @@
+//TestFolders ::= [
+//]
+
+TestTemplates ::= [
+	"ExpressionGrammar_1": [],
+	"ExpressionGrammar_2": []
+]

--- a/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
@@ -112,6 +112,9 @@ public void test<test.name>() throws Exception {
 
 testAnnotations(test) ::= <%
 @Test
+<if(test.Options.("Timeout"))>
+(timeout = <test.Options.("Timeout")>)
+<endif>
 <if(test.Options.("Ignore"))>
 <\n>@Ignore(<writeStringLiteral(test.Options.("Ignore"))>)
 <elseif(IgnoredTests.(({<file.name>.<test.name>})))>

--- a/tool/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -1943,59 +1943,6 @@ public class TestPerformance extends BaseTest {
 		}
 	}
 
-	/**
-	 * This is a regression test for antlr/antlr4#192 "Poor performance of
-	 * expression parsing".
-	 * https://github.com/antlr/antlr4/issues/192
-	 */
-	@Test(timeout = 60000)
-	public void testExpressionGrammar() {
-		String grammar =
-			"grammar Expr;\n" +
-			"\n" +
-			"program: expr EOF;\n" +
-			"\n" +
-			"expr: ID\n" +
-			"    | 'not' expr\n" +
-			"    | expr 'and' expr\n" +
-			"    | expr 'or' expr\n" +
-			"    ;\n" +
-			"\n" +
-			"ID: [a-zA-Z_][a-zA-Z_0-9]*;\n" +
-			"WS: [ \\t\\n\\r\\f]+ -> skip;\n" +
-			"ERROR: .;\n";
-		String input =
-			"not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or\n" +
-			"    X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or\n" +
-			"not X1 and     X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or\n" +
-			"not X1 and not X2 and     X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or\n" +
-			"not X1 and not X2 and not X3 and     X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or\n" +
-			"not X1 and not X2 and not X3 and not X4 and     X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or\n" +
-			"not X1 and not X2 and not X3 and not X4 and not X5 and     X6 and not X7 and not X8 and not X9 and not X10 and not X11 and not X12 or\n" +
-			"not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and     X7 and not X8 and not X9 and not X10 and not X11 and not X12 or\n" +
-			"not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and     X8 and not X9 and not X10 and not X11 and not X12 or\n" +
-			"not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and     X9 and not X10 and not X11 and not X12 or\n" +
-			"not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and     X10 and not X11 and not X12 or\n" +
-			"not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and     X11 and not X12 or\n" +
-			"not X1 and not X2 and not X3 and not X4 and not X5 and not X6 and not X7 and not X8 and not X9 and not X10 and not X11 and     X12\n";
-
-		String found = execParser("Expr.g4", grammar, "ExprParser", "ExprLexer", "program",
-								  input, false);
-		Assert.assertEquals("", found);
-		Assert.assertEquals(null, stderrDuringParse);
-
-		List<String> inputs = new ArrayList<String>();
-		for (int i = 0; i < 10; i++) {
-			inputs.add(input);
-		}
-
-		input = Utils.join(inputs.iterator(), " or\n");
-		found = execParser("Expr.g4", grammar, "ExprParser", "ExprLexer", "program",
-								  input, false);
-		Assert.assertEquals("", found);
-		Assert.assertEquals(null, stderrDuringParse);
-	}
-
 	@Test(timeout = 20000)
 	public void testExponentialInclude() {
 		String grammarFormat =


### PR DESCRIPTION
Fixes #909