### PR TITLE
Update LexerATNSimulator.cpp

### DIFF
--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -604,11 +604,15 @@ void LexerATNSimulator::setCharPositionInLine(size_t charPositionInLine) {
 
 void LexerATNSimulator::consume(CharStream *input) {
   size_t curChar = input->LA(1);
-  if (curChar == '\n') {
-    _line++;
+  if ((curChar == '\n')
+      || (curChar == 0x2028 /*'\u2028'*/)
+      || (curChar == 0x2029 /*'\u2029'*/)
+      || (curChar == 0x0085 /*'\u0085'*/)
+      || (curChar == 0x000C /*'\u000C'*/)) {
+    ++_line;
     _charPositionInLine = 0;
   } else {
-    _charPositionInLine++;
+    ++_charPositionInLine;
   }
   input->consume();
 }


### PR DESCRIPTION
added unicode line breaks to LexerATNSimulator::consume() for correct line and position

[cut]
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
[/cut]
