### PR TITLE
update the runtime paths to work in windows

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -92,3 +92,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/03/27, beardlybread, Bradley Steinbacher, bradley.j.steinbacher@gmail.com
 2016/03/29, msteiger, Martin Steiger, antlr@martin-steiger.de
 2016/03/28, gagern, Martin von Gagern, gagern@ma.tum.de
+2016/08/19, andjo403, Andreas Jonson, andjo403@hotmail.com

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseTest.java
@@ -482,6 +482,9 @@ public abstract class BaseTest {
 				throw new RuntimeException("C# runtime project file not found!");
 			}
 			String runtimeProjPath = runtimeProj.getPath();
+			if(isWindows()){
+				runtimeProjPath = runtimeProjPath.replaceFirst("/", "");
+			}
 			XPathExpression exp = XPathFactory.newInstance().newXPath()
 				.compile("/Project/ItemGroup/ProjectReference[@Include='" + runtimeName + "']");
 			Element node = (Element)exp.evaluate(prjXml, XPathConstants.NODE);

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/node/BaseTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/node/BaseTest.java
@@ -445,7 +445,14 @@ public abstract class BaseTest {
 		if ( runtimeSrc==null ) {
 			throw new RuntimeException("Cannot find JavaScript runtime");
 		}
+		if(isWindows()){
+			return runtimeSrc.getPath().replaceFirst("/", "");
+		}
 		return runtimeSrc.getPath();
+	}
+
+	private boolean isWindows() {
+		return System.getProperty("os.name").toLowerCase().contains("windows");
 	}
 
 	public void testErrors(String[] pairs, boolean printTree) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python/BasePythonTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python/BasePythonTest.java
@@ -583,7 +583,14 @@ public abstract class BasePythonTest {
 		if ( runtimeSrc==null ) {
 			throw new RuntimeException("Cannot find "+targetName+" runtime");
 		}
+		if(isWindows()){
+			return runtimeSrc.getPath().replaceFirst("/", "");
+		}
 		return runtimeSrc.getPath();
+	}
+
+	private boolean isWindows() {
+		return System.getProperty("os.name").toLowerCase().contains("windows");
 	}
 
 	public void testErrors(String[] pairs, boolean printTree) {


### PR DESCRIPTION
the old paths contained a / at the beginning of the path e.g. "/C:/" but the expected path is "C:/" and due to this all test for the targets javascript, python and c# failed on windows.