### PR TITLE
%n should be used in place of \n to produce the platform-specific line separator

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNState.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNState.java
@@ -187,7 +187,7 @@ public abstract class ATNState {
 			epsilonOnlyTransitions = e.isEpsilon();
 		}
 		else if (epsilonOnlyTransitions != e.isEpsilon()) {
-			System.err.format(Locale.getDefault(), "ATN state %d has both epsilon and non-epsilon transitions.\n", stateNumber);
+			System.err.format(Locale.getDefault(), "ATN state %d has both epsilon and non-epsilon transitions.%n", stateNumber);
 			epsilonOnlyTransitions = false;
 		}
 

--- a/tool/src/org/antlr/v4/gui/PostScriptDocument.java
+++ b/tool/src/org/antlr/v4/gui/PostScriptDocument.java
@@ -84,7 +84,7 @@ public class PostScriptDocument {
 	public void boundingBox(int w, int h) {
 		boundingBoxWidth = w;
 		boundingBoxHeight = h;
-		boundingBox = String.format(Locale.US, "%%%%BoundingBox: %d %d %d %d\n", 0,0,
+		boundingBox = String.format(Locale.US, "%%%%BoundingBox: %d %d %d %d %n", 0,0,
 									boundingBoxWidth,boundingBoxHeight);
 	}
 
@@ -135,7 +135,7 @@ public class PostScriptDocument {
 			psname = this.fontName;
 		}
 
-		ps.append(String.format(Locale.US, "/%s findfont %d scalefont setfont\n", psname, fontSize));
+		ps.append(String.format(Locale.US, "/%s findfont %d scalefont setfont%n", psname, fontSize));
 	}
 
 	public void lineWidth(double w) {
@@ -144,11 +144,11 @@ public class PostScriptDocument {
 	}
 
 	public void move(double x, double y) {
-		ps.append(String.format(Locale.US, "%1.3f %1.3f moveto\n", x, y));
+		ps.append(String.format(Locale.US, "%1.3f %1.3f moveto%n", x, y));
 	}
 
 	public void lineto(double x, double y) {
-		ps.append(String.format(Locale.US, "%1.3f %1.3f lineto\n", x, y));
+		ps.append(String.format(Locale.US, "%1.3f %1.3f lineto%n", x, y));
 	}
 
 	public void line(double x1, double y1, double x2, double y2) {
@@ -165,7 +165,7 @@ public class PostScriptDocument {
 
 	/** Make red box */
 	public void highlight(double x, double y, double width, double height) {
-		ps.append(String.format(Locale.US, "%1.3f %1.3f %1.3f %1.3f highlight\n", x, y, width, height));
+		ps.append(String.format(Locale.US, "%1.3f %1.3f %1.3f %1.3f highlight%n", x, y, width, height));
 	}
 
 	public void stroke() {
@@ -198,7 +198,7 @@ public class PostScriptDocument {
 		}
 		s = buf.toString();
 		move(x,y);
-		ps.append(String.format(Locale.US, "(%s) show\n", s));
+		ps.append(String.format(Locale.US, "(%s) show%n", s));
 		stroke();
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue squid:S2275 - %n should be used in place of \n to produce the platform-specific line separator
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2275
Please let me know if you have any questions.
Kirill Vlasov