### PR TITLE
Update doc comment in C# base listener and visitor classes

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -77,4 +77,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/06/29, jvanzyl, Jason van Zyl, jason@takari.io
 2015/08/18, krzkaczor, Krzysztof Kaczor, krzysztof@kaczor.io
 2015/09/18, worsht, Rajiv Subrahmanyam, rajiv.public@gmail.com
-2015/10/06, brwml, Bryan Wilhelm, bryan.wilhelm@live.com
+2015/10/06, brwml, Bryan Wilhelm, bryan.wilhelm@microsoft.com

--- a/contributors.txt
+++ b/contributors.txt
@@ -77,3 +77,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/06/29, jvanzyl, Jason van Zyl, jason@takari.io
 2015/08/18, krzkaczor, Krzysztof Kaczor, krzysztof@kaczor.io
 2015/09/18, worsht, Rajiv Subrahmanyam, rajiv.public@gmail.com
+2015/10/06, brwml, Bryan Wilhelm, bryan.wilhelm@live.com

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -73,7 +73,7 @@ public interface I<file.grammarName>Listener : IParseTreeListener {
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Enter a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
 <else>
 /// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
@@ -83,7 +83,7 @@ void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lnam
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Exit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
 <else>
 /// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
@@ -121,7 +121,7 @@ public partial class <file.grammarName>BaseListener : I<file.grammarName>Listene
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Enter a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
 <else>
 /// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
@@ -132,7 +132,7 @@ public virtual void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.par
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Exit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
 <else>
 /// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
@@ -181,7 +181,7 @@ public interface I<file.grammarName>Visitor\<Result> : IParseTreeVisitor\<Result
 /// \<summary>
 <if(file.visitorLabelRuleNames.(lname))>
 /// Visit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>()"/>.
 <else>
 /// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
@@ -219,7 +219,7 @@ public partial class <file.grammarName>BaseVisitor\<Result> : AbstractParseTreeV
 /// \<summary>
 <if(file.visitorLabelRuleNames.(lname))>
 /// Visit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>()"/>.
 <else>
 /// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -73,9 +73,9 @@ public interface I<file.grammarName>Listener : IParseTreeListener {
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Enter a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
 <else>
-/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -83,9 +83,9 @@ void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lnam
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Exit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
 <else>
-/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -121,9 +121,9 @@ public partial class <file.grammarName>BaseListener : I<file.grammarName>Listene
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Enter a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
 <else>
-/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
@@ -132,9 +132,9 @@ public virtual void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.par
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Exit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
 <else>
-/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
@@ -181,9 +181,9 @@ public interface I<file.grammarName>Visitor\<Result> : IParseTreeVisitor\<Result
 /// \<summary>
 <if(file.visitorLabelRuleNames.(lname))>
 /// Visit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>()"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>"/>.
 <else>
-/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -219,9 +219,9 @@ public partial class <file.grammarName>BaseVisitor\<Result> : AbstractParseTreeV
 /// \<summary>
 <if(file.visitorLabelRuleNames.(lname))>
 /// Visit a parse tree produced by the \<c><lname>\</c>
-/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>()"/>.
+/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>"/>.
 <else>
-/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
+/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
 <endif>
 /// \<para>
 /// The default implementation returns the result of calling \<see cref="AbstractParseTreeVisitor{Result\}.VisitChildren(IRuleNode)"/>
@@ -256,6 +256,8 @@ fileHeader(grammarFileName, ANTLRVersion) ::= <<
 #pragma warning disable 0219
 // Missing XML comment for publicly visible type or member '...'
 #pragma warning disable 1591
+// Ambiguous reference in cref attribute
+#pragma warning disable 419
 
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -119,13 +119,23 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 public partial class <file.grammarName>BaseListener : I<file.grammarName>Listener {
 	<file.listenerNames:{lname |
 /// \<summary>
-/// Enter a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
+<if(file.listenerLabelRuleNames.(lname))>
+/// Enter a parse tree produced by the \<c><lname>\</c>
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
+<else>
+/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+<endif>
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
 public virtual void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lname; format="cap">Context context) { \}
 /// \<summary>
-/// Exit a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
+<if(file.listenerLabelRuleNames.(lname))>
+/// Exit a parse tree produced by the \<c><lname>\</c>
+/// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>"/>.
+<else>
+/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+<endif>
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -207,7 +217,12 @@ using ParserRuleContext = Antlr4.Runtime.ParserRuleContext;
 public partial class <file.grammarName>BaseVisitor\<Result> : AbstractParseTreeVisitor\<Result>, I<file.grammarName>Visitor\<Result> {
 	<file.visitorNames:{lname |
 /// \<summary>
-/// Visit a parse tree produced by \<see cref="<csIdentifier.(file.parserName)>.<csIdentifier.(lname)>"/>.
+<if(file.visitorLabelRuleNames.(lname))>
+/// Visit a parse tree produced by the \<c><lname>\</c>
+/// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>"/>.
+<else>
+/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+<endif>
 /// \<para>
 /// The default implementation returns the result of calling \<see cref="AbstractParseTreeVisitor{Result\}.VisitChildren(IRuleNode)"/>
 /// on \<paramref name="context"/>.

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -75,7 +75,7 @@ public interface I<file.grammarName>Listener : IParseTreeListener {
 /// Enter a parse tree produced by the \<c><lname>\</c>
 /// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
 <else>
-/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -85,7 +85,7 @@ void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lnam
 /// Exit a parse tree produced by the \<c><lname>\</c>
 /// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
 <else>
-/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -123,7 +123,7 @@ public partial class <file.grammarName>BaseListener : I<file.grammarName>Listene
 /// Enter a parse tree produced by the \<c><lname>\</c>
 /// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
 <else>
-/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+/// Enter a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
 <endif>
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
@@ -134,7 +134,7 @@ public virtual void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.par
 /// Exit a parse tree produced by the \<c><lname>\</c>
 /// labeled alternative in \<see cref="<file.parserName>.<file.listenerLabelRuleNames.(lname)>()"/>.
 <else>
-/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+/// Exit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
 <endif>
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
@@ -183,7 +183,7 @@ public interface I<file.grammarName>Visitor\<Result> : IParseTreeVisitor\<Result
 /// Visit a parse tree produced by the \<c><lname>\</c>
 /// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>()"/>.
 <else>
-/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
@@ -221,7 +221,7 @@ public partial class <file.grammarName>BaseVisitor\<Result> : AbstractParseTreeV
 /// Visit a parse tree produced by the \<c><lname>\</c>
 /// labeled alternative in \<see cref="<file.parserName>.<file.visitorLabelRuleNames.(lname)>()"/>.
 <else>
-/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>"/>.
+/// Visit a parse tree produced by \<see cref="<file.parserName>.<lname>()"/>.
 <endif>
 /// \<para>
 /// The default implementation returns the result of calling \<see cref="AbstractParseTreeVisitor{Result\}.VisitChildren(IRuleNode)"/>


### PR DESCRIPTION
When using labeled rules, the doc comments in the emitted C# base listener and visitor classes contain a reference that does not exist. This produces a compiler warning. However, the corresponding interfaces are correct. It seems appropriate to use those comments for the base classes.