### PR TITLE
Fixing Issue #1148

### DIFF
--- a/tool/src/org/antlr/v4/codegen/target/Python2Target.java
+++ b/tool/src/org/antlr/v4/codegen/target/Python2Target.java
@@ -61,7 +61,7 @@ public class Python2Target extends Target {
 		"memoryview",
 		"object", "oct", "open", "ord",
 		"pow", "print", "property",
-		"range", "raw_input", "reduce", "reload", "repr", "reversed", "round",
+		"range", "raw_input", "reduce", "reload", "repr", "return", "reversed", "round",
 		"set", "setattr", "slice", "sorted", "staticmethod", "str", "sum", "super",
 		"tuple", "type",
 		"unichr", "unicode",


### PR DESCRIPTION
Just added return to the list of python2 keywords. It appears to be missing in the Python3 Target as well.