### PR TITLE
Issue 1457

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -126,3 +126,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/11/29, Naios, Denis Blank, naios@users.noreply.github.com
 2016/12/01, samtatasurya, Samuel Tatasurya, xemradiant@gmail.com
 2016/12/03, redxdev, Samuel Bloomberg, sam@redxdev.com
+2016/12/11, Gaulouis <gaulouis.com@gmail.com>

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
@@ -70,14 +70,14 @@ ParserPropertyCall(p, call) ::= "<call>"
 
 PositionAdjustingLexer() ::= <<
 protected:
-  class PositionAdjustingLexerATNSimulator : public atn::LexerATNSimulator {
+  class PositionAdjustingLexerATNSimulator : public antlr4::atn::LexerATNSimulator {
   public:
-    PositionAdjustingLexerATNSimulator(Lexer *recog, const atn::ATN &atn, std::vector\<dfa::DFA> &decisionToDFA,
-                                       atn::PredictionContextCache &sharedContextCache)
-      : atn::LexerATNSimulator(recog, atn, decisionToDFA, sharedContextCache) {
+    PositionAdjustingLexerATNSimulator(antlr4::Lexer *recog, const antlr4::atn::ATN &atn, std::vector\<antlr4::dfa::DFA> &decisionToDFA,
+                                       antlr4::atn::PredictionContextCache &sharedContextCache)
+      : antlr4::atn::LexerATNSimulator(recog, atn, decisionToDFA, sharedContextCache) {
     }
 
-    void resetAcceptPosition(CharStream *input, int index, int line, int charPositionInLine) {
+    void resetAcceptPosition(antlr4::CharStream *input, int index, int line, int charPositionInLine) {
       input->seek(index);
       _line = line;
       _charPositionInLine = charPositionInLine;
@@ -87,16 +87,16 @@ protected:
   };
 
 public:
-  virtual std::unique_ptr\<Token> nextToken() override {
+  virtual std::unique_ptr\<antlr4::Token> nextToken() override {
     if (dynamic_cast\<PositionAdjustingLexerATNSimulator *>(_interpreter) == nullptr) {
       delete _interpreter;
       _interpreter = new PositionAdjustingLexerATNSimulator(this, _atn, _decisionToDFA, _sharedContextCache);
     }
 
-    return Lexer::nextToken();
+    return antlr4::Lexer::nextToken();
   }
 
-  virtual Token* emit() override {
+  virtual antlr4::Token* emit() override {
     switch (type) {
       case TOKENS:
         handleAcceptPositionForKeyword("tokens");
@@ -109,7 +109,7 @@ public:
       default:
         break;
     }
-    return Lexer::emit();
+    return antlr4::Lexer::emit();
   }
 
 private:

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
@@ -167,11 +167,11 @@ tree::ParseTreeWalker::DEFAULT.walk(&listener, <s>);
 
 TreeNodeWithAltNumField(X) ::= <<
 @parser::members {
-class MyRuleNode : public ParserRuleContext {
+class MyRuleNode : public antlr4::ParserRuleContext {
 public:
   size_t altNum;
-	MyRuleNode(ParserRuleContext *parent, int invokingStateNumber)
-		: ParserRuleContext(parent, invokingStateNumber) {
+	MyRuleNode(antlr4::ParserRuleContext *parent, int invokingStateNumber)
+		: antlr4::ParserRuleContext(parent, invokingStateNumber) {
 	}
 	virtual size_t getAltNumber() const override { return altNum; }
 	virtual void setAltNumber(size_t altNum) override { this->altNum = altNum; }

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -153,7 +153,7 @@ const atn::ATN& <lexer.name>::getATN() const {
 <if (actionFuncs)>
 void <lexer.name>::action(RuleContext *context, size_t ruleIndex, size_t actionIndex) {
   switch (ruleIndex) {
-    <lexer.actionFuncs.values: {f | case <f.ruleIndex>: <f.name>Action(dynamic_cast\<RuleContext *>(context), actionIndex); break;}; separator="\n">
+    <lexer.actionFuncs.values: {f | case <f.ruleIndex>: <f.name>Action(context, actionIndex); break;}; separator="\n">
 
   default:
     break;
@@ -164,7 +164,7 @@ void <lexer.name>::action(RuleContext *context, size_t ruleIndex, size_t actionI
 <if (sempredFuncs)>
 bool <lexer.name>::sempred(RuleContext *context, size_t ruleIndex, size_t predicateIndex) {
   switch (ruleIndex) {
-    <lexer.sempredFuncs.values: {f | case <f.ruleIndex>: return <f.name>Sempred(dynamic_cast\<RuleContext *>(context), predicateIndex);}; separator="\n">
+    <lexer.sempredFuncs.values: {f | case <f.ruleIndex>: return <f.name>Sempred(context, predicateIndex);}; separator="\n">
 
   default:
     break;

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -40,7 +40,7 @@ cppTypeInitMap ::= [
     default: "nullptr" // anything other than a primitive type is an object
 ]
 
-LexerHeader(lexer, atn, actionFuncs, sempredFuncs, superClass = {Lexer}) ::= <<
+LexerHeader(lexer, atn, actionFuncs, sempredFuncs, superClass = {antlr4::Lexer}) ::= <<
 <namedActions.context>
 
 class <lexer.name> : public <superClass> {
@@ -63,7 +63,7 @@ public:
   };
 <endif>
 
-  <lexer.name>(CharStream *input);
+  <lexer.name>(antlr4::CharStream *input);
   ~<lexer.name>();
 
   <namedActions.members>
@@ -72,28 +72,28 @@ public:
 
   virtual const std::vector\<std::string>& getModeNames() const override;
   virtual const std::vector\<std::string>& getTokenNames() const override; // deprecated, use vocabulary instead
-  virtual dfa::Vocabulary& getVocabulary() const override;
+  virtual antlr4::dfa::Vocabulary& getVocabulary() const override;
 
   virtual const std::vector\<uint16_t> getSerializedATN() const override;
-  virtual const atn::ATN& getATN() const override;
+  virtual const antlr4::atn::ATN& getATN() const override;
 
   <if (actionFuncs)>
-  virtual void action(RuleContext *context, size_t ruleIndex, size_t actionIndex) override;
+  virtual void action(antlr4::RuleContext *context, size_t ruleIndex, size_t actionIndex) override;
   <endif>
   <if (sempredFuncs)>
-  virtual bool sempred(RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
+  virtual bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
   <endif>
 
 private:
-  static std::vector\<dfa::DFA> _decisionToDFA;
-  static atn::PredictionContextCache _sharedContextCache;
+  static std::vector\<antlr4::dfa::DFA> _decisionToDFA;
+  static antlr4::atn::PredictionContextCache _sharedContextCache;
   static std::vector\<std::string> _ruleNames;
   static std::vector\<std::string> _tokenNames;
   static std::vector\<std::string> _modeNames;
 
   static std::vector\<std::string> _literalNames;
   static std::vector\<std::string> _symbolicNames;
-  static dfa::Vocabulary _vocabulary;
+  static antlr4::dfa::Vocabulary _vocabulary;
   <atn>
 
   <namedActions.declarations>
@@ -153,7 +153,7 @@ const atn::ATN& <lexer.name>::getATN() const {
 <if (actionFuncs)>
 void <lexer.name>::action(RuleContext *context, size_t ruleIndex, size_t actionIndex) {
   switch (ruleIndex) {
-    <lexer.actionFuncs.values: {f | case <f.ruleIndex>: <f.name>Action(dynamic_cast\<<f.ctxType> *>(context), actionIndex); break;}; separator="\n">
+    <lexer.actionFuncs.values: {f | case <f.ruleIndex>: <f.name>Action(dynamic_cast\<RuleContext *>(context), actionIndex); break;}; separator="\n">
 
   default:
     break;
@@ -164,7 +164,7 @@ void <lexer.name>::action(RuleContext *context, size_t ruleIndex, size_t actionI
 <if (sempredFuncs)>
 bool <lexer.name>::sempred(RuleContext *context, size_t ruleIndex, size_t predicateIndex) {
   switch (ruleIndex) {
-    <lexer.sempredFuncs.values: {f | case <f.ruleIndex>: return <f.name>Sempred(dynamic_cast\<<f.ctxType> *>(context), predicateIndex);}; separator="\n">
+    <lexer.sempredFuncs.values: {f | case <f.ruleIndex>: return <f.name>Sempred(dynamic_cast\<RuleContext *>(context), predicateIndex);}; separator="\n">
 
   default:
     break;
@@ -263,7 +263,7 @@ bool <if (r.factory.g.lexer)><lexer.name><else><parser.name><endif>::<r.name>Sem
 
 //--------------------------------------------------------------------------------------------------
 
-ParserHeader(parser, funcs, atn, sempredFuncs, superClass = {Parser}) ::= <<
+ParserHeader(parser, funcs, atn, sempredFuncs, superClass = {antlr4::Parser}) ::= <<
 <namedActions.context>
 
 class <parser.name> : public <superClass> {
@@ -280,14 +280,14 @@ public:
   };
 <endif>
 
-  <parser.name>(TokenStream *input);
+  <parser.name>(antlr4::TokenStream *input);
   ~<parser.name>();
 
   virtual std::string getGrammarFileName() const override;
-  virtual const atn::ATN& getATN() const override { return _atn; };
+  virtual const antlr4::atn::ATN& getATN() const override { return _atn; };
   virtual const std::vector\<std::string>& getTokenNames() const override { return _tokenNames; }; // deprecated: use vocabulary instead.
   virtual const std::vector\<std::string>& getRuleNames() const override;
-  virtual dfa::Vocabulary& getVocabulary() const override;
+  virtual antlr4::dfa::Vocabulary& getVocabulary() const override;
 
   <namedActions.members>
 
@@ -296,19 +296,19 @@ public:
   <funcs; separator = "\n">
 
   <if (sempredFuncs)>
-  virtual bool sempred(RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
+  virtual bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
   <sempredFuncs.values; separator = "\n">
   <endif>
 
 private:
-  static std::vector\<dfa::DFA> _decisionToDFA;
-  static atn::PredictionContextCache _sharedContextCache;
+  static std::vector\<antlr4::dfa::DFA> _decisionToDFA;
+  static antlr4::atn::PredictionContextCache _sharedContextCache;
   static std::vector\<std::string> _ruleNames;
   static std::vector\<std::string> _tokenNames;
 
   static std::vector\<std::string> _literalNames;
   static std::vector\<std::string> _symbolicNames;
-  static dfa::Vocabulary _vocabulary;
+  static antlr4::dfa::Vocabulary _vocabulary;
   <atn>
 
   <namedActions.declarations>
@@ -406,7 +406,7 @@ std::vector\<std::string> <parser.name>::_tokenNames;
 >>
 
 SerializedATNHeader(model) ::= <<
-static atn::ATN _atn;
+static antlr4::atn::ATN _atn;
 static std::vector\<uint16_t> _serializedATN;
 >>
 
@@ -526,15 +526,15 @@ LeftRecursiveRuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs
 >>
 
 StructDeclHeader(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers) ::= <<
-class <struct.name> : public <if (contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
+class <struct.name> : public <if (contextSuperClass)><contextSuperClass><else>antlr4::ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 public:
   <attrs: {a | <a>;}; separator="\n">
-  <if (ctorAttrs)><struct.name>(ParserRuleContext *parent, size_t invokingState);<endif>
-  <struct.name>(ParserRuleContext *parent, size_t invokingState<ctorAttrs: {a | , <a>}>);
+  <if (ctorAttrs)><struct.name>(antlr4::ParserRuleContext *parent, size_t invokingState);<endif>
+  <struct.name>(antlr4::ParserRuleContext *parent, size_t invokingState<ctorAttrs: {a | , <a>}>);
 <if (struct.provideCopyFrom)> <! don't need copy unless we have subclasses !>
-  <struct.name>() : ParserRuleContext() { }
+  <struct.name>() : antlr4::ParserRuleContext() { }
   void copyFrom(<struct.name> *context);
-  using ParserRuleContext::copyFrom;
+  using antlr4::ParserRuleContext::copyFrom;
 <endif>
 
   virtual size_t getRuleIndex() const override;
@@ -948,13 +948,13 @@ AddToLabelList(a) ::= <<
 
 TokenLabelType() ::= "<file.TokenLabelType; null = {Token}> *"
 
-TokenDeclHeader(t) ::= "<TokenLabelType()><t.name> = nullptr;"
+TokenDeclHeader(t) ::= "antlr4::<TokenLabelType()><t.name> = nullptr;"
 TokenDecl(t) ::= "<! Variable Declaration !>"
 
 TokenTypeDeclHeader(t) ::= "<! Local Variable !>"
 TokenTypeDecl(t) ::= "size_t <t.name> = 0;"
 
-TokenListDeclHeader(t) ::= "std::vector\<Token *> <t.name>;"
+TokenListDeclHeader(t) ::= "std::vector\<antlr4::Token *> <t.name>;"
 TokenListDecl(t) ::= "<! Variable Declaration !>"
 
 RuleContextDeclHeader(r) ::= "<parser.name>::<r.ctxName> *<r.name> = nullptr;"
@@ -963,7 +963,7 @@ RuleContextDecl(r) ::= "<! Variable Declaration !>"
 RuleContextListDeclHeader(rdecl) ::= "std::vector\<<rdecl.ctxName> *> <rdecl.name>;"
 RuleContextListDecl(rdecl) ::= "<! Variable Declaration !>"
 
-ContextTokenGetterDeclHeader(t) ::= "tree::TerminalNode *<t.name>();"
+ContextTokenGetterDeclHeader(t) ::= "antlr4::tree::TerminalNode *<t.name>();"
 ContextTokenGetterDecl(t) ::= <<
 tree::TerminalNode* <parser.name>::<t.ctx.name>::<t.name>() {
   return getToken(<parser.name>::<t.name>, 0);
@@ -971,7 +971,7 @@ tree::TerminalNode* <parser.name>::<t.ctx.name>::<t.name>() {
 
 >>
 
-ContextTokenListGetterDeclHeader(t) ::= "std::vector\<tree::TerminalNode *> <t.name>();"
+ContextTokenListGetterDeclHeader(t) ::= "std::vector\<antlr4::tree::TerminalNode *> <t.name>();"
 ContextTokenListGetterDecl(t) ::= <<
 std::vector\<tree::TerminalNode *> <parser.name>::<t.ctx.name>::<t.name>() {
   return getTokens(<parser.name>::<t.name>);
@@ -979,7 +979,7 @@ std::vector\<tree::TerminalNode *> <parser.name>::<t.ctx.name>::<t.name>() {
 
 >>
 
-ContextTokenListIndexedGetterDeclHeader(t) ::= "tree::TerminalNode* <t.name>(size_t i);"
+ContextTokenListIndexedGetterDeclHeader(t) ::= "antlr4::tree::TerminalNode* <t.name>(size_t i);"
 ContextTokenListIndexedGetterDecl(t)  ::= <<
 tree::TerminalNode* <parser.name>::<t.ctx.name>::<t.name>(size_t i) {
   return getToken(<parser.name>::<t.name>, i);
@@ -1012,7 +1012,7 @@ ContextRuleListIndexedGetterDecl(r) ::= <<
 
 >>
 
-LexerRuleContext() ::= "RuleContext"
+LexerRuleContext() ::= "antlr4::RuleContext"
 
 // The rule context name is the rule followed by a suffix; e.g. r becomes rContext.
 RuleContextNameSuffix() ::= "Context"
@@ -1031,7 +1031,7 @@ CaptureNextTokenTypeHeader(d) ::= "<! Required but unused. !>"
 CaptureNextTokenType(d) ::= "<d.varName> = _input->LA(1);"
 
 ListenerDispatchMethodHeader(method) ::= <<
-virtual void <if (method.isEnter)>enter<else>exit<endif>Rule(tree::ParseTreeListener *listener) override;
+virtual void <if (method.isEnter)>enter<else>exit<endif>Rule(antlr4::tree::ParseTreeListener *listener) override;
 >>
 ListenerDispatchMethod(method) ::= <<
 void <parser.name>::<struct.name>::<if (method.isEnter)>enter<else>exit<endif>Rule(tree::ParseTreeListener *listener) {
@@ -1043,7 +1043,7 @@ void <parser.name>::<struct.name>::<if (method.isEnter)>enter<else>exit<endif>Ru
 
 VisitorDispatchMethodHeader(method) ::= <<
 
-virtual antlrcpp::Any accept(tree::ParseTreeVisitor *visitor) override;
+virtual antlrcpp::Any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
 >>
 VisitorDispatchMethod(method) ::=  <<
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -153,7 +153,7 @@ const atn::ATN& <lexer.name>::getATN() const {
 <if (actionFuncs)>
 void <lexer.name>::action(RuleContext *context, size_t ruleIndex, size_t actionIndex) {
   switch (ruleIndex) {
-    <lexer.actionFuncs.values: {f | case <f.ruleIndex>: <f.name>Action(context, actionIndex); break;}; separator="\n">
+    <lexer.actionFuncs.values: {f | case <f.ruleIndex>: <f.name>Action(dynamic_cast\<<f.ctxType> *>(context), actionIndex); break;}; separator="\n">
 
   default:
     break;
@@ -164,7 +164,7 @@ void <lexer.name>::action(RuleContext *context, size_t ruleIndex, size_t actionI
 <if (sempredFuncs)>
 bool <lexer.name>::sempred(RuleContext *context, size_t ruleIndex, size_t predicateIndex) {
   switch (ruleIndex) {
-    <lexer.sempredFuncs.values: {f | case <f.ruleIndex>: return <f.name>Sempred(context, predicateIndex);}; separator="\n">
+    <lexer.sempredFuncs.values: {f | case <f.ruleIndex>: return <f.name>Sempred(dynamic_cast\<<f.ctxType> *>(context), predicateIndex);}; separator="\n">
 
   default:
     break;

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Files.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Files.stg
@@ -47,8 +47,6 @@ LexerFileHeader(file, lexer, namedActions) ::= <<
 
 <namedActions.postinclude>
 
-using namespace antlr4;
-
 <if(file.genPackage)>namespace <file.genPackage> {<endif>
 
 <lexer>
@@ -85,8 +83,6 @@ ParserFileHeader(file, parser, namedActions, contextSuperClass) ::= <<
 #include "antlr4-runtime.h"
 
 <namedActions.postinclude>
-
-using namespace antlr4;
 
 <if (file.genPackage)>namespace <file.genPackage> {<endif>
 
@@ -145,10 +141,10 @@ public:
   virtual void exit<lname; format="cap">(<file.parserName>::<lname; format = "cap">Context * /*ctx*/) override { \}
 }; separator="\n">
 
-  virtual void enterEveryRule(ParserRuleContext * /*ctx*/) override { }
-  virtual void exitEveryRule(ParserRuleContext * /*ctx*/) override { }
-  virtual void visitTerminal(tree::TerminalNode * /*node*/) override { }
-  virtual void visitErrorNode(tree::ErrorNode * /*node*/) override { }
+  virtual void enterEveryRule(antlr4::ParserRuleContext * /*ctx*/) override { }
+  virtual void exitEveryRule(antlr4::ParserRuleContext * /*ctx*/) override { }
+  virtual void visitTerminal(antlr4::tree::TerminalNode * /*node*/) override { }
+  virtual void visitErrorNode(antlr4::tree::ErrorNode * /*node*/) override { }
   
 <if (namedActions.baselistenermembers)>
 private:  


### PR DESCRIPTION
This Pull Request fix #1457 

- Ensured that there is no "using namespace" in the generated header files

- Ensured that there is any "using namespace" in runtime/src headers included by antlr-runtime.h:
``$]find runtime/Cpp/runtime/src/ -type f -name *.h -print | xargs grep "namespace" | grep using``

