### PR TITLE
Add missing default pass statements to Python targets.

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -319,7 +319,7 @@ self.state = <choice.stateNumber>
 token = self._input.LA(1)
 <choice.altLook,alts:{look,alt| <cases(ttypes=look)>
     <alt>
-	}; separator="\nel">
+    pass}; separator="\nel">
 else:
     <error>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -327,7 +327,7 @@ self.state = <choice.stateNumber>
 token = self._input.LA(1)
 <choice.altLook,alts:{look,alt| <cases(ttypes=look)>
     <alt>
-	}; separator="\nel">
+    pass}; separator="\nel">
 else:
     <error>
 


### PR DESCRIPTION
The default pass statements were missing from the LL1AltBlock's
template in case of Python targets, which generated conditional statements
without body in some cases and ended in syntax error. The patch fixes this.