### PR TITLE
TreeViewer: Fix NPE

### DIFF
--- a/tool/src/org/antlr/v4/gui/TreeViewer.java
+++ b/tool/src/org/antlr/v4/gui/TreeViewer.java
@@ -372,10 +372,12 @@ public class TreeViewer extends JComponent {
 
 				JTree selectedTree = (JTree) e.getSource();
 				TreePath path = selectedTree.getSelectionPath();
-				TreeNodeWrapper treeNode = (TreeNodeWrapper) path.getLastPathComponent();
+				if (path!=null) {
+					TreeNodeWrapper treeNode = (TreeNodeWrapper) path.getLastPathComponent();
 
-				// Set the clicked AST.
-				viewer.setTree((Tree) treeNode.getUserObject());
+					// Set the clicked AST.
+					viewer.setTree((Tree) treeNode.getUserObject());
+				}
 			}
 		});
 


### PR DESCRIPTION
The `selectedTree.getSelectionPath()` return null if nothing is selected.
Added check to avoid NPE:
```java
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at org.antlr.v4.gui.TreeViewer$4.valueChanged(TreeViewer.java:376)
	at javax.swing.JTree.fireValueChanged(JTree.java:2921)
	at javax.swing.JTree$TreeSelectionRedirector.valueChanged(JTree.java:3382)
	at javax.swing.tree.DefaultTreeSelectionModel.fireValueChanged(DefaultTreeSelectionModel.java:635)
	at javax.swing.tree.DefaultTreeSelectionModel.notifyPathChange(DefaultTreeSelectionModel.java:1093)
	at javax.swing.tree.DefaultTreeSelectionModel.removeSelectionPaths(DefaultTreeSelectionModel.java:502)
	at javax.swing.JTree.removeDescendantSelectedPaths(JTree.java:3714)
	at javax.swing.JTree.setExpandedState(JTree.java:3597)
	at javax.swing.JTree.collapsePath(JTree.java:2231)
	at javax.swing.plaf.basic.BasicTreeUI.toggleExpandState(BasicTreeUI.java:2297)
	at javax.swing.plaf.basic.BasicTreeUI.handleExpandControlClick(BasicTreeUI.java:2273)
	at javax.swing.plaf.basic.BasicTreeUI.checkForClickInExpandControl(BasicTreeUI.java:2231)
	at javax.swing.plaf.basic.BasicTreeUI$Handler.handleSelection(BasicTreeUI.java:3600)
	at javax.swing.plaf.basic.BasicTreeUI$Handler.mousePressed(BasicTreeUI.java:3548)
	at java.awt.Component.processMouseEvent(Component.java:6524)
	at javax.swing.JComponent.processMouseEvent(JComponent.java:3321)
	at java.awt.Component.processEvent(Component.java:6292)
	at java.awt.Container.processEvent(Container.java:2234)
	at java.awt.Component.dispatchEventImpl(Component.java:4883)
	at java.awt.Container.dispatchEventImpl(Container.java:2292)
	at java.awt.Component.dispatchEvent(Component.java:4705)
	at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4898)
	at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4530)
	at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4462)
	at java.awt.Container.dispatchEventImpl(Container.java:2278)
	at java.awt.Window.dispatchEventImpl(Window.java:2739)
	at java.awt.Component.dispatchEvent(Component.java:4705)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:746)
	at java.awt.EventQueue.access$400(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:697)
	at java.awt.EventQueue$3.run(EventQueue.java:691)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:75)
	at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.awt.EventQueue$4.run(EventQueue.java:719)
	at java.awt.EventQueue$4.run(EventQueue.java:717)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:75)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:716)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```