### PR TITLE
Update contributors.txt

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -118,3 +118,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/11/06, janyou, Janyou, janyou.antlr@outlook.com
 2016/11/20, marcohu, Marco Hunsicker, antlr@hunsicker.de
 2016/09/02, lygav, Vladimir (Vladi) Lyga, lyvladi@gmail.com
+2016/11/25, MrSampson, Oliver Sampson, olsam@quickaudio.com


### PR DESCRIPTION
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors most "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
