### PR TITLE
Fix for redeclared error is generated Go code. 

### DIFF
--- a/runtime/Go/antlr/lexer.go
+++ b/runtime/Go/antlr/lexer.go
@@ -282,6 +282,10 @@ func (b *BaseLexer) setInputStream(input CharStream) {
 	b.tokenFactorySourcePair = &TokenSourceCharStreamPair{b, b.input}
 }
 
+func (b *BaseLexer) GetTokenSourceCharStreamPair() *TokenSourceCharStreamPair {
+	return b.tokenFactorySourcePair
+}
+
 // By default does not support multiple emits per NextToken invocation
 // for efficiency reasons. Subclass and override l method, NextToken,
 // and GetToken (to push tokens into a list and pull from that list

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -741,36 +741,40 @@ bitsetInlineComparison(s, bits) ::= <%
 %>
 
 InvokeRule(r, argExprsChunks) ::= <<
-p.SetState(<r.stateNumber>)
-<if(r.labels)>
+{
+	p.SetState(<r.stateNumber>)
+	<if(r.labels)>
 
-<if(r.ast.options.p)>
-var _x = p.<r.name>(<r.ast.options.p><if(argExprsChunks)>, <endif><argExprsChunks>)
-<else>
-var _x = p.<r.name; format="cap">(<argExprsChunks>)
-<endif>
+	<if(r.ast.options.p)>
+	var _x = p.<r.name>(<r.ast.options.p><if(argExprsChunks)>, <endif><argExprsChunks>)
+	<else>
+	var _x = p.<r.name; format="cap">(<argExprsChunks>)
+	<endif>
 
 
-<r.labels:{l | <labelref(l)> = _x}; separator="\n">
-<else>
-<if(r.ast.options.p)>
-p.<r.name>(<r.ast.options.p><if(argExprsChunks)>, <endif><argExprsChunks>)
-<else>
-p.<r.name; format="cap">(<argExprsChunks>)
-<endif>
-<endif>
+	<r.labels:{l | <labelref(l)> = _x}; separator="\n">
+	<else>
+	<if(r.ast.options.p)>
+	p.<r.name>(<r.ast.options.p><if(argExprsChunks)>, <endif><argExprsChunks>)
+	<else>
+	p.<r.name; format="cap">(<argExprsChunks>)
+	<endif>
+	<endif>
+}
 >>
 
 MatchToken(m) ::= <<
-p.SetState(<m.stateNumber>)
-<if(m.labels)>
+{
+	p.SetState(<m.stateNumber>)
+	<if(m.labels)>
 
-var _m = p.Match(<parser.name><m.name>)
+	var _m = p.Match(<parser.name><m.name>)
 
-<m.labels:{l | <labelref(l)> = _m}; separator="\n">
-<else>
-p.Match(<parser.name><m.name>)
-<endif>
+	<m.labels:{l | <labelref(l)> = _m}; separator="\n">
+	<else>
+	p.Match(<parser.name><m.name>)
+	<endif>
+}
 >>
 
 MatchSet(m, expr, capture) ::= "<CommonSetStuff(m, expr, capture, false)>"


### PR DESCRIPTION
@parrt @pboyer 
Clean pull request for redeclared var error.

Create block so _x and _m var are created in a local scope.