### PR TITLE
Fix to Issue #1434

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -124,3 +124,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/11/29, millergarym, Gary Miller, miller.garym@gmail.com
 2016/11/29, wxio, Gary Miller, gm@wx.io
 2016/11/29, Naios, Denis Blank, naios@users.noreply.github.com
+2016/12/01, samtatasurya, Samuel Tatasurya, xemradiant@gmail.com

--- a/runtime/Cpp/runtime/src/RuleContext.cpp
+++ b/runtime/Cpp/runtime/src/RuleContext.cpp
@@ -78,9 +78,6 @@ std::string RuleContext::getText() {
 
   std::stringstream ss;
   for (size_t i = 0; i < children.size(); i++) {
-    if (i > 0)
-      ss << ", ";
-
     ParseTree *tree = children[i];
     if (tree != nullptr)
       ss << tree->getText();


### PR DESCRIPTION
**Problem**
In C++ target, `getText()` returns a string in which the tokens are separated by a comma and a space. On the other hand, Java target returns a string which results from direct appending of the tokens.

**Solution**
Removed comma and space appended to the stringstream in C++ `getText()` for consistency with Java target.

Fix to Issue #1434 