### PR TITLE
Fix for #1397

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -407,7 +407,7 @@ func (p *<parser.name>) <currentRule.name; format="cap">(<currentRule.args:{a | 
 	}()
 	
 	<if(currentRule.hasLookaheadBlock)>
-	var _int alt
+	var _alt int
 	<endif>
 
 	<if(code)>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -405,6 +405,10 @@ func (p *<parser.name>) <currentRule.name; format="cap">(<currentRule.args:{a | 
 			<endif>
 		}
 	}()
+	
+	<if(currentRule.hasLookaheadBlock)>
+	var _int alt
+	<endif>
 
 	<if(code)>
 	<code>
@@ -663,7 +667,7 @@ la_ := p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>,
 StarBlock(choice, alts, Sync, iteration) ::= <<
 p.SetState(<choice.stateNumber>)
 p.GetErrorHandler().Sync(p)
-_alt := p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext())
+_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext())
 
 for _alt != <choice.exitAlt> && _alt != antlr.ATNInvalidAltNumber {
 	if _alt == 1<if(!choice.ast.greedy)>+1<endif> {
@@ -683,7 +687,7 @@ for _alt != <choice.exitAlt> && _alt != antlr.ATNInvalidAltNumber {
 PlusBlock(choice, alts, error) ::= <<
 p.SetState(<choice.blockStartStateNumber>)<! alt block decision !>
 p.GetErrorHandler().Sync(p)
-_alt := 1<if(!choice.ast.greedy)>+1<endif>
+_alt = 1<if(!choice.ast.greedy)>+1<endif>
 for ok := true; ok; ok = _alt != <choice.exitAlt> && _alt != antlr.ATNInvalidAltNumber {
 	switch _alt {
 	<if(alts)>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -480,6 +480,10 @@ func (p *<parser.name>) <currentRule.name>(_p int<args:{a | , <a.name> <a.type>}
 		}
 	}()
 
+	<if(currentRule.hasLookaheadBlock)>
+	var _alt int
+	<endif>
+
 	<if(code)>
 	<code>
 


### PR DESCRIPTION
### Problem 

The issue here was that I used a := short variable declaration in the template, when there could be multiple assignments of this variable. Hence, duplicate assignment compiler errors were encountered. 

### Solution 

Here, I follow the model set by `Java.stg` and use a single variable declaration. I observed no regressions in the test suite and @ereyes01 was kind enough to test it out on the `Java.g4` grammar. 

### Question

I need a verification that the `currentRule.hasLookaheadBlock` field will not provide "false positives". Specifically, we need to be sure that `_alt` is not declared and not used. Go will emit a compile error if a variable is declared and not used. If this is not guaranteed I can provide a simple "proxy" usage to silence the error.

PTAL @parrt.

This is a fix for #1397. 