### PR TITLE
Fix 1298

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
@@ -110,6 +110,7 @@ public abstract class BaseRuntimeTest {
 
 	@Test
 	public void testOne() throws Exception {
+		// System.out.println(delegate.getTmpDir());
 		if ( descriptor.ignore(descriptor.getTarget()) ) {
 			System.out.printf("Ignore "+descriptor);
 			return;

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParseTreesDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParseTreesDescriptors.java
@@ -74,9 +74,9 @@ public class ParseTreesDescriptors {
 
 	}
 
-	public static class ExtraTokensShouldBeInTree extends BaseParserTestDescriptor {
+	public static class ExtraTokensAndAltLabels extends BaseParserTestDescriptor {
 		public String input = "${ ? a ?}";
-		public String output = "(s ${ ? (v a) ? })\n";
+		public String output = "(s ${ (v ? a) ? })\n";
 		public String errors =
 			"line 1:3 extraneous input '?' expecting {'a', 'b'}\n"+
 			"line 1:7 extraneous input '?' expecting '}'\n";

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParseTreesDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParseTreesDescriptors.java
@@ -109,6 +109,11 @@ public class ParseTreesDescriptors {
 		 */
 		@CommentHasStringValue
 		public String grammar;
+
+		@Override
+		public boolean ignore(String targetName) {
+			return !targetName.equals("Java");
+		}
 	}
 
 	public static class NoViableAlt extends BaseParserTestDescriptor {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParseTreesDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParseTreesDescriptors.java
@@ -74,6 +74,43 @@ public class ParseTreesDescriptors {
 
 	}
 
+	public static class ExtraTokensShouldBeInTree extends BaseParserTestDescriptor {
+		public String input = "${ ? a ?}";
+		public String output = "(s ${ ? (v a) ? })\n";
+		public String errors =
+			"line 1:3 extraneous input '?' expecting {'a', 'b'}\n"+
+			"line 1:7 extraneous input '?' expecting '}'\n";
+		public String startRule = "s";
+		public String grammarName = "T";
+
+		/**
+		 grammar T;
+
+		 s
+		 @init {
+		 <BuildParseTrees()>
+		 }
+		 @after {
+		 <ToStringTree("$ctx"):writeln()>
+		 }
+   		   : '${' v '}'
+		   ;
+
+		 v : A #altA
+		   | B #altB
+		   ;
+
+		 A : 'a' ;
+		 B : 'b' ;
+
+		 WHITESPACE : [ \n\t\r]+ -> channel(HIDDEN) ;
+
+		 ERROR : . ;
+		 */
+		@CommentHasStringValue
+		public String grammar;
+	}
+
 	public static class NoViableAlt extends BaseParserTestDescriptor {
 		public String input = "z";
 		public String output = "(a z)\n";

--- a/runtime/Java/src/org/antlr/v4/runtime/ParserRuleContext.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ParserRuleContext.java
@@ -80,6 +80,14 @@ public class ParserRuleContext extends RuleContext {
 
 	/** COPY a ctx (I'm deliberately not using copy constructor) to avoid
 	 *  confusion with creating node with parent. Does not copy children.
+	 *
+	 *  This is used in the generated parser code to flip a generic XContext
+	 *  node for rule X to a YContext for alt label Y. In that sense, it is
+	 *  not really a generic copy function.
+	 *
+	 *  If we do an error sync() at start of a rule, we might add error nodes
+	 *  to the generic XContext so this function must copy those nodes to
+	 *  the YContext as well else they are lost!
 	 */
 	public void copyFrom(ParserRuleContext ctx) {
 		this.parent = ctx.parent;
@@ -87,6 +95,18 @@ public class ParserRuleContext extends RuleContext {
 
 		this.start = ctx.start;
 		this.stop = ctx.stop;
+
+		// copy any error nodes to alt label node
+		if ( ctx.children!=null ) {
+			this.children = new ArrayList<>();
+			// reset parent pointer for any error nodes
+			for (ParseTree child : ctx.children) {
+				if ( child instanceof ErrorNodeImpl ) {
+					this.children.add(child);
+					((ErrorNodeImpl) child).parent = this;
+				}
+			}
+		}
 	}
 
 	public ParserRuleContext(ParserRuleContext parent, int invokingStateNumber) {


### PR DESCRIPTION
`sync()` was could add error nodes that were ignored when we converted regular RuleContext nodes to those for alt labels.