### PR TITLE
Fix comparisons in ATNConfigSet.__contains__ of Python targets.

### DIFF
--- a/runtime/Python2/src/antlr4/atn/ATNConfigSet.py
+++ b/runtime/Python2/src/antlr4/atn/ATNConfigSet.py
@@ -195,9 +195,13 @@ class ATNConfigSet(object):
     def __contains__(self, config):
         if self.configLookup is None:
             raise UnsupportedOperationException("This method is not implemented for readonly sets.")
-        h = hash(config)
+        h = config.hashCodeForConfigSet()
         l = self.configLookup.get(h, None)
-        return l is not None and config in l
+        if l is not None:
+            for c in l:
+                if config.equalsForConfigSet(c):
+                    return True
+        return False
 
     def clear(self):
         if self.readonly:

--- a/runtime/Python3/src/antlr4/atn/ATNConfigSet.py
+++ b/runtime/Python3/src/antlr4/atn/ATNConfigSet.py
@@ -198,9 +198,13 @@ class ATNConfigSet(object):
     def __contains__(self, config):
         if self.configLookup is None:
             raise UnsupportedOperationException("This method is not implemented for readonly sets.")
-        h = hash(config)
+        h = config.hashCodeForConfigSet()
         l = self.configLookup.get(h, None)
-        return l is not None and config in l
+        if l is not None:
+            for c in l:
+                if config.equalsForConfigSet(c):
+                    return True
+        return False
 
     def clear(self):
         if self.readonly:


### PR DESCRIPTION
The **contains** method of ATNConfigSet used different hashing
function (hash) for indexing the config dictionary than the
getOrAdd method (hashCodeForConfigSet) which filled it.
Furthermore, they also used different methods for comparing
ATNConfig objects. The patch makes them consistent.
