### PR TITLE
JS: SemanticPredicate should be SemanticContext

### DIFF
--- a/runtime/JavaScript/src/antlr4/atn/SemanticContext.js
+++ b/runtime/JavaScript/src/antlr4/atn/SemanticContext.js
@@ -301,7 +301,7 @@ AND.prototype.evalPrecedence = function(parser, outerContext) {
 	}
 	var result = null;
 	operands.map(function(o) {
-		result = result === null ? o : SemanticPredicate.andContext(result, o);
+		result = result === null ? o : SemanticContext.andContext(result, o);
 	});
 	return result;
 };


### PR DESCRIPTION
AND.evalPrecedence() method is attempting to invoke a method on a non-existent class "SemanticPredicate". It should be using "SemanticContext" instead.