### PR TITLE
JS: LL1Analyzer passing PredictionContext incorrectly to ATNConfig ctor

### DIFF
--- a/runtime/JavaScript/src/antlr4/LL1Analyzer.js
+++ b/runtime/JavaScript/src/antlr4/LL1Analyzer.js
@@ -145,7 +145,7 @@ LL1Analyzer.prototype.LOOK = function(s, stopState, ctx) {
 // is {@code null}.
 ///
 LL1Analyzer.prototype._LOOK = function(s, stopState , ctx, look, lookBusy, calledRuleStack, seeThruPreds, addEOF) {
-    var c = new ATNConfig({state:s, alt:0}, ctx);
+    var c = new ATNConfig({state:s, alt:0, context: ctx}, null);
     if (lookBusy.contains(c)) {
         return;
     }


### PR DESCRIPTION
The PredictionContext should be passed to the ATNConfig constructor in the first argument, the `params` object. Instead, it is being passed as the second argument which is intended to be the config.