### PR TITLE
Create ParseTree.getSourceText to retrieve the original underlying input

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/ParserRuleContext.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ParserRuleContext.java
@@ -281,6 +281,26 @@ public class ParserRuleContext extends RuleContext {
 		return Interval.of(start.getTokenIndex(), stop.getTokenIndex());
 	}
 
+	@Override
+	public String getSourceText() {
+		if (start == null) {
+			return null; // Invalid
+		}
+		if (stop == null) {
+			return getText();
+		}
+		int startIndex = start.getStartIndex();
+		int stopIndex  = stop.getStopIndex();
+		if (stopIndex < startIndex) {
+			return getText();
+		}
+		CharStream inputStream = start.getInputStream();
+		if (inputStream == null) {
+			return null;
+		}
+		return inputStream.getText(new Interval(startIndex, stopIndex));
+	}
+
 	/**
 	 * Get the initial token in this context.
 	 * Note that the range from start to stop is inclusive, so for rules that do not consume anything

--- a/runtime/Java/src/org/antlr/v4/runtime/RuleContext.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/RuleContext.java
@@ -164,6 +164,12 @@ public class RuleContext implements RuleNode {
 		return builder.toString();
 	}
 
+	@Override
+	public String getSourceText() {
+		throw new UnsupportedOperationException("The getSourceText has not been implemented for the class "
+			+ this.getClass().getCanonicalName());
+	}
+
 	public int getRuleIndex() { return -1; }
 
 	/** For rule associated with this parse tree internal node, return

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/ParseTree.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/ParseTree.java
@@ -57,6 +57,14 @@ public interface ParseTree extends SyntaxTree {
 	 */
 	String getText();
 
+	/**
+	 * Return the original underlying source text of this entire ParseTree
+	 * including all leaf nodes. Also includes all off-channel tokens
+	 * (if any) so it will return whitespace and comments even if they
+	 * were not sent (or on a hidden channel) to the parser.
+	 */
+	String getSourceText();
+
 	/** Specialize toStringTree so that it can print out more information
 	 * 	based upon the parser.
 	 */

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/TerminalNodeImpl.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/TerminalNodeImpl.java
@@ -72,6 +72,9 @@ public class TerminalNodeImpl implements TerminalNode {
 	public String getText() { return symbol.getText(); }
 
 	@Override
+	public String getSourceText() { return symbol.getText(); }
+
+	@Override
 	public String toStringTree(Parser parser) {
 		return toString();
 	}

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestParseTreeMatcher.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestParseTreeMatcher.java
@@ -405,6 +405,29 @@ public class TestParseTreeMatcher extends BaseTest {
 		checkPatternMatch(grammar, "expr", input, pattern, "X6");
 	}
 
+	@Test
+	public void testGetSourceText() throws Exception {
+		String grammar =
+			"grammar X7;\n" +
+			"s : ID '=' expr ';' ;\n" +
+			"expr : ID | INT ;\n" +
+			"ID : [a-z]+ ;\n" +
+			"INT : [0-9]+ ;\n" +
+			"WS : [ \\r\\n\\t]+ -> channel(HIDDEN) ;\n";
+
+		String grammarFileName = "X7.g4";
+		String parserName = "X7Parser";
+		String lexerName = "X7Lexer";
+		boolean ok =
+						rawGenerateAndBuildRecognizer(grammarFileName, grammar, parserName, lexerName, false);
+		assertTrue(ok);
+
+		ParseTree tree = execParser("s", "  foo = \n 42 ;   ", parserName, lexerName);
+
+		assertEquals("foo=42;", tree.getText());
+		assertEquals("foo = \n 42 ;", tree.getSourceText());
+	}
+
 	public ParseTreeMatch checkPatternMatch(String grammar, String startRule,
 											String input, String pattern,
 											String grammarName)


### PR DESCRIPTION
This implements #1302
