### PR TITLE
Constructors should only call non-overridable methods

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/ANTLRFileStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ANTLRFileStream.java
@@ -49,7 +49,7 @@ public class ANTLRFileStream extends ANTLRInputStream {
 		load(fileName, encoding);
 	}
 
-	public void load(String fileName, String encoding)
+	public final void load(String fileName, String encoding)
 		throws IOException
 	{
 		data = Utils.readFile(fileName, encoding);

--- a/runtime/Java/src/org/antlr/v4/runtime/ANTLRInputStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ANTLRInputStream.java
@@ -98,7 +98,7 @@ public class ANTLRInputStream implements CharStream {
 		this(new InputStreamReader(input), initialSize, readChunkSize);
 	}
 
-	public void load(Reader r, int size, int readChunkSize)
+	public final void load(Reader r, int size, int readChunkSize)
 		throws IOException
 	{
 		if ( r==null ) {

--- a/runtime/Java/src/org/antlr/v4/runtime/Recognizer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Recognizer.java
@@ -189,7 +189,7 @@ public abstract class Recognizer<Symbol, ATNInterpreter extends ATNSimulator> {
 	 * @param interpreter The ATN interpreter used by the recognizer for
 	 * prediction.
 	 */
-	public void setInterpreter(ATNInterpreter interpreter) {
+	public final void setInterpreter(ATNInterpreter interpreter) {
 		_interp = interpreter;
 	}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/UnbufferedCharStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/UnbufferedCharStream.java
@@ -167,7 +167,7 @@ public class UnbufferedCharStream implements CharStream {
 	 * actually added to the buffer. If the return value is less than {@code n},
 	 * then EOF was reached before {@code n} characters could be added.
 	 */
-	protected int fill(int n) {
+	protected final int fill(int n) {
 		for (int i=0; i<n; i++) {
 			if (this.n > 0 && data[this.n - 1] == (char)IntStream.EOF) {
 				return i;

--- a/runtime/Java/src/org/antlr/v4/runtime/UnbufferedTokenStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/UnbufferedTokenStream.java
@@ -194,7 +194,7 @@ public class UnbufferedTokenStream<T extends Token> implements TokenStream {
 	 * actually added to the buffer. If the return value is less than {@code n},
 	 * then EOF was reached before {@code n} tokens could be added.
 	 */
-	protected int fill(int n) {
+	protected final int fill(int n) {
 		for (int i=0; i<n; i++) {
 			if (this.n > 0 && tokens[this.n-1].getType() == Token.EOF) {
 				return i;

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNConfigSet.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNConfigSet.java
@@ -245,7 +245,7 @@ public class ATNConfigSet implements Set<ATNConfig> {
 	}
 
 	@Override
-	public boolean addAll(Collection<? extends ATNConfig> coll) {
+	public final boolean addAll(Collection<? extends ATNConfig> coll) {
 		for (ATNConfig c : coll) add(c);
 		return false;
 	}

--- a/runtime/Java/src/org/antlr/v4/runtime/misc/IntervalSet.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/IntervalSet.java
@@ -112,7 +112,7 @@ public class IntervalSet implements IntSet {
      *  as a range el..el.
      */
     @Override
-    public void add(int el) {
+    public final void add(int el) {
         if ( readonly ) throw new IllegalStateException("can't alter readonly IntervalSet");
         add(el,el);
     }
@@ -183,7 +183,7 @@ public class IntervalSet implements IntSet {
 	}
 
 	@Override
-	public IntervalSet addAll(IntSet set) {
+	public final IntervalSet addAll(IntSet set) {
 		if ( set==null ) {
 			return this;
 		}

--- a/runtime/Java/src/org/antlr/v4/runtime/misc/ParseCancellationException.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/ParseCancellationException.java
@@ -61,4 +61,8 @@ public class ParseCancellationException extends CancellationException {
 		initCause(cause);
 	}
 
+	@Override
+	public final synchronized Throwable initCause(Throwable cause) {
+		return super.initCause(cause);
+	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/xpath/XPath.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/xpath/XPath.java
@@ -76,7 +76,7 @@ public class XPath {
 
 	// TODO: check for invalid token/rule names, bad syntax
 
-	public XPathElement[] split(String path) {
+	public final XPathElement[] split(String path) {
 		ANTLRInputStream in;
 		try {
 			in = new ANTLRInputStream(new StringReader(path));

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -219,7 +219,7 @@ public class Tool {
 		handleArgs();
 	}
 
-	protected void handleArgs() {
+	protected final void handleArgs() {
 		int i=0;
 		while ( args!=null && i<args.length ) {
 			String arg = args[i];

--- a/tool/src/org/antlr/v4/analysis/LeftRecursiveRuleAnalyzer.java
+++ b/tool/src/org/antlr/v4/analysis/LeftRecursiveRuleAnalyzer.java
@@ -101,7 +101,7 @@ public class LeftRecursiveRuleAnalyzer extends LeftRecursiveRuleWalker {
 		loadPrecRuleTemplates();
 	}
 
-	public void loadPrecRuleTemplates() {
+	public final void loadPrecRuleTemplates() {
 		String templateGroupFile = "org/antlr/v4/tool/templates/LeftRecursiveRules.stg";
 		recRuleTemplates = new STGroupFile(templateGroupFile);
 		if ( !recRuleTemplates.isDefined("recRule") ) {

--- a/tool/src/org/antlr/v4/codegen/model/Choice.java
+++ b/tool/src/org/antlr/v4/codegen/model/Choice.java
@@ -69,7 +69,7 @@ public abstract class Choice extends RuleElement {
 		preamble.add(op);
 	}
 
-	public List<String[]> getAltLookaheadAsStringLists(IntervalSet[] altLookSets) {
+	public final List<String[]> getAltLookaheadAsStringLists(IntervalSet[] altLookSets) {
 		List<String[]> altLook = new ArrayList<String[]>();
 		for (IntervalSet s : altLookSets) {
 			altLook.add(factory.getGenerator().getTarget().getTokenTypesAsTargetLabels(factory.getGrammar(), s.toArray()));
@@ -77,7 +77,7 @@ public abstract class Choice extends RuleElement {
 		return altLook;
 	}
 
-	public TestSetInline addCodeForLookaheadTempVar(IntervalSet look) {
+	public final TestSetInline addCodeForLookaheadTempVar(IntervalSet look) {
 		List<SrcOp> testOps = factory.getLL1Test(look, ast);
 		TestSetInline expr = Utils.find(testOps, TestSetInline.class);
 		if (expr != null) {
@@ -89,7 +89,7 @@ public abstract class Choice extends RuleElement {
 		return expr;
 	}
 
-	public ThrowNoViableAlt getThrowNoViableAlt(OutputModelFactory factory,
+	public final ThrowNoViableAlt getThrowNoViableAlt(OutputModelFactory factory,
 												GrammarAST blkAST,
 												IntervalSet expecting) {
 		return new ThrowNoViableAlt(factory, blkAST, expecting);

--- a/tool/src/org/antlr/v4/codegen/model/LL1Loop.java
+++ b/tool/src/org/antlr/v4/codegen/model/LL1Loop.java
@@ -60,7 +60,7 @@ public abstract class LL1Loop extends Choice {
 		iteration.add(op);
 	}
 
-	public SrcOp addCodeForLoopLookaheadTempVar(IntervalSet look) {
+	public final SrcOp addCodeForLoopLookaheadTempVar(IntervalSet look) {
 		TestSetInline expr = addCodeForLookaheadTempVar(look);
 		if (expr != null) {
 			CaptureNextTokenType nextType = new CaptureNextTokenType(factory, expr.varName);

--- a/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
@@ -140,7 +140,7 @@ public class RuleFunction extends OutputModelObject {
 		startState = factory.getGrammar().atn.ruleToStartState[r.index];
 	}
 
-	public void addContextGetters(OutputModelFactory factory, Rule r) {
+	public final void addContextGetters(OutputModelFactory factory, Rule r) {
 		// Add ctx labels for elements in alts with no -> label
 		List<AltAST> altsNoLabels = r.getUnlabeledAltASTs();
 		if ( altsNoLabels!=null ) {

--- a/tool/src/org/antlr/v4/codegen/model/decl/AltLabelStructDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/AltLabelStructDecl.java
@@ -52,7 +52,7 @@ public class AltLabelStructDecl extends StructDecl {
 	}
 
 	@Override
-	public void addDispatchMethods(Rule r) {
+	public final void addDispatchMethods(Rule r) {
 		dispatchMethods = new ArrayList<DispatchMethod>();
 		if ( factory.getGrammar().tool.gen_listener ) {
 			dispatchMethods.add(new ListenerDispatchMethod(factory, true));

--- a/tool/src/org/antlr/v4/gui/PostScriptDocument.java
+++ b/tool/src/org/antlr/v4/gui/PostScriptDocument.java
@@ -96,7 +96,7 @@ public class PostScriptDocument {
 	}
 
 	/** Compute the header separately because we need to wait for the bounding box */
-	protected StringBuilder header() {
+	protected final StringBuilder header() {
 		StringBuilder b = new StringBuilder();
 		b.append("%!PS-Adobe-3.0 EPSF-3.0\n");
 		b.append(boundingBox).append("\n");
@@ -125,7 +125,7 @@ public class PostScriptDocument {
 		return b;
 	}
 
-	public void setFont(String fontName, int fontSize) {
+	public final void setFont(String fontName, int fontSize) {
 		this.fontMetrics = new SystemFontMetrics(fontName);
 		this.fontName = fontMetrics.getFont().getPSName();
 		this.fontSize = fontSize;

--- a/tool/src/org/antlr/v4/gui/TreePostScriptGenerator.java
+++ b/tool/src/org/antlr/v4/gui/TreePostScriptGenerator.java
@@ -169,7 +169,7 @@ public class TreePostScriptGenerator {
 		return treeTextProvider;
 	}
 
-	public void setTreeTextProvider(TreeTextProvider treeTextProvider) {
+	public final void setTreeTextProvider(TreeTextProvider treeTextProvider) {
 		this.treeTextProvider = treeTextProvider;
 	}
 

--- a/tool/src/org/antlr/v4/gui/TreeViewer.java
+++ b/tool/src/org/antlr/v4/gui/TreeViewer.java
@@ -643,7 +643,7 @@ public class TreeViewer extends JComponent {
 	}
 
 	@Override
-	public void setFont(Font font) {
+	public final void setFont(Font font) {
 		this.font = font;
 	}
 
@@ -691,7 +691,7 @@ public class TreeViewer extends JComponent {
 		return treeLayout.getTree();
 	}
 
-	public void setTree(Tree root) {
+	public final void setTree(Tree root) {
 		if ( root!=null ) {
 			boolean useIdentity = true; // compare node identity
 			this.treeLayout =
@@ -727,7 +727,7 @@ public class TreeViewer extends JComponent {
 		updatePreferredSize();
 	}
 
-	public void setRuleNames(List<String> ruleNames) {
+	public final void setRuleNames(List<String> ruleNames) {
 		setTreeTextProvider(new DefaultTreeTextProvider(ruleNames));
 	}
 

--- a/tool/src/org/antlr/v4/tool/Grammar.java
+++ b/tool/src/org/antlr/v4/tool/Grammar.java
@@ -371,7 +371,7 @@ public class Grammar implements AttributeResolver {
 		tool.process(this, false);
     }
 
-	protected void initTokenSymbolTables() {
+	protected final void initTokenSymbolTables() {
 		tokenNameToTypeMap.put("EOF", Token.EOF);
 
 		// reserve a spot for the INVALID token
@@ -944,7 +944,7 @@ public class Grammar implements AttributeResolver {
 		}
 	}
 
-	public void importVocab(Grammar importG) {
+	public final void importVocab(Grammar importG) {
 		for (String tokenName: importG.tokenNameToTypeMap.keySet()) {
 			defineTokenName(tokenName, importG.tokenNameToTypeMap.get(tokenName));
 		}

--- a/tool/src/org/antlr/v4/tool/GrammarParserInterpreter.java
+++ b/tool/src/org/antlr/v4/tool/GrammarParserInterpreter.java
@@ -120,7 +120,7 @@ public class GrammarParserInterpreter extends ParserInterpreter {
 	 *  like a regular rule's outer block, and the star loop block (always
 	 *  there even if 1 alt).
 	 */
-	public BitSet findOuterMostDecisionStates() {
+	public final BitSet findOuterMostDecisionStates() {
 		BitSet track = new BitSet(atn.states.size());
 		int numberOfDecisions = atn.getNumberOfDecisions();
 		for (int i = 0; i < numberOfDecisions; i++) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue Fixing squid:S1699 - Constructors should only call non-overridable methods
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1699

Please let me know if you have any questions.

Kirill Vlasov