### PR TITLE
Allow paths as tokenVocab option

### DIFF
--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -521,6 +521,19 @@ public class Tool {
 			// Make grammars depend on any tokenVocab options
 			if ( tokenVocabNode!=null ) {
 				String vocabName = tokenVocabNode.getText();
+				// Strip quote characters if any
+				int len = vocabName.length();
+				int firstChar = vocabName.charAt(0);
+				int lastChar = vocabName.charAt(len - 1);
+				if (len >= 2 && firstChar == '\'' && lastChar == '\'') {
+					vocabName = vocabName.substring(1, len-1);
+				}
+				// If the name contains a path delimited by forward slashes,
+				// use only the part after the last slash as the name
+				int lastSlash = vocabName.lastIndexOf('/');
+				if (lastSlash >= 0) {
+					vocabName = vocabName.substring(lastSlash + 1);
+				}
 				g.addEdge(grammarName, vocabName);
 			}
 			// add cycle to graph so we always process a grammar if no error


### PR DESCRIPTION
As reported on the mailing list in 2007 and also in the Gradle forums in the last years, it is currently impossible to define two different grammars in different packages using separate lexer and parser files and import the lexer files using `tokenVocab`.

Ultimately the problem is that the referenced `tokenVocab` cannot be resolved when processing a grammar that does not reside in the default package. Using the `-lib` makes it possible to work around this problem for a single package, but this fails to work for multiple grammars in different packages because `-lib` can only be specified once.

This patch allows the `tokenVocab` to specify paths instead of only file names, i.e. it is then possible to write `tokenVocab='com/test/html/HTMLLexer';`

The ANTLR parser allows quoted strings for the `tokenVocab` already, and resolving the files just works when specifying a path. However, processing the fileset can still fail because the dependency graph is not built correctly. (Because the dependency graph builder does not identify that `HTMLLexer` and `'com/test/html/HTMLLexer';` are references to the same thing.

To make the dependency graph builder work, I added some code that removes the quotes and extracts only the filename from the specified `tokenVocab`.

I have created [a testing repository](https://github.com/sebkur/antlr4-tests) that demonstrates the new behavior of the `Tool` for two example grammars from the [grammars-v4](https://github.com/antlr/grammars-v4) repository, that have been moved to packages to fit the use case.
