### PR TITLE
Encapsulate the fields of DFA to enhance its polymorphism

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/DiagnosticErrorListener.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/DiagnosticErrorListener.java
@@ -135,8 +135,8 @@ public class DiagnosticErrorListener extends BaseErrorListener {
 	}
 
 	protected String getDecisionDescription(Parser recognizer, DFA dfa) {
-		int decision = dfa.decision;
-		int ruleIndex = dfa.atnStartState.ruleIndex;
+		int decision = dfa.getDecision();
+		int ruleIndex = dfa.getAtnStartState().ruleIndex;
 
 		String[] ruleNames = recognizer.getRuleNames();
 		if (ruleIndex < 0 || ruleIndex >= ruleNames.length) {

--- a/runtime/Java/src/org/antlr/v4/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Parser.java
@@ -882,9 +882,9 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 			boolean seenOne = false;
 			for (int d = 0; d < _interp.decisionToDFA.length; d++) {
 				DFA dfa = _interp.decisionToDFA[d];
-				if ( !dfa.states.isEmpty() ) {
+				if ( !dfa.getStatesMap().isEmpty() ) {
 					if ( seenOne ) System.out.println();
-					System.out.println("Decision " + dfa.decision + ":");
+					System.out.println("Decision " + dfa.getDecision() + ":");
 					System.out.print(dfa.toString(getVocabulary()));
 					seenOne = true;
 				}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -134,11 +134,11 @@ public class LexerATNSimulator extends ATNSimulator {
 			this.startIndex = input.index();
 			this.prevAccept.reset();
 			DFA dfa = decisionToDFA[mode];
-			if ( dfa.s0==null ) {
+			if ( dfa.getS0() ==null ) {
 				return matchATN(input);
 			}
 			else {
-				return execATN(input, dfa.s0);
+				return execATN(input, dfa.getS0());
 			}
 		}
 		finally {
@@ -177,7 +177,7 @@ public class LexerATNSimulator extends ATNSimulator {
 
 		DFAState next = addDFAState(s0_closure);
 		if (!suppressEdge) {
-			decisionToDFA[mode].s0 = next;
+			decisionToDFA[mode].setS0(next);
 		}
 
 		int predict = execATN(input, next);
@@ -714,16 +714,16 @@ public class LexerATNSimulator extends ATNSimulator {
 		}
 
 		DFA dfa = decisionToDFA[mode];
-		synchronized (dfa.states) {
-			DFAState existing = dfa.states.get(proposed);
+		synchronized (dfa.getStatesMap()) {
+			DFAState existing = dfa.getStatesMap().get(proposed);
 			if ( existing!=null ) return existing;
 
 			DFAState newState = proposed;
 
-			newState.stateNumber = dfa.states.size();
+			newState.stateNumber = dfa.getStatesMap().size();
 			configs.setReadonly(true);
 			newState.configs = configs;
-			dfa.states.put(newState, newState);
+			dfa.getStatesMap().put(newState, newState);
 			return newState;
 		}
 	}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParseInfo.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParseInfo.java
@@ -182,6 +182,6 @@ public class ParseInfo {
 	 */
 	public int getDFASize(int decision) {
 		DFA decisionToDFA = atnSimulator.decisionToDFA[decision];
-		return decisionToDFA.states.size();
+		return decisionToDFA.getStatesMap().size();
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/DFA.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/DFA.java
@@ -46,19 +46,14 @@ import java.util.Map;
 import java.util.Set;
 
 public class DFA {
-	/** A set of all DFA states. Use {@link Map} so we can get old state back
-	 *  ({@link Set} only allows you to see if it's there).
-     */
 
-	public final Map<DFAState, DFAState> states = new HashMap<DFAState, DFAState>();
+	private final Map<DFAState, DFAState> statesMap = new HashMap<DFAState, DFAState>();
 
-	public volatile DFAState s0;
+	private volatile DFAState s0;
 
-	public final int decision;
+	private final int decision;
 
-	/** From which ATN state did we create this DFA? */
-
-	public final DecisionState atnStartState;
+	private final DecisionState atnStartState;
 
 	/**
 	 * {@code true} if this DFA is for a precedence decision; otherwise,
@@ -91,7 +86,7 @@ public class DFA {
 
 	/**
 	 * Gets whether this DFA is a precedence DFA. Precedence DFAs use a special
-	 * start state {@link #s0} which is not stored in {@link #states}. The
+	 * start state {@link #s0} which is not stored in {@link #statesMap}. The
 	 * {@link DFAState#edges} array for this start state contains outgoing edges
 	 * supplying individual start states corresponding to specific precedence
 	 * values.
@@ -183,7 +178,7 @@ public class DFA {
 	 */
 
 	public List<DFAState> getStates() {
-		List<DFAState> result = new ArrayList<DFAState>(states.keySet());
+		List<DFAState> result = new ArrayList<DFAState>(statesMap.keySet());
 		Collections.sort(result, new Comparator<DFAState>() {
 			@Override
 			public int compare(DFAState o1, DFAState o2) {
@@ -222,4 +217,27 @@ public class DFA {
 		return serializer.toString();
 	}
 
+	/** A set of all DFA states. Use {@link Map} so we can get old state back
+	 *  ({@link Set} only allows you to see if it's there).
+     */
+	public Map<DFAState, DFAState> getStatesMap() {
+		return statesMap;
+	}
+
+	public DFAState getS0() {
+		return s0;
+	}
+
+	public void setS0(DFAState s0) {
+		this.s0 = s0;
+	}
+
+	public int getDecision() {
+		return decision;
+	}
+
+	/** From which ATN state did we create this DFA? */
+	public DecisionState getAtnStartState() {
+		return atnStartState;
+	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/DFASerializer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/DFASerializer.java
@@ -58,7 +58,7 @@ public class DFASerializer {
 
 	@Override
 	public String toString() {
-		if ( dfa.s0==null ) return null;
+		if ( dfa.getS0() ==null ) return null;
 		StringBuilder buf = new StringBuilder();
 		List<DFAState> states = dfa.getStates();
 		for (DFAState s : states) {

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -905,8 +905,8 @@ public class TestPerformance extends BaseTest {
 						continue;
 					}
 
-					states += dfa.states.size();
-					for (DFAState state : dfa.states.values()) {
+					states += dfa.getStatesMap().size();
+					for (DFAState state : dfa.getStatesMap().values()) {
 						configs += state.configs.size();
 						uniqueConfigs.addAll(state.configs);
 					}
@@ -918,17 +918,17 @@ public class TestPerformance extends BaseTest {
 					System.out.format("\tMode\tStates\tConfigs\tMode%n");
 					for (int i = 0; i < modeToDFA.length; i++) {
 						DFA dfa = modeToDFA[i];
-						if (dfa == null || dfa.states.isEmpty()) {
+						if (dfa == null || dfa.getStatesMap().isEmpty()) {
 							continue;
 						}
 
 						int modeConfigs = 0;
-						for (DFAState state : dfa.states.values()) {
+						for (DFAState state : dfa.getStatesMap().values()) {
 							modeConfigs += state.configs.size();
 						}
 
 						String modeName = lexer.getModeNames()[i];
-						System.out.format("\t%d\t%d\t%d\t%s%n", dfa.decision, dfa.states.size(), modeConfigs, modeName);
+						System.out.format("\t%d\t%d\t%d\t%s%n", dfa.getDecision(), dfa.getStatesMap().size(), modeConfigs, modeName);
 					}
 				}
 			}
@@ -952,8 +952,8 @@ public class TestPerformance extends BaseTest {
                         continue;
                     }
 
-                    states += dfa.states.size();
-					for (DFAState state : dfa.states.values()) {
+                    states += dfa.getStatesMap().size();
+					for (DFAState state : dfa.getStatesMap().values()) {
 						configs += state.configs.size();
 						uniqueConfigs.addAll(state.configs);
 					}
@@ -971,16 +971,16 @@ public class TestPerformance extends BaseTest {
 
 					for (int i = 0; i < decisionToDFA.length; i++) {
 						DFA dfa = decisionToDFA[i];
-						if (dfa == null || dfa.states.isEmpty()) {
+						if (dfa == null || dfa.getStatesMap().isEmpty()) {
 							continue;
 						}
 
 						int decisionConfigs = 0;
-						for (DFAState state : dfa.states.values()) {
+						for (DFAState state : dfa.getStatesMap().values()) {
 							decisionConfigs += state.configs.size();
 						}
 
-						String ruleName = parser.getRuleNames()[parser.getATN().decisionToState.get(dfa.decision).ruleIndex];
+						String ruleName = parser.getRuleNames()[parser.getATN().decisionToState.get(dfa.getDecision()).ruleIndex];
 
 						long calls = 0;
 						long fullContextCalls = 0;
@@ -1031,7 +1031,7 @@ public class TestPerformance extends BaseTest {
 							formatString = "\t%1$d\t%2$d\t%3$d\t%12$s%n";
 						}
 
-						System.out.format(formatString, dfa.decision, dfa.states.size(), decisionConfigs, calls, fullContextCalls, nonSllCalls, transitions, computedTransitions, fullContextTransitions, lookahead, fullContextLookahead, ruleName);
+						System.out.format(formatString, dfa.getDecision(), dfa.getStatesMap().size(), decisionConfigs, calls, fullContextCalls, nonSllCalls, transitions, computedTransitions, fullContextTransitions, lookahead, fullContextLookahead, ruleName);
 					}
 				}
             }
@@ -1049,7 +1049,7 @@ public class TestPerformance extends BaseTest {
                 }
 
                 if (SHOW_CONFIG_STATS) {
-                    for (DFAState state : dfa.states.keySet()) {
+                    for (DFAState state : dfa.getStatesMap().keySet()) {
                         if (state.configs.size() >= contextsInDFAState.length) {
                             contextsInDFAState = Arrays.copyOf(contextsInDFAState, state.configs.size() + 1);
                         }
@@ -1423,7 +1423,7 @@ public class TestPerformance extends BaseTest {
 				int dfaSize = 0;
 				for (DFA dfa : interpreter.decisionToDFA) {
 					if (dfa != null) {
-						dfaSize += dfa.states.size();
+						dfaSize += dfa.getStatesMap().size();
 					}
 				}
 
@@ -1455,7 +1455,7 @@ public class TestPerformance extends BaseTest {
 				int dfaSize = 0;
 				for (DFA dfa : interpreter.decisionToDFA) {
 					if (dfa != null) {
-						dfaSize += dfa.states.size();
+						dfaSize += dfa.getStatesMap().size();
 					}
 				}
 
@@ -1605,7 +1605,7 @@ public class TestPerformance extends BaseTest {
 				BitSet llPredictions = getConflictingAlts(ambigAlts, configs);
 				int llPrediction = llPredictions.cardinality() == 0 ? ATN.INVALID_ALT_NUMBER : llPredictions.nextSetBit(0);
 				if (sllPrediction != llPrediction) {
-					((StatisticsParserATNSimulator)recognizer.getInterpreter()).nonSll[dfa.decision]++;
+					((StatisticsParserATNSimulator)recognizer.getInterpreter()).nonSll[dfa.getDecision()]++;
 				}
 			}
 
@@ -1615,8 +1615,8 @@ public class TestPerformance extends BaseTest {
 
 			// show the rule name along with the decision
 			String format = "reportAmbiguity d=%d (%s): ambigAlts=%s, input='%s'";
-			int decision = dfa.decision;
-			String rule = recognizer.getRuleNames()[dfa.atnStartState.ruleIndex];
+			int decision = dfa.getDecision();
+			String rule = recognizer.getRuleNames()[dfa.getAtnStartState().ruleIndex];
 			String input = recognizer.getTokenStream().getText(Interval.of(startIndex, stopIndex));
 			recognizer.notifyErrorListeners(String.format(format, decision, rule, ambigAlts, input));
 		}
@@ -1631,8 +1631,8 @@ public class TestPerformance extends BaseTest {
 
 			// show the rule name and viable configs along with the base info
 			String format = "reportAttemptingFullContext d=%d (%s), input='%s', viable=%s";
-			int decision = dfa.decision;
-			String rule = recognizer.getRuleNames()[dfa.atnStartState.ruleIndex];
+			int decision = dfa.getDecision();
+			String rule = recognizer.getRuleNames()[dfa.getAtnStartState().ruleIndex];
 			String input = recognizer.getTokenStream().getText(Interval.of(startIndex, stopIndex));
 			BitSet representedAlts = getConflictingAlts(conflictingAlts, configs);
 			recognizer.notifyErrorListeners(String.format(format, decision, rule, input, representedAlts));
@@ -1644,7 +1644,7 @@ public class TestPerformance extends BaseTest {
 				BitSet sllPredictions = getConflictingAlts(_sllConflict, _sllConfigs);
 				int sllPrediction = sllPredictions.nextSetBit(0);
 				if (sllPrediction != prediction) {
-					((StatisticsParserATNSimulator)recognizer.getInterpreter()).nonSll[dfa.decision]++;
+					((StatisticsParserATNSimulator)recognizer.getInterpreter()).nonSll[dfa.getDecision()]++;
 				}
 			}
 
@@ -1654,8 +1654,8 @@ public class TestPerformance extends BaseTest {
 
 			// show the rule name and viable configs along with the base info
 			String format = "reportContextSensitivity d=%d (%s), input='%s', viable={%d}";
-			int decision = dfa.decision;
-			String rule = recognizer.getRuleNames()[dfa.atnStartState.ruleIndex];
+			int decision = dfa.getDecision();
+			String rule = recognizer.getRuleNames()[dfa.getAtnStartState().ruleIndex];
 			String input = recognizer.getTokenStream().getText(Interval.of(startIndex, stopIndex));
 			recognizer.notifyErrorListeners(String.format(format, decision, rule, input, prediction));
 		}

--- a/tool/src/org/antlr/v4/tool/DOTGenerator.java
+++ b/tool/src/org/antlr/v4/tool/DOTGenerator.java
@@ -82,16 +82,16 @@ public class DOTGenerator {
 	}
 
 	public String getDOT(DFA dfa, boolean isLexer) {
-		if ( dfa.s0==null )	return null;
+		if ( dfa.getS0() ==null )	return null;
 
 		ST dot = stlib.getInstanceOf("dfa");
-		dot.add("name", "DFA"+dfa.decision);
-		dot.add("startState", dfa.s0.stateNumber);
+		dot.add("name", "DFA"+ dfa.getDecision());
+		dot.add("startState", dfa.getS0().stateNumber);
 //		dot.add("useBox", Tool.internalOption_ShowATNConfigsInDFA);
 		dot.add("rankdir", rankdir);
 
 		// define stop states first; seems to be a bug in DOT where doublecircle
-		for (DFAState d : dfa.states.keySet()) {
+		for (DFAState d : dfa.getStatesMap().keySet()) {
 			if ( !d.isAcceptState ) continue;
 			ST st = stlib.getInstanceOf("stopstate");
 			st.add("name", "s"+d.stateNumber);
@@ -99,7 +99,7 @@ public class DOTGenerator {
 			dot.add("states", st);
 		}
 
-		for (DFAState d : dfa.states.keySet()) {
+		for (DFAState d : dfa.getStatesMap().keySet()) {
 			if ( d.isAcceptState ) continue;
 			if ( d.stateNumber == Integer.MAX_VALUE ) continue;
 			ST st = stlib.getInstanceOf("state");
@@ -108,7 +108,7 @@ public class DOTGenerator {
 			dot.add("states", st);
 		}
 
-		for (DFAState d : dfa.states.keySet()) {
+		for (DFAState d : dfa.getStatesMap().keySet()) {
 			if ( d.edges!=null ) {
 				for (int i = 0; i < d.edges.length; i++) {
 					DFAState target = d.edges[i];


### PR DESCRIPTION
Currently most fields of DFA are public, we can not extend the DFA and control the access of its fields.

For example, in order to avoid DFA cache grow forever, I implement DfaWrapper(https://github.com/danielsun1106/groovy-parser/blob/master/src/main/java/org/apache/groovy/parser/antlr4/internal/DfaWrapper.java) which delegate all invocation to the wrapped DFA instance and the DFA instance is held by a SoftReference instance, so the DFA instance can be GCed when JVM is lack of memory and recreate one when it is needed.

In the above example, if DFA's fields are public, we can not delegate access of fields to the wrapped DFA instance. 

Please review the codes. 

Thanks,
Daniel.Sun
