### PR TITLE
Stgwotempvar

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -109,4 +109,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/11/01, RYDB3RG, Kai Stammerjohann, RYDB3RG@users.noreply.github.com
 2016/11/05, runner-mei, meifakun, runner.mei@gmail.com
 2016/11/15, hanjoes, Hanzhou Shi, hanzhou87@gmail.com
-2016/11/06, sridharxp, Sridharan S, aurosridhar@gmail.com
+2016/11/16, sridharxp, Sridharan S, aurosridhar@gmail.com

--- a/contributors.txt
+++ b/contributors.txt
@@ -109,3 +109,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/11/01, RYDB3RG, Kai Stammerjohann, RYDB3RG@users.noreply.github.com
 2016/11/05, runner-mei, meifakun, runner.mei@gmail.com
 2016/11/15, hanjoes, Hanzhou Shi, hanzhou87@gmail.com
+2016/11/06, sridharxp, Sridharan S, aurosridhar@gmail.com

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -742,35 +742,12 @@ bitsetInlineComparison(s, bits) ::= <%
 
 InvokeRule(r, argExprsChunks) ::= <<
 p.SetState(<r.stateNumber>)
-<if(r.labels)>
-
-<if(r.ast.options.p)>
-var _x = p.<r.name>(<r.ast.options.p><if(argExprsChunks)>, <endif><argExprsChunks>)
-<else>
-var _x = p.<r.name; format="cap">(<argExprsChunks>)
-<endif>
-
-
-<r.labels:{l | <labelref(l)> = _x}; separator="\n">
-<else>
-<if(r.ast.options.p)>
-p.<r.name>(<r.ast.options.p><if(argExprsChunks)>, <endif><argExprsChunks>)
-<else>
-p.<r.name; format="cap">(<argExprsChunks>)
-<endif>
-<endif>
+<if(r.labels)><r.labels:{l | <labelref(l)> = }><endif>p.<r.name; format="cap">(<if(r.ast.options.p)><r.ast.options.p><if(argExprsChunks)>,<endif><endif><argExprsChunks>);
 >>
 
 MatchToken(m) ::= <<
 p.SetState(<m.stateNumber>)
-<if(m.labels)>
-
-var _m = p.Match(<parser.name><m.name>)
-
-<m.labels:{l | <labelref(l)> = _m}; separator="\n">
-<else>
-p.Match(<parser.name><m.name>)
-<endif>
+<if(m.labels)><m.labels:{l | <labelref(l)> = }><endif>p.Match(<parser.name><m.name>);
 >>
 
 MatchSet(m, expr, capture) ::= "<CommonSetStuff(m, expr, capture, false)>"


### PR DESCRIPTION
[@pboyer](https://github.com/pboyer), [@millergarym](https://github.com/millergarym)
Creating Temp Var _x looks to me error prone.
Following java.stg seems to me more robust.
In this way Var re declaration issue does not arise.
For [_x redeclared in this block](https://github.com/pboyer/antlr4/issues/88) this seems to be a safer solution than the PR [Fix for redeclared error is generated Go code](https://github.com/pboyer/antlr4/pull/89)

Congratulations to Antlr team and specially to Go contributors