### PR TITLE
ANTLRFileStream,java: field fileName

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/ANTLRFileStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ANTLRFileStream.java
@@ -38,26 +38,22 @@ import java.io.IOException;
  * when you construct the object.
  */
 public class ANTLRFileStream extends ANTLRInputStream {
-	protected String fileName;
-
+	private String encoding;
+	
 	public ANTLRFileStream(String fileName) throws IOException {
 		this(fileName, null);
 	}
 
 	public ANTLRFileStream(String fileName, String encoding) throws IOException {
-		this.fileName = fileName;
-		load(fileName, encoding);
+		this.name = fileName;
+		this.encoding=encoding;
+		load();
 	}
 
-	public void load(String fileName, String encoding)
+	private void load()
 		throws IOException
 	{
-		data = Utils.readFile(fileName, encoding);
+		data = Utils.readFile(this.name, this.encoding);
 		this.n = data.length;
-	}
-
-	@Override
-	public String getSourceName() {
-		return fileName;
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/ANTLRFileStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ANTLRFileStream.java
@@ -38,22 +38,32 @@ import java.io.IOException;
  * when you construct the object.
  */
 public class ANTLRFileStream extends ANTLRInputStream {
+	@Deprecated
+	protected String fileName;
 	private String encoding;
-	
+
 	public ANTLRFileStream(String fileName) throws IOException {
 		this(fileName, null);
 	}
 
 	public ANTLRFileStream(String fileName, String encoding) throws IOException {
-		this.name = fileName;
+		this.fileName = fileName;
+		this.name=fileName;
 		this.encoding=encoding;
 		load();
 	}
 
-	private void load()
+	@Deprecated
+	public void load(String fileName, String encoding)
 		throws IOException
 	{
-		data = Utils.readFile(this.name, this.encoding);
+		data = Utils.readFile(fileName, encoding);
 		this.n = data.length;
 	}
+
+	public void load() throws IOException
+		{
+			this.data = Utils.readFile(this.name, this.encoding);
+			this.n = data.length;
+		}
 }


### PR DESCRIPTION
Simplify ANTLRFileStream by using the field "name" for super class ANTLRInputStream
* Change field fileName to use the field name from ANTLRInputStream.
* Change load( ) method to private
* Remove getSourceName()