### PR TITLE
Add default .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# This rule applies to all files which don't match another line below
+* text=auto


### PR DESCRIPTION
During review of #1304, I noticed that the repository did not include a **.gitattributes** file to ensure EOL characters are handled consistently across developers who may vary.

📝 All files already in the repository are already handled consistently. This file ensures new developers and/or developers working on new machines continue to do the same things we've always been doing.