### PR TITLE
Fix multiple problems with optional block bypass at end of rule

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParserErrorsDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParserErrorsDescriptors.java
@@ -135,7 +135,7 @@ public class ParserErrorsDescriptors {
 	public static class InvalidEmptyInput extends BaseParserTestDescriptor {
 		public String input = "";
 		public String output = null;
-		public String errors = "line 1:0 missing ID at '<EOF>'\n";
+		public String errors = "line 1:0 mismatched input '<EOF>' expecting ID\n";
 		public String startRule = "start";
 		public String grammarName = "T";
 
@@ -414,7 +414,7 @@ public class ParserErrorsDescriptors {
 
 		/**
 		 grammar T;
-		 a : 'a' 'b'* ;
+		 a : 'a' 'b'* EOF ;
 		 */
 		@CommentHasStringValue
 		public String grammar;
@@ -436,7 +436,7 @@ public class ParserErrorsDescriptors {
 
 		/**
 		 grammar T;
-		 a : 'a' ('b'|'z'{<Pass()>})*;
+		 a : 'a' ('b'|'z'{<Pass()>})* EOF ;
 		 */
 		@CommentHasStringValue
 		public String grammar;

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParserExecDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParserExecDescriptors.java
@@ -753,6 +753,83 @@ public class ParserExecDescriptors {
 		 */
 		@CommentHasStringValue
 		public String grammar;
+	}
 
+	/**
+	 * This is a regression test for antlr/antlr4#1545, case 1.
+	 */
+	public static class OpenDeviceStatement_Case1 extends BaseParserTestDescriptor {
+		public String input = "OPEN DEVICE DEVICE";
+		public String output = "OPEN DEVICE DEVICE\n";
+		public String errors = null;
+		public String startRule = "statement";
+		public String grammarName = "OpenDeviceStatement";
+
+		/**
+		 grammar OpenDeviceStatement;
+		 program : statement+ '.' ;
+
+		 statement : 'OPEN' ( 'DEVICE' (  OPT1  |  OPT2  |  OPT3  )? )+ {<writeln("$text")>} ;
+
+		 OPT1 : 'OPT-1';
+		 OPT2 : 'OPT-2';
+		 OPT3 : 'OPT-3';
+
+		 WS : (' '|'\n')+ -> channel(HIDDEN);
+		 */
+		@CommentHasStringValue
+		public String grammar;
+	}
+
+	/**
+	 * This is a regression test for antlr/antlr4#1545, case 2.
+	 */
+	public static class OpenDeviceStatement_Case2 extends BaseParserTestDescriptor {
+		public String input = "OPEN DEVICE DEVICE";
+		public String output = "OPEN DEVICE DEVICE\n";
+		public String errors = null;
+		public String startRule = "statement";
+		public String grammarName = "OpenDeviceStatement";
+
+		/**
+		 grammar OpenDeviceStatement;
+		 program : statement+ '.' ;
+
+		 statement : 'OPEN' ( 'DEVICE' (  (OPT1)  |  OPT2  |  OPT3  )? )+ {<writeln("$text")>} ;
+
+		 OPT1 : 'OPT-1';
+		 OPT2 : 'OPT-2';
+		 OPT3 : 'OPT-3';
+
+		 WS : (' '|'\n')+ -> channel(HIDDEN);
+		 */
+		@CommentHasStringValue
+		public String grammar;
+	}
+
+	/**
+	 * This is a regression test for antlr/antlr4#1545, case 3.
+	 */
+	public static class OpenDeviceStatement_Case3 extends BaseParserTestDescriptor {
+		public String input = "OPEN DEVICE DEVICE.";
+		public String output = "OPEN DEVICE DEVICE\n";
+		public String errors = null;
+		public String startRule = "statement";
+		public String grammarName = "OpenDeviceStatement";
+
+		/**
+		 grammar OpenDeviceStatement;
+		 program : statement+ '.' ;
+
+		 statement : 'OPEN' ( 'DEVICE' (  (OPT1)  |  OPT2  |  OPT3  )? )+ {<writeln("$text")>} ;
+
+		 OPT1 : 'OPT-1';
+		 OPT2 : 'OPT-2';
+		 OPT3 : 'OPT-3';
+
+		 WS : (' '|'\n')+ -> channel(HIDDEN);
+		 */
+		@CommentHasStringValue
+		public String grammar;
 	}
 }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/DefaultErrorStrategy.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/DefaultErrorStrategy.cs
@@ -265,7 +265,8 @@ namespace Antlr4.Runtime
             ITokenStream tokens = ((ITokenStream)recognizer.InputStream);
             int la = tokens.LA(1);
             // try cheaper subset first; might get lucky. seems to shave a wee bit off
-            if (recognizer.Atn.NextTokens(s).Contains(la) || la == TokenConstants.EOF)
+            var nextTokens = recognizer.Atn.NextTokens(s);
+            if (nextTokens.Contains(TokenConstants.EPSILON) || nextTokens.Contains(la))
             {
                 return;
             }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/DefaultErrorStrategy.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/DefaultErrorStrategy.cs
@@ -270,11 +270,6 @@ namespace Antlr4.Runtime
             {
                 return;
             }
-            // Return but don't end recovery. only do that upon valid token match
-            if (recognizer.IsExpectedToken(la))
-            {
-                return;
-            }
             switch (s.StateType)
             {
                 case StateType.BlockStart:

--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
@@ -105,11 +105,6 @@ void DefaultErrorStrategy::sync(Parser *recognizer) {
     return;
   }
 
-  // Return but don't end recovery. only do that upon valid token match
-  if (recognizer->isExpectedToken((int)la)) {
-    return;
-  }
-
   switch (s->getStateType()) {
     case atn::ATNState::BLOCK_START:
     case atn::ATNState::STAR_BLOCK_START:

--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
@@ -100,7 +100,8 @@ void DefaultErrorStrategy::sync(Parser *recognizer) {
   size_t la = tokens->LA(1);
 
   // try cheaper subset first; might get lucky. seems to shave a wee bit off
-  if (recognizer->getATN().nextTokens(s).contains(la) || la == Token::EOF) {
+  auto nextTokens = recognizer->getATN().nextTokens(s);
+  if (nextTokens.contains(Token::EPSILON) || nextTokens.contains(la)) {
     return;
   }
 

--- a/runtime/Go/antlr/error_strategy.go
+++ b/runtime/Go/antlr/error_strategy.go
@@ -222,10 +222,6 @@ func (d *DefaultErrorStrategy) Sync(recognizer Parser) {
 	if nextTokens.contains(TokenEpsilon) || nextTokens.contains(la) {
 		return
 	}
-	// Return but don't end recovery. only do that upon valid token Match
-	if recognizer.IsExpectedToken(la) {
-		return
-	}
 
 	switch s.GetStateType() {
 	case ATNStateBlockStart, ATNStateStarBlockStart, ATNStatePlusBlockStart, ATNStateStarLoopEntry:

--- a/runtime/Go/antlr/error_strategy.go
+++ b/runtime/Go/antlr/error_strategy.go
@@ -218,7 +218,8 @@ func (d *DefaultErrorStrategy) Sync(recognizer Parser) {
 	la := recognizer.GetTokenStream().LA(1)
 
 	// try cheaper subset first might get lucky. seems to shave a wee bit off
-	if la == TokenEOF || recognizer.GetATN().NextTokens(s, nil).contains(la) {
+	nextTokens := recognizer.GetATN().NextTokens(s, nil)
+	if nextTokens.contains(TokenEpsilon) || nextTokens.contains(la) {
 		return
 	}
 	// Return but don't end recovery. only do that upon valid token Match

--- a/runtime/Java/src/org/antlr/v4/runtime/DefaultErrorStrategy.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/DefaultErrorStrategy.java
@@ -229,11 +229,6 @@ public class DefaultErrorStrategy implements ANTLRErrorStrategy {
 			return;
 		}
 
-		// Return but don't end recovery. only do that upon valid token match
-		if (recognizer.isExpectedToken(la)) {
-			return;
-		}
-
 		switch (s.getStateType()) {
 		case ATNState.BLOCK_START:
 		case ATNState.STAR_BLOCK_START:

--- a/runtime/Java/src/org/antlr/v4/runtime/DefaultErrorStrategy.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/DefaultErrorStrategy.java
@@ -224,7 +224,10 @@ public class DefaultErrorStrategy implements ANTLRErrorStrategy {
         int la = tokens.LA(1);
 
         // try cheaper subset first; might get lucky. seems to shave a wee bit off
-        if ( recognizer.getATN().nextTokens(s).contains(la) || la==Token.EOF ) return;
+		IntervalSet nextTokens = recognizer.getATN().nextTokens(s);
+		if (nextTokens.contains(Token.EPSILON) || nextTokens.contains(la)) {
+			return;
+		}
 
 		// Return but don't end recovery. only do that upon valid token match
 		if (recognizer.isExpectedToken(la)) {

--- a/runtime/JavaScript/src/antlr4/error/ErrorStrategy.js
+++ b/runtime/JavaScript/src/antlr4/error/ErrorStrategy.js
@@ -227,10 +227,6 @@ DefaultErrorStrategy.prototype.sync = function(recognizer) {
     if (nextTokens.contains(Token.EPSILON) || nextTokens.contains(la)) {
         return;
     }
-    // Return but don't end recovery. only do that upon valid token match
-    if(recognizer.isExpectedToken(la)) {
-        return;
-    }
     switch (s.stateType) {
     case ATNState.BLOCK_START:
     case ATNState.STAR_BLOCK_START:

--- a/runtime/JavaScript/src/antlr4/error/ErrorStrategy.js
+++ b/runtime/JavaScript/src/antlr4/error/ErrorStrategy.js
@@ -223,7 +223,8 @@ DefaultErrorStrategy.prototype.sync = function(recognizer) {
     var s = recognizer._interp.atn.states[recognizer.state];
     var la = recognizer.getTokenStream().LA(1);
     // try cheaper subset first; might get lucky. seems to shave a wee bit off
-    if (la===Token.EOF || recognizer.atn.nextTokens(s).contains(la)) {
+    var nextTokens = recognizer.atn.nextTokens(s);
+    if (nextTokens.contains(Token.EPSILON) || nextTokens.contains(la)) {
         return;
     }
     // Return but don't end recovery. only do that upon valid token match

--- a/runtime/Python2/src/antlr4/error/ErrorStrategy.py
+++ b/runtime/Python2/src/antlr4/error/ErrorStrategy.py
@@ -202,7 +202,8 @@ class DefaultErrorStrategy(ErrorStrategy):
         s = recognizer._interp.atn.states[recognizer.state]
         la = recognizer.getTokenStream().LA(1)
         # try cheaper subset first; might get lucky. seems to shave a wee bit off
-        if la==Token.EOF or la in recognizer.atn.nextTokens(s):
+        nextTokens = recognizer.atn.nextTokens(s)
+        if Token.EPSILON in nextTokens or la in nextTokens:
             return
 
         # Return but don't end recovery. only do that upon valid token match

--- a/runtime/Python2/src/antlr4/error/ErrorStrategy.py
+++ b/runtime/Python2/src/antlr4/error/ErrorStrategy.py
@@ -206,10 +206,6 @@ class DefaultErrorStrategy(ErrorStrategy):
         if Token.EPSILON in nextTokens or la in nextTokens:
             return
 
-        # Return but don't end recovery. only do that upon valid token match
-        if recognizer.isExpectedToken(la):
-            return
-
         if s.stateType in [ATNState.BLOCK_START, ATNState.STAR_BLOCK_START,
                                 ATNState.PLUS_BLOCK_START, ATNState.STAR_LOOP_ENTRY]:
             # report error and recover if possible

--- a/runtime/Python3/src/antlr4/error/ErrorStrategy.py
+++ b/runtime/Python3/src/antlr4/error/ErrorStrategy.py
@@ -207,7 +207,8 @@ class DefaultErrorStrategy(ErrorStrategy):
         s = recognizer._interp.atn.states[recognizer.state]
         la = recognizer.getTokenStream().LA(1)
         # try cheaper subset first; might get lucky. seems to shave a wee bit off
-        if la==Token.EOF or la in recognizer.atn.nextTokens(s):
+        nextTokens = recognizer.atn.nextTokens(s)
+        if Token.EPSILON in nextTokens or la in nextTokens:
             return
 
         # Return but don't end recovery. only do that upon valid token match

--- a/runtime/Python3/src/antlr4/error/ErrorStrategy.py
+++ b/runtime/Python3/src/antlr4/error/ErrorStrategy.py
@@ -211,10 +211,6 @@ class DefaultErrorStrategy(ErrorStrategy):
         if Token.EPSILON in nextTokens or la in nextTokens:
             return
 
-        # Return but don't end recovery. only do that upon valid token match
-        if recognizer.isExpectedToken(la):
-            return
-
         if s.stateType in [ATNState.BLOCK_START, ATNState.STAR_BLOCK_START,
                                 ATNState.PLUS_BLOCK_START, ATNState.STAR_LOOP_ENTRY]:
            # report error and recover if possible

--- a/runtime/Swift/Antlr4/org/antlr/v4/runtime/DefaultErrorStrategy.swift
+++ b/runtime/Swift/Antlr4/org/antlr/v4/runtime/DefaultErrorStrategy.swift
@@ -226,7 +226,11 @@ public class DefaultErrorStrategy: ANTLRErrorStrategy {
         // try cheaper subset first; might get lucky. seems to shave a wee bit off
         //let set : IntervalSet = recognizer.getATN().nextTokens(s)
 
-        if try recognizer.getATN().nextTokens(s).contains(la) || la == CommonToken.EOF {
+        if try recognizer.getATN().nextTokens(s).contains(CommonToken.EPSILON) {
+            return
+        }
+
+        if try recognizer.getATN().nextTokens(s).contains(la) {
             return
         }
 

--- a/runtime/Swift/Antlr4/org/antlr/v4/runtime/DefaultErrorStrategy.swift
+++ b/runtime/Swift/Antlr4/org/antlr/v4/runtime/DefaultErrorStrategy.swift
@@ -234,11 +234,6 @@ public class DefaultErrorStrategy: ANTLRErrorStrategy {
             return
         }
 
-        // Return but don't end recovery. only do that upon valid token match
-        if try recognizer.isExpectedToken(la) {
-            return
-        }
-
         switch s.getStateType() {
         case ATNState.BLOCK_START: fallthrough
         case ATNState.STAR_BLOCK_START: fallthrough

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -566,7 +566,7 @@ switch (TokenStream.LA(1)) {
 	<alt>
 	break;}; separator="\n">
 default:
-	<error>
+	break;
 }
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -644,7 +644,7 @@ switch (_input->LA(1)) {
 \}
 }; separator="\n">
 default:
-  <error>
+  break;
 }
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -563,9 +563,6 @@ switch p.GetTokenStream().LA(1) {
 
 <endif>
 default:
-	<if(error)>
-	<error>
-	<endif>
 }
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -489,7 +489,7 @@ switch (_input.LA(1)) {
 	<alt>
 	break;}; separator="\n">
 default:
-	<error>
+	break;
 }
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -360,7 +360,7 @@ switch (this._input.LA(1)) {
 	<alt>
 	break;}; separator="\n">
 default:
-	<error>
+	break;
 }
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -334,7 +334,7 @@ token = self._input.LA(1)
     <alt>
     pass}; separator="\nel">
 else:
-    <error>
+    pass
 >>
 
 LL1OptionalBlockSingleAlt(choice, expr, alts, preamble, error, followExpr) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -342,7 +342,7 @@ token = self._input.LA(1)
     <alt>
     pass}; separator="\nel">
 else:
-    <error>
+    pass
 >>
 
 LL1OptionalBlockSingleAlt(choice, expr, alts, preamble, error, followExpr) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -510,7 +510,7 @@ switch (<parser.name>.Tokens(rawValue: try _input.LA(1))!) {
  	<alt>
 	break}; separator="\n">
 default:
-	<error>
+	break
 }
 >>
 


### PR DESCRIPTION
* Add tests for scenarios presented in the original bug
* Fix `DefaultErrorStrategy.sync` not handling falling off decision rule the same way as `adaptivePredict`
* Fix code generation for `LL1OptionalBlock`

Fixes #1545