### PR TITLE
Fixing issue #1295 - $e.v yields incorrect value for recursive rule

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -1,4 +1,4 @@
-﻿ANTLR Project Contributors Certification of Origin and Rights
+ANTLR Project Contributors Certification of Origin and Rights
 
 All contributors to ANTLR v4 must formally agree to abide by this
 certificate of origin by signing on the bottom with their github
@@ -103,6 +103,7 @@ YYYY/MM/DD, github id, Full name, email
 2016/08/08, wjkohnen, Wolfgang Johannes Kohnen, wjkohnen-go-antlr@ko-sys.com
 2016/08/11, BurtHarris, Ralph "Burt" Harris, Burt_Harris_antlr4@azxs.33mail.com
 2016/08/19, andjo403, Andreas Jonson, andjo403@hotmail.com
+2016/09/27, harriman, Kurt Harriman, harriman@acm.org
 2016/10/13, cgudrian, Christian Gudrian, christian.gudrian@gmx.de
 2016/10/13, nielsbasjes, Niels Basjes, niels@basjes.nl
 2016/10/21, FloorGoddijn, Floor Goddijn, floor.goddijn[at]aimms.com

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
@@ -30,6 +30,7 @@
 package org.antlr.v4.test.runtime.java;
 
 import org.antlr.v4.Tool;
+import org.antlr.v4.analysis.AnalysisPipeline;
 import org.antlr.v4.automata.ATNFactory;
 import org.antlr.v4.automata.ATNPrinter;
 import org.antlr.v4.automata.LexerATNFactory;
@@ -912,6 +913,9 @@ public class BaseJavaTest implements RuntimeTestSupport {
 			ATNFactory factory = new ParserATNFactory(g);
 			if ( g.isLexer() ) factory = new LexerATNFactory((LexerGrammar)g);
 			g.atn = factory.createATN();
+
+            AnalysisPipeline anal = new AnalysisPipeline(g);
+            anal.process();
 
 			CodeGenerator gen = new CodeGenerator(g);
 			ST outputFileST = gen.generateParser(false);

--- a/tool/src/org/antlr/v4/codegen/ActionTranslator.java
+++ b/tool/src/org/antlr/v4/codegen/ActionTranslator.java
@@ -214,23 +214,10 @@ public class ActionTranslator implements ActionSplitterListener {
 		switch ( a.dict.type ) {
 			case ARG: chunks.add(new ArgRef(nodeContext,y.getText())); break; // has to be current rule
 			case RET:
-				if ( factory.getCurrentRuleFunction()!=null &&
-					factory.getCurrentRuleFunction().name.equals(x.getText()) )
-				{
-					chunks.add(new RetValueRef(rf.ruleCtx, y.getText())); break;
-				}
-				else {
-					chunks.add(new QRetValueRef(nodeContext, getRuleLabel(x.getText()), y.getText())); break;
-				}
+				chunks.add(new QRetValueRef(nodeContext, getRuleLabel(x.getText()), y.getText()));
+				break;
 			case PREDEFINED_RULE:
-				if ( factory.getCurrentRuleFunction()!=null &&
-					factory.getCurrentRuleFunction().name.equals(x.getText()) )
-				{
-					chunks.add(getRulePropertyRef(y));
-				}
-				else {
-					chunks.add(getRulePropertyRef(x, y));
-				}
+				chunks.add(getRulePropertyRef(x, y));
 				break;
 			case TOKEN:
 				chunks.add(getTokenPropertyRef(x, y));


### PR DESCRIPTION
ActionTranslator.java - the fix
TestActionTranslation.java - regression test
BaseTest.java - allow left-recursive rule in test
