### PR TITLE
JS: ATNConfig can incorrectly change "alt" of 0 to null

### DIFF
--- a/runtime/JavaScript/src/antlr4/atn/ATNConfig.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNConfig.js
@@ -50,7 +50,7 @@ function checkParams(params, isCfg) {
 	} else {
 		var props = {};
 		props.state = params.state || null;
-		props.alt = params.alt || null;
+		props.alt = (params.alt === undefined) ? null : params.alt;
 		props.context = params.context || null;
 		props.semanticContext = params.semanticContext || null;
 		if(isCfg) {


### PR DESCRIPTION
When an ATNConfig instance is created with an alt of 0, it is possible for it to be incorrectly changed to null due to its "falsey" nature.