### PR TITLE
Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseTest.java
@@ -294,7 +294,7 @@ public abstract class BaseTest {
 			return stderrDuringParse;
 		}
 		String output = execTest();
-		if ( stderrDuringParse!=null && stderrDuringParse.length()>0 ) {
+		if ( stderrDuringParse!=null && !stderrDuringParse.isEmpty()) {
 			System.err.println(stderrDuringParse);
 		}
 		return output;
@@ -545,7 +545,7 @@ public abstract class BaseTest {
 			stdoutVacuum.join();
 			stderrVacuum.join();
 			String output = stdoutVacuum.toString();
-			if ( stderrVacuum.toString().length()>0 ) {
+			if (!stderrVacuum.toString().isEmpty()) {
 				this.stderrDuringParse = stderrVacuum.toString();
 				System.err.println("exec stderrVacuum: "+ stderrVacuum);
 			}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseTest.java
@@ -555,7 +555,7 @@ public abstract class BaseTest {
 		writeLexerTestFile(lexerName, showDFA);
 		compile("Test.java");
 		String output = execClass("Test");
-		if ( stderrDuringParse!=null && stderrDuringParse.length()>0 ) {
+		if ( stderrDuringParse!=null && !stderrDuringParse.isEmpty()) {
 			System.err.println(stderrDuringParse);
 		}
 		return output;
@@ -761,7 +761,7 @@ public abstract class BaseTest {
 				stdoutVacuum.join();
 				stderrVacuum.join();
 				String output = stdoutVacuum.toString();
-				if ( stderrVacuum.toString().length()>0 ) {
+				if (!stderrVacuum.toString().isEmpty()) {
 					this.stderrDuringParse = stderrVacuum.toString();
 					System.err.println("exec stderrVacuum: "+ stderrVacuum);
 				}
@@ -813,7 +813,7 @@ public abstract class BaseTest {
 			stdoutVacuum.join();
 			stderrVacuum.join();
 			String output = stdoutVacuum.toString();
-			if ( stderrVacuum.toString().length()>0 ) {
+			if (!stderrVacuum.toString().isEmpty()) {
 				this.stderrDuringParse = stderrVacuum.toString();
 				System.err.println("exec stderrVacuum: "+ stderrVacuum);
 			}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/browser/BaseBrowserTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/browser/BaseBrowserTest.java
@@ -132,7 +132,7 @@ public abstract class BaseBrowserTest {
 	public void setUp() throws Exception {
         // new output dir for each test
     	String prop = System.getProperty("antlr-javascript-test-dir");
-    	if(prop!=null && prop.length()>0)
+    	if(prop!=null && !prop.isEmpty())
     		httpdir = prop;
     	else
     		httpdir = new File(System.getProperty("java.io.tmpdir"), getClass().getSimpleName()+"-"+System.currentTimeMillis()).getAbsolutePath();
@@ -302,7 +302,7 @@ public abstract class BaseBrowserTest {
 		assertTrue(success);
 		writeLexerTestFile(lexerName, showDFA);
 		String output = execHtmlPage("Test.html", input);
-		if ( stderrDuringParse!=null && stderrDuringParse.length()>0 ) {
+		if ( stderrDuringParse!=null && !stderrDuringParse.isEmpty()) {
 			System.err.println(stderrDuringParse);
 		}
 		return output;
@@ -462,13 +462,13 @@ public abstract class BaseBrowserTest {
 			driver.findElement(new ById("load")).click();
 			driver.findElement(new ById("submit")).click();
 			String errors = driver.findElement(new ById("errors")).getAttribute("value");
-			if(errors!=null && errors.length()>0) {
+			if(errors!=null && !errors.isEmpty()) {
 				this.stderrDuringParse = errors;
 				System.err.print(errors);
 			}
 			String value = driver.findElement(new ById("output")).getAttribute("value");
 			// mimic stdout which adds a NL
-			if(value.length()>0 && !value.endsWith("\n"))
+			if(!value.isEmpty() && !value.endsWith("\n"))
 				value = value + "\n";
 			return value;
 		}
@@ -489,7 +489,7 @@ public abstract class BaseBrowserTest {
 	private String locateRuntime() {
 		String propName = "antlr-javascript-runtime";
 		String prop = System.getProperty(propName);
-		if(prop==null || prop.length()==0)
+		if(prop==null || prop.isEmpty())
 			prop = "../runtime/JavaScript/src";
 		File file = new File(prop);
 		System.out.println(file.getAbsolutePath());
@@ -913,7 +913,7 @@ public abstract class BaseBrowserTest {
        	boolean doErase = true;
     	String propName = "antlr-javascript-erase-test-dir";
     	String prop = System.getProperty(propName);
-    	if(prop!=null && prop.length()>0)
+    	if(prop!=null && !prop.isEmpty())
     		doErase = Boolean.getBoolean(prop);
         if(doErase) {
 	        File tmpdirF = new File(httpdir);

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/node/BaseTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/node/BaseTest.java
@@ -128,7 +128,7 @@ public abstract class BaseTest {
 	public void setUp() throws Exception {
 		// new output dir for each test
 		String prop = System.getProperty("antlr-javascript-test-dir");
-		if (prop != null && prop.length() > 0)
+		if (prop != null && !prop.isEmpty())
 			tmpdir = prop;
 		else
 			tmpdir = new File(System.getProperty("java.io.tmpdir"), getClass()
@@ -300,7 +300,7 @@ public abstract class BaseTest {
 		writeFile(tmpdir, "input", input);
 		writeLexerTestFile(lexerName, showDFA);
 		String output = execModule("Test.js");
-		if (stderrDuringParse != null && stderrDuringParse.length() > 0) {
+		if (stderrDuringParse != null && !stderrDuringParse.isEmpty()) {
 			System.err.println(stderrDuringParse);
 		}
 		return output;
@@ -399,7 +399,7 @@ public abstract class BaseTest {
 			stdoutVacuum.join();
 			stderrVacuum.join();
 			String output = stdoutVacuum.toString();
-			if (stderrVacuum.toString().length() > 0) {
+			if (!stderrVacuum.toString().isEmpty()) {
 				this.stderrDuringParse = stderrVacuum.toString();
 				System.err.println("exec stderrVacuum: " + stderrVacuum);
 			}
@@ -426,7 +426,7 @@ public abstract class BaseTest {
 		// typically /usr/local/bin/node
 		String propName = "antlr-javascript-nodejs";
 		String prop = System.getProperty(propName);
-		if (prop == null || prop.length() == 0) {
+		if (prop == null || prop.isEmpty()) {
 			prop = locateTool("nodejs"); // seems to be nodejs on ubuntu
 		}
 		if ( prop==null ) {
@@ -859,7 +859,7 @@ public abstract class BaseTest {
 		boolean doErase = true;
 		String propName = "antlr-javascript-erase-test-dir";
 		String prop = System.getProperty(propName);
-		if (prop != null && prop.length() > 0)
+		if (prop != null && !prop.isEmpty())
 			doErase = Boolean.getBoolean(prop);
 		if (doErase) {
 			File tmpdirF = new File(tmpdir);

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python/BasePythonTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python/BasePythonTest.java
@@ -134,7 +134,7 @@ public abstract class BasePythonTest {
         // new output dir for each test
     	String propName = getPropertyPrefix() + "-test-dir";
     	String prop = System.getProperty(propName);
-    	if(prop!=null && prop.length()>0)
+    	if(prop!=null && !prop.isEmpty())
     		tmpdir = prop;
     	else
     		tmpdir = new File(System.getProperty("java.io.tmpdir"), getClass().getSimpleName()+"-"+System.currentTimeMillis()).getAbsolutePath();
@@ -389,7 +389,7 @@ public abstract class BasePythonTest {
 		writeFile(tmpdir, "input", input);
 		writeLexerTestFile(lexerName, showDFA);
 		String output = execModule("Test.py");
-		if ( stderrDuringParse!=null && stderrDuringParse.length()>0 ) {
+		if ( stderrDuringParse!=null && !stderrDuringParse.isEmpty()) {
 			System.err.println(stderrDuringParse);
 		}
 		return output;
@@ -540,7 +540,7 @@ public abstract class BasePythonTest {
 			stdoutVacuum.join();
 			stderrVacuum.join();
 			String output = stdoutVacuum.toString();
-			if ( stderrVacuum.toString().length()>0 ) {
+			if (!stderrVacuum.toString().isEmpty()) {
 				this.stderrDuringParse = stderrVacuum.toString();
 				System.err.println("exec stderrVacuum: "+ stderrVacuum);
 			}
@@ -565,7 +565,7 @@ public abstract class BasePythonTest {
 	protected String locatePython() {
 		String propName = getPropertyPrefix() + "-python";
     	String prop = System.getProperty(propName);
-    	if(prop==null || prop.length()==0)
+    	if(prop==null || prop.isEmpty())
     		prop = locateTool(getPythonExecutable());
 		File file = new File(prop);
 		if(!file.exists())
@@ -900,7 +900,7 @@ public abstract class BasePythonTest {
     	boolean doErase = true;
     	String propName = getPropertyPrefix() + "-erase-test-dir";
     	String prop = System.getProperty(propName);
-    	if(prop!=null && prop.length()>0)
+    	if(prop!=null && !prop.isEmpty())
     		doErase = Boolean.getBoolean(prop);
         if(doErase) {
         	File tmpdirF = new File(tmpdir);

--- a/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
@@ -445,7 +445,7 @@ public class BufferedTokenStream implements TokenStream {
 				if ( t.getChannel()==channel ) hidden.add(t);
 			}
 		}
-		if ( hidden.size()==0 ) return null;
+		if (hidden.isEmpty()) return null;
 		return hidden;
 	}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/ListTokenSource.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ListTokenSource.java
@@ -89,7 +89,7 @@ public class ListTokenSource implements TokenSource {
 		else if (eofToken != null) {
 			return eofToken.getCharPositionInLine();
 		}
-		else if (tokens.size() > 0) {
+		else if (!tokens.isEmpty()) {
 			// have to calculate the result from the line/column of the previous
 			// token, along with the text of the token.
 			Token lastToken = tokens.get(tokens.size() - 1);
@@ -117,7 +117,7 @@ public class ListTokenSource implements TokenSource {
 		if (i >= tokens.size()) {
 			if (eofToken == null) {
 				int start = -1;
-				if (tokens.size() > 0) {
+				if (!tokens.isEmpty()) {
 					int previousStop = tokens.get(tokens.size() - 1).getStopIndex();
 					if (previousStop != -1) {
 						start = previousStop + 1;
@@ -151,7 +151,7 @@ public class ListTokenSource implements TokenSource {
 		else if (eofToken != null) {
 			return eofToken.getLine();
 		}
-		else if (tokens.size() > 0) {
+		else if (!tokens.isEmpty()) {
 			// have to calculate the result from the line/column of the previous
 			// token, along with the text of the token.
 			Token lastToken = tokens.get(tokens.size() - 1);
@@ -186,7 +186,7 @@ public class ListTokenSource implements TokenSource {
 		else if (eofToken != null) {
 			return eofToken.getInputStream();
 		}
-		else if (tokens.size() > 0) {
+		else if (!tokens.isEmpty()) {
 			return tokens.get(tokens.size() - 1).getInputStream();
 		}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -1328,7 +1328,7 @@ public class ParserATNSimulator extends ATNSimulator {
 			return alt;
 		}
 		// Is there a syntactically valid path with a failed pred?
-		if ( semInvalidConfigs.size()>0 ) {
+		if (!semInvalidConfigs.isEmpty()) {
 			alt = getAltThatFinishedDecisionEntryRule(semInvalidConfigs);
 			if ( alt!=ATN.INVALID_ALT_NUMBER ) { // syntactically viable path exists
 				return alt;

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/SingletonPredictionContext.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/SingletonPredictionContext.java
@@ -87,7 +87,7 @@ public class SingletonPredictionContext extends PredictionContext {
 	@Override
 	public String toString() {
 		String up = parent!=null ? parent.toString() : "";
-		if ( up.length()==0 ) {
+		if (up.isEmpty()) {
 			if ( returnState == EMPTY_RETURN_STATE ) {
 				return "$";
 			}

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/DFASerializer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/DFASerializer.java
@@ -75,7 +75,7 @@ public class DFASerializer {
 		}
 
 		String output = buf.toString();
-		if ( output.length()==0 ) return null;
+		if (output.isEmpty()) return null;
 		//return Utils.sortLinesInString(output);
 		return output;
 	}

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/pattern/ParseTreeMatch.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/pattern/ParseTreeMatch.java
@@ -113,7 +113,7 @@ public class ParseTreeMatch {
 
 	public ParseTree get(String label) {
 		List<ParseTree> parseTrees = labels.get(label);
-		if ( parseTrees==null || parseTrees.size()==0 ) {
+		if ( parseTrees==null || parseTrees.isEmpty()) {
 			return null;
 		}
 

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -301,7 +301,7 @@ public class Tool {
 		if ( eq>0 && arg.length()>3 ) {
 			String option = arg.substring("-D".length(), eq);
 			String value = arg.substring(eq+1);
-			if ( value.length()==0 ) {
+			if (value.isEmpty()) {
 				errMgr.toolError(ErrorType.BAD_OPTION_SET_SYNTAX, arg);
 				return;
 			}

--- a/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
@@ -110,7 +110,7 @@ public class RuleFunction extends OutputModelObject {
 
 		if ( r.args!=null ) {
 			Collection<Attribute> decls = r.args.attributes.values();
-			if ( decls.size()>0 ) {
+			if (!decls.isEmpty()) {
 				args = new ArrayList<AttributeDecl>();
 				ruleCtx.addDecls(decls);
 				for (Attribute a : decls) {

--- a/tool/src/org/antlr/v4/gui/TestRig.java
+++ b/tool/src/org/antlr/v4/gui/TestRig.java
@@ -176,7 +176,7 @@ public class TestRig {
 			parser = parserCtor.newInstance((TokenStream)null);
 		}
 
-		if ( inputFiles.size()==0 ) {
+		if (inputFiles.isEmpty()) {
 			InputStream is = System.in;
 			Reader r;
 			if ( encoding!=null ) {

--- a/tool/src/org/antlr/v4/parse/ScopeParser.java
+++ b/tool/src/org/antlr/v4/parse/ScopeParser.java
@@ -69,7 +69,7 @@ public class ScopeParser {
 		List<Pair<String, Integer>> decls = splitDecls(s, separator);
 		for (Pair<String, Integer> decl : decls) {
 //            System.out.println("decl="+decl);
-            if ( decl.a.trim().length()>0 ) {
+            if (!decl.a.trim().isEmpty()) {
                 Attribute a = parseAttributeDef(action, decl, g);
                 dict.add(a);
             }
@@ -137,7 +137,7 @@ public class ScopeParser {
             attr.type += decl.a.substring(stop,rightEdgeOfDeclarator+1);
         }
         attr.type = attr.type.trim();
-        if ( attr.type.length()==0 ) {
+        if (attr.type.isEmpty()) {
             attr.type = null;
         }
 
@@ -286,7 +286,7 @@ public class ScopeParser {
 				index++;
 			}
             //System.out.println("arg="+arg);
-            if ( arg.length()>0 ) {
+            if (!arg.isEmpty()) {
                 args.add(new Pair<String, Integer>(arg.trim(), index));
             }
         }

--- a/tool/src/org/antlr/v4/parse/TokenVocabParser.java
+++ b/tool/src/org/antlr/v4/parse/TokenVocabParser.java
@@ -101,7 +101,7 @@ public class TokenVocabParser {
 					lineNum++;
 				}
 				else {
-					if ( tokenDef.length()>0 ) { // ignore blank lines
+					if (!tokenDef.isEmpty()) { // ignore blank lines
 						tool.errMgr.toolError(ErrorType.TOKENS_FILE_SYNTAX_ERROR,
 											  vocabName + CodeGenerator.VOCAB_FILE_EXTENSION,
 											  " bad token def: " + tokenDef,

--- a/tool/src/org/antlr/v4/tool/LeftRecursiveRule.java
+++ b/tool/src/org/antlr/v4/tool/LeftRecursiveRule.java
@@ -103,7 +103,7 @@ public class LeftRecursiveRule extends Rule {
 	 *  @since 4.5.1
 	 */
 	public int[] getPrimaryAlts() {
-		if ( recPrimaryAlts.size()==0 ) return null;
+		if (recPrimaryAlts.isEmpty()) return null;
 		int[] alts = new int[recPrimaryAlts.size()+1];
 		for (int i = 0; i < recPrimaryAlts.size(); i++) { // recPrimaryAlts is a List not Map like recOpAlts
 			LeftRecursiveRuleAltInfo altInfo = recPrimaryAlts.get(i);
@@ -126,7 +126,7 @@ public class LeftRecursiveRule extends Rule {
 	 *  @since 4.5.1
 	 */
 	public int[] getRecursiveOpAlts() {
-		if ( recOpAlts.size()==0 ) return null;
+		if (recOpAlts.isEmpty()) return null;
 		int[] alts = new int[recOpAlts.size()+1];
 		int alt = 1;
 		for (LeftRecursiveRuleAltInfo altInfo : recOpAlts.values()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue squid:S1155 - Collection.isEmpty() should be used to test for emptiness
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
Please let me know if you have any questions.
Kirill Vlasov