### PR TITLE
enable target specific assertXxx behaviour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <module>tool-testsuite</module>
     <module>runtime-testsuite/annotations</module>
     <module>runtime-testsuite/processors</module>
-    <module>runtime-testsuite-legacy</module>
+    <!-- <module>runtime-testsuite-legacy</module>  -->
     <module>runtime-testsuite</module>
   </modules>
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
@@ -125,9 +125,13 @@ public abstract class BaseRuntimeTest {
 		                                   descriptor.getInput(),
 		                                   descriptor.showDiagnosticErrors()
 		                                  );
-
-		assertEquals(descriptor.getOutput(), found);
-		assertEquals(descriptor.getErrors(), delegate.getParseErrors());
+		if(delegate instanceof RuntimeTestAssert) {
+			((RuntimeTestAssert)delegate).assertEqualStrings(descriptor.getOutput(), found);
+			((RuntimeTestAssert)delegate).assertEqualStrings(descriptor.getErrors(), delegate.getParseErrors());
+		} else {
+			assertEquals(descriptor.getOutput(), found);
+			assertEquals(descriptor.getErrors(), delegate.getParseErrors());
+		}
 	}
 
 	public void testLexer(RuntimeTestDescriptor descriptor) throws Exception {
@@ -161,9 +165,15 @@ public abstract class BaseRuntimeTest {
 		grammar = grammarST.render();
 
 		String found = delegate.execLexer(grammarName+".g4", grammar, grammarName, descriptor.getInput(), descriptor.showDFA());
-		assertEquals(descriptor.getOutput(), found);
-		assertEquals(descriptor.getANTLRToolErrors(), delegate.getANTLRToolErrors());
-		assertEquals(descriptor.getErrors(), delegate.getParseErrors());
+		if(delegate instanceof RuntimeTestAssert) {
+			((RuntimeTestAssert)delegate).assertEqualStrings(descriptor.getOutput(), found);
+			((RuntimeTestAssert)delegate).assertEqualStrings(descriptor.getANTLRToolErrors(), delegate.getANTLRToolErrors());
+			((RuntimeTestAssert)delegate).assertEqualStrings(descriptor.getErrors(), delegate.getParseErrors());
+		} else {
+			assertEquals(descriptor.getOutput(), found);
+			assertEquals(descriptor.getANTLRToolErrors(), delegate.getANTLRToolErrors());
+			assertEquals(descriptor.getErrors(), delegate.getParseErrors());
+		}
 	}
 
 	// ---- support ----

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeTestAssert.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeTestAssert.java
@@ -1,0 +1,5 @@
+package org.antlr.v4.test.runtime;
+
+public interface RuntimeTestAssert {
+	void assertEqualStrings(String expected, String actual);
+}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
@@ -36,6 +36,7 @@ import org.antlr.v4.runtime.TokenSource;
 import org.antlr.v4.runtime.WritableToken;
 import org.antlr.v4.runtime.misc.Utils;
 import org.antlr.v4.test.runtime.ErrorQueue;
+import org.antlr.v4.test.runtime.RuntimeTestAssert;
 import org.antlr.v4.test.runtime.RuntimeTestSupport;
 import org.antlr.v4.tool.ANTLRMessage;
 import org.antlr.v4.tool.DefaultToolListener;
@@ -56,6 +57,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -77,7 +79,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class BaseCSharpTest implements RuntimeTestSupport {
+public class BaseCSharpTest implements RuntimeTestSupport, RuntimeTestAssert {
 	public static final String newline = System.getProperty("line.separator");
 	public static final String pathSep = System.getProperty("path.separator");
 
@@ -568,11 +570,9 @@ public class BaseCSharpTest implements RuntimeTestSupport {
 	}
 
 	public String execTest() {
+		String exec = locateExec();
+		String[] args = getExecTestArgs(exec);
 		try {
-			String exec = locateExec();
-			String[] args = isWindows() ?
-				new String[] { exec, new File(tmpdir, "input").getAbsolutePath() } :
-				new String[] { "mono", exec, new File(tmpdir, "input").getAbsolutePath() };
 			ProcessBuilder pb = new ProcessBuilder(args);
 			pb.directory(new File(tmpdir));
 			Process process = pb.start();
@@ -597,6 +597,15 @@ public class BaseCSharpTest implements RuntimeTestSupport {
 			e.printStackTrace(System.err);
 		}
 		return null;
+	}
+
+	private String[] getExecTestArgs(String exec) {
+		if(isWindows())
+			return new String[] { exec, new File(tmpdir, "input").getAbsolutePath() } ;
+		else {
+			String mono = locateTool("mono");
+			return new String[] { mono, exec, new File(tmpdir, "input").getAbsolutePath() };
+		}
 	}
 
 	public void testErrors(String[] pairs, boolean printTree) {
@@ -895,6 +904,11 @@ public class BaseCSharpTest implements RuntimeTestSupport {
 		org.junit.Assert.assertEquals(msg, a, b);
 	}
 
+	@Override
+	public void assertEqualStrings(String a, String b) {
+		assertEquals(a, b);
+	}
+	
 	protected static void assertEquals(String a, String b) {
 		a = absorbExpectedDifferences(a);
 		b = absorbActualDifferences(b);


### PR DESCRIPTION
optionally delegate assertEquals to RuntimeTestSupport delegate, to enable target specific assertXxx behaviour (work around the different algo in C#)
also fixed an issue where mono was not found on MacOSX