### PR TITLE
Fix typo in the parser of the Python3 runtime.

### DIFF
--- a/runtime/Python3/src/antlr4/Parser.py
+++ b/runtime/Python3/src/antlr4/Parser.py
@@ -371,7 +371,7 @@ class Parser (Recognizer):
     # Always called by generated parsers upon entry to a rule. Access field
     # {@link #_ctx} get the current context.
     #
-    def enterRule(self, localctx:ParserRuleContext , state:int , ruleIndexint ):
+    def enterRule(self, localctx:ParserRuleContext , state:int , ruleIndex:int):
         self.state = state
         self._ctx = localctx
         self._ctx.start = self._input.LT(1)


### PR DESCRIPTION
The last parameter name of Parser::enterRule in the Python3 runtime
was mistakenly combined with its type. The patch fixes this.
