### PR TITLE
Extra 'null' check in TestRig#process

### DIFF
--- a/tool/src/org/antlr/v4/gui/TestRig.java
+++ b/tool/src/org/antlr/v4/gui/TestRig.java
@@ -172,9 +172,6 @@ public class TestRig {
 		if ( !startRuleName.equals(LEXER_START_RULE_NAME) ) {
 			String parserName = grammarName+"Parser";
 			parserClass = cl.loadClass(parserName).asSubclass(Parser.class);
-			if ( parserClass==null ) {
-				System.err.println("Can't load "+parserName);
-			}
 			Constructor<? extends Parser> parserCtor = parserClass.getConstructor(TokenStream.class);
 			parser = parserCtor.newInstance((TokenStream)null);
 		}


### PR DESCRIPTION
After loading and casting the parserClass in TestRig#process using `cl.loadClass(parserName).asSubclass(Parser.class)` there is a check if the class returned by `#asSubclass` is not null:

```
parserClass = cl.loadClass(parserName).asSubclass(Parser.class);
if ( parserClass==null ) {
	System.err.println("Can't load "+parserName);
}
```

The method `#asSubclass` will never return `null`, but throw an `ClassCastException` when the cast is not valid, therefore the check can be removed.

See also: [TestRig#process Documentation](http://docs.oracle.com/javase/6/docs/api/java/lang/Class.html#asSubclass(java.lang.Class))