### PR TITLE
Look in /usr/local/bin before /usr/bin for mono

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
@@ -409,7 +409,7 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
 	}
 
 	private String locateTool(String tool) {
-		String[] roots = { "/opt/local/bin/", "/usr/bin/", "/usr/local/bin/" };
+		String[] roots = { "/opt/local/bin/", "/usr/local/bin/", "/usr/bin/" };
 		for(String root : roots) {
 			if(new File(root + tool).exists())
 				return root + tool;


### PR DESCRIPTION
I wanted to run the C# tests on a CentOS 7 machine, which doesn't have a new enough `mono` package available to run the tests (we need 4.6).

I built from source, which installs in `/usr/local/bin` by default, but the tests still failed. This PR fixes the issue by looking in `/usr/local/bin` before `/usr/bin` (which is fairly standard for `$PATH` searching).