### PR TITLE
move api lib test to runtime tests

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/TestTokenStreamRewriter.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/TestTokenStreamRewriter.java
@@ -3,13 +3,14 @@
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
-package org.antlr.v4.test.tool;
+package org.antlr.v4.test.runtime.java.api;
 
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.LexerInterpreter;
 import org.antlr.v4.runtime.TokenStreamRewriter;
 import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.test.runtime.java.BaseJavaTest;
 import org.antlr.v4.tool.LexerGrammar;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,7 +18,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class TestTokenStreamRewriter extends BaseJavaToolTest {
+public class TestTokenStreamRewriter extends BaseJavaTest {
 
 	/** Public default constructor used by TestRig */
 	public TestTokenStreamRewriter() {


### PR DESCRIPTION
@antlr/antlr-targets you are free to make runtime lib api tests in your runtime subdirectory. E.g., https://github.com/antlr/antlr4/blob/master/runtime/Python2/tests/TestTokenStreamRewriter.py is the analog of this Java code I'm moving. In my case, it makes most sense to put the test in the runtime-testsuite group not under runtime/java.