### PR TITLE
JS: Fix copy-and-paste error in OR SemanticContext toString() method

### DIFF
--- a/runtime/JavaScript/src/antlr4/atn/SemanticContext.js
+++ b/runtime/JavaScript/src/antlr4/atn/SemanticContext.js
@@ -408,7 +408,7 @@ OR.prototype.evalPrecedence = function(parser, outerContext) {
 	return result;
 };
 
-AND.prototype.toString = function() {
+OR.prototype.toString = function() {
 	var s = "";
 	this.opnds.map(function(o) {
 		s += "|| " + o.toString();


### PR DESCRIPTION
The OR toString() method was incorrectly added to the AND prototype