### PR TITLE
Use tabs for code formatting in Emacs (except for Python)

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,6 @@
+; Basic ANTLR code style for Emacs: Indents are tabs and represent 4 columns
+(
+ (nil . ((indent-tabs-mode . t)
+         (tab-width . 4)
+         (c-basic-offset . 4)))
+ )

--- a/runtime/Python2/.dir-locals.el
+++ b/runtime/Python2/.dir-locals.el
@@ -1,0 +1,6 @@
+; Python ANTLR code style for Emacs: 4-space indents
+(
+ (nil . ((indent-tabs-mode . nil)
+         (tab-width . 4)
+         (c-basic-offset . 4)))
+ )

--- a/runtime/Python3/.dir-locals.el
+++ b/runtime/Python3/.dir-locals.el
@@ -1,0 +1,6 @@
+; Python ANTLR code style for Emacs: 4-space indents
+(
+ (nil . ((indent-tabs-mode . nil)
+         (tab-width . 4)
+         (c-basic-offset . 4)))
+ )


### PR DESCRIPTION
Most of the ANTLR code base (except for Python) uses tabs for indentation, so this sets up Emacs `.dir-locals.el` files to ensure contributors use the correct style for each directory.