### PR TITLE
Fixes #1556.

### DIFF
--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestToolSyntaxErrors.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestToolSyntaxErrors.java
@@ -729,4 +729,20 @@ public class TestToolSyntaxErrors extends BaseJavaToolTest {
 		String[] pair = { grammar, expected };
 		super.testErrors(pair, true);
 	}
+
+	// Test for https://github.com/antlr/antlr4/issues/1556
+	@Test public void testRangeInParserGrammar() {
+		String grammar =
+			"grammar T;\n"+
+			"a:  'A'..'Z' ;\n";
+		String expected =
+			"error(" + ErrorType.TOKEN_RANGE_IN_PARSER.code + "): T.g4:2:4: token ranges not allowed in parser: 'A'..'Z'\n";
+
+		String[] pair = new String[] {
+			grammar,
+			expected
+		};
+
+		super.testErrors(pair, true);
+	}
 }

--- a/tool/src/org/antlr/v4/automata/ParserATNFactory.java
+++ b/tool/src/org/antlr/v4/automata/ParserATNFactory.java
@@ -233,7 +233,12 @@ public class ParserATNFactory implements ATNFactory {
 
 	@Override
 	public Handle range(GrammarAST a, GrammarAST b) {
-		throw new UnsupportedOperationException("This construct is not valid in parsers.");
+		g.tool.errMgr.grammarError(ErrorType.TOKEN_RANGE_IN_PARSER, g.fileName,
+		                           a.getToken(),
+		                           a.getToken().getText(),
+		                           b.getToken().getText());
+		// From a..b, yield ATN for just a.
+		return tokenRef((TerminalAST)a);
 	}
 
 	protected int getTokenType(GrammarAST atom) {

--- a/tool/src/org/antlr/v4/parse/GrammarTreeVisitor.g
+++ b/tool/src/org/antlr/v4/parse/GrammarTreeVisitor.g
@@ -844,7 +844,7 @@ element
 	|   SEMPRED						{sempredInAlt((PredAST)$SEMPRED);}
 	|   ^(ACTION elementOptions)	{actionInAlt((ActionAST)$ACTION);}
 	|   ^(SEMPRED elementOptions)	{sempredInAlt((PredAST)$SEMPRED);}
-
+	|	range
 	|	^(NOT blockSet)
 	|	^(NOT block)
 	;

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -1045,6 +1045,21 @@ public enum ErrorType {
 	 */
 	CHARACTERS_COLLISION_IN_SET(180, "chars \"<arg>\" used multiple times in set <arg2>", ErrorSeverity.WARNING),
 
+	/**
+	 * Compiler Warning 181
+	 *
+	 * <p>The token range operator makes no sense in the parser as token types
+	 * are not ordered (except in implementation).
+	 * </p>
+	 *
+	 * <pre>
+	 * grammar T;
+	 * a : 'A'..'Z' ;
+	 * </pre>
+	 *
+	 */
+	TOKEN_RANGE_IN_PARSER(181, "token ranges not allowed in parser: <arg>..<arg2>", ErrorSeverity.ERROR),
+
 	/*
 	 * Backward incompatibility errors
 	 */


### PR DESCRIPTION
```
beast:/tmp $ a4.6 T.g4
org/antlr/v4/parse/GrammarTreeVisitor.g: node from line 2:7 no viable alternative at input '..'
org/antlr/v4/parse/GrammarTreeVisitor.g: node from line 2:7 no viable alternative at input '..'
org/antlr/v4/parse/GrammarTreeVisitor.g: node from line 2:7 no viable alternative at input '..'
org/antlr/v4/parse/GrammarTreeVisitor.g: node from line 2:7 no viable alternative at input '..'
org/antlr/v4/parse/GrammarTreeVisitor.g: node from line 2:7 no viable alternative at input '..'
context [/report INTERNAL_ERROR] 1:17 attribute arg isn't defined
error(20):  internal error:
beast:/tmp $ a4.6.1 T.g4
error(181): T.g4:2:4: token ranges not allowed in parser: 'A'..'Z'
```