### PR TITLE
fixes bug in visit()

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -88,3 +88,5 @@ YYYY/MM/DD, github id, Full name, email
 2015/12/17, sebadur, Sebastian Badur, sebadur@users.noreply.github.com
 2015/12/23, pboyer, Peter Boyer, peter.b.boyer@gmail.com
 2015/12/24, dtymon, David Tymon, david.tymon@gmail.com
+2016/01/31, sp, Seth Purcell, sp@users.noreply.github.com
+

--- a/runtime/JavaScript/src/antlr4/tree/Tree.js
+++ b/runtime/JavaScript/src/antlr4/tree/Tree.js
@@ -107,8 +107,8 @@ var visitAtom = function(visitor, ctx) {
 		return;
 	}
 
-	var name = ctx.parser.ruleNames[ctx.ruleIndex];
-	var funcName = "visit" + Utils.titleCase(name);
+	// trim off 'Context' and prepend 'visit'
+	var funcName = 'visit' + ctx.constructor.name.substr(0, ctx.constructor.name.length - 7);
 
 	return visitor[funcName](ctx);
 };


### PR DESCRIPTION
In the common case where a rule has labeled productions, visit() would look for a function named visitX where X was the rule name, not the *label* name - and that function isn't even generated by the generator, since it generates functions for each labeled rule.

E.g. in the rule below, the visitor would be generated with functions visitWrap(), visitAdd(), and visitMult() - but the visit function logic would attempt to call visitExpr(), which is *not* generated.

```
expr
    : '(' expr ')'	# wrap
    | expr '+' expr	# add
    | expr '*' expr	# mult
    ;
```

Also: the package on NPM is seriously out of date and there's critical stuff missing (e.g. a working visitor) - an update would be appreciated!