### PR TITLE
Fix for #1459

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -644,10 +644,7 @@ p.GetErrorHandler().Sync(p)
 
 <endif>
 
-
-la_ := p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext())
-
-switch la_ {
+switch p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext()) {
 <if(alts)>
 <alts:{alt | case <i>:
 	<alt>}; separator="\n\n">
@@ -658,10 +655,10 @@ switch la_ {
 OptionalBlock(choice, alts, error) ::= <<
 p.SetState(<choice.stateNumber>)
 p.GetErrorHandler().Sync(p)
-la_ := p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext())
+
 <if(alts)>
 
-<alts:{alt | if la_ == <i><if(!choice.ast.greedy)>+1<endif> {
+<alts:{alt | if p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext()) == <i><if(!choice.ast.greedy)>+1<endif> {
 	<alt>
 }; separator="} else ">
 <endif>


### PR DESCRIPTION
## Issue 

#1459 shows that `la_` may end up being redeclared in generated code.

## Fix

This variable doesn't need to be declared at all. We can just use inline it.

## Testing

All tests continue to pass. I used @syn-ful's example code to confirm this now compiles and from basic experimentation, it seems to work as expected.

PTAL @parrt CC @syn-ful