### PR TITLE
Fix parse tree property

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -129,3 +129,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/12/11, Gaulouis, Gaulouis, gaulouis.com@gmail.com
 2016/12/22, akosthekiss, Akos Kiss, akiss@inf.u-szeged.hu
 2016/12/24, adrpo, Adrian Pop, adrian.pop@liu.se
+2017/01/13, marcelo-rocha, Marcelo Rocha, mcrocha@gmail.com

--- a/runtime/Cpp/runtime/src/tree/ParseTreeProperty.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeProperty.h
@@ -29,27 +29,20 @@ namespace tree {
   template<typename V>
   class ANTLR4CPP_PUBLIC ParseTreeProperty {
   public:
-    ParseTreeProperty() {
-      InitializeInstanceFields();
-    }
-
     virtual V get(ParseTree *node) {
-      return _annotations.get(node);
+      return _annotations[node];
     }
     virtual void put(ParseTree *node, V value) {
-      _annotations.put(node, value);
+      _annotations[node] = value;
     }
     virtual V removeFrom(ParseTree *node) {
-      return _annotations->remove(node);
+      auto value = _annotations[node];
+      _annotations.erase(node);
+      return value;
     }
 
   protected:
     std::map<ParseTree*, V> _annotations;
-
-  private:
-    void InitializeInstanceFields() {
-    }
-
   };
 
 } // namespace tree


### PR DESCRIPTION
- The std::map doesn't have get, put and remove methods. 
- Removed empty InitializeInstanceFields method. 