### PR TITLE
Fix NameError in LexerATNSimulator.reset()

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -75,3 +75,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/05/20, peturingi, Pétur Ingi Egilsson, petur@petur.eu
 2015/05/27, jcbrinfo, Jean-Christophe Beaupré, jcbrinfo@users.noreply.github.com
 2015/06/29, jvanzyl, Jason van Zyl, jason@takari.io
+2015/11/12, cooperra, Robbie Cooper, cooperra@users.noreply.github.com

--- a/runtime/Python3/src/antlr4/atn/LexerATNSimulator.py
+++ b/runtime/Python3/src/antlr4/atn/LexerATNSimulator.py
@@ -130,6 +130,7 @@ class LexerATNSimulator(ATNSimulator):
         self.startIndex = -1
         self.line = 1
         self.column = 0
+        from antlr4.Lexer import Lexer
         self.mode = Lexer.DEFAULT_MODE
 
     def matchATN(self, input:InputStream):


### PR DESCRIPTION
Without this line, one gets "NameError: name 'Lexer' is not defined" when calling reset(). This is the same way \__init__() assigns self.mode.