### PR TITLE
Visitor function is now searched by context's constructor name

### DIFF
--- a/runtime/JavaScript/src/antlr4/tree/Tree.js
+++ b/runtime/JavaScript/src/antlr4/tree/Tree.js
@@ -100,8 +100,9 @@ var visitAtom = function(visitor, ctx) {
 		return;
 	}
 
-	var name = ctx.parser.ruleNames[ctx.ruleIndex];
-	var funcName = "visit" + Utils.titleCase(name);
+	var exactCtxName = ctx.constructor.name.replace(/Context$/, '');
+
+	var funcName = "visit" + exactCtxName;
 
 	return visitor[funcName](ctx);
 };


### PR DESCRIPTION
I changed the way that visit function searches next function to call. Previous solution didn't support labels. 

Is there any way to find label similar to `ctx.ruleindex`? I couldn't found anything so I came up with hacky solution that transforms constructor name. However it works perfectly fine for me.
