### PR TITLE
Execute commands for test suite using the PATH

### DIFF
--- a/doc/building-antlr.md
+++ b/doc/building-antlr.md
@@ -112,6 +112,18 @@ antlr4-tool-testsuite/4.5.2-SNAPSHOT/antlr4-tool-testsuite-4.5.2-SNAPSHOT.jar
 
 Note that ANTLR is written in itself, which is why maven downloads antlr4-4.5.jar for boostrapping 4.5.2-SNAPSHOT purposes.
 
+If the test suite fails to find some required tool, it is possible to specify a name or full path
+using a system property, i.e. using a `-Dkey=value` argument to the `mvn` invocation.
+The following keys are understood:
+
+| language   | key                        | default value (documentation might be outdated)          |
+|------------|----------------------------|----------------------------------------------------------|
+| Python     | `antlr-python2-python`     | `python2.7`                                              |
+| Python     | `antlr-python3-python`     | `python3.5`                                              |
+| JavaScript | `antlr-javascript-nodejs`  | `nodejs` if found, `node` otherwise                      |
+| C#         | `antlr-javascript-msbuild` | default MSBuild 12.0 path on Windows, `xbuild` otherwise |
+| C#         | `antlr-javascript-mono`    | omitted on Windows, `mono` otherwise                     |
+
 To build without running the tests (saves about 8 minutes), do this:
 
 ```bash

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseTest.java
@@ -440,10 +440,25 @@ public abstract class BaseTest {
 	}
 
 	private String locateMSBuild() {
+		String propName = "antlr-csharp-msbuild";
+		String prop = System.getProperty(propName);
+		if (prop != null && prop.length() != 0)
+			return prop;
 		if(isWindows())
 			return "\"C:\\Program Files (x86)\\MSBuild\\12.0\\Bin\\MSBuild.exe\"";
 		else
-			return locateTool("xbuild");
+			return "xbuild";
+	}
+
+	private String locateMono() {
+		String propName = "antlr-csharp-mono";
+		String prop = System.getProperty(propName);
+		if (prop != null && prop.length() != 0)
+			return prop;
+		if(isWindows())
+			return null;
+		else
+			return "mono";
 	}
 
 	private boolean isWindows() {
@@ -452,15 +467,6 @@ public abstract class BaseTest {
 
 	private String locateExec() {
 		return new File(tmpdir, "bin/Release/Test.exe").getAbsolutePath();
-	}
-
-	private String locateTool(String tool) {
-		String[] roots = { "/usr/bin/", "/usr/local/bin/" };
-		for(String root : roots) {
-			if(new File(root + tool).exists())
-				return root + tool;
-		}
-		throw new RuntimeException("Could not locate " + tool);
 	}
 
 	public boolean createProject() {
@@ -531,9 +537,11 @@ public abstract class BaseTest {
 	public String execTest() {
 		try {
 			String exec = locateExec();
-			String[] args = isWindows() ?
-					new String[] { exec, new File(tmpdir, "input").getAbsolutePath() } :
-					new String[] { "mono", exec, new File(tmpdir, "input").getAbsolutePath() };
+			String mono = locateMono();
+			String input = new File(tmpdir, "input").getAbsolutePath();
+			String[] args = mono == null ?
+					new String[] { exec,  input} :
+					new String[] { mono, exec, input };
 			ProcessBuilder pb = new ProcessBuilder(args);
 			pb.directory(new File(tmpdir));
 			Process process = pb.start();

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python/BasePythonTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python/BasePythonTest.java
@@ -553,24 +553,12 @@ public abstract class BasePythonTest {
 		return null;
 	}
 
-	private String locateTool(String tool) {
-		String[] roots = { "/usr/bin/", "/usr/local/bin/" };
-		for(String root : roots) {
-			if(new File(root + tool).exists())
-				return root + tool;
-		}
-		throw new RuntimeException("Could not locate " + tool);
-	}
-
 	protected String locatePython() {
 		String propName = getPropertyPrefix() + "-python";
-    	String prop = System.getProperty(propName);
-    	if(prop==null || prop.length()==0)
-    		prop = locateTool(getPythonExecutable());
-		File file = new File(prop);
-		if(!file.exists())
-			throw new RuntimeException("Missing system property:" + propName);
-		return file.getAbsolutePath();
+		String prop = System.getProperty(propName);
+		if(prop==null || prop.length()==0)
+			prop = getPythonExecutable();
+		return prop;
 	}
 
 	protected abstract String getPythonExecutable();


### PR DESCRIPTION
This switches from some hardwired search paths to using command names only, relying on the system's `PATH` to locate the appropriate binary.
If that fails, there are system properties to override each setting, now even for C#.

This fixes #1156 for me on MacPorts Mac, but it should be tested on Ubuntu and Windows, too.
