### PR TITLE
Fix go get command in the Go target instructions

### DIFF
--- a/doc/go-target.md
+++ b/doc/go-target.md
@@ -13,7 +13,7 @@ Each target language for ANTLR has a runtime package for running parser generate
 Get the runtime and install it on your GOPATH:
 
 ```bash
-go get github.com/antlr/antlr4
+go get github.com/antlr/antlr4/runtime/Go/antlr
 ```
 
 #### 3. Set the release tag (optional)


### PR DESCRIPTION
Great work, I was able to make the example work, and play around with it a little further. However, I had to modify your `go get` command to what I edited in this PR. Thanks for adding Go support!