### PR TITLE
Add postfix types in args like x:T for Swift target

### DIFF
--- a/doc/parser-rules.md
+++ b/doc/parser-rules.md
@@ -380,8 +380,17 @@ The attributes defined within those [...] can be used like any other variable. H
 add[int x] returns [int result] : '+=' INT {$result = $x + $INT.int;} ;
 ```
 
-As with the grammar level, you can specify rule-level named actions. For rules, the valid names are init and after. As the names imply, parsers execute init actions immediately before trying to match the associated rule and execute after actions immediately after matching the rule. ANTLR after actions do not execute as part of the finally code block of the generated rule function. Use the ANTLR finally action to place code in the generated rule function finally code block.
-The actions come after any argument, return value, or local attribute definition actions. The row rule preamble from Section 10.2, Accessing Token and Rule Attributes illustrates the syntax nicely:
+The args, locals, and return `[...]` are generally in the target language but with some constraints. The `[...]` string is a comma-separated list of declarations either with prefix or postfix type notation or no-type notation. The elements can have initializer such as `[int x = 32, float y]` but don't go too crazy as we are parsing this generic text manually in [ScopeParser](https://github.com/antlr/antlr4/blob/master/tool/src/org/antlr/v4/parse/ScopeParser.java).  
+
+* Java, CSharp, C++ use `int x` notation but C++ must use a slightly altered notation for array references, `int[] x`, to fit in the *type* *id* syntax.
+* Go and Swift give the type after the variable name, but Swift requires a `:` in between. Go `i int`, Swift `i:int`.  For Go target, you must either use `int i` or `i:int`.
+* Python and JavaScript don't specify static types so actions are just identifier lists such as `[i,j]`.
+
+Technically any target could use either notation. For examples, see [TestScopeParsing](https://github.com/antlr/antlr4/blob/master/tool-testsuite/test/org/antlr/v4/test/tool/TestScopeParsing.java).
+
+As with the grammar level, you can specify rule-level named actions. For rules, the valid names are `init` and `after`. As the names imply, parsers execute init actions immediately before trying to match the associated rule and execute after actions immediately after matching the rule. ANTLR after actions do not execute as part of the finally code block of the generated rule function. Use the ANTLR finally action to place code in the generated rule function finally code block.
+
+The actions come after any argument, return value, or local attribute definition actions. The `row` rule preamble from Section 10.2, Accessing Token and Rule Attributes illustrates the syntax nicely:
 actions/CSV.g4
 
 ```

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestScopeParsing.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestScopeParsing.java
@@ -30,32 +30,66 @@
 
 package org.antlr.v4.test.tool;
 
+import org.antlr.v4.misc.Utils;
 import org.antlr.v4.parse.ScopeParser;
 import org.antlr.v4.test.runtime.java.BaseJavaTest;
+import org.antlr.v4.tool.Attribute;
 import org.antlr.v4.tool.Grammar;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(Parameterized.class)
 public class TestScopeParsing extends BaseJavaTest {
-    String[] argPairs = {
-        "",                                 "{}",
-        " ",                                "{}",
-        "int i",                            "{i=int i}",
-        "int[] i, int j[]",                 "{i=int[] i, j=int [] j}",
-		"Map<A,B>[] i, int j[]",          	"{i=Map<A,B>[] i, j=int [] j}",
-		"Map<A,List<B>>[] i",	          	"{i=Map<A,List<B>>[] i}",
+    static String[] argPairs = {
+        "",                                 "",
+        " ",                                "",
+        "int i",                            "i:int",
+        "int[] i, int j[]",                 "i:int[], j:int []",
+		"Map<A,B>[] i, int j[]",          	"i:Map<A,B>[], j:int []",
+		"Map<A,List<B>>[] i",	          	"i:Map<A,List<B>>[]",
         "int i = 34+a[3], int j[] = new int[34]",
-                                            "{i=int i= 34+a[3], j=int [] j= new int[34]}",
-        "char *foo32[3] = {1,2,3}",     	"{3=char *foo32[] 3= {1,2,3}}",
-		"String[] headers",					"{headers=String[] headers}",
+                                            "i:int=34+a[3], j:int []=new int[34]",
+        "char *[3] foo = {1,2,3}",     	    "foo:char *[3]={1,2,3}", // not valid C really, C is "type name" however so this is cool (this was broken in 4.5 anyway)
+		"String[] headers",					"headers:String[]",
 
         // python/ruby style
-        "i",                                "{i=null i}",
-        "i,j",                              "{i=null i, j=null j}",
-        "i,j, k",                           "{i=null i, j=null j, k=null k}",
+        "i",                                "i",
+        "i,j",                              "i, j",
+        "i\t,j, k",                         "i, j, k",
+
+	    // swift style
+	    "x: int",                           "x:int",
+	    "x :int",                           "x:int",
+	    "x:int",                            "x:int",
+	    "x:int=3",                          "x:int=3",
+	    "r:Rectangle=Rectangle(fromLength: 6, fromBreadth: 12)", "r:Rectangle=Rectangle(fromLength: 6, fromBreadth: 12)",
+	    "p:pointer to int",                 "p:pointer to int",
+	    "a: array[3] of int",               "a:array[3] of int",
+	    "a \t:\tfunc(array[3] of int)",     "a:func(array[3] of int)",
+	    "x:int, y:float",                   "x:int, y:float",
+	    "x:T?, f:func(array[3] of int), y:int", "x:T?, f:func(array[3] of int), y:int",
+
+	    // go is postfix type notation like "x int" but must use either "int x" or "x:int" in [...] actions
+	    "float64 x = 3",                    "x:float64=3",
+	    "map[string]int x",                 "x:map[string]int",
     };
+
+    String input;
+	String output;
+
+	public TestScopeParsing(String input, String output) {
+		this.input = input;
+		this.output = output;
+	}
 
 	@Before
 	@Override
@@ -63,13 +97,28 @@ public class TestScopeParsing extends BaseJavaTest {
 		super.testSetUp();
 	}
 
-    @Test public void testArgs() throws Exception {
-        for (int i = 0; i < argPairs.length; i+=2) {
-            String input = argPairs[i];
-            String expected = argPairs[i+1];
-			Grammar dummy = new Grammar("grammar T; a:'a';");
-			String actual = ScopeParser.parseTypedArgList(null, input, dummy).attributes.toString();
-            assertEquals(expected, actual);
-        }
+    @Test
+    public void testArgs() throws Exception {
+	    Grammar dummy = new Grammar("grammar T; a:'a';");
+
+	    LinkedHashMap<String, Attribute> attributes = ScopeParser.parseTypedArgList(null, input, dummy).attributes;
+	    List<String> out = new ArrayList<>();
+	    for (String arg : attributes.keySet()) {
+		    Attribute attr = attributes.get(arg);
+		    out.add(attr.toString());
+	    }
+	    String actual = Utils.join(out.toArray(), ", ");
+	    assertEquals(output, actual);
     }
+
+	@Parameterized.Parameters(name="{0}")
+	public static Collection<Object[]> getAllTestDescriptors() {
+		List<Object[]> tests = new ArrayList<>();
+		for (int i = 0; i < argPairs.length; i+=2) {
+			String arg = argPairs[i];
+			String output = argPairs[i+1];
+			tests.add(new Object[]{arg,output});
+		}
+		return tests;
+	}
 }

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestScopeParsing.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestScopeParsing.java
@@ -61,6 +61,9 @@ public class TestScopeParsing extends BaseJavaTest {
         "char *[3] foo = {1,2,3}",     	    "foo:char *[3]={1,2,3}", // not valid C really, C is "type name" however so this is cool (this was broken in 4.5 anyway)
 		"String[] headers",					"headers:String[]",
 
+	    // C++
+	    "std::vector<std::string> x",       "x:std::vector<std::string>", // yuck. Don't choose :: as the : of a declaration
+
         // python/ruby style
         "i",                                "i",
         "i,j",                              "i, j",

--- a/tool/src/org/antlr/v4/parse/ScopeParser.java
+++ b/tool/src/org/antlr/v4/parse/ScopeParser.java
@@ -32,6 +32,7 @@ package org.antlr.v4.parse;
 
 import org.antlr.runtime.BaseRecognizer;
 import org.antlr.runtime.CommonToken;
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.runtime.misc.Pair;
 import org.antlr.v4.tool.Attribute;
 import org.antlr.v4.tool.AttributeDict;
@@ -42,110 +43,78 @@ import org.antlr.v4.tool.ast.ActionAST;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Parse args, return values, locals
- *
- *  rule[arg1, arg2, ..., argN] returns [ret1, ..., retN]
- *
- *  text is target language dependent.  Java/C#/C/C++ would
- *  use "int i" but ruby/python would use "i".
+/**
+ * Parse args, return values, locals
+ * <p>
+ * rule[arg1, arg2, ..., argN] returns [ret1, ..., retN]
+ * <p>
+ * text is target language dependent.  Java/C#/C/C++ would
+ * use "int i" but ruby/python would use "i".
  */
 public class ScopeParser {
-    /** Given an arg or retval scope definition list like
-     *
-     *  <code>
-     *  Map&lt;String, String&gt;, int[] j3, char *foo32[3]
-     *  </code>
-     *
-     *  or
-     *
-     *  <code>
-     *  int i=3, j=a[34]+20
-     *  </code>
-     *
-     *  convert to an attribute scope.
-     */
+	/**
+	 * Given an arg or retval scope definition list like
+	 * <p>
+	 * <code>
+	 * Map&lt;String, String&gt;, int[] j3, char *foo32[3]
+	 * </code>
+	 * <p>
+	 * or
+	 * <p>
+	 * <code>
+	 * int i=3, j=a[34]+20
+	 * </code>
+	 * <p>
+	 * convert to an attribute scope.
+	 */
 	public static AttributeDict parseTypedArgList(ActionAST action, String s, Grammar g) {
 		return parse(action, s, ',', g);
 	}
 
-    public static AttributeDict parse(ActionAST action, String s, char separator, Grammar g) {
-        AttributeDict dict = new AttributeDict();
+	public static AttributeDict parse(ActionAST action, String s, char separator, Grammar g) {
+		AttributeDict dict = new AttributeDict();
 		List<Pair<String, Integer>> decls = splitDecls(s, separator);
 		for (Pair<String, Integer> decl : decls) {
-//            System.out.println("decl="+decl);
-            if ( decl.a.trim().length()>0 ) {
-                Attribute a = parseAttributeDef(action, decl, g);
-                dict.add(a);
-            }
+			if (decl.a.trim().length() > 0) {
+				Attribute a = parseAttributeDef(action, decl, g);
+				dict.add(a);
+			}
 		}
-        return dict;
-    }
+		return dict;
+	}
 
-    /** For decls like "String foo" or "char *foo32[]" compute the ID
-     *  and type declarations.  Also handle "int x=3" and 'T t = new T("foo")'
-     *  but if the separator is ',' you cannot use ',' in the initvalue
-     *  unless you escape use "\," escape.
-     */
-    public static Attribute parseAttributeDef(ActionAST action, Pair<String, Integer> decl, Grammar g) {
-        if ( decl.a==null ) return null;
-        Attribute attr = new Attribute();
-        boolean inID = false;
-        int start = -1;
-        int rightEdgeOfDeclarator = decl.a.length()-1;
-        int equalsIndex = decl.a.indexOf('=');
-        if ( equalsIndex>0 ) {
-            // everything after the '=' is the init value
-            attr.initValue = decl.a.substring(equalsIndex+1,decl.a.length());
-            rightEdgeOfDeclarator = equalsIndex-1;
-        }
-        // walk backwards looking for start of an ID
-        for (int i=rightEdgeOfDeclarator; i>=0; i--) {
-            // if we haven't found the end yet, keep going
-            if ( !inID && Character.isLetterOrDigit(decl.a.charAt(i)) ) {
-                inID = true;
-            }
-            else if ( inID &&
-                      !(Character.isLetterOrDigit(decl.a.charAt(i))||
-                       decl.a.charAt(i)=='_') ) {
-                start = i+1;
-                break;
-            }
-        }
-        if ( start<0 && inID ) {
-            start = 0;
-        }
-        if ( start<0 ) {
-            g.tool.errMgr.grammarError(ErrorType.CANNOT_FIND_ATTRIBUTE_NAME_IN_DECL, g.fileName, action.token, decl);
-        }
-        // walk forwards looking for end of an ID
-        int stop=-1;
-        for (int i=start; i<=rightEdgeOfDeclarator; i++) {
-            // if we haven't found the end yet, keep going
-            if ( !(Character.isLetterOrDigit(decl.a.charAt(i))||
-                decl.a.charAt(i)=='_') )
-            {
-                stop = i;
-                break;
-            }
-            if ( i==rightEdgeOfDeclarator ) {
-                stop = i+1;
-            }
-        }
+	/**
+	 * For decls like "String foo" or "char *foo32[]" compute the ID
+	 * and type declarations.  Also handle "int x=3" and 'T t = new T("foo")'
+	 * but if the separator is ',' you cannot use ',' in the initvalue
+	 * unless you escape use "\," escape.
+	 */
+	public static Attribute parseAttributeDef(ActionAST action, Pair<String, Integer> decl, Grammar g) {
+		if (decl.a == null) return null;
 
-        // the name is the last ID
-        attr.name = decl.a.substring(start,stop);
+		Attribute attr = new Attribute();
+		int rightEdgeOfDeclarator = decl.a.length() - 1;
+		int equalsIndex = decl.a.indexOf('=');
+		if (equalsIndex > 0) {
+			// everything after the '=' is the init value
+			attr.initValue = decl.a.substring(equalsIndex + 1, decl.a.length());
+			rightEdgeOfDeclarator = equalsIndex - 1;
+		}
 
-        // the type is the decl minus the ID (could be empty)
-        attr.type = decl.a.substring(0,start);
-        if ( stop<=rightEdgeOfDeclarator ) {
-            attr.type += decl.a.substring(stop,rightEdgeOfDeclarator+1);
-        }
-        attr.type = attr.type.trim();
-        if ( attr.type.length()==0 ) {
-            attr.type = null;
-        }
+		String declarator = decl.a.substring(0, rightEdgeOfDeclarator + 1);
+		Pair<Integer, Integer> p;
+		if (decl.a.indexOf(':') != -1) {
+			// declarator has type appear after the name
+			p = _parsePostfixDecl(attr, declarator, action, g);
+		}
+		else {
+			// declarator has type appear before the name
+			p = _parsePrefixDecl(attr, declarator, action, g);
+		}
+		int idStart = p.a;
+		int idStop = p.b;
 
-        attr.decl = decl.a;
+		attr.decl = decl.a;
 
 		if (action != null) {
 			String actionText = action.getText();
@@ -163,6 +132,7 @@ public class ScopeParser {
 			int[] charIndexes = new int[actionText.length()];
 			for (int i = 0, j = 0; i < actionText.length(); i++, j++) {
 				charIndexes[j] = i;
+				// skip comments
 				if (i < actionText.length() - 1 && actionText.charAt(i) == '/' && actionText.charAt(i + 1) == '/') {
 					while (i < actionText.length() && actionText.charAt(i) != '\n') {
 						i++;
@@ -171,10 +141,10 @@ public class ScopeParser {
 			}
 
 			int declOffset = charIndexes[decl.b];
-			int declLine = lines[declOffset + start];
+			int declLine = lines[declOffset + idStart];
 
 			int line = action.getToken().getLine() + declLine;
-			int charPositionInLine = charPositionInLines[declOffset + start];
+			int charPositionInLine = charPositionInLines[declOffset + idStart];
 			if (declLine == 0) {
 				/* offset for the start position of the ARG_ACTION token, plus 1
 				 * since the ARG_ACTION text had the leading '[' stripped before
@@ -183,119 +153,222 @@ public class ScopeParser {
 				charPositionInLine += action.getToken().getCharPositionInLine() + 1;
 			}
 
-			int offset = ((CommonToken)action.getToken()).getStartIndex();
-			attr.token = new CommonToken(action.getToken().getInputStream(), ANTLRParser.ID, BaseRecognizer.DEFAULT_TOKEN_CHANNEL, offset + declOffset + start + 1, offset + declOffset + stop);
+			int offset = ((CommonToken) action.getToken()).getStartIndex();
+			attr.token = new CommonToken(action.getToken().getInputStream(), ANTLRParser.ID, BaseRecognizer.DEFAULT_TOKEN_CHANNEL, offset + declOffset + idStart + 1, offset + declOffset + idStop);
 			attr.token.setLine(line);
 			attr.token.setCharPositionInLine(charPositionInLine);
 			assert attr.name.equals(attr.token.getText()) : "Attribute text should match the pseudo-token text at this point.";
 		}
 
-        return attr;
-    }
+		return attr;
+	}
 
-    /** Given an argument list like
-     *
-     *  x, (*a).foo(21,33), 3.2+1, '\n',
-     *  "a,oo\nick", {bl, "fdkj"eck}, ["cat\n,", x, 43]
-     *
-     *  convert to a list of attributes.  Allow nested square brackets etc...
-     *  Set separatorChar to ';' or ',' or whatever you want.
-     */
-    public static List<Pair<String, Integer>> splitDecls(String s, int separatorChar) {
-        List<Pair<String, Integer>> args = new ArrayList<Pair<String, Integer>>();
-        _splitArgumentList(s, 0, -1, separatorChar, args);
-        return args;
-    }
+	public static Pair<Integer, Integer> _parsePrefixDecl(Attribute attr, String decl, ActionAST a, Grammar g) {
+		// walk backwards looking for start of an ID
+		boolean inID = false;
+		int start = -1;
+		for (int i = decl.length() - 1; i >= 0; i--) {
+			char ch = decl.charAt(i);
+			// if we haven't found the end yet, keep going
+			if (!inID && Character.isLetterOrDigit(ch)) {
+				inID = true;
+			}
+			else if (inID && !(Character.isLetterOrDigit(ch) || ch == '_')) {
+				start = i + 1;
+				break;
+			}
+		}
+		if (start < 0 && inID) {
+			start = 0;
+		}
+		if (start < 0) {
+			g.tool.errMgr.grammarError(ErrorType.CANNOT_FIND_ATTRIBUTE_NAME_IN_DECL, g.fileName, a.token, decl);
+		}
 
-    public static int _splitArgumentList(String actionText,
-                                         int start,
-                                         int targetChar,
-                                         int separatorChar,
-                                         List<Pair<String, Integer>> args)
-    {
-        if ( actionText==null ) {
-            return -1;
-        }
+		// walk forward looking for end of an ID
+		int stop = -1;
+		for (int i = start; i < decl.length(); i++) {
+			char ch = decl.charAt(i);
+			// if we haven't found the end yet, keep going
+			if (!(Character.isLetterOrDigit(ch) || ch == '_')) {
+				stop = i;
+				break;
+			}
+			if (i == decl.length() - 1) {
+				stop = i + 1;
+			}
+		}
 
-        actionText = actionText.replaceAll("//[^\\n]*", "");
-        int n = actionText.length();
-        //System.out.println("actionText@"+start+"->"+(char)targetChar+"="+actionText.substring(start,n));
-        int p = start;
-        int last = p;
-        while ( p<n && actionText.charAt(p)!=targetChar ) {
-            int c = actionText.charAt(p);
-            switch ( c ) {
-                case '\'' :
-                    p++;
-                    while ( p<n && actionText.charAt(p)!='\'' ) {
-                        if ( actionText.charAt(p)=='\\' && (p+1)<n &&
-                             actionText.charAt(p+1)=='\'' )
-                        {
-                            p++; // skip escaped quote
-                        }
-                        p++;
-                    }
-                    p++;
-                    break;
-                case '"' :
-                    p++;
-                    while ( p<n && actionText.charAt(p)!='\"' ) {
-                        if ( actionText.charAt(p)=='\\' && (p+1)<n &&
-                             actionText.charAt(p+1)=='\"' )
-                        {
-                            p++; // skip escaped quote
-                        }
-                        p++;
-                    }
-                    p++;
-                    break;
-                case '(' :
-                    p = _splitArgumentList(actionText,p+1,')',separatorChar,args);
-                    break;
-                case '{' :
-                    p = _splitArgumentList(actionText,p+1,'}',separatorChar,args);
-                    break;
-                case '<' :
-                    if ( actionText.indexOf('>',p+1)>=p ) {
-                        // do we see a matching '>' ahead?  if so, hope it's a generic
-                        // and not less followed by expr with greater than
-                        p = _splitArgumentList(actionText,p+1,'>',separatorChar,args);
-                    }
-                    else {
-                        p++; // treat as normal char
-                    }
-                    break;
-                case '[' :
-                    p = _splitArgumentList(actionText,p+1,']',separatorChar,args);
-                    break;
-                default :
-                    if ( c==separatorChar && targetChar==-1 ) {
-                        String arg = actionText.substring(last, p);
+		// the name is the last ID
+		attr.name = decl.substring(start, stop);
+
+		// the type is the decl minus the ID (could be empty)
+		attr.type = decl.substring(0, start);
+		if (stop <= decl.length() - 1) {
+			attr.type += decl.substring(stop, decl.length());
+		}
+
+		attr.type = attr.type.trim();
+		if (attr.type.length() == 0) {
+			attr.type = null;
+		}
+		return new Pair<Integer, Integer>(start, stop);
+	}
+
+	public static Pair<Integer, Integer> _parsePostfixDecl(Attribute attr, String decl, ActionAST a, Grammar g) {
+		int start = -1;
+		int stop = -1;
+		int colon = decl.indexOf(':');
+		int namePartEnd = colon == -1 ? decl.length() : colon;
+
+		// look for start of name
+		for (int i = 0; i < namePartEnd; ++i) {
+			char ch = decl.charAt(i);
+			if (Character.isLetterOrDigit(ch) || ch == '_') {
+				start = i;
+				break;
+			}
+		}
+
+		if (start == -1) {
+			start = 0;
+			g.tool.errMgr.grammarError(ErrorType.CANNOT_FIND_ATTRIBUTE_NAME_IN_DECL, g.fileName, a.token, decl);
+		}
+
+		// look for stop of name
+		for (int i = start; i < namePartEnd; ++i) {
+			char ch = decl.charAt(i);
+			if (!(Character.isLetterOrDigit(ch) || ch == '_')) {
+				stop = i;
+				break;
+			}
+			if (i == namePartEnd - 1) {
+				stop = namePartEnd;
+			}
+		}
+
+		if (stop == -1) {
+			stop = start;
+		}
+
+		// extract name from decl
+		attr.name =  decl.substring(start, stop);
+
+		// extract type from decl (could be empty)
+		if (colon == -1) {
+			attr.type = "";
+		}
+		else {
+			attr.type = decl.substring(colon + 1, decl.length());
+		}
+		attr.type = attr.type.trim();
+
+		if (attr.type.length() == 0) {
+			attr.type = null;
+		}
+		return new Pair<Integer, Integer>(start, stop);
+	}
+
+	/**
+	 * Given an argument list like
+	 * <p>
+	 * x, (*a).foo(21,33), 3.2+1, '\n',
+	 * "a,oo\nick", {bl, "fdkj"eck}, ["cat\n,", x, 43]
+	 * <p>
+	 * convert to a list of attributes.  Allow nested square brackets etc...
+	 * Set separatorChar to ';' or ',' or whatever you want.
+	 */
+	public static List<Pair<String, Integer>> splitDecls(String s, int separatorChar) {
+		List<Pair<String, Integer>> args = new ArrayList<Pair<String, Integer>>();
+		_splitArgumentList(s, 0, -1, separatorChar, args);
+		return args;
+	}
+
+	public static int _splitArgumentList(String actionText,
+	                                     int start,
+	                                     int targetChar,
+	                                     int separatorChar,
+	                                     List<Pair<String, Integer>> args) {
+		if (actionText == null) {
+			return -1;
+		}
+
+		actionText = actionText.replaceAll("//[^\\n]*", "");
+		int n = actionText.length();
+		//System.out.println("actionText@"+start+"->"+(char)targetChar+"="+actionText.substring(start,n));
+		int p = start;
+		int last = p;
+		while (p < n && actionText.charAt(p) != targetChar) {
+			int c = actionText.charAt(p);
+			switch (c) {
+				case '\'':
+					p++;
+					while (p < n && actionText.charAt(p) != '\'') {
+						if (actionText.charAt(p) == '\\' && (p + 1) < n &&
+								actionText.charAt(p + 1) == '\'') {
+							p++; // skip escaped quote
+						}
+						p++;
+					}
+					p++;
+					break;
+				case '"':
+					p++;
+					while (p < n && actionText.charAt(p) != '\"') {
+						if (actionText.charAt(p) == '\\' && (p + 1) < n &&
+								actionText.charAt(p + 1) == '\"') {
+							p++; // skip escaped quote
+						}
+						p++;
+					}
+					p++;
+					break;
+				case '(':
+					p = _splitArgumentList(actionText, p + 1, ')', separatorChar, args);
+					break;
+				case '{':
+					p = _splitArgumentList(actionText, p + 1, '}', separatorChar, args);
+					break;
+				case '<':
+					if (actionText.indexOf('>', p + 1) >= p) {
+						// do we see a matching '>' ahead?  if so, hope it's a generic
+						// and not less followed by expr with greater than
+						p = _splitArgumentList(actionText, p + 1, '>', separatorChar, args);
+					} else {
+						p++; // treat as normal char
+					}
+					break;
+				case '[':
+					p = _splitArgumentList(actionText, p + 1, ']', separatorChar, args);
+					break;
+				default:
+					if (c == separatorChar && targetChar == -1) {
+						String arg = actionText.substring(last, p);
 						int index = last;
 						while (index < p && Character.isWhitespace(actionText.charAt(index))) {
 							index++;
 						}
-                        //System.out.println("arg="+arg);
-                        args.add(new Pair<String, Integer>(arg.trim(), index));
-                        last = p+1;
-                    }
-                    p++;
-                    break;
-            }
-        }
-        if ( targetChar==-1 && p<=n ) {
-            String arg = actionText.substring(last, p).trim();
+						//System.out.println("arg="+arg);
+						args.add(new Pair<String, Integer>(arg.trim(), index));
+						last = p + 1;
+					}
+					p++;
+					break;
+			}
+		}
+		if (targetChar == -1 && p <= n) {
+			String arg = actionText.substring(last, p).trim();
 			int index = last;
 			while (index < p && Character.isWhitespace(actionText.charAt(index))) {
 				index++;
 			}
-            //System.out.println("arg="+arg);
-            if ( arg.length()>0 ) {
-                args.add(new Pair<String, Integer>(arg.trim(), index));
-            }
-        }
-        p++;
-        return p;
-    }
+			//System.out.println("arg="+arg);
+			if (arg.length() > 0) {
+				args.add(new Pair<String, Integer>(arg.trim(), index));
+			}
+		}
+		p++;
+		return p;
+	}
 
 }

--- a/tool/src/org/antlr/v4/parse/ScopeParser.java
+++ b/tool/src/org/antlr/v4/parse/ScopeParser.java
@@ -32,7 +32,6 @@ package org.antlr.v4.parse;
 
 import org.antlr.runtime.BaseRecognizer;
 import org.antlr.runtime.CommonToken;
-import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.runtime.misc.Pair;
 import org.antlr.v4.tool.Attribute;
 import org.antlr.v4.tool.AttributeDict;
@@ -49,7 +48,8 @@ import java.util.List;
  * rule[arg1, arg2, ..., argN] returns [ret1, ..., retN]
  * <p>
  * text is target language dependent.  Java/C#/C/C++ would
- * use "int i" but ruby/python would use "i".
+ * use "int i" but ruby/python would use "i". Languages with
+ * postfix types like Go, Swift use "x : T" notation or "T x".
  */
 public class ScopeParser {
 	/**
@@ -97,7 +97,7 @@ public class ScopeParser {
 		int equalsIndex = decl.a.indexOf('=');
 		if (equalsIndex > 0) {
 			// everything after the '=' is the init value
-			attr.initValue = decl.a.substring(equalsIndex + 1, decl.a.length());
+			attr.initValue = decl.a.substring(equalsIndex + 1, decl.a.length()).trim();
 			rightEdgeOfDeclarator = equalsIndex - 1;
 		}
 

--- a/tool/src/org/antlr/v4/parse/ScopeParser.java
+++ b/tool/src/org/antlr/v4/parse/ScopeParser.java
@@ -103,12 +103,14 @@ public class ScopeParser {
 
 		String declarator = decl.a.substring(0, rightEdgeOfDeclarator + 1);
 		Pair<Integer, Integer> p;
-		if (decl.a.indexOf(':') != -1) {
-			// declarator has type appear after the name
+		String text = decl.a;
+		text = text.replaceAll("::","");
+		if ( text.contains(":") ) {
+			// declarator has type appearing after the name like "x:T"
 			p = _parsePostfixDecl(attr, declarator, action, g);
 		}
 		else {
-			// declarator has type appear before the name
+			// declarator has type appearing before the name like "T x"
 			p = _parsePrefixDecl(attr, declarator, action, g);
 		}
 		int idStart = p.a;

--- a/tool/src/org/antlr/v4/tool/Attribute.java
+++ b/tool/src/org/antlr/v4/tool/Attribute.java
@@ -32,11 +32,11 @@ package org.antlr.v4.tool;
 
 import org.antlr.runtime.Token;
 
-/** Track the names of attributes define in arg lists, return values,
+/** Track the names of attributes defined in arg lists, return values,
  *  scope blocks etc...
  */
 public class Attribute {
-    /** The entire declaration such as "String foo;" */
+    /** The entire declaration such as "String foo" or "x:int" */
     public String decl;
 
     /** The type; might be empty such as for Python which has no static typing */
@@ -66,8 +66,11 @@ public class Attribute {
     @Override
     public String toString() {
         if ( initValue!=null ) {
-            return type+" "+name+"="+initValue;
+	        return name+":"+type+"="+initValue;
         }
-        return type+" "+name;
+        if ( type!=null ) {
+	        return name+":"+type;
+        }
+        return name;
     }
 }

--- a/tool/src/org/antlr/v4/tool/AttributeDict.java
+++ b/tool/src/org/antlr/v4/tool/AttributeDict.java
@@ -65,7 +65,7 @@ public class AttributeDict {
         predefinedTokenDict.add(new Attribute("int"));
     }
 
-    public static enum DictType {
+    public enum DictType {
         ARG, RET, LOCAL, TOKEN,
 		PREDEFINED_RULE, PREDEFINED_LEXER_RULE,
     }


### PR DESCRIPTION
Support `x:T` argument/local notation in `[...]` blocks. Updated scope testing. Updated doc.  Any target can use `x:T` or `T x` notation as we parse into generic `Attribute` object and code generators do the right thing.