### PR TITLE
Fix conflict lexer command in CppTarget demo

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -126,3 +126,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/11/29, Naios, Denis Blank, naios@users.noreply.github.com
 2016/12/01, samtatasurya, Samuel Tatasurya, xemradiant@gmail.com
 2016/12/03, redxdev, Samuel Bloomberg, sam@redxdev.com
+2016/12/11, Gaulouis <gaulouis.com@gmail.com>

--- a/runtime/Cpp/demo/TLexer.g4
+++ b/runtime/Cpp/demo/TLexer.g4
@@ -66,8 +66,9 @@ OpenCurly: '{' -> pushMode(Mode1);
 CloseCurly: '}' -> popMode;
 QuestionMark: '?';
 Comma: ',' -> skip;
-Dollar: '$' -> more, mode(Mode1), type(DUMMY);
-		   
+Dollar: '$' -> more, mode(Mode1);
+Ampersand: '&' -> type(DUMMY);
+ 
 String: '"' .*? '"';
 Foo: {canTestFoo()}? 'foo' {isItFoo()}? { myFooLexerAction(); };
 Bar: 'bar' {isItBar()}? { myBarLexerAction(); };


### PR DESCRIPTION
Since Tool generates errors if token have several identical commands, the demo grammar in CppTarget throw an error at compile time.

This Pull Request fix this, by creating a new token.
