### PR TITLE
Use relative links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ ANTLR project lead and supreme dictator for life
 ## Useful information
 
 * [Release notes](https://github.com/antlr/antlr4/releases)
-* [Getting started with v4](https://raw.githubusercontent.com/antlr/antlr4/master/doc/getting-started.md)
+* [Getting started with v4](doc/getting-started.md)
 * [Official site](http://www.antlr.org/)
-* [Documentation](https://raw.githubusercontent.com/antlr/antlr4/master/doc/index.md)
-* [FAQ](https://raw.githubusercontent.com/antlr/antlr4/master/doc/faq/index.md)
+* [Documentation](doc/index.md)
+* [FAQ](doc/faq/index.md)
 * [API](http://www.antlr.org/api/Java/index.html)
 * [ANTLR v3](http://www.antlr3.org/)
-* [v3 to v4 Migration, differences](https://raw.githubusercontent.com/antlr/antlr4/master/doc/faq/general.md)
+* [v3 to v4 Migration, differences](doc/faq/general.md)
 
 You might also find the following pages useful, particularly if you want to mess around with the various target languages.
  
-* [How to build ANTLR itself](https://raw.githubusercontent.com/antlr/antlr4/master/doc/building-antlr.md)
-* [How we create and deploy an ANTLR release](https://raw.githubusercontent.com/antlr/antlr4/master/doc/releasing-antlr.md)
+* [How to build ANTLR itself](doc/building-antlr.md)
+* [How we create and deploy an ANTLR release](doc/releasing-antlr.md)
 
 ## The Definitive ANTLR 4 Reference
 


### PR DESCRIPTION
According to [GitHub Help: Relative links in READMEs](https://help.github.com/articles/relative-links-in-readmes/) it's cooler to use relative links. You'll also get the correct Markdown rendering.
