### PR TITLE
Repalce string exceptions in Python targets.

### DIFF
--- a/runtime/Python2/src/antlr4/PredictionContext.py
+++ b/runtime/Python2/src/antlr4/PredictionContext.py
@@ -85,7 +85,7 @@ class PredictionContext(object):
         return self.getReturnState(len(self) - 1) == self.EMPTY_RETURN_STATE
 
     def getReturnState(self, index):
-        raise "illegal!"
+        raise Exception("illegal!")
 
     def __hash__(self):
         return self.cachedHashCode

--- a/runtime/Python3/src/antlr4/PredictionContext.py
+++ b/runtime/Python3/src/antlr4/PredictionContext.py
@@ -85,7 +85,7 @@ class PredictionContext(object):
         return self.getReturnState(len(self) - 1) == self.EMPTY_RETURN_STATE
 
     def getReturnState(self, index:int):
-        raise "illegal!"
+        raise Exception("illegal!")
 
     def __hash__(self):
         return self.cachedHashCode


### PR DESCRIPTION
Raising string exception in Python is not supported.
PredictionContext.getReturnState attempted this what is
fixed by the patch.
