### PR TITLE
Enforce JDK runtime requirements

### DIFF
--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -10,6 +10,51 @@
   <name>ANTLR 4 Runtime</name>
   <description>The ANTLR 4 Runtime</description>
 
+  <profiles>
+    <profile>
+      <id>jdk6</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-maven-plugin</artifactId>
+            <version>1.15</version>
+            <executions>
+              <execution>
+                <id>check-java-version</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <configuration>
+                  <signature>
+                    <groupId>org.codehaus.mojo.signature</groupId>
+                    <artifactId>java16</artifactId>
+                    <version>1.0</version>
+                  </signature>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-maven-plugin</artifactId>
+          <version>1.15</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <build>
     <sourceDirectory>src</sourceDirectory>
     <plugins>


### PR DESCRIPTION
Use 1.6 version for the compiler and employ animal sniffer to enforce Java 6 compatibility.