### PR TITLE
Update TestRig.java help text with correct package name

### DIFF
--- a/tool/src/org/antlr/v4/gui/TestRig.java
+++ b/tool/src/org/antlr/v4/gui/TestRig.java
@@ -80,7 +80,7 @@ public class TestRig {
 
 	public TestRig(String[] args) throws Exception {
 		if ( args.length < 2 ) {
-			System.err.println("java org.antlr.v4.runtime.misc.TestRig GrammarName startRuleName\n" +
+			System.err.println("java org.antlr.v4.gui.TestRig GrammarName startRuleName\n" +
 							   "  [-tokens] [-tree] [-gui] [-ps file.ps] [-encoding encodingname]\n" +
 							   "  [-trace] [-diagnostics] [-SLL]\n"+
 							   "  [input-filename(s)]");


### PR DESCRIPTION
The help and error message from the TestRig program refers to the old `runtime.misc` instead of the new `gui` package:
```
java org.antlr.v4.runtime.misc.TestRig GrammarName startRuleName
  [-tokens] [-tree] [-gui] [-ps file.ps] [-encoding encodingname]
  [-trace] [-diagnostics] [-SLL]
  [input-filename(s)]
Use startRuleName='tokens' if GrammarName is a lexer grammar.
Omitting input-filename makes rig read from stdin.
```