### PR TITLE
Fixing squid:S1161 and missing @Deprecated issues

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/misc/NotNull.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/NotNull.java
@@ -38,6 +38,7 @@ import java.lang.annotation.Target;
 /** @deprecated THIS IS HERE FOR BACKWARD COMPATIBILITY WITH 4.5 ONLY.  It will
  *  disappear in 4.6+
  */
+@Deprecated
 @Documented
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})

--- a/runtime/Java/src/org/antlr/v4/runtime/misc/TestRig.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/TestRig.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
  *  @deprecated
  *  @since 4.5.1
  */
+@Deprecated
 public class TestRig {
 	public static void main(String[] args) {
 		try {

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/Trees.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/Trees.java
@@ -203,6 +203,7 @@ public class Trees {
 	}
 
 	/** @deprecated */
+	@Deprecated
 	public static List<ParseTree> descendants(ParseTree t) {
 		return getDescendants(t);
 	}

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/xpath/XPath.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/xpath/XPath.java
@@ -85,6 +85,7 @@ public class XPath {
 			throw new IllegalArgumentException("Could not read path: "+path, ioe);
 		}
 		XPathLexer lexer = new XPathLexer(in) {
+			@Override
 			public void recover(LexerNoViableAltException e) { throw e;	}
 		};
 		lexer.removeErrorListeners();

--- a/tool/src/org/antlr/v4/codegen/target/JavaScriptTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/JavaScriptTarget.java
@@ -220,14 +220,17 @@ public class JavaScriptTarget extends Target {
 
 	}
 
+	@Override
 	public boolean wantsBaseListener() {
 		return false;
 	}
 
+	@Override
 	public boolean wantsBaseVisitor() {
 		return false;
 	}
 
+	@Override
 	public boolean supportsOverloadedMethods() {
 		return false;
 	}

--- a/tool/src/org/antlr/v4/gui/TreeViewer.java
+++ b/tool/src/org/antlr/v4/gui/TreeViewer.java
@@ -393,7 +393,8 @@ public class TreeViewer extends JComponent {
 
 		// make viz
         WindowListener exitListener = new WindowAdapter() {
-            public void windowClosing(WindowEvent e) {
+            @Override
+			public void windowClosing(WindowEvent e) {
                 prefs.putInt(DIALOG_WIDTH_PREFS_KEY, (int) dialog.getSize().getWidth());
                 prefs.putInt(DIALOG_HEIGHT_PREFS_KEY, (int) dialog.getSize().getHeight());
                 prefs.putDouble(DIALOG_X_PREFS_KEY, dialog.getLocationOnScreen().getX());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one
and missing Deprecated issue 
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1161

Please let me know if you have any questions.

Kirill Vlasov
