### PR TITLE
Added proper visit function in ParseTreeVisitor

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -75,3 +75,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/05/20, peturingi, Pétur Ingi Egilsson, petur@petur.eu
 2015/05/27, jcbrinfo, Jean-Christophe Beaupré, jcbrinfo@users.noreply.github.com
 2015/06/29, jvanzyl, Jason van Zyl, jason@takari.io
+2015/08/18, krzkaczor, Krzysztof Kaczor, krzysztof@kaczor.io

--- a/runtime/JavaScript/src/antlr4/FileStream.js
+++ b/runtime/JavaScript/src/antlr4/FileStream.js
@@ -34,7 +34,7 @@
 //  when you construct the object.
 // 
 var InputStream = require('./InputStream').InputStream;
-var isNodeJs = typeof window === 'undefined' && typeof(importScripts) === 'undefined';
+var isNodeJs = typeof window === 'undefined' && importScripts === 'undefined';
 var fs = isNodeJs ? require("fs") : null;
 
 function FileStream(fileName) {

--- a/runtime/JavaScript/src/antlr4/FileStream.js
+++ b/runtime/JavaScript/src/antlr4/FileStream.js
@@ -34,7 +34,7 @@
 //  when you construct the object.
 // 
 var InputStream = require('./InputStream').InputStream;
-var isNodeJs = typeof window === 'undefined' && importScripts === 'undefined';
+var isNodeJs = typeof window === 'undefined' && typeof(importScripts) === 'undefined';
 var fs = isNodeJs ? require("fs") : null;
 
 function FileStream(fileName) {

--- a/runtime/JavaScript/src/antlr4/Utils.js
+++ b/runtime/JavaScript/src/antlr4/Utils.js
@@ -191,6 +191,13 @@ function escapeWhitespace(s, escapeSpaces) {
 	return s;
 }
 
+exports.isArray = function (entity) {
+	return Object.prototype.toString.call( entity ) === '[object Array]'
+};
+
+exports.titleCase = function(str) {
+	return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1);});
+};
 
 exports.Set = Set;
 exports.BitSet = BitSet;

--- a/runtime/JavaScript/src/antlr4/tree/Tree.js
+++ b/runtime/JavaScript/src/antlr4/tree/Tree.js
@@ -35,6 +35,8 @@
 var Token = require('./../Token').Token;
 var Interval = require('./../IntervalSet').Interval;
 var INVALID_INTERVAL = new Interval(-1, -2);
+var Utils = require('../Utils.js');
+
 
 function Tree() {
 	return this;
@@ -83,6 +85,26 @@ ErrorNode.prototype.constructor = ErrorNode;
 function ParseTreeVisitor() {
 	return this;
 }
+
+ParseTreeVisitor.prototype.visit = function(ctx) {
+	if (Utils.isArray(ctx)) {
+		var self = this;
+		return ctx.map(function(child) { return visitAtom(self, child)});
+	} else {
+		return visitAtom(this, ctx);
+	}
+};
+
+var visitAtom = function(visitor, ctx) {
+	if (ctx.parser === undefined) { //is terminal
+		return;
+	}
+
+	var name = ctx.parser.ruleNames[ctx.ruleIndex];
+	var funcName = "visit" + Utils.titleCase(name);
+
+	return visitor[funcName](ctx);
+};
 
 function ParseTreeListener() {
 	return this;


### PR DESCRIPTION
It provides proper implementation for visit function which is essential for visitors. It fires appropriate visit function in visitors. It behaves in the same way as java implementation.

I have also fixed bug that prevented running runtime on nodejs. There is no importScripts symbol in scope so JS throws exception - we need to use typeof operator to avoid it.