### PR TITLE
Possible NullPointerException in ActionTranslator#translateActionChunk

### DIFF
--- a/tool/src/org/antlr/v4/codegen/ActionTranslator.java
+++ b/tool/src/org/antlr/v4/codegen/ActionTranslator.java
@@ -158,8 +158,10 @@ public class ActionTranslator implements ActionSplitterListener {
 		translator.rf = rf;
         factory.getGrammar().tool.log("action-translator", "translate " + action);
 		String altLabel = node.getAltLabel();
-		if ( rf!=null ) translator.nodeContext = rf.ruleCtx;
-		if ( altLabel!=null ) translator.nodeContext = rf.altLabelCtxs.get(altLabel);
+		if ( rf!=null ) { 
+		    translator.nodeContext = rf.ruleCtx;
+	        if ( altLabel!=null ) translator.nodeContext = rf.altLabelCtxs.get(altLabel);
+		}
 		ANTLRStringStream in = new ANTLRStringStream(action);
 		in.setLine(tokenWithinAction.getLine());
 		in.setCharPositionInLine(tokenWithinAction.getCharPositionInLine());


### PR DESCRIPTION
The parameter `RuleFunction rf` in `ActionTranslator#translateActionChunk` may be `null`.

The method's implementation takes care of this by checking `rf` before making its `ruleCtx` the translator's nodeContext:

```
if ( rf!=null ) translator.nodeContext = rf.ruleCtx;
```

However in the statement following this code the check for `rf!=null` is missing. This will lead to a `NullPointerException` when  `altLabel` is defined and `rf` is `null`:

```
if ( altLabel!=null ) translator.nodeContext = rf.altLabelCtxs.get(altLabel);
```

To avoid the problem only access `rf.altLabelCtxs` when `rf` is not null:

```
if ( rf!=null ) {
    translator.nodeContext = rf.ruleCtx;
    if ( altLabel!=null ) translator.nodeContext = rf.altLabelCtxs.get(altLabel);
}
```