### PR TITLE
Fix eofToken access in ListTokenSource.nextToken() by Python targets.

### DIFF
--- a/runtime/Python2/src/antlr4/ListTokenSource.py
+++ b/runtime/Python2/src/antlr4/ListTokenSource.py
@@ -81,7 +81,7 @@ class ListTokenSource(TokenSource):
             return self.eofToken
         t = self.tokens[self.pos]
         if self.pos == len(self.tokens) - 1 and t.type == Token.EOF:
-            eofToken = t
+            self.eofToken = t
         self.pos += 1
         return t
 

--- a/runtime/Python3/src/antlr4/ListTokenSource.py
+++ b/runtime/Python3/src/antlr4/ListTokenSource.py
@@ -81,7 +81,7 @@ class ListTokenSource(TokenSource):
             return self.eofToken
         t = self.tokens[self.pos]
         if self.pos == len(self.tokens) - 1 and t.type == Token.EOF:
-            eofToken = t
+            self.eofToken = t
         self.pos += 1
         return t
 


### PR DESCRIPTION
At the end of the nextToken() function, setting the eofToken field was
attempted without the 'self' keyword, resulting in accessing
and setting a new local and unused variable. The patch supplements
the missing 'self' keywords for both targets.
