### PR TITLE
Fix AttributeError when trying to write an immutable variable in Python.

### DIFF
--- a/runtime/Python2/src/antlr4/IntervalSet.py
+++ b/runtime/Python2/src/antlr4/IntervalSet.py
@@ -158,7 +158,7 @@ class IntervalSet(object):
                 # split existing range
                 elif v<i.stop-1:
                     x = Interval(i.start, v)
-                    i.start = v + 1
+                    self.intervals[k] = range(v + 1, i.stop)
                     self.intervals.insert(k, x)
                     return
                 k += 1

--- a/runtime/Python3/src/antlr4/IntervalSet.py
+++ b/runtime/Python3/src/antlr4/IntervalSet.py
@@ -138,7 +138,7 @@ class IntervalSet(object):
                 # split existing range
                 elif v<i.stop-1:
                     x = range(i.start, v)
-                    i.start = v + 1
+                    self.intervals[k] = range(v + 1, i.stop)
                     self.intervals.insert(k, x)
                     return
                 k += 1


### PR DESCRIPTION
The `removeOne` function of IntervalSet tries to directly
rewrite the start field of an immutable range variable when
splitting an existing interval. This causes AttributeError which
is fixed by the patch.