### PR TITLE
Rename org.antlr.v4.test.tool.Java-LR.g4 to JavaLR.g4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ bilder.pyc
 bild.log
 
 bild_output.txt
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ bilder.pyc
 bild.log
 
 bild_output.txt
-/bin/

--- a/contributors.txt
+++ b/contributors.txt
@@ -75,3 +75,5 @@ YYYY/MM/DD, github id, Full name, email
 2015/05/20, peturingi, Pétur Ingi Egilsson, petur@petur.eu
 2015/05/27, jcbrinfo, Jean-Christophe Beaupré, jcbrinfo@users.noreply.github.com
 2015/06/29, jvanzyl, Jason van Zyl, jason@takari.io
+2015/08/14, HSorensen, Henrik Sorensen, henrik.b.sorensen@gmail.com
+2015/08/14, nttdatahenriksorensen, Henrik Sorensen, henrik.sorensen@nttdata.com

--- a/tool-testsuite/test/org/antlr/v4/test/tool/JavaLR.g4
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/JavaLR.g4
@@ -168,7 +168,7 @@
  *      letter-or-digit is a character for which the method 
  *      Character.isJavaIdentifierPart(int) returns true."
  */
-grammar Java;
+grammar JavaLR;
 
 // starting point for parsing a java file
 /* The annotations are separated out to make parsing faster, but must be associated with

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -153,7 +153,7 @@ public class TestPerformance extends BaseTest {
 
     /**
      * {@code true} to use the Java grammar with expressions in the v4
-     * left-recursive syntax (Java-LR.g4). {@code false} to use the standard
+     * left-recursive syntax (JavaLR.g4). {@code false} to use the standard
      * grammar (Java.g4). In either case, the grammar is renamed in the
      * temporary directory to Java.g4 before compiling.
      */
@@ -415,9 +415,9 @@ public class TestPerformance extends BaseTest {
 		assertTrue("The JDK_SOURCE_ROOT environment variable must be set for performance testing.", jdkSourceRoot != null && !jdkSourceRoot.isEmpty());
 
         compileJavaParser(USE_LR_GRAMMAR);
-		final String lexerName = "JavaLexer";
-		final String parserName = "JavaParser";
-		final String listenerName = "JavaBaseListener";
+		final String lexerName    = USE_LR_GRAMMAR ? "JavaLRLexer"        : "JavaLexer";
+		final String parserName   = USE_LR_GRAMMAR ? "JavaLRParser"       : "JavaParser";
+		final String listenerName = USE_LR_GRAMMAR ? "JavaLRBaseListener" : "JavaBaseListener";
 		final String entryPoint = "compilationUnit";
         final ParserFactory factory = getParserFactory(lexerName, parserName, listenerName, entryPoint);
 
@@ -1108,8 +1108,10 @@ public class TestPerformance extends BaseTest {
 	}
 
     protected void compileJavaParser(boolean leftRecursive) throws IOException {
-        String grammarFileName = "Java.g4";
-        String sourceName = leftRecursive ? "Java-LR.g4" : "Java.g4";
+        String grammarFileName = leftRecursive ? "JavaLR.g4"    : "Java.g4";
+        String sourceName      = leftRecursive ? "JavaLR.g4"    : "Java.g4";
+        String parserName      = leftRecursive ? "JavaLRParser" : "JavaParser";
+        String lexerName       = leftRecursive ? "JavaLRLexer"  : "JavaLexer";
         String body = load(sourceName, null);
         List<String> extraOptions = new ArrayList<String>();
 		extraOptions.add("-Werror");
@@ -1127,7 +1129,7 @@ public class TestPerformance extends BaseTest {
 		}
 		extraOptions.add("-visitor");
         String[] extraOptionsArray = extraOptions.toArray(new String[extraOptions.size()]);
-        boolean success = rawGenerateAndBuildRecognizer(grammarFileName, body, "JavaParser", "JavaLexer", true, extraOptionsArray);
+        boolean success = rawGenerateAndBuildRecognizer(grammarFileName, body, parserName, lexerName, true, extraOptionsArray);
         assertTrue(success);
     }
 

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -415,10 +415,10 @@ public class TestPerformance extends BaseTest {
 		assertTrue("The JDK_SOURCE_ROOT environment variable must be set for performance testing.", jdkSourceRoot != null && !jdkSourceRoot.isEmpty());
 
         compileJavaParser(USE_LR_GRAMMAR);
-		final String lexerName    = USE_LR_GRAMMAR ? "JavaLRLexer"        : "JavaLexer";
-		final String parserName   = USE_LR_GRAMMAR ? "JavaLRParser"       : "JavaParser";
-		final String listenerName = USE_LR_GRAMMAR ? "JavaLRBaseListener" : "JavaBaseListener";
-		final String entryPoint = "compilationUnit";
+        final String lexerName    = USE_LR_GRAMMAR ? "JavaLRLexer"        : "JavaLexer";
+        final String parserName   = USE_LR_GRAMMAR ? "JavaLRParser"       : "JavaParser";
+        final String listenerName = USE_LR_GRAMMAR ? "JavaLRBaseListener" : "JavaBaseListener";
+        final String entryPoint = "compilationUnit";
         final ParserFactory factory = getParserFactory(lexerName, parserName, listenerName, entryPoint);
 
 		if (!TOP_PACKAGE.isEmpty()) {

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -1109,10 +1109,9 @@ public class TestPerformance extends BaseTest {
 
     protected void compileJavaParser(boolean leftRecursive) throws IOException {
         String grammarFileName = leftRecursive ? "JavaLR.g4"    : "Java.g4";
-        String sourceName      = leftRecursive ? "JavaLR.g4"    : "Java.g4";
         String parserName      = leftRecursive ? "JavaLRParser" : "JavaParser";
         String lexerName       = leftRecursive ? "JavaLRLexer"  : "JavaLexer";
-        String body = load(sourceName, null);
+        String body = load(grammarFileName, null);
         List<String> extraOptions = new ArrayList<String>();
 		extraOptions.add("-Werror");
         if (FORCE_ATN) {


### PR DESCRIPTION
Eclipse AntlrIDE reports a syntax error in the tool-testsuite/test directroy for one file Java-LR.g4.

Rename the file from Java-LR.g4 to JavaLR.g4 and adjust the grammar statement accordingly.