### PR TITLE
Update VS2015 cpp runtime project

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -125,3 +125,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/11/29, wxio, Gary Miller, gm@wx.io
 2016/11/29, Naios, Denis Blank, naios@users.noreply.github.com
 2016/12/01, samtatasurya, Samuel Tatasurya, xemradiant@gmail.com
+2016/12/03, redxdev, Samuel Bloomberg, sam@redxdev.com

--- a/runtime/Cpp/runtime/antlr4cpp-vs2015.vcxproj
+++ b/runtime/Cpp/runtime/antlr4cpp-vs2015.vcxproj
@@ -430,6 +430,7 @@
     <ClCompile Include="src\TokenStream.cpp" />
     <ClCompile Include="src\TokenStreamRewriter.cpp" />
     <ClCompile Include="src\tree\ErrorNodeImpl.cpp" />
+    <ClCompile Include="src\tree\ParseTree.cpp" />
     <ClCompile Include="src\tree\ParseTreeWalker.cpp" />
     <ClCompile Include="src\tree\pattern\ParseTreeMatch.cpp" />
     <ClCompile Include="src\tree\pattern\ParseTreePattern.cpp" />
@@ -439,7 +440,6 @@
     <ClCompile Include="src\tree\pattern\TextChunk.cpp" />
     <ClCompile Include="src\tree\pattern\TokenTagToken.cpp" />
     <ClCompile Include="src\tree\TerminalNodeImpl.cpp" />
-    <ClCompile Include="src\tree\Tree.cpp" />
     <ClCompile Include="src\tree\Trees.cpp" />
     <ClCompile Include="src\tree\xpath\XPath.cpp" />
     <ClCompile Include="src\tree\xpath\XPathElement.cpp" />

--- a/runtime/Cpp/runtime/antlr4cpp-vs2015.vcxproj.filters
+++ b/runtime/Cpp/runtime/antlr4cpp-vs2015.vcxproj.filters
@@ -812,9 +812,6 @@
     <ClCompile Include="src\tree\TerminalNodeImpl.cpp">
       <Filter>Source Files\tree</Filter>
     </ClCompile>
-    <ClCompile Include="src\tree\Tree.cpp">
-      <Filter>Source Files\tree</Filter>
-    </ClCompile>
     <ClCompile Include="src\tree\Trees.cpp">
       <Filter>Source Files\tree</Filter>
     </ClCompile>
@@ -937,6 +934,9 @@
     </ClCompile>
     <ClCompile Include="src\Vocabulary.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\tree\ParseTree.cpp">
+      <Filter>Source Files\tree</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePattern.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePattern.cpp
@@ -29,7 +29,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "ParseTree.h"
+#include "tree/ParseTree.h"
 #include "tree/pattern/ParseTreePatternMatcher.h"
 #include "tree/pattern/ParseTreeMatch.h"
 


### PR DESCRIPTION
The VS2015 project for the cpp runtime references a nonexistant file (Tree.cpp) and doesn't reference a file required for compilation and linking (ParseTree.cpp). Additionally, an include directive doesn't compile as ParseTree.cpp is in a subfolder. This should fix the above issues with VS2015.