### PR TITLE
Fix the type hint of SemanticContext.filterPrecedencePredicates parameter.

### DIFF
--- a/runtime/Python3/src/antlr4/atn/SemanticContext.py
+++ b/runtime/Python3/src/antlr4/atn/SemanticContext.py
@@ -115,7 +115,7 @@ def orContext(a:SemanticContext, b:SemanticContext):
     else:
         return result
 
-def filterPrecedencePredicates(collection:list):
+def filterPrecedencePredicates(collection:set):
     result = []
     for context in collection:
         if isinstance(context, PrecedencePredicate):


### PR DESCRIPTION
SemanticContext.filterPrecedencePredicates() takes a set as parameter
in Python3 but the hint tells list instead. The patch fixes this.
