### PR TITLE
fix #1023: getExpectedTokens() returns out of context tokens on conse…

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -78,3 +78,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/08/18, krzkaczor, Krzysztof Kaczor, krzysztof@kaczor.io
 2015/09/18, worsht, Rajiv Subrahmanyam, rajiv.public@gmail.com
 2015/10/08, fedotovalex, Alex Fedotov, me@alexfedotov.com
+2015/10/21, martin-probst, Martin Probst, martin-probst@web.de

--- a/runtime/JavaScript/src/antlr4/error/ErrorStrategy.js
+++ b/runtime/JavaScript/src/antlr4/error/ErrorStrategy.js
@@ -269,7 +269,8 @@ DefaultErrorStrategy.prototype.sync = function(recognizer) {
     case ATNState.PLUS_LOOP_BACK:
     case ATNState.STAR_LOOP_BACK:
         this.reportUnwantedToken(recognizer);
-        var expecting = recognizer.getExpectedTokens();
+        var expecting = new IntervalSet();
+        expecting.addSet(recognizer.getExpectedTokens());
         var whatFollowsLoopIterationOrRule = expecting.addSet(this.getErrorRecoverySet(recognizer));
         this.consumeUntil(recognizer, whatFollowsLoopIterationOrRule);
         break;


### PR DESCRIPTION
recognizer.getExpectedTokens() returns the cached object from the ATN state. Therefore this object must not be modified to prevent unforeseeable behaviour. IntervalSet.addSet added the errorRecoverySet to the original cached expectedTokens, what lead to the behaviour observed in #1023 .