### PR TITLE
Fix multiple bugs with the new optional element analysis

### DIFF
--- a/tool/src/org/antlr/v4/codegen/model/ElementFrequenciesVisitor.java
+++ b/tool/src/org/antlr/v4/codegen/model/ElementFrequenciesVisitor.java
@@ -185,6 +185,14 @@ public class ElementFrequenciesVisitor extends GrammarTreeVisitor {
 
 	@Override
 	protected void exitBlockSet(GrammarAST tree) {
+		for (Map.Entry<String, MutableInt> entry : frequencies.peek().entrySet()) {
+			// This visitor counts a block set as a sequence of elements, not a
+			// sequence of alternatives of elements. Reset the count back to 1
+			// for all items when leaving the set to ensure duplicate entries in
+			// the set are treated as a maximum of one item.
+			entry.getValue().v = 1;
+		}
+
 		if (minFrequencies.peek().size() > 1) {
 			// Everything is optional
 			minFrequencies.peek().clear();

--- a/tool/src/org/antlr/v4/codegen/model/ElementFrequenciesVisitor.java
+++ b/tool/src/org/antlr/v4/codegen/model/ElementFrequenciesVisitor.java
@@ -96,7 +96,7 @@ public class ElementFrequenciesVisitor extends GrammarTreeVisitor {
 		}
 
 		assert a != SENTINEL;
-		FrequencySet<String> result = combineAndClip(a, b, 1);
+		FrequencySet<String> result = combineAndClip(a, b, Integer.MAX_VALUE);
 		for (Map.Entry<String, MutableInt> entry : result.entrySet()) {
 			entry.getValue().v = Math.min(a.count(entry.getKey()), b.count(entry.getKey()));
 		}
@@ -178,6 +178,23 @@ public class ElementFrequenciesVisitor extends GrammarTreeVisitor {
 	}
 
 	@Override
+	protected void enterBlockSet(GrammarAST tree) {
+		frequencies.push(new FrequencySet<String>());
+		minFrequencies.push(new FrequencySet<String>());
+	}
+
+	@Override
+	protected void exitBlockSet(GrammarAST tree) {
+		if (minFrequencies.peek().size() > 1) {
+			// Everything is optional
+			minFrequencies.peek().clear();
+		}
+
+		frequencies.push(combineAndClip(frequencies.pop(), frequencies.pop(), 2));
+		minFrequencies.push(combineAndClip(minFrequencies.pop(), minFrequencies.pop(), 2));
+	}
+
+	@Override
 	protected void exitSubrule(GrammarAST tree) {
 		if (tree.getType() == CLOSURE || tree.getType() == POSITIVE_CLOSURE) {
 			for (Map.Entry<String, MutableInt> entry : frequencies.peek().entrySet()) {
@@ -185,7 +202,7 @@ public class ElementFrequenciesVisitor extends GrammarTreeVisitor {
 			}
 		}
 
-		if (tree.getType() == CLOSURE) {
+		if (tree.getType() == CLOSURE || tree.getType() == OPTIONAL) {
 			// Everything inside a closure is optional, so the minimum
 			// number of occurrences for all elements is 0.
 			minFrequencies.peek().clear();


### PR DESCRIPTION
These issues were found when I was implementing the new optional element tests for TypeScript.

* Properly handle elements that are optional in some alts but not others
* Properly handle block sets (a group of terminals producing a SetTransition)
* Properly handle OPTIONAL subrule
* Don't use list labels for elements that appear twice in a block set