### PR TITLE
Fix travis runtime-test Cpp

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
@@ -589,7 +589,7 @@ public class BaseCppTest implements RuntimeTestSupport {
 		String inputPath = new File(new File(tmpdir), "input").getAbsolutePath();
 		String cxx = System.getenv("CXX");// clang++, g++-5, ...
 		if (cxx==null || cxx.length()==0) {
-			cxx = String("clang++");// FIXME: with $> export CXX="clang++"
+			cxx = new String("clang++");// FIXME: with $> export CXX="clang++"
 		}
 
 		// Build runtime using cmake once.

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
@@ -587,12 +587,13 @@ public class BaseCppTest implements RuntimeTestSupport {
 		String includePath = runtimePath + "/runtime/src";
 		String binPath = new File(new File(tmpdir), "a.out").getAbsolutePath();
 		String inputPath = new File(new File(tmpdir), "input").getAbsolutePath();
+		String cxx = System.getenv("CXX");// clang++, g++-5, ...
 
 		// Build runtime using cmake once.
 		synchronized (runtimeBuiltOnce) {
 			if ( !runtimeBuiltOnce ) {
 				try {
-					String command[] = {"clang++", "--version"};
+					String command[] = {cxx, "--version"};
 					String output = runCommand(command, tmpdir, "printing compiler version");
 					System.out.println("Compiler version is: "+output);
 				}
@@ -623,8 +624,9 @@ public class BaseCppTest implements RuntimeTestSupport {
 		}
 
 		try {
-			List<String> command2 = new ArrayList<String>(Arrays.asList("clang++", "-std=c++11", "-I", includePath, "-L.", "-lantlr4-runtime", "-o", "a.out"));
+			List<String> command2 = new ArrayList<String>(Arrays.asList(cxx, "-std=c++11"));
 			command2.addAll(allCppFiles(tmpdir));
+			command2.addAll(Arrays.asList("-o", "a.out", "-I", includePath, "-L.", "-lantlr4-runtime"));
 			if (runCommand(command2.toArray(new String[0]), tmpdir, "building test binary") == null) {
 				return null;
 			}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
@@ -588,7 +588,7 @@ public class BaseCppTest implements RuntimeTestSupport {
 		String binPath = new File(new File(tmpdir), "a.out").getAbsolutePath();
 		String inputPath = new File(new File(tmpdir), "input").getAbsolutePath();
 		String cxx = System.getenv("CXX");// clang++, g++-5, ...
-		if (!cxx || cxx.length()==0) {
+		if (cxx==null || cxx.length()==0) {
 			cxx = String("clang++");// FIXME: with $> export CXX="clang++"
 		}
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
@@ -588,6 +588,9 @@ public class BaseCppTest implements RuntimeTestSupport {
 		String binPath = new File(new File(tmpdir), "a.out").getAbsolutePath();
 		String inputPath = new File(new File(tmpdir), "input").getAbsolutePath();
 		String cxx = System.getenv("CXX");// clang++, g++-5, ...
+		if (!cxx || cxx.length()==0) {
+			cxx = String("clang++");// FIXME: with $> export CXX="clang++"
+		}
 
 		// Build runtime using cmake once.
 		synchronized (runtimeBuiltOnce) {


### PR DESCRIPTION
Since divide to conquer with travis. CppTarget test unit are break

This Pull Request fix the command line argument order.

Replace:
``g++ -std=c++11 -I/xxx -L/yyy -lantlr4-runtime -o a.out zzz.cpp``
By:
``g++ -std=c++11 zzz.cpp -o a.out -I/xxx -L/yyy -lantlr4-runtime``

