### PR TITLE
adapt code to compile with msys2 mingw compiler

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -128,3 +128,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/12/03, redxdev, Samuel Bloomberg, sam@redxdev.com
 2016/12/11, Gaulouis, Gaulouis, gaulouis.com@gmail.com
 2016/12/22, akosthekiss, Akos Kiss, akiss@inf.u-szeged.hu
+2016/12/24, adrpo, Adrian Pop, adrian.pop@liu.se

--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 include_directories(
   ${PROJECT_SOURCE_DIR}/runtime/src
   ${PROJECT_SOURCE_DIR}/runtime/src/atn
@@ -50,7 +51,13 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   set(disabled_compile_warnings "${disabled_compile_warnings} -Wno-multichar")
 endif()
 
-  
+set(extra_share_compile_flags "")
+set(extra_static_compile_flags "")
+if (WIN32)
+  set(extra_share_compile_flags "-DANTLR4CPP_EXPORTS")
+  set(extra_static_compile_flags "-DANTLR4CPP_STATIC")
+endif(WIN32)
+
 set_target_properties(antlr4_shared
                       PROPERTIES VERSION   ${ANTLR_VERSION}
                                  SOVERSION ${ANTLR_VERSION}
@@ -59,14 +66,15 @@ set_target_properties(antlr4_shared
                                  # TODO: test in windows. DLL is treated as runtime.
                                  # see https://cmake.org/cmake/help/v3.0/prop_tgt/LIBRARY_OUTPUT_DIRECTORY.html
                                  RUNTIME_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
-                                 COMPILE_FLAGS "${disabled_compile_warnings}")
+                                 ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
+                                 COMPILE_FLAGS "${disabled_compile_warnings} ${extra_share_compile_flags}")
 
 set_target_properties(antlr4_static
                       PROPERTIES VERSION   ${ANTLR_VERSION}
                                  SOVERSION ${ANTLR_VERSION}
                                  OUTPUT_NAME antlr4-runtime
                                  ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
-                                 COMPILE_FLAGS "${disabled_compile_warnings}")
+                                 COMPILE_FLAGS "${disabled_compile_warnings} ${extra_static_compile_flags}")
 
 install(TARGETS antlr4_shared
         DESTINATION lib)

--- a/runtime/Cpp/runtime/src/ANTLRFileStream.cpp
+++ b/runtime/Cpp/runtime/src/ANTLRFileStream.cpp
@@ -20,7 +20,7 @@ void ANTLRFileStream::loadFromFile(const std::string &fileName) {
     return;
   }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
   std::ifstream stream(antlrcpp::s2ws(fileName), std::ios::binary);
 #else
   std::ifstream stream(fileName, std::ios::binary);

--- a/runtime/Cpp/runtime/src/antlr4-common.h
+++ b/runtime/Cpp/runtime/src/antlr4-common.h
@@ -36,12 +36,14 @@
 
 // Defines for the Guid class and other platform dependent stuff.
 #ifdef _WIN32
-  #pragma warning (disable: 4250) // Class inherits by dominance.
-  #pragma warning (disable: 4512) // assignment operator could not be generated
+  #ifdef _MSC_VER
+    #pragma warning (disable: 4250) // Class inherits by dominance.
+    #pragma warning (disable: 4512) // assignment operator could not be generated
 
-  #if _MSC_VER < 1900
-    // Before VS 2015 code like "while (true)" will create a (useless) warning in level 4.
-    #pragma warning (disable: 4127) // conditional expression is constant
+    #if _MSC_VER < 1900
+      // Before VS 2015 code like "while (true)" will create a (useless) warning in level 4.
+      #pragma warning (disable: 4127) // conditional expression is constant
+    #endif
   #endif
 
   #define GUID_WINDOWS
@@ -69,7 +71,9 @@
     #endif
   #endif
 
+#ifdef _MSC_VER
   class ANTLR4CPP_PUBLIC std::exception; // Needed for VS 2015.
+#endif
 
 #elif __APPLE__
   #define GUID_CFUUID

--- a/runtime/Cpp/runtime/src/support/Any.h
+++ b/runtime/Cpp/runtime/src/support/Any.h
@@ -9,7 +9,7 @@
 
 #include "antlr4-common.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
   #pragma warning(push)
   #pragma warning(disable: 4521) // 'antlrcpp::Any': multiple copy constructors specified
 #endif
@@ -139,6 +139,6 @@ private:
 
 } // namespace antlrcpp
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif


### PR DESCRIPTION
- add required extra flags to the C++ compiler in CMakeLists.txt
- guard some code with _MSC_VER instead of WIN32

[cut]
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
[/cut]
