### PR TITLE
Remove lower case formatting on Go types & super import

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
@@ -325,5 +325,5 @@ func pred(v bool) bool {
 
 Invoke_pred(v) ::= <<pred(<v>)>>
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
-StringType() ::= "String"
+StringType() ::= "string"
 ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member; format={cap}>"

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -145,10 +145,6 @@ func (v *Base<file.grammarName>Visitor) Visit<lname; format="cap">(ctx *<lname; 
 >>
 
 Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
-<if(superClass)>
-import "./<superClass>"
-
-<endif>
 <if(atn)>
 var parserATN = <atn>
 <else>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -898,7 +898,7 @@ TokenListDecl(t) ::= "<t.name> []antlr.Token"
 RuleContextDecl(r) ::= "<r.name> I<r.ctxName> "
 RuleContextListDecl(rdecl) ::= "<rdecl.name> []I<rdecl.ctxName>"
 
-AttributeDecl(d) ::= "<d.name> <d.type;format={lower}><if(d.initValue)>// TODO = <d.initValue><endif>"
+AttributeDecl(d) ::= "<d.name> <d.type><if(d.initValue)>// TODO = <d.initValue><endif>"
 
 ContextTokenGetterDecl(t) ::= <<
 <t.name; format="cap">() antlr.TerminalNode {
@@ -1042,13 +1042,13 @@ Set<a.name; format="cap">([]I<a.ctxName>) }; separator="\n\n">
 	<if(struct.attributeDecls)>
 
 	<struct.attributeDecls:{a | // Get<a.name; format="cap"> returns the <a.name> attribute.
-Get<a.name; format="cap">() <a.type;format="lower">}; separator="\n\n">
+Get<a.name; format="cap">() <a.type>}; separator="\n\n">
 	<endif>
 
 	<if(struct.attributeDecls)>
 
 	<struct.attributeDecls:{a | // Set<a.name; format="cap"> sets the <a.name> attribute.
-Set<a.name; format="cap">(<a.type;format="lower">)}; separator="\n\n">
+Set<a.name; format="cap">(<a.type>)}; separator="\n\n">
 	<endif>
 
 
@@ -1073,7 +1073,7 @@ func NewEmpty<struct.name>() *<struct.name> {
 
 func (*<struct.name>) Is<struct.name>() {}
 
-func New<struct.name>(parser antlr.Parser, parent antlr.ParserRuleContext, invokingState int<struct.ctorAttrs:{a | , <a.name> <a.type;format="lower">}>) *<struct.name> {
+func New<struct.name>(parser antlr.Parser, parent antlr.ParserRuleContext, invokingState int<struct.ctorAttrs:{a | , <a.name> <a.type>}>) *<struct.name> {
 	var p = new(<struct.name>)
 
 	p.<if(contextSuperClass)><contextSuperClass><else>BaseParserRuleContext<endif> = <if(contextSuperClass)>New<contextSuperClass><else>antlr.NewBaseParserRuleContext<endif>(parent, invokingState)
@@ -1141,12 +1141,12 @@ func (s *<struct.name>) GetParser() antlr.Parser { return s.parser }
 
 <if(struct.attributeDecls)>
 
-<struct.attributeDecls:{a | func (s *<struct.name>) Get<a.name; format="cap">() <a.type;format="lower"> { return s.<a.name> \}}; separator="\n\n">
+<struct.attributeDecls:{a | func (s *<struct.name>) Get<a.name; format="cap">() <a.type> { return s.<a.name> \}}; separator="\n\n">
 <endif>
 
 <if(struct.attributeDecls)>
 
-<struct.attributeDecls:{a | func (s *<struct.name>) Set<a.name; format="cap">(v <a.type;format="lower">) { s.<a.name> = v \}}; separator="\n\n">
+<struct.attributeDecls:{a | func (s *<struct.name>) Set<a.name; format="cap">(v <a.type>) { s.<a.name> = v \}}; separator="\n\n">
 <endif>
 
 <if(getters)>
@@ -1251,12 +1251,12 @@ func New<struct.name>(parser antlr.Parser, ctx antlr.ParserRuleContext) *<struct
 
 <if(struct.attributeDecls)>
 
-<struct.attributeDecls:{a | func (s *<struct.name>) Get<a.name; format="cap">() <a.type;format="lower"> { return s.<a.name> \}}; separator="\n\n">
+<struct.attributeDecls:{a | func (s *<struct.name>) Get<a.name; format="cap">() <a.type> { return s.<a.name> \}}; separator="\n\n">
 <endif>
 
 <if(struct.attributeDecls)>
 
-<struct.attributeDecls:{a | func (s *<struct.name>) Set<a.name; format="cap">(v <a.type;format="lower">) { s.<a.name> = v \}}; separator="\n\n">
+<struct.attributeDecls:{a | func (s *<struct.name>) Set<a.name; format="cap">(v <a.type>) { s.<a.name> = v \}}; separator="\n\n">
 <endif>
 
 func (s *<struct.name>) GetRuleContext() antlr.RuleContext {


### PR DESCRIPTION
Since case formatting in Go denotes private verses public the format={lower} is getting in the way.
Currently the only workaround to place the generated code in the same package as the types being used, and these types can't be exported. This is inconvenient and unnecessary. I see know downside to leave the case on the type as set in the grammar.

The `import "./<superClass>"` also get in the way. I tried using superClass to add fields to a parser. This works nicely, but the import needed to be removed by hand. Relative imports are of very limited use in Go. Also in the grammar developer needs an import for the superClass it is trivial to place the import statement in the `@members` block.