### PR TITLE
Fix a dangerous c-cast in the cpp codegen

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -123,3 +123,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/11/25, MrSampson, Oliver Sampson, olsam@quickaudio.com
 2016/11/29, millergarym, Gary Miller, miller.garym@gmail.com
 2016/11/29, wxio, Gary Miller, gm@wx.io
+2016/11/29, Naios, Denis Blank, naios@users.noreply.github.com

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -1048,8 +1048,8 @@ virtual antlrcpp::Any accept(tree::ParseTreeVisitor *visitor) override;
 VisitorDispatchMethod(method) ::=  <<
 
 antlrcpp::Any <parser.name>::<struct.name>::accept(tree::ParseTreeVisitor *visitor) {
-  if (dynamic_cast\<<parser.grammarName>Visitor*>(visitor) != nullptr)
-    return ((<parser.grammarName>Visitor *)visitor)->visit<struct.derivedFromName; format="cap">(this);
+  if (auto parserVisitor = dynamic_cast\<<parser.grammarName>Visitor*>(visitor))
+    return parserVisitor->visit<struct.derivedFromName; format="cap">(this);
   else
     return visitor->visitChildren(this);
 }


### PR DESCRIPTION
Following code was generated by the cpp backend for the demo project:

```cpp
antlrcpp::Any TParser::StatContext::accept(tree::ParseTreeVisitor *visitor) {
  if (dynamic_cast<TParserVisitor*>(visitor) != nullptr)
    return ((TParserVisitor *)visitor)->visitStat(this);
//           ~~~~~~~~~~~~~~~~
  else
    return visitor->visitChildren(this);
}
```

There is a C-Cast used after the class was checked through a dynamic cast.
This could lead to undefined behaviour when casting classes with virtual bases.

This PR changes the cpp template in order to cache the result returned by the dynamic cast to remove the c-cast.