### PR TITLE
Fix the initialization of conflictingAlts in execATN in Python targets.

### DIFF
--- a/runtime/Python2/src/antlr4/atn/ParserATNSimulator.py
+++ b/runtime/Python2/src/antlr4/atn/ParserATNSimulator.py
@@ -443,7 +443,7 @@ class ParserATNSimulator(ATNSimulator):
 
             if D.requiresFullContext and self.predictionMode != PredictionMode.SLL:
                 # IF PREDS, MIGHT RESOLVE TO SINGLE ALT => SLL (or syntax error)
-                conflictingAlts = None
+                conflictingAlts = D.configs.conflictingAlts
                 if D.predicates is not None:
                     if ParserATNSimulator.debug:
                         print("DFA state has preds in DFA sim LL failover")

--- a/runtime/Python3/src/antlr4/atn/ParserATNSimulator.py
+++ b/runtime/Python3/src/antlr4/atn/ParserATNSimulator.py
@@ -448,7 +448,7 @@ class ParserATNSimulator(ATNSimulator):
 
             if D.requiresFullContext and self.predictionMode != PredictionMode.SLL:
                 # IF PREDS, MIGHT RESOLVE TO SINGLE ALT => SLL (or syntax error)
-                conflictingAlts = None
+                conflictingAlts = D.configs.conflictingAlts
                 if D.predicates is not None:
                     if ParserATNSimulator.debug:
                         print("DFA state has preds in DFA sim LL failover")


### PR DESCRIPTION
The Java target initializes the conflictingAlt local variable
based on the conflictingAlts property of the target state.
However, the Python targets reset it to None. The patch makes the
initializations consistent.
