### PR TITLE
Fix mistake in tokenIndex bounds check

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -84,3 +84,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/10/21, martin-probst, Martin Probst, martin-probst@web.de
 2015/10/21, hkff, Walid Benghabrit, walid.benghabrit@mines-nantes.fr
 2015/11/25, abego, Udo Borkowski, ub@abego.org
+2015/12/23, pboyer, Peter Boyer, peter.b.boyer@gmail.com

--- a/runtime/JavaScript/src/antlr4/BufferedTokenStream.js
+++ b/runtime/JavaScript/src/antlr4/BufferedTokenStream.js
@@ -301,7 +301,7 @@ BufferedTokenStream.prototype.getHiddenTokensToRight = function(tokenIndex,
 		channel = -1;
 	}
 	this.lazyInit();
-	if (this.tokenIndex < 0 || tokenIndex >= this.tokens.length) {
+	if (tokenIndex < 0 || tokenIndex >= this.tokens.length) {
 		throw "" + tokenIndex + " not in 0.." + this.tokens.length - 1;
 	}
 	var nextOnChannel = this.nextTokenOnChannel(tokenIndex + 1,


### PR DESCRIPTION
I noticed a minor mistake in the JavaScript runtime. From what I can tell the `tokenIndex` property is never assigned and thus is `undefined`

Note that in JavaScript,

```js
undefined < anyInteger
```

returns `false` 