### PR TITLE
fix #1023: getExpectedTokens() returns out of context tokens

### DIFF
--- a/runtime/JavaScript/src/antlr4/atn/ATN.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATN.js
@@ -77,9 +77,9 @@ ATN.prototype.nextTokensNoContext = function(s) {
     if (s.nextTokenWithinRule !== null ) {
         return s.nextTokenWithinRule;
     }
-    s.nextTokenWithinRule = this.nextTokensInContext(s, null);
-    s.nextTokenWithinRule.readOnly = true;
-    return s.nextTokenWithinRule;
+    var nextTokenWithinRule = this.nextTokensInContext(s, null);
+    nextTokenWithinRule.readOnly = true;
+    return nextTokenWithinRule;
 };
 
 ATN.prototype.nextTokens = function(s, ctx) {


### PR DESCRIPTION
Proposed fix for #1023 
nextTokensNoContext unintentionally added token intervals from the root context to the state when being called within error recovery of the default error strategy.