### PR TITLE
Reset BufferedTokenStream.fetchedEOF when calling setTokenSource

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/TestTokenStream.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/TestTokenStream.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012-2016 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+package org.antlr.v4.test.runtime.java.api;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.BufferedTokenStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This class contains tests for specific API functionality in {@link TokenStream} and derived types.
+ */
+public class TestTokenStream {
+
+	/**
+	 * This is a targeted regression test for antlr/antlr4#1584 ({@link BufferedTokenStream} cannot be reused after EOF).
+	 */
+	@Test
+	public void testBufferedTokenStreamReuseAfterFill() {
+		CharStream firstInput = new ANTLRInputStream("A");
+		BufferedTokenStream tokenStream = new BufferedTokenStream(new VisitorBasicLexer(firstInput));
+		tokenStream.fill();
+		Assert.assertEquals(2, tokenStream.size());
+		Assert.assertEquals(VisitorBasicLexer.A, tokenStream.get(0).getType());
+		Assert.assertEquals(Token.EOF, tokenStream.get(1).getType());
+
+		CharStream secondInput = new ANTLRInputStream("AA");
+		tokenStream.setTokenSource(new VisitorBasicLexer(secondInput));
+		tokenStream.fill();
+		Assert.assertEquals(3, tokenStream.size());
+		Assert.assertEquals(VisitorBasicLexer.A, tokenStream.get(0).getType());
+		Assert.assertEquals(VisitorBasicLexer.A, tokenStream.get(1).getType());
+		Assert.assertEquals(Token.EOF, tokenStream.get(2).getType());
+	}
+
+}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/VisitorBasic.g4
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/VisitorBasic.g4
@@ -3,3 +3,5 @@ grammar VisitorBasic;
 s
 	:	'A' EOF
 	;
+
+A : 'A';

--- a/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
@@ -252,6 +252,7 @@ public class BufferedTokenStream implements TokenStream {
         this.tokenSource = tokenSource;
         tokens.clear();
         p = -1;
+        fetchedEOF = false;
     }
 
     public List<Token> getTokens() { return tokens; }

--- a/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
@@ -89,6 +89,14 @@ public class BufferedTokenStream implements TokenStream {
 		// no resources to release
 	}
 
+	/**
+	 * This method resets the token stream back to the first token in the
+	 * buffer. It is equivalent to calling {@link #seek}{@code (0)}.
+	 *
+	 * @see #setTokenSource(TokenSource)
+	 * @deprecated Use {@code seek(0)} instead.
+	 */
+	@Deprecated
     public void reset() {
         seek(0);
     }

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -1288,7 +1288,7 @@ public class TestPerformance extends BaseJavaToolTest {
 								throw ex;
 							}
 
-							tokens.reset();
+							tokens.seek(0);
 							if (REUSE_PARSER && parser != null) {
 								parser.setInputStream(tokens);
 							} else {


### PR DESCRIPTION
Fixes #1584

@antlr/antlr-targets This bug may affect other targets.