### PR TITLE
Disable label checks for left recursive rules

### DIFF
--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestSymbolIssues.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestSymbolIssues.java
@@ -9,6 +9,7 @@ package org.antlr.v4.test.tool;
 import org.antlr.v4.tool.ErrorType;
 import org.antlr.v4.tool.LexerGrammar;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -316,6 +317,49 @@ public class TestSymbolIssues extends BaseJavaToolTest {
 
 				"error(" + ErrorType.LABEL_TYPE_CONFLICT.code + "): L.g4:8:15: label t2=b type mismatch with previous definition: t2=a\n" +
 				"error(" + ErrorType.LABEL_TYPE_CONFLICT.code + "): L.g4:11:17: label t3+=c type mismatch with previous definition: t3+=a\n"
+		};
+
+		testErrors(test, false);
+	}
+
+	// https://github.com/antlr/antlr4/issues/1543
+	@Test public void testLabelsForTokensWithMixedTypesLRWithLabels() {
+		String[] test = {
+				"grammar L;\n" +
+				"\n" +
+				"expr\n" +
+				"    : left=A '+' right=A        #primary\n" +
+				"    | left=expr '-' right=expr  #sub\n" +
+				"    ;\n" +
+				"\n" +
+				"A: 'a';\n" +
+				"B: 'b';\n" +
+				"C: 'c';\n",
+
+				""
+		};
+
+		testErrors(test, false);
+	}
+
+	// https://github.com/antlr/antlr4/issues/1543
+	@Test
+	@Ignore
+	public void testLabelsForTokensWithMixedTypesLRWithoutLabels() {
+		String[] test = {
+				"grammar L;\n" +
+				"\n" +
+				"expr\n" +
+				"    : left=A '+' right=A\n" +
+				"    | left=expr '-' right=expr\n" +
+				"    ;\n" +
+				"\n" +
+				"A: 'a';\n" +
+				"B: 'b';\n" +
+				"C: 'c';\n",
+
+				"error(" + ErrorType.LABEL_TYPE_CONFLICT.code + "): L.g4:5:7: label left=expr type mismatch with previous definition: left=A\n" +
+				"error(" + ErrorType.LABEL_TYPE_CONFLICT.code + "): L.g4:5:19: label right=expr type mismatch with previous definition: right=A\n"
 		};
 
 		testErrors(test, false);

--- a/tool/src/org/antlr/v4/semantics/SymbolChecks.java
+++ b/tool/src/org/antlr/v4/semantics/SymbolChecks.java
@@ -20,6 +20,7 @@ import org.antlr.v4.tool.LexerGrammar;
 import org.antlr.v4.tool.Rule;
 import org.antlr.v4.tool.ast.GrammarAST;
 import org.antlr.v4.tool.LabelType;
+import org.antlr.v4.tool.LeftRecursiveRule;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -127,6 +128,12 @@ public class SymbolChecks {
     public void checkForLabelConflicts(Collection<Rule> rules) {
 		for (Rule r : rules) {
 			checkForAttributeConflicts(r);
+			if (r instanceof LeftRecursiveRule) {
+				// Label conflicts for left recursive rules need to be checked
+				// prior to the left recursion elimination step.
+				continue;
+			}
+
 			Map<String, LabelElementPair> labelNameSpace =
 					new HashMap<String, LabelElementPair>();
 			for (int i = 1; i <= r.numberOfAlts; i++) {


### PR DESCRIPTION
This fixes the critical regression described in #1543.

A disabled test is also included showing the desired final behavior for error 75.