### PR TITLE
#999: Using unicode(c) instead of str(c) to avoid exception when unic…

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -75,3 +75,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/05/20, peturingi, Pétur Ingi Egilsson, petur@petur.eu
 2015/05/27, jcbrinfo, Jean-Christophe Beaupré, jcbrinfo@users.noreply.github.com
 2015/06/29, jvanzyl, Jason van Zyl, jason@takari.io
+2015/09/18, worsht, Rajiv Subrahmanyam, rajiv.public@gmail.com

--- a/runtime/Python2/src/antlr4/Lexer.py
+++ b/runtime/Python2/src/antlr4/Lexer.py
@@ -320,7 +320,7 @@ class Lexer(Recognizer, TokenSource):
         elif c=='\r':
             return "\\r"
         else:
-            return str(c)
+            return unicode(c)
 
     def getCharErrorDisplay(self, c):
         return "'" + self.getErrorDisplayForChar(c) + "'"


### PR DESCRIPTION
…ode string contains high byte chars