### PR TITLE
Fix documentation of getHiddenTokensToRight in BufferedTokenStream

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -127,3 +127,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/12/01, samtatasurya, Samuel Tatasurya, xemradiant@gmail.com
 2016/12/03, redxdev, Samuel Bloomberg, sam@redxdev.com
 2016/12/11, Gaulouis, Gaulouis, gaulouis.com@gmail.com
+2016/12/22, akosthekiss, Akos Kiss, akiss@inf.u-szeged.hu

--- a/runtime/Cpp/runtime/src/BufferedTokenStream.h
+++ b/runtime/Cpp/runtime/src/BufferedTokenStream.h
@@ -68,7 +68,7 @@ namespace antlr4 {
     /// <summary>
     /// Collect all hidden tokens (any off-default channel) to the right of
     ///  the current token up until we see a token on DEFAULT_TOKEN_CHANNEL
-    ///  of EOF.
+    ///  or EOF.
     /// </summary>
     virtual std::vector<Token *> getHiddenTokensToRight(size_t tokenIndex);
 

--- a/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
@@ -372,7 +372,7 @@ public class BufferedTokenStream implements TokenStream {
 
 	/** Collect all hidden tokens (any off-default channel) to the right of
 	 *  the current token up until we see a token on DEFAULT_TOKEN_CHANNEL
-	 *  of EOF.
+	 *  or EOF.
 	 */
 	public List<Token> getHiddenTokensToRight(int tokenIndex) {
 		return getHiddenTokensToRight(tokenIndex, -1);

--- a/runtime/Swift/Antlr4/org/antlr/v4/runtime/BufferedTokenStream.swift
+++ b/runtime/Swift/Antlr4/org/antlr/v4/runtime/BufferedTokenStream.swift
@@ -402,7 +402,7 @@ public class BufferedTokenStream: TokenStream {
 
     /** Collect all hidden tokens (any off-default channel) to the right of
      *  the current token up until we see a token on DEFAULT_TOKEN_CHANNEL
-     *  of EOF.
+     *  or EOF.
      */
     public func getHiddenTokensToRight(_ tokenIndex: Int) throws -> Array<Token>? {
         return try getHiddenTokensToRight(tokenIndex, -1)


### PR DESCRIPTION
I've found the documentation somewhat confusing at first sight, so thought it would be worth getting it right, even if the fix is quite trivial.

(The patch touches all runtimes where the wording was incorrect.)