### PR TITLE
Include files while scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ bilder.pyc
 bild.log
 
 bild_output.txt
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ bilder.pyc
 bild.log
 
 bild_output.txt
-/bin/

--- a/contributors.txt
+++ b/contributors.txt
@@ -75,3 +75,5 @@ YYYY/MM/DD, github id, Full name, email
 2015/05/20, peturingi, Pétur Ingi Egilsson, petur@petur.eu
 2015/05/27, jcbrinfo, Jean-Christophe Beaupré, jcbrinfo@users.noreply.github.com
 2015/06/29, jvanzyl, Jason van Zyl, jason@takari.io
+2015/08/14, HSorensen, Henrik Sorensen, henrik.b.sorensen@gmail.com
+2015/08/14, nttdatahenriksorensen, Henrik Sorensen, henrik.sorensen@nttdata.com

--- a/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
@@ -531,7 +531,6 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 		_lexerScannerStateStack.push(stackItem);
 		
 		// open _includeFileName ...
-		// should just be a new file. Lexer will keep track of files included.
 		CharStream newfile = _lexerScannerIncludeSource.embedSource(_includeFileName,_includeSubstFrom,_includeSubstTo);
 		this._input = newfile;
         this._tokenFactorySourcePair = new Pair<TokenSource, CharStream>(this, _input);
@@ -541,7 +540,7 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 	
 	/**
 	 * Set how the lexer handle inclusion of source code.
-	 * @param lsis
+	 * @param LexerScannerIncludeSource
 	 */
 	public void setLexerScannerIncludeSource( LexerScannerIncludeSource lsis) {_lexerScannerIncludeSource=lsis;}
 	

--- a/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
@@ -512,7 +512,11 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 		}
 		LexerScannerStateStackItem stackItem ;
 		stackItem=_lexerScannerStateStack.pop();
+		// close current input stream before continuing
+		// this._input.close();
 		// restore _input and _tokenFactorySourcePair
+		//this._input=stackItem.getInput();
+		//this._tokenFactorySourcePair=stackItem.getTokenFactorySourcePair();
 	}
 
 	/**
@@ -525,6 +529,14 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 		
 		LexerScannerStateStackItem stackItem = new LexerScannerStateStackItem(_input, _tokenFactorySourcePair);
 		_lexerScannerStateStack.push(stackItem);
+		
+		// if (this._input instanceof ANTLRInputStream) {} 
+		
+		// open _includeFileName ...
+		//this._input = ...
+        //this._tokenFactorySourcePair = new Pair<TokenSource, CharStream>(this, _input);
+        //this._input.seek(0); // ensure position is set
+        //getInterpreter().reset();
 	}
 
 

--- a/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
@@ -507,6 +507,9 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 	 * Retrieve old lexer state and make it the current state.
 	 */
 	public void popLexerScannerState() {
+		if (_lexerScannerStateStack.isEmpty() == true) {
+			throw new IllegalStateException("popLexerScanner cannot operate on empty stack.");
+		}
 		LexerScannerStateStackItem stackItem ;
 		stackItem=_lexerScannerStateStack.pop();
 		// restore _input and _tokenFactorySourcePair
@@ -516,6 +519,10 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 	 * Store current lexer state, and open new file for input.
 	 */
 	public void pushLexerScannerState() {
+		if (_hitInclude == false) {
+			throw new IllegalStateException("pushLexerScanner requires performIncludeSourceFile action.");
+		}
+		
 		LexerScannerStateStackItem stackItem = new LexerScannerStateStackItem(_input, _tokenFactorySourcePair);
 		_lexerScannerStateStack.push(stackItem);
 	}

--- a/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
@@ -526,10 +526,6 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 			throw new IllegalStateException("pushLexerScanner requires performIncludeSourceFile action.");
 		}
 		
-		if (this._input instanceof ANTLRFileStream == false) {
-			throw new IllegalStateException("pushLexerScanner requires input to be ANTLRFileStream.");
-		} 
-
 		// store current lexer scanner state
 		LexerScannerStateStackItem stackItem = new LexerScannerStateStackItem(_input, _tokenFactorySourcePair);
 		_lexerScannerStateStack.push(stackItem);

--- a/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
@@ -527,6 +527,10 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 			throw new IllegalStateException("pushLexerScanner requires performIncludeSourceFile action.");
 		}
 		
+		if (this._input instanceof ANTLRInputStream == false) {
+			throw new IllegalStateException("pushLexerScanner requires input to be ANTLRInputStream.");
+		} 
+
 		LexerScannerStateStackItem stackItem = new LexerScannerStateStackItem(_input, _tokenFactorySourcePair);
 		_lexerScannerStateStack.push(stackItem);
 		

--- a/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
@@ -106,11 +106,11 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 	
 	
 	/** 
-	 * Keep track of lexer states.
+	 * Keep track of lexerScanner states.
 	 * Needed to handling grammars that allow to include 
-	 * content into the current scanning. 
+	 * new content into the current scanning stream. 
 	 */
-	public final Stack<?> _lexerStateStack = new Stack(); 
+	public final Stack<LexerScannerStateStackItem> _lexerScannerStateStack = new Stack<LexerScannerStateStackItem>(); 
 	
 	/** The channel number for the current token */
 	public int _channel;
@@ -171,8 +171,8 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 			while (true) {
 				if (_hitEOF) {
 					// check if any input has been stacked
-					if (!_lexerStateStack.isEmpty()) {
-						popLexerState( );
+					if (!_lexerScannerStateStack.isEmpty()) {
+						popLexerScannerState( );
 						_hitEOF = false;
 					} else {
 						emitEOF();
@@ -182,7 +182,7 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 
 				if (_hitInclude) {
 					// store current lexer state, and open _includeFileName for reading.
-					pushLexerState( );
+					pushLexerScannerState( );
 					_hitInclude=false;					
 				}
 				
@@ -506,13 +506,18 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 	/**
 	 * Retrieve old lexer state and make it the current state.
 	 */
-	public void popLexerState() {
+	public void popLexerScannerState() {
+		LexerScannerStateStackItem stackItem ;
+		stackItem=_lexerScannerStateStack.pop();
+		// restore _input and _tokenFactorySourcePair
 	}
 
 	/**
 	 * Store current lexer state, and open new file for input.
 	 */
-	public void pushLexerState() {
+	public void pushLexerScannerState() {
+		LexerScannerStateStackItem stackItem = new LexerScannerStateStackItem(_input, _tokenFactorySourcePair);
+		_lexerScannerStateStack.push(stackItem);
 	}
 
 

--- a/runtime/Java/src/org/antlr/v4/runtime/LexerScannerIncludeSource.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/LexerScannerIncludeSource.java
@@ -1,0 +1,8 @@
+package org.antlr.v4.runtime;
+
+public interface LexerScannerIncludeSource {
+	
+	public CharStream embedSource(String fileName, String substituteFrom, String substituteTo);
+	
+
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/LexerScannerIncludeSourceImpl.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/LexerScannerIncludeSourceImpl.java
@@ -1,0 +1,25 @@
+package org.antlr.v4.runtime;
+
+import java.io.IOException;
+
+public class LexerScannerIncludeSourceImpl implements LexerScannerIncludeSource {
+
+	@Override
+	public CharStream embedSource(String fileName, String substituteFrom,String substituteTo) {
+		ANTLRInputStream istrm=null;
+		try {
+			istrm = new ANTLRFileStream(fileName);
+			if (substituteFrom != null) {
+				String beforeStream = String.copyValueOf(istrm.data, 0,istrm.size());
+				String replacedStream = beforeStream.replaceAll(substituteFrom,substituteTo);
+				istrm = new ANTLRInputStream(replacedStream);
+			}
+		} catch (IOException e) {
+			//TODO: Add error handling
+			e.printStackTrace();
+		}
+		
+		return istrm;
+	}
+
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/LexerScannerStateStackItem.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/LexerScannerStateStackItem.java
@@ -1,0 +1,20 @@
+package org.antlr.v4.runtime;
+
+//import org.antlr.v4.runtime.atn.LexerATNSimulatorState;
+import org.antlr.v4.runtime.misc.Pair;
+
+public class LexerScannerStateStackItem {
+	private CharStream input;
+    private Pair<TokenSource, CharStream> tokenFactorySourcePair;
+    //private Integer streamRef;
+    //private LexerATNSimulatorState lexerATNSimulatorState;
+    
+	public LexerScannerStateStackItem(CharStream input,
+			Pair<TokenSource, CharStream> tokenFactorySourcePair) {
+		this.input = input;
+		this.tokenFactorySourcePair = tokenFactorySourcePair;
+	}
+
+	public CharStream getInput() {return input;}
+	public Pair<TokenSource, CharStream> getTokenFactorySourcePair() {return tokenFactorySourcePair;}
+}

--- a/tool-testsuite/test/org/antlr/v4/test/tool/JavaLR.g4
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/JavaLR.g4
@@ -168,7 +168,7 @@
  *      letter-or-digit is a character for which the method 
  *      Character.isJavaIdentifierPart(int) returns true."
  */
-grammar Java;
+grammar JavaLR;
 
 // starting point for parsing a java file
 /* The annotations are separated out to make parsing faster, but must be associated with

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
@@ -13,7 +13,7 @@ public class TestLexerIncludeActions extends BaseTest {
 
 	@Test public void testActionPerformIncludeSourceFile() throws Exception {
 		// prepare test files
-		String path="c:/temp/"; //TODO: use tmpdir variable
+		String path="/tmp/"; //TODO: use tmpdir variable
 		String fn[] = {"test_#0.test","test_#1.test"};
 		File f[] = {new File(path+fn[0]),new File(path+fn[1])};
 		FileWriter f0=new FileWriter(f[0]);
@@ -26,7 +26,7 @@ public class TestLexerIncludeActions extends BaseTest {
 		String grammar =
 			"lexer grammar L;\n"+
 			"I : 'A'..'Z' {} ;\n"+
-			"CP: '#' ('0'|'1') { performIncludeSourceFile( \"c:/temp/test_\"+getText()+\".test\" ); skip(); };\n" +
+			"CP: '#' ('0'|'1') { performIncludeSourceFile( \"/tmp/test_\"+getText()+\".test\" ); skip(); };\n" +
 			"WS: (' '|'\\n') -> skip ;";
 		String found = execLexer("L.g4", grammar, "L", "A B C D #0 N O P");
 		

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
@@ -1,0 +1,51 @@
+package org.antlr.v4.test.tool;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import org.antlr.v4.test.runtime.java.BaseTest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestLexerIncludeActions extends BaseTest {
+	// ----- ACTIONS --------------------------------------------------------
+
+	@Test public void testActionPerformIncludeSourceFile() throws Exception {
+		// prepare test files
+		String fn[] = {"test_Z0.test","test_Z1.test"};
+		File f[] = {new File(fn[0]),new File(fn[1])};
+		FileWriter f0=new FileWriter(f[0]);
+		FileWriter f1=new FileWriter(f[1]);
+		f0.write("E F G Z2 L M");
+		f0.close();
+		f1.write("H I J K");
+		f1.close();
+
+		String grammar =
+			"lexer grammar L;\n"+
+			"I : 'A'..'Z' {} ;\n"+
+			"CP: 'Z' ('0'|'1') { performIncludeSourceFile( \"test_\"+getText()+\".test\" ); skip(); };\n" +
+			"WS : (' '|'\\n') -> skip ;";
+		String found = execLexer("L.g4", grammar, "L", "A B C D Z1 N O P");
+		
+		// clean up test files
+		f[0].delete();
+		f[1].delete();
+
+		String expecting =
+			"[@0,0:0='A',<1>,1:0]\n" +
+			"[@1,2:2='B',<1>,1:2]\n" +
+			"[@2,4:4='C',<1>,1:4]\n" +
+			"[@3,6:6='D',<1>,1:6]\n" +
+			"[@4,11:11='N',<1>,1:11]\n" +
+			"[@5,13:13='O',<1>,1:13]\n" +
+			"[@6,15:15='P',<1>,1:15]\n" +
+			"[@7,16:15='<EOF>',<-1>,1:16]\n"
+					;
+		assertEquals(expecting, found);
+
+		
+	}
+
+}

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
@@ -13,11 +13,11 @@ public class TestLexerIncludeActions extends BaseTest {
 
 	@Test public void testActionPerformIncludeSourceFile() throws Exception {
 		// prepare test files
-		String fn[] = {"test_Z0.test","test_Z1.test"};
+		String fn[] = {"test_#0.test","test_#1.test"};
 		File f[] = {new File(fn[0]),new File(fn[1])};
 		FileWriter f0=new FileWriter(f[0]);
 		FileWriter f1=new FileWriter(f[1]);
-		f0.write("E F G Z2 L M");
+		f0.write("E F G #1 L M");
 		f0.close();
 		f1.write("H I J K");
 		f1.close();
@@ -25,9 +25,9 @@ public class TestLexerIncludeActions extends BaseTest {
 		String grammar =
 			"lexer grammar L;\n"+
 			"I : 'A'..'Z' {} ;\n"+
-			"CP: 'Z' ('0'|'1') { performIncludeSourceFile( \"test_\"+getText()+\".test\" ); skip(); };\n" +
+			"CP: '#' ('0'|'1') { performIncludeSourceFile( \"test_\"+getText()+\".test\" ); skip(); };\n" +
 			"WS : (' '|'\\n') -> skip ;";
-		String found = execLexer("L.g4", grammar, "L", "A B C D Z1 N O P");
+		String found = execLexer("L.g4", grammar, "L", "A B C D #0 N O P");
 		
 		// clean up test files
 		f[0].delete();

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
@@ -13,7 +13,7 @@ public class TestLexerIncludeActions extends BaseTest {
 
 	@Test public void testActionPerformIncludeSourceFile() throws Exception {
 		// prepare test files
-		String path="c:/temp/";
+		String path="c:/temp/"; //TODO: use tmpdir variable
 		String fn[] = {"test_#0.test","test_#1.test"};
 		File f[] = {new File(path+fn[0]),new File(path+fn[1])};
 		FileWriter f0=new FileWriter(f[0]);
@@ -56,8 +56,52 @@ public class TestLexerIncludeActions extends BaseTest {
 			"[@16,16:15='<EOF>',<-1>,1:17]\n"
 					;
 		assertEquals(expecting, found);
-
-		
 	}
 
+	@Test public void testActionPerformIncludeSourceFileSubstitute() throws Exception {
+		// prepare test files
+		String path="c:/temp/";
+		String fn[] = {"test_#0.test","test_#1.test"};
+		File f[] = {new File(path+fn[0]),new File(path+fn[1])};
+		FileWriter f0=new FileWriter(f[0]);
+		FileWriter f1=new FileWriter(f[1]);
+		f0.write("Z F G #1 L M");
+		f0.close();
+		f1.write("H I J K");
+		f1.close();
+
+		String grammar =
+			"lexer grammar L;\n"+
+			"I : 'A'..'Z' {} ;\n"+
+			"CP: '#' ('0'|'1') { performIncludeSourceFile( \"c:/temp/test_\"+getText()+\".test\", \"Z\", \"E\" ); skip(); };\n" +
+			"WS: (' '|'\\n') -> skip ;";
+		String found = execLexer("L.g4", grammar, "L", "A B C D #0 N O P");
+		
+		System.err.println("lexer found>"+found+"<");
+		
+		// clean up test files
+		f[0].delete();
+		f[1].delete();
+
+		String expecting =
+			"[@0,0:0='A',<1>,1:0]\n"+
+			"[@1,2:2='B',<1>,1:2]\n"+
+			"[@2,4:4='C',<1>,1:4]\n"+
+			"[@3,6:6='D',<1>,1:6]\n"+
+			"[@4,0:0='E',<1>,1:0]\n"+
+			"[@5,2:2='F',<1>,1:2]\n"+
+			"[@6,4:4='G',<1>,1:4]\n"+
+			"[@7,0:0='H',<1>,1:0]\n"+
+			"[@8,2:2='I',<1>,1:2]\n"+
+			"[@9,4:4='J',<1>,1:4]\n"+
+			"[@10,6:6='K',<1>,1:6]\n"+
+			"[@11,9:9='L',<1>,1:8]\n"+
+			"[@12,11:11='M',<1>,1:10]\n"+
+			"[@13,11:11='N',<1>,1:12]\n"+
+			"[@14,13:13='O',<1>,1:14]\n"+
+			"[@15,15:15='P',<1>,1:16]\n"+
+			"[@16,16:15='<EOF>',<-1>,1:17]\n"
+					;
+		assertEquals(expecting, found);
+	}
 }

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
@@ -13,7 +13,7 @@ public class TestLexerIncludeActions extends BaseTest {
 
 	@Test public void testActionPerformIncludeSourceFile() throws Exception {
 		// prepare test files
-		String path="/tmp/"; //TODO: use tmpdir variable
+		String path=BASE_TEST_DIR.replace('\\', '/') ;
 		String fn[] = {"test_#0.test","test_#1.test"};
 		File f[] = {new File(path+fn[0]),new File(path+fn[1])};
 		FileWriter f0=new FileWriter(f[0]);
@@ -26,7 +26,7 @@ public class TestLexerIncludeActions extends BaseTest {
 		String grammar =
 			"lexer grammar L;\n"+
 			"I : 'A'..'Z' {} ;\n"+
-			"CP: '#' ('0'|'1') { performIncludeSourceFile( \"/tmp/test_\"+getText()+\".test\" ); skip(); };\n" +
+			"CP: '#' ('0'|'1') { performIncludeSourceFile(\""+path+"test_\"+getText()+\".test\" ); skip(); };\n" +
 			"WS: (' '|'\\n') -> skip ;";
 		String found = execLexer("L.g4", grammar, "L", "A B C D #0 N O P");
 		
@@ -60,7 +60,7 @@ public class TestLexerIncludeActions extends BaseTest {
 
 	@Test public void testActionPerformIncludeSourceFileSubstitute() throws Exception {
 		// prepare test files
-		String path="c:/temp/";
+		String path=BASE_TEST_DIR.replace('\\', '/') ;
 		String fn[] = {"test_#0.test","test_#1.test"};
 		File f[] = {new File(path+fn[0]),new File(path+fn[1])};
 		FileWriter f0=new FileWriter(f[0]);
@@ -73,7 +73,7 @@ public class TestLexerIncludeActions extends BaseTest {
 		String grammar =
 			"lexer grammar L;\n"+
 			"I : 'A'..'Z' {} ;\n"+
-			"CP: '#' ('0'|'1') { performIncludeSourceFile( \"c:/temp/test_\"+getText()+\".test\", \"Z\", \"E\" ); skip(); };\n" +
+			"CP: '#' ('0'|'1') { performIncludeSourceFile(\""+path+"test_\"+getText()+\".test\", \"Z\", \"E\" ); skip(); };\n" +
 			"WS: (' '|'\\n') -> skip ;";
 		String found = execLexer("L.g4", grammar, "L", "A B C D #0 N O P");
 		

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
@@ -13,7 +13,7 @@ public class TestLexerIncludeActions extends BaseTest {
 
 	@Test public void testActionPerformIncludeSourceFile() throws Exception {
 		// prepare test files
-		String path=BASE_TEST_DIR.replace('\\', '/') ;
+		String path=BASE_TEST_DIR.replace('\\', '/') +"/";
 		String fn[] = {"test_#0.test","test_#1.test"};
 		File f[] = {new File(path+fn[0]),new File(path+fn[1])};
 		FileWriter f0=new FileWriter(f[0]);
@@ -60,7 +60,7 @@ public class TestLexerIncludeActions extends BaseTest {
 
 	@Test public void testActionPerformIncludeSourceFileSubstitute() throws Exception {
 		// prepare test files
-		String path=BASE_TEST_DIR.replace('\\', '/') ;
+		String path=BASE_TEST_DIR.replace('\\', '/') +"/" ;
 		String fn[] = {"test_#0.test","test_#1.test"};
 		File f[] = {new File(path+fn[0]),new File(path+fn[1])};
 		FileWriter f0=new FileWriter(f[0]);

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestLexerIncludeActions.java
@@ -13,8 +13,9 @@ public class TestLexerIncludeActions extends BaseTest {
 
 	@Test public void testActionPerformIncludeSourceFile() throws Exception {
 		// prepare test files
+		String path="c:/temp/";
 		String fn[] = {"test_#0.test","test_#1.test"};
-		File f[] = {new File(fn[0]),new File(fn[1])};
+		File f[] = {new File(path+fn[0]),new File(path+fn[1])};
 		FileWriter f0=new FileWriter(f[0]);
 		FileWriter f1=new FileWriter(f[1]);
 		f0.write("E F G #1 L M");
@@ -25,23 +26,34 @@ public class TestLexerIncludeActions extends BaseTest {
 		String grammar =
 			"lexer grammar L;\n"+
 			"I : 'A'..'Z' {} ;\n"+
-			"CP: '#' ('0'|'1') { performIncludeSourceFile( \"test_\"+getText()+\".test\" ); skip(); };\n" +
-			"WS : (' '|'\\n') -> skip ;";
+			"CP: '#' ('0'|'1') { performIncludeSourceFile( \"c:/temp/test_\"+getText()+\".test\" ); skip(); };\n" +
+			"WS: (' '|'\\n') -> skip ;";
 		String found = execLexer("L.g4", grammar, "L", "A B C D #0 N O P");
+		
+		System.err.println("lexer found>"+found+"<");
 		
 		// clean up test files
 		f[0].delete();
 		f[1].delete();
 
 		String expecting =
-			"[@0,0:0='A',<1>,1:0]\n" +
-			"[@1,2:2='B',<1>,1:2]\n" +
-			"[@2,4:4='C',<1>,1:4]\n" +
-			"[@3,6:6='D',<1>,1:6]\n" +
-			"[@4,11:11='N',<1>,1:11]\n" +
-			"[@5,13:13='O',<1>,1:13]\n" +
-			"[@6,15:15='P',<1>,1:15]\n" +
-			"[@7,16:15='<EOF>',<-1>,1:16]\n"
+			"[@0,0:0='A',<1>,1:0]\n"+
+			"[@1,2:2='B',<1>,1:2]\n"+
+			"[@2,4:4='C',<1>,1:4]\n"+
+			"[@3,6:6='D',<1>,1:6]\n"+
+			"[@4,0:0='E',<1>,1:0]\n"+
+			"[@5,2:2='F',<1>,1:2]\n"+
+			"[@6,4:4='G',<1>,1:4]\n"+
+			"[@7,0:0='H',<1>,1:0]\n"+
+			"[@8,2:2='I',<1>,1:2]\n"+
+			"[@9,4:4='J',<1>,1:4]\n"+
+			"[@10,6:6='K',<1>,1:6]\n"+
+			"[@11,9:9='L',<1>,1:8]\n"+
+			"[@12,11:11='M',<1>,1:10]\n"+
+			"[@13,11:11='N',<1>,1:12]\n"+
+			"[@14,13:13='O',<1>,1:14]\n"+
+			"[@15,15:15='P',<1>,1:16]\n"+
+			"[@16,16:15='<EOF>',<-1>,1:17]\n"
 					;
 		assertEquals(expecting, found);
 

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -153,7 +153,7 @@ public class TestPerformance extends BaseTest {
 
     /**
      * {@code true} to use the Java grammar with expressions in the v4
-     * left-recursive syntax (Java-LR.g4). {@code false} to use the standard
+     * left-recursive syntax (JavaLR.g4). {@code false} to use the standard
      * grammar (Java.g4). In either case, the grammar is renamed in the
      * temporary directory to Java.g4 before compiling.
      */
@@ -415,9 +415,9 @@ public class TestPerformance extends BaseTest {
 		assertTrue("The JDK_SOURCE_ROOT environment variable must be set for performance testing.", jdkSourceRoot != null && !jdkSourceRoot.isEmpty());
 
         compileJavaParser(USE_LR_GRAMMAR);
-		final String lexerName = "JavaLexer";
-		final String parserName = "JavaParser";
-		final String listenerName = "JavaBaseListener";
+		final String lexerName    = USE_LR_GRAMMAR ? "JavaLRLexer"        : "JavaLexer";
+		final String parserName   = USE_LR_GRAMMAR ? "JavaLRParser"       : "JavaParser";
+		final String listenerName = USE_LR_GRAMMAR ? "JavaLRBaseListener" : "JavaBaseListener";
 		final String entryPoint = "compilationUnit";
         final ParserFactory factory = getParserFactory(lexerName, parserName, listenerName, entryPoint);
 
@@ -1108,8 +1108,10 @@ public class TestPerformance extends BaseTest {
 	}
 
     protected void compileJavaParser(boolean leftRecursive) throws IOException {
-        String grammarFileName = "Java.g4";
-        String sourceName = leftRecursive ? "Java-LR.g4" : "Java.g4";
+        String grammarFileName = leftRecursive ? "JavaLR.g4"    : "Java.g4";
+        String sourceName      = leftRecursive ? "JavaLR.g4"    : "Java.g4";
+        String parserName      = leftRecursive ? "JavaLRParser" : "JavaParser";
+        String lexerName       = leftRecursive ? "JavaLRLexer"  : "JavaLexer";
         String body = load(sourceName, null);
         List<String> extraOptions = new ArrayList<String>();
 		extraOptions.add("-Werror");
@@ -1127,7 +1129,7 @@ public class TestPerformance extends BaseTest {
 		}
 		extraOptions.add("-visitor");
         String[] extraOptionsArray = extraOptions.toArray(new String[extraOptions.size()]);
-        boolean success = rawGenerateAndBuildRecognizer(grammarFileName, body, "JavaParser", "JavaLexer", true, extraOptionsArray);
+        boolean success = rawGenerateAndBuildRecognizer(grammarFileName, body, parserName, lexerName, true, extraOptionsArray);
         assertTrue(success);
     }
 

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -415,10 +415,10 @@ public class TestPerformance extends BaseTest {
 		assertTrue("The JDK_SOURCE_ROOT environment variable must be set for performance testing.", jdkSourceRoot != null && !jdkSourceRoot.isEmpty());
 
         compileJavaParser(USE_LR_GRAMMAR);
-		final String lexerName    = USE_LR_GRAMMAR ? "JavaLRLexer"        : "JavaLexer";
-		final String parserName   = USE_LR_GRAMMAR ? "JavaLRParser"       : "JavaParser";
-		final String listenerName = USE_LR_GRAMMAR ? "JavaLRBaseListener" : "JavaBaseListener";
-		final String entryPoint = "compilationUnit";
+        final String lexerName    = USE_LR_GRAMMAR ? "JavaLRLexer"        : "JavaLexer";
+        final String parserName   = USE_LR_GRAMMAR ? "JavaLRParser"       : "JavaParser";
+        final String listenerName = USE_LR_GRAMMAR ? "JavaLRBaseListener" : "JavaBaseListener";
+        final String entryPoint = "compilationUnit";
         final ParserFactory factory = getParserFactory(lexerName, parserName, listenerName, entryPoint);
 
 		if (!TOP_PACKAGE.isEmpty()) {

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -1109,10 +1109,9 @@ public class TestPerformance extends BaseTest {
 
     protected void compileJavaParser(boolean leftRecursive) throws IOException {
         String grammarFileName = leftRecursive ? "JavaLR.g4"    : "Java.g4";
-        String sourceName      = leftRecursive ? "JavaLR.g4"    : "Java.g4";
         String parserName      = leftRecursive ? "JavaLRParser" : "JavaParser";
         String lexerName       = leftRecursive ? "JavaLRLexer"  : "JavaLexer";
-        String body = load(sourceName, null);
+        String body = load(grammarFileName, null);
         List<String> extraOptions = new ArrayList<String>();
 		extraOptions.add("-Werror");
         if (FORCE_ATN) {


### PR DESCRIPTION
Yet another attempt to enable antlr to include additional files while scanning a source file.
Look at the provided JUnit for an example.

Comments and feedback is definitely needed.
Suggestions to better names etc.

Still todo: token location tracking is relative to the current file being read. This needs to be reflected when printing the token information.