### PR TITLE
JS: Do deep Actions array comparison in LexerActionExecutor equals()

### DIFF
--- a/runtime/JavaScript/src/antlr4/atn/LexerActionExecutor.js
+++ b/runtime/JavaScript/src/antlr4/atn/LexerActionExecutor.js
@@ -166,9 +166,18 @@ LexerActionExecutor.prototype.equals = function(other) {
 		return true;
 	} else if (!(other instanceof LexerActionExecutor)) {
 		return false;
+	} else if (this._hashString != other._hashString) {
+		return false;
+	} else if (this.lexerActions.length != other.lexerActions.length) {
+		return false;
 	} else {
-		return this._hashString === other._hashString &&
-				this.lexerActions === other.lexerActions;
+		var numActions = this.lexerActions.length
+		for (var idx = 0; idx < numActions; ++idx) {
+			if (!this.lexerActions[idx].equals(other.lexerActions[idx])) {
+				return false;
+			}
+		}
+		return true;
 	}
 };
 


### PR DESCRIPTION
According to the corresponding Java implementation, the equals() method for LexerActionExecutor should be doing an equals() test on each of the actions rather than testing the Array reference is equal.