### PR TITLE
Fixed visiting labeled rules for Javascript Visitors.

### DIFF
--- a/runtime/JavaScript/src/antlr4/tree/Tree.js
+++ b/runtime/JavaScript/src/antlr4/tree/Tree.js
@@ -107,10 +107,7 @@ var visitAtom = function(visitor, ctx) {
 		return;
 	}
 
-	var name = ctx.parser.ruleNames[ctx.ruleIndex];
-	var funcName = "visit" + Utils.titleCase(name);
-
-	return visitor[funcName](ctx);
+	return ctx.accept(visitor);
 };
 
 function ParseTreeListener() {


### PR DESCRIPTION
Changed the visitAtom method in Tree.js to call the accept method on the context object in order to visit the proper visitor functions for labeled rules. Tested locally on a simple example. No additional thorough testing has been done.

See #1275 #1100 for some details.
