### PR TITLE
Add AppVeyor.yml for Windows contious integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,4 +6,3 @@ test_script:
   - mvn install -q -Dantlr-python2-python="C:\Python27\python.exe" -Dantlr-python3-python="C:\Python35\python.exe" -Dantlr-javascript-nodejs="C:\Program Files (x86)\nodejs\node.exe" --batch-mode
 build:
   verbosity: minimal
-  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,3 +4,6 @@ build_script:
   - mvn compile -q --batch-mode 
 test_script:
   - mvn install -q -Dantlr-python2-python="C:\Python27\python.exe" -Dantlr-python3-python="C:\Python35\python.exe" -Dantlr-javascript-nodejs="C:\Program Files (x86)\nodejs\node.exe" --batch-mode
+build:
+  verbosity: minimal
+  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '4.5.4-SNAPSHOT+Appveyor.{build}'
+version: '4.5.4-SNAPSHOT+AppVeyor.{build}'
 os: Windows Server 2012
 build_script:
   - mvn compile --batch-mode 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,6 @@
+version: '4.5.4-SNAPSHOT+Appveyor.{build}'
+os: Windows Server 2012
+build_script:
+  - mvn compile --batch-mode 
+test_script:
+  - mvn install -Dantlr-python2-python="C:\Python27\python.exe" -Dantlr-python3-python="C:\Python35\python.exe" -Dantlr-javascript-nodejs="C:\Program Files (x86)\nodejs\node.exe" --batch-mode

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '4.5.4-SNAPSHOT+AppVeyor.{build}'
 os: Windows Server 2012
 build_script:
-  - mvn compile --batch-mode 
+  - mvn compile -q --batch-mode 
 test_script:
-  - mvn install -Dantlr-python2-python="C:\Python27\python.exe" -Dantlr-python3-python="C:\Python35\python.exe" -Dantlr-javascript-nodejs="C:\Program Files (x86)\nodejs\node.exe" --batch-mode
+  - mvn install -q -Dantlr-python2-python="C:\Python27\python.exe" -Dantlr-python3-python="C:\Python35\python.exe" -Dantlr-javascript-nodejs="C:\Program Files (x86)\nodejs\node.exe" --batch-mode


### PR DESCRIPTION
This adds a simple configuration file to the root directory which enables use of appveyor.com for Windows-based integration testing.   See a sample build from my fork at    https://ci.appveyor.com/project/BurtHarris/antlr4
