### PR TITLE
Remove unnecessary semicolons from Python targets.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -92,3 +92,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/03/27, beardlybread, Bradley Steinbacher, bradley.j.steinbacher@gmail.com
 2016/03/29, msteiger, Martin Steiger, antlr@martin-steiger.de
 2016/03/28, gagern, Martin von Gagern, gagern@ma.tum.de
+2016/04/13, renatahodovan, Renata Hodovan, reni@inf.u-szeged.hu

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -375,7 +375,7 @@ while True:
 
 AltBlock(choice, preamble, alts, error) ::= <<
 self.state = <choice.stateNumber>
-self._errHandler.sync(self);
+self._errHandler.sync(self)
 <if(choice.label)><labelref(choice.label)> = _input.LT(1)<endif>
 <preamble; separator="\n">
 la_ = self._interp.adaptivePredict(self._input,<choice.decision>,self._ctx)
@@ -389,7 +389,7 @@ if la_ == <i>:
 
 OptionalBlock(choice, alts, error) ::= <<
 self.state = <choice.stateNumber>
-self._errHandler.sync(self);
+self._errHandler.sync(self)
 la_ = self._interp.adaptivePredict(self._input,<choice.decision>,self._ctx)
 <alts:{alt |
 if la_ == <i><if(!choice.ast.greedy)>+1<endif>:

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -383,7 +383,7 @@ while True:
 
 AltBlock(choice, preamble, alts, error) ::= <<
 self.state = <choice.stateNumber>
-self._errHandler.sync(self);
+self._errHandler.sync(self)
 <if(choice.label)><labelref(choice.label)> = _input.LT(1)<endif>
 <preamble; separator="\n">
 la_ = self._interp.adaptivePredict(self._input,<choice.decision>,self._ctx)
@@ -397,7 +397,7 @@ if la_ == <i>:
 
 OptionalBlock(choice, alts, error) ::= <<
 self.state = <choice.stateNumber>
-self._errHandler.sync(self);
+self._errHandler.sync(self)
 la_ = self._interp.adaptivePredict(self._input,<choice.decision>,self._ctx)
 <alts:{alt |
 if la_ == <i><if(!choice.ast.greedy)>+1<endif>:


### PR DESCRIPTION
The Python templates contained superfluous semicolons after
the sync call of errHandler. This patch removes them.
