### PR TITLE
Maven property cleanup

### DIFF
--- a/antlr4-testgen-maven-plugin/pom.xml
+++ b/antlr4-testgen-maven-plugin/pom.xml
@@ -56,10 +56,6 @@
       -->
     <inceptionYear>2009</inceptionYear>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <!-- ============================================================================= -->
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <antlr.testinprocess>true</antlr.testinprocess>
-    <java.version>1.6</java.version>
+
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <mailingLists>
@@ -105,17 +107,5 @@
         <directory>test</directory>
       </testResource>
     </testResources>    
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>          
-            <source>${java.version}</source>
-            <target>${java.version}</target>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>  
 </project>


### PR DESCRIPTION
This pull request simplifies the Maven build by removing unnecessary properties

* The `project.build.sourceEncoding` property was already set to `UTF-8` by a parent POM
* The `java.version` property was unnecessarily complex, as identified during the code review for #920

/cc @jvanzyl 