### PR TITLE
Generate tests automatically during Maven builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: false
 language: java
 script:
-  - cd antlr4
   - mvn install
-  - mvn test
 jdk:
   - openjdk6
   - oraclejdk7

--- a/antlr4-testgen-maven-plugin/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/antlr4-testgen-maven-plugin/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -4,7 +4,7 @@
         <pluginExecution>
             <pluginExecutionFilter>
                 <goals>
-                    <goal>antlr4</goal>
+                    <goal>antlr4.testgen</goal>
                 </goals>
             </pluginExecutionFilter>
             <action>

--- a/antlr4-testgen-maven-plugin/src/main/java/org/antlr/mojo/antlr4/testgen/Antlr4TestGeneratorMojo.java
+++ b/antlr4-testgen-maven-plugin/src/main/java/org/antlr/mojo/antlr4/testgen/Antlr4TestGeneratorMojo.java
@@ -31,13 +31,18 @@ import org.antlr.v4.testgen.TestGenerator;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.sonatype.plexus.build.incremental.BuildContext;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 
 @Mojo(
 	name = "antlr4.testgen",
@@ -64,6 +69,9 @@ public class Antlr4TestGeneratorMojo extends AbstractMojo {
 	@Parameter
 	private boolean visualize;
 
+	@Component
+	private BuildContext buildContext;
+
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		TestGenerator testGenerator = new MavenTestGenerator(encoding, runtimeTemplates, outputDirectory, visualize);
@@ -78,6 +86,20 @@ public class Antlr4TestGeneratorMojo extends AbstractMojo {
 
 		public MavenTestGenerator(String encoding, File runtimeTemplates, File outputDirectory, boolean visualize) {
 			super(encoding, runtimeTemplates, outputDirectory, visualize);
+		}
+
+		@Override
+		public void writeFile(File file, String content) throws IOException {
+			file.getParentFile().mkdirs();
+
+			OutputStream fos = buildContext.newFileOutputStream(file);
+			OutputStreamWriter osw = new OutputStreamWriter(fos, encoding != null ? encoding : "UTF-8");
+			try {
+				osw.write(content);
+			}
+			finally {
+				osw.close();
+			}
 		}
 
 		@Override

--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -24,11 +24,6 @@
       <version>4.0.8</version>
     </dependency>
     <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
@@ -38,5 +33,6 @@
 
   <build>
     <sourceDirectory>src</sourceDirectory>
+    <testSourceDirectory>ignored</testSourceDirectory>
   </build>
 </project>

--- a/runtime-testsuite/src/org/antlr/v4/testgen/TestGenerator.java
+++ b/runtime-testsuite/src/org/antlr/v4/testgen/TestGenerator.java
@@ -263,9 +263,8 @@ public class TestGenerator {
 	public String getTargetNameFromTemplatesFileName() {
 		// runtimeTemplates is like /Users/parrt/antlr/code/antlr4/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
 		// extra target name
-		int targetEnd = runtimeTemplates.getPath().indexOf(".test.stg");
-		String targetAtEnd = runtimeTemplates.getPath().substring(0, targetEnd);
-		return targetAtEnd.substring(targetAtEnd.lastIndexOf('/') + 1);
+		int targetEnd = runtimeTemplates.getName().indexOf(".test.stg");
+		return runtimeTemplates.getName().substring(0, targetEnd);
 	}
 
 	public File getOutputDir(String templateFolder) {

--- a/runtime-testsuite/src/org/antlr/v4/testgen/TestGenerator.java
+++ b/runtime-testsuite/src/org/antlr/v4/testgen/TestGenerator.java
@@ -124,7 +124,7 @@ public class TestGenerator {
 				System.err.println(message);
 			}
 			@Override
-			public File getOutputDir(String templateFolder) {
+			public File getOutputDir() {
 				String targetName = getTargetNameFromTemplatesFileName();
 				// compute package
 				String templatePath = runtimeTemplates.getPath();
@@ -181,7 +181,7 @@ public class TestGenerator {
 	}
 
 	private void generateTestFile(STGroup index, STGroup targetGroup, String testFile, String templateFolder, Collection<String> testTemplates) {
-		File targetFolder = getOutputDir(templateFolder);
+		File targetFolder = getOutputDir();
 		File targetFile = new File(targetFolder, "Test" + testFile + ".java");
 		info("Generating file "+targetFile.getAbsolutePath());
 		List<ST> templates = new ArrayList<ST>();
@@ -267,8 +267,9 @@ public class TestGenerator {
 		return runtimeTemplates.getName().substring(0, targetEnd);
 	}
 
-	public File getOutputDir(String templateFolder) {
-		return new File(outputDirectory, templateFolder.substring(0, templateFolder.indexOf("/templates")));
+	public File getOutputDir() {
+		String basePackageDir = "org/antlr/v4/test/runtime/";
+		return new File(outputDirectory, basePackageDir + getTargetNameFromTemplatesFileName().toLowerCase());
 	}
 
 	protected void info(String message) {

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -73,6 +73,22 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr4-testgen-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>antlr4.testgen</goal>
+            </goals>
+            <configuration>
+              <runtimeTemplates>test/org/antlr/v4/test/runtime/java/Java.test.stg</runtimeTemplates>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This commit also fixes the build errors introduced in 9c57b650c1edd0a5733afabef067a71c476580f1 by excluding the pre-generated tests from the Maven build. It provides an intermediate step on the road to compiling the rest of the tests by immediately bringing the build back to a working state and allows us to leverage Travis feedback on future pull requests.

/cc @jvanzyl 