### PR TITLE
Write visitor tests with specific tests for expected runtime semantics

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CSharp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CSharp.test.stg
@@ -72,6 +72,8 @@ TokenStartColumnEquals(i) ::= <%this.TokenStartColumn==<i>%>
 
 ImportListener(X) ::= ""
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "this.GetExpectedTokens().ToString(this.Vocabulary)"
 
 RuleInvocationStack() ::= "GetRuleInvocationStackAsString()"
@@ -266,13 +268,12 @@ public class LeafListener : TBaseListener {
 }
 >>
 
-ImportVisitor(X) ::= ""
-BasicVisitor(X) ::= ""
 WalkVisitor(s) ::= ""
-LRWithLabelsVisitor(X) ::= ""
-RuleGetterVisitor(X) ::= ""
-LRVisitor(x) ::= ""
-TokenGetterVisitor(x) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 void foo() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Chrome.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Chrome.test.stg
@@ -72,6 +72,8 @@ TokenStartColumnEquals(i) ::= <%this._tokenStartColumn===<i>%>
 
 ImportListener(X) ::= <<var <X>Listener = require('./<X>Listener').<X>Listener;>>
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "this.getExpectedTokens().toString(this.literalNames)"
 
 RuleInvocationStack() ::= "antlr4.Utils.arrayToString(this.getRuleInvocationStack())"
@@ -258,6 +260,13 @@ this.LeafListener.prototype = Object.create(<X>Listener.prototype);
 this.LeafListener.prototype.constructor = this.LeafListener;
 
 >>
+
+WalkVisitor(s) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 	function foo() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
@@ -46,6 +46,8 @@ TokenStartColumnEquals(i) ::= "tokenStartCharPositionInLine == <i>"
 
 ImportListener(X) ::= ""
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "getExpectedTokens().toString(_tokenNames)"
 
 RuleInvocationStack() ::= "Arrays::listToString(getRuleInvocationStack(), \", \")"
@@ -243,13 +245,12 @@ public:
 }
 >>
 
-ImportVisitor(X) ::= ""
-BasicVisitor(X) ::= ""
 WalkVisitor(s) ::= ""
-LRWithLabelsVisitor(X) ::= ""
-RuleGetterVisitor(X) ::= ""
-LRVisitor(x) ::= ""
-TokenGetterVisitor(x) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 void foo() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Explorer.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Explorer.test.stg
@@ -76,6 +76,8 @@ var <X>Listener = require('./<X>Listener').<X>Listener;
 }
 >>
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "this.getExpectedTokens().toString(this.literalNames)"
 
 RuleInvocationStack() ::= "antlr4.Utils.arrayToString(this.getRuleInvocationStack())"
@@ -268,6 +270,13 @@ this.LeafListener.prototype = Object.create(<X>Listener.prototype);
 this.LeafListener.prototype.constructor = this.LeafListener;
 }
 >>
+
+WalkVisitor(s) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 	function foo() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Firefox.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Firefox.test.stg
@@ -78,6 +78,8 @@ var <X>Listener = require('./<X>Listener').<X>Listener;
 }
 >>
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "this.getExpectedTokens().toString(this.literalNames)"
 
 RuleInvocationStack() ::= "antlr4.Utils.arrayToString(this.getRuleInvocationStack())"
@@ -270,6 +272,13 @@ this.LeafListener.prototype = Object.create(<X>Listener.prototype);
 this.LeafListener.prototype.constructor = this.LeafListener;
 }
 >>
+
+WalkVisitor(s) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 	function foo() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
@@ -72,6 +72,8 @@ TokenStartColumnEquals(i) ::= <%p.TokenStartColumn == <i>%>
 
 ImportListener(X) ::= ""
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "p.GetExpectedTokens().StringVerbose(p.GetTokenNames(), nil, false)"
 
 RuleInvocationStack() ::= "antlr.PrintArrayJavaStyle(p.GetRuleInvocationStack(nil))"
@@ -298,13 +300,12 @@ func (*LeafListener) ExitInt(ctx *IntContext) {
 }
 >>
 
-ImportVisitor(X) ::= ""
-BasicVisitor(X) ::= ""
 WalkVisitor(s) ::= ""
-LRWithLabelsVisitor(X) ::= ""
-RuleGetterVisitor(X) ::= ""
-LRVisitor(x) ::= ""
-TokenGetterVisitor(x) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 func foo() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Java.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Java.test.stg
@@ -72,6 +72,8 @@ TokenStartColumnEquals(i) ::= <%this._tokenStartCharPositionInLine==<i>%>
 
 ImportListener(X) ::= ""
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "this.getExpectedTokens().toString(this.tokenNames)"
 
 RuleInvocationStack() ::= "getRuleInvocationStack()"
@@ -234,7 +236,6 @@ public static class LeafListener extends TBaseListener {
 }
 >>
 
-
 LRListener(X) ::= <<
 @parser::members {
 public static class LeafListener extends TBaseListener {
@@ -262,13 +263,138 @@ public static class LeafListener extends TBaseListener {
 }
 >>
 
-ImportVisitor(X) ::= ""
-BasicVisitor(X) ::= ""
-WalkVisitor(s) ::= ""
-LRWithLabelsVisitor(X) ::= ""
-RuleGetterVisitor(X) ::= ""
-LRVisitor(x) ::= ""
-TokenGetterVisitor(x) ::= ""
+WalkVisitor(s) ::= <<
+System.out.println(new LeafVisitor().visit(<s>));
+>>
+
+TerminalVisitor(grammarName) ::= <<
+@parser::members {
+	public static class LeafVisitor extends <grammarName>BaseVisitor\<String> {
+		@Override
+		public String visitTerminal(TerminalNode node) {
+			return node.getSymbol().toString() + "\n";
+		}
+
+		@Override
+		protected String defaultResult() {
+			return "";
+		}
+
+		@Override
+		protected String aggregateResult(String aggregate, String nextResult) {
+			return aggregate + nextResult;
+		}
+	}
+}
+>>
+
+ErrorVisitor(grammarName) ::= <<
+@parser::members {
+	public static class LeafVisitor extends <grammarName>BaseVisitor\<String> {
+		@Override
+		public String visitErrorNode(ErrorNode node) {
+			return "Error encountered: " + node.getSymbol();
+		}
+
+		@Override
+		protected String defaultResult() {
+			return "";
+		}
+
+		@Override
+		protected String aggregateResult(String aggregate, String nextResult) {
+			return aggregate + nextResult;
+		}
+	}
+}
+>>
+
+ShouldNotVisitEOFVisitor(grammarName) ::= <<
+@parser::members {
+	public static class LeafVisitor extends <grammarName>BaseVisitor\<String> {
+		@Override
+		public String visitTerminal(TerminalNode node) {
+			return node.getSymbol().toString() + "\n";
+		}
+
+		@Override
+		protected boolean shouldVisitNextChild(RuleNode node, String currentResult) {
+			return currentResult == null || currentResult.isEmpty();
+		}
+	}
+}
+>>
+
+ShouldNotVisitTerminalVisitor(grammarName) ::= <<
+@parser::members {
+	public static class LeafVisitor extends <grammarName>BaseVisitor\<String> {
+		@Override
+		public String visitTerminal(TerminalNode node) {
+			throw new RuntimeException("Should not be reachable");
+		}
+
+		@Override
+		protected String defaultResult() {
+			return "default result";
+		}
+
+		@Override
+		protected boolean shouldVisitNextChild(RuleNode node, String currentResult) {
+			return false;
+		}
+	}
+}
+>>
+
+CalculatorVisitor(grammarName) ::= <<
+@parser::members {
+	public static class LeafVisitor extends <grammarName>BaseVisitor\<Integer> {
+		@Override
+		public Integer visitS(SContext ctx) {
+			return visit(ctx.expr());
+		}
+
+		@Override
+		public Integer visitNumber(NumberContext ctx) {
+			return Integer.valueOf(ctx.INT().getText());
+		}
+
+		@Override
+		public Integer visitMultiply(MultiplyContext ctx) {
+			Integer left = visit(ctx.expr(0));
+			Integer right = visit(ctx.expr(1));
+			if (ctx.MUL() != null) {
+				return left * right;
+			}
+			else {
+				return left / right;
+			}
+		}
+
+		@Override
+		public Integer visitAdd(AddContext ctx) {
+			Integer left = visit(ctx.expr(0));
+			Integer right = visit(ctx.expr(1));
+			if (ctx.ADD() != null) {
+				return left + right;
+			}
+			else {
+				return left - right;
+			}
+		}
+
+		@Override
+		protected Integer defaultResult() {
+			throw new RuntimeException("Should not be reachable");
+		}
+
+		@Override
+		protected Integer aggregateResult(Integer aggregate, Integer nextResult) {
+			throw new RuntimeException("Should not be reachable");
+		}
+	}
+}
+>>
 
 DeclareContextListGettersFunction() ::= <<
 void foo() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Node.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Node.test.stg
@@ -182,24 +182,6 @@ var walker = new antlr4.tree.ParseTreeWalker();
 walker.walk(new this.LeafListener(), <s>);
 >>
 
-BasicVisitor(X) ::= <<
-this.LeafVisitor = function() {
-    this.visitTerminal = function(node) {
-        return node.symbol.text;
-    };
-    return this;
-};
-this.LeafVisitor.prototype = Object.create(<X>Visitor.prototype);
-this.LeafVisitor.prototype.constructor = this.LeafVisitor;
-
->>
-
-WalkVisitor(s) ::= <<
-var visitor = new this.LeafVisitor();
-console.log(<s>.accept(visitor));
->>
-
-
 TreeNodeWithAltNumField(X) ::= <<
 @parser::header {
 MyRuleNode = function(parent, invokingState) {
@@ -236,24 +218,6 @@ this.LeafListener.prototype.constructor = this.LeafListener;
 }
 >>
 
-TokenGetterVisitor(X) ::= <<
-this.LeafVisitor = function() {
-    this.visitA = function(ctx) {
-        var str;
-        if(ctx.getChildCount()===2) {
-            str = ctx.INT(0).symbol.text + ' ' + ctx.INT(1).symbol.text + ' ' + antlr4.Utils.arrayToString(ctx.INT());
-        } else {
-            str = ctx.ID().symbol.toString();
-        }
-        return this.visitChildren(ctx) + str;
-    };
-    return this;
-};
-this.LeafVisitor.prototype = Object.create(<X>Visitor.prototype);
-this.LeafVisitor.prototype.constructor = this.LeafVisitor;
-
->>
-
 RuleGetterListener(X) ::= <<
 @parser::members {
 this.LeafListener = function() {
@@ -272,25 +236,6 @@ this.LeafListener.prototype = Object.create(<X>Listener.prototype);
 this.LeafListener.prototype.constructor = this.LeafListener;
 }
 >>
-
-RuleGetterVisitor(X) ::= <<
-this.LeafVisitor = function() {
-    this.visitA = function(ctx) {
-        var str;
-        if(ctx.getChildCount()===2) {
-            str = ctx.b(0).start.text + ' ' + ctx.b(1).start.text + ' ' + ctx.b()[0].start.text;
-        } else {
-            str = ctx.b(0).start.text;
-        }
-        return this.visitChildren(ctx) + str;
-    };
-    return this;
-};
-this.LeafVisitor.prototype = Object.create(<X>Visitor.prototype);
-this.LeafVisitor.prototype.constructor = this.LeafVisitor;
-
->>
-
 
 LRListener(X) ::= <<
 @parser::members {
@@ -311,24 +256,6 @@ this.LeafListener.prototype.constructor = this.LeafListener;
 }
 >>
 
-LRVisitor(X) ::= <<
-this.LeafVisitor = function() {
-    this.visitE = function(ctx) {
-        var str;
-        if(ctx.getChildCount()===3) {
-            str = ctx.e(0).start.text + ' ' + ctx.e(1).start.text + ' ' + ctx.e()[0].start.text;
-        } else {
-            str = ctx.INT().symbol.text;
-        }
-        return this.visitChildren(ctx) + str;
-    };
-    return this;
-};
-this.LeafVisitor.prototype = Object.create(<X>Visitor.prototype);
-this.LeafVisitor.prototype.constructor = this.LeafVisitor;
-
->>
-
 LRWithLabelsListener(X) ::= <<
 @parser::members {
 this.LeafListener = function() {
@@ -347,22 +274,12 @@ this.LeafListener.prototype.constructor = this.LeafListener;
 }
 >>
 
-LRWithLabelsVisitor(X) ::= <<
-this.LeafVisitor = function() {
-    this.visitCall = function(ctx) {
-        var str = ctx.e().start.text + ' ' + ctx.eList();
-        return this.visitChildren(ctx) + str;
-    };
-    this.visitInt = function(ctx) {
-        var str = ctx.INT().symbol.text;
-        return this.visitChildren(ctx) + str;
-    };
-    return this;
-};
-this.LeafVisitor.prototype = Object.create(<X>Visitor.prototype);
-this.LeafVisitor.prototype.constructor = this.LeafVisitor;
-
->>
+WalkVisitor(s) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 	function foo() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python2.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python2.test.stg
@@ -72,6 +72,8 @@ TokenStartColumnEquals(i) ::= <%self._tokenStartColumn==<i>%>
 
 ImportListener(X) ::= ""
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "self.getExpectedTokens().toString(self.literalNames, self.symbolicNames)"
 
 RuleInvocationStack() ::= "str_list(self.getRuleInvocationStack())"
@@ -239,13 +241,12 @@ class LeafListener(TListener):
 }
 >>
 
-ImportVisitor(X) ::= ""
-BasicVisitor(X) ::= ""
 WalkVisitor(s) ::= ""
-LRWithLabelsVisitor(X) ::= ""
-RuleGetterVisitor(X) ::= ""
-LRVisitor(x) ::= ""
-TokenGetterVisitor(x) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 def foo():

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python3.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python3.test.stg
@@ -77,6 +77,8 @@ class MockListener:
 }
 >>
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "self.getExpectedTokens().toString(self.literalNames, self.symbolicNames)"
 
 RuleInvocationStack() ::= "str_list(self.getRuleInvocationStack())"
@@ -224,13 +226,12 @@ class LeafListener(MockListener):
 }
 >>
 
-ImportVisitor(X) ::= ""
-BasicVisitor(X) ::= ""
 WalkVisitor(s) ::= ""
-LRWithLabelsVisitor(X) ::= ""
-RuleGetterVisitor(X) ::= ""
-LRVisitor(x) ::= ""
-TokenGetterVisitor(x) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 def foo():

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Safari.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Safari.test.stg
@@ -76,6 +76,8 @@ var <X>Listener = require('./<X>Listener').<X>Listener;
 }
 >>
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "this.getExpectedTokens().toString(this.literalNames)"
 
 RuleInvocationStack() ::= "antlr4.Utils.arrayToString(this.getRuleInvocationStack())"
@@ -269,6 +271,13 @@ this.LeafListener.prototype = Object.create(<X>Listener.prototype);
 this.LeafListener.prototype.constructor = this.LeafListener;
 }
 >>
+
+WalkVisitor(s) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 	function foo() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
@@ -72,6 +72,8 @@ TokenStartColumnEquals(i) ::= <%self._tokenStartCharPositionInLine == <i>%>
 
 ImportListener(X) ::= ""
 
+ImportVisitor(grammarName) ::= ""
+
 GetExpectedTokenNames() ::= "try self.getExpectedTokens().toString(self.tokenNames)"
 
 RuleInvocationStack() ::= "getRuleInvocationStack().description.replacingOccurrences(of: \"\\\"\", with: \"\")"
@@ -271,13 +273,12 @@ open class LeafListener: TBaseListener {
 }
 >>
 
-ImportVisitor(X) ::= ""
-BasicVisitor(X) ::= ""
 WalkVisitor(s) ::= ""
-LRWithLabelsVisitor(X) ::= ""
-RuleGetterVisitor(X) ::= ""
-LRVisitor(x) ::= ""
-TokenGetterVisitor(x) ::= ""
+TerminalVisitor(grammarName) ::= ""
+ErrorVisitor(grammarName) ::= ""
+ShouldNotVisitEOFVisitor(grammarName) ::= ""
+ShouldNotVisitTerminalVisitor(grammarName) ::= ""
+CalculatorVisitor(grammarName) ::= ""
 
 DeclareContextListGettersFunction() ::= <<
 func foo() {


### PR DESCRIPTION
* Add tests for runtime visitor implementations with (hopefully) complete coverage of semantics
* Remove previous visitor tests because they didn't test anything that the current tests do not cover, and didn't reflect the expected behavior of generated visitors