### PR TITLE
Update contributors.txt

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -129,3 +129,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/12/11, Gaulouis, Gaulouis, gaulouis.com@gmail.com
 2016/12/22, akosthekiss, Akos Kiss, akiss@inf.u-szeged.hu
 2016/12/24, adrpo, Adrian Pop, adrian.pop@liu.se
+2017/01/04, jkra, Jan Krause, jan.krause.no19@gmail.com


### PR DESCRIPTION
[cut]
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
[/cut]
