### PR TITLE
Fix initialization of ATNConfig when computing SLL prediction termination condition.

### DIFF
--- a/runtime/Python2/src/antlr4/atn/PredictionMode.py
+++ b/runtime/Python2/src/antlr4/atn/PredictionMode.py
@@ -213,7 +213,7 @@ class PredictionMode(object):
                 # dup configs, tossing out semantic predicates
                 dup = ATNConfigSet()
                 for c in configs:
-                    c = ATNConfig(c,SemanticContext.NONE)
+                    c = ATNConfig(config=c, semantic=SemanticContext.NONE)
                     dup.add(c)
                 configs = dup
             # now we have combined contexts for configs with dissimilar preds

--- a/runtime/Python3/src/antlr4/atn/PredictionMode.py
+++ b/runtime/Python3/src/antlr4/atn/PredictionMode.py
@@ -216,7 +216,7 @@ class PredictionMode(Enum):
                 # dup configs, tossing out semantic predicates
                 dup = ATNConfigSet()
                 for c in configs:
-                    c = ATNConfig(c,SemanticContext.NONE)
+                    c = ATNConfig(config=c, semantic=SemanticContext.NONE)
                     dup.add(c)
                 configs = dup
             # now we have combined contexts for configs with dissimilar preds


### PR DESCRIPTION
The PredictionMode::hasSLLConflictTerminatingPrediction method aims to
create ATNConfig objects from another ATNConfig and SemanticContext
objects. In case of the Python targets, the initialization
happened without keyword arguments. Since the called **init**
method had default values set for all the parameters, the parameter
substitution worked by indices. As a consequence, the first ATNConfig
parameter was wrongly interpreted as an ATNState and the SemanticContext as
an alternative. The patch fixes this by adding the missing keywords.
