### PR TITLE
CPP runtime :  Added a specialized ctor for Any for nullptr.

### DIFF
--- a/runtime/Cpp/runtime/src/support/Any.h
+++ b/runtime/Cpp/runtime/src/support/Any.h
@@ -74,7 +74,7 @@ struct Any
 
     auto derived = dynamic_cast<Derived<T> *>(_ptr);
 
-    return derived;
+    return derived != nullptr;
   }
 
   template<class U>
@@ -155,6 +155,11 @@ private:
   Base *_ptr;
 
 };
+
+  template<> inline 
+  Any::Any(std::nullptr_t&& ) : _ptr(nullptr) {
+  }
+
 
 } // namespace antlrcpp
 


### PR DESCRIPTION
* There was an inconvenience that an Any created with a nullptr returned false for isNull(), resolved by adding the ctor
* removed warning [forcing value to bool 'true' or 'false'] when calling is<>