### PR TITLE
Call visitErrorNodes properly in Python targets.

### DIFF
--- a/runtime/Python2/src/antlr4/Parser.py
+++ b/runtime/Python2/src/antlr4/Parser.py
@@ -328,7 +328,10 @@ class Parser (Recognizer):
                 node = self._ctx.addTokenNode(o)
             if hasListener:
                 for listener in self._parseListeners:
-                    listener.visitTerminal(node)
+                    if isinstance(node, ErrorNode):
+                        listener.visitErrorNode(node)
+                    elif isinstance(node, TerminalNode):
+                        listener.visitTerminal(node)
         return o
 
     def addContextToParseTree(self):

--- a/runtime/Python3/src/antlr4/Parser.py
+++ b/runtime/Python3/src/antlr4/Parser.py
@@ -335,7 +335,10 @@ class Parser (Recognizer):
                 node = self._ctx.addTokenNode(o)
             if hasListener:
                 for listener in self._parseListeners:
-                    listener.visitTerminal(node)
+                    if isinstance(node, ErrorNode):
+                        listener.visitErrorNode(node)
+                    elif isinstance(node, TerminalNode):
+                        listener.visitTerminal(node)
         return o
 
     def addContextToParseTree(self):


### PR DESCRIPTION
The consume method of the Parser class calls visitTerminal on both
TerminalNodes and ErrorNodes even if the comment above states that
ErrorNodes should be visited by visitErrorNodes. This behaviour
is also inconsitent with the Java target. The patch fixes this in
both Python targets.