### PR TITLE
JS: ParserRuleContext can change invokingState from 0 to null

### DIFF
--- a/runtime/JavaScript/src/antlr4/ParserRuleContext.js
+++ b/runtime/JavaScript/src/antlr4/ParserRuleContext.js
@@ -59,8 +59,6 @@ var ErrorNodeImpl = Tree.ErrorNodeImpl;
 var Interval = require("./IntervalSet").Interval;
 
 function ParserRuleContext(parent, invokingStateNumber) {
-	parent = parent || null;
-	invokingStateNumber = invokingStateNumber || null;
 	RuleContext.call(this, parent, invokingStateNumber);
 	this.ruleIndex = -1;
     // * If we are debugging or building a parse tree for a visitor,

--- a/runtime/JavaScript/src/antlr4/RuleContext.js
+++ b/runtime/JavaScript/src/antlr4/RuleContext.js
@@ -56,11 +56,11 @@ var INVALID_ALT_NUMBER = require('./atn/ATN').INVALID_ALT_NUMBER;
 function RuleContext(parent, invokingState) {
 	RuleNode.call(this);
 	// What context invoked this rule?
-	this.parentCtx = parent || null;
+	this.parentCtx = parent;
 	// What state invoked the rule associated with this context?
 	// The "return address" is the followState of invokingState
 	// If parent is null, this should be -1.
-	this.invokingState = invokingState || -1;
+	this.invokingState = (parent == null) ? -1 : invokingState;
 	return this;
 }
 


### PR DESCRIPTION
If an instance of a class deriving from ParserRuleContext is created
with an invokingState of 0 then the constructor will incorrectly
change this to null due to the falsey nature of 0.

A similar problem exists in the base class RuleContext, where it
will change an invokingState of 0 to -1. Using the Java source as
a reference, this appears to be a bug. The invokingState should
be set to -1 when the parent is null.

It looks like the code is trying to watch for an invokingState of
null or undefined. However, I think this is unnecessary since the
rule context classes generated from the grammar already handle
these cases in their constructor, for example:

function ContentContext(parser, parent, invokingState) {
        if(parent===undefined) {
            parent = null;
        }
        if(invokingState===undefined || invokingState===null) {
                invokingState = -1;
        }
