### PR TITLE
Fix writing Unicode values in runtime tests

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
@@ -224,7 +224,7 @@ public abstract class BaseRuntimeTest {
 	                                       String... extraOptions)
 	{
 		mkdir(workdir);
-		BaseJavaTest.writeFile(workdir, grammarFileName, grammarStr);
+		writeFile(workdir, grammarFileName, grammarStr);
 		return antlrOnString(workdir, targetName, grammarFileName, defaultListener, extraOptions);
 	}
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
@@ -47,9 +47,7 @@ import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.STGroupString;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -70,6 +68,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static org.antlr.v4.test.runtime.BaseRuntimeTest.antlrOnString;
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -866,21 +865,6 @@ public class BaseCppTest implements RuntimeTestSupport {
 		}
 		public void setTokenTypeChannel(int ttype, int channel) {
 			hide.add(ttype);
-		}
-	}
-
-	public static void writeFile(String dir, String fileName, String content) {
-		try {
-			File f = new File(dir, fileName);
-			FileWriter w = new FileWriter(f);
-			BufferedWriter bw = new BufferedWriter(w);
-			bw.write(content);
-			bw.close();
-			w.close();
-		}
-		catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
 		}
 	}
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.antlr.v4.test.runtime.BaseRuntimeTest.antlrOnString;
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -608,16 +609,6 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
 		}
 		public void setTokenTypeChannel(int ttype, int channel) {
 			hide.add(ttype);
-		}
-	}
-
-	public static void writeFile(String dir, String fileName, String content) {
-		try {
-			Utils.writeFile(dir+"/"+fileName, content, "UTF-8");
-		}
-		catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
 		}
 	}
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/BaseGoTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/BaseGoTest.java
@@ -70,6 +70,7 @@ import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 import static org.antlr.v4.test.runtime.BaseRuntimeTest.antlrOnString;
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 import static org.junit.Assert.assertArrayEquals;
 
 public class BaseGoTest implements RuntimeTestSupport {
@@ -309,7 +310,7 @@ public class BaseGoTest implements RuntimeTestSupport {
 		boolean success = rawGenerateAndBuildRecognizer(grammarFileName,
 		                                                grammarStr, null, lexerName, "-no-listener");
 		assertTrue(success);
-		writeFile(overall_tmpdir, "input", input);
+		writeFile(overall_tmpdir.toString(), "input", input);
 		writeLexerTestFile(lexerName, showDFA);
 		String output = execModule("Test.go");
 		return output;
@@ -338,7 +339,7 @@ public class BaseGoTest implements RuntimeTestSupport {
 		boolean success = rawGenerateAndBuildRecognizer(grammarFileName,
 		                                                grammarStr, parserName, lexerName, "-visitor");
 		assertTrue(success);
-		writeFile(overall_tmpdir, "input", input);
+		writeFile(overall_tmpdir.toString(), "input", input);
 		rawBuildRecognizerTestFile(parserName, lexerName, listenerName,
 		                           visitorName, startRuleName, showDiagnosticErrors);
 		return execRecognizer();
@@ -700,35 +701,6 @@ public class BaseGoTest implements RuntimeTestSupport {
 		}
 	}
 
-	public static void writeFile(File dir, String fileName, String content) {
-		try {
-			File f = new File(dir, fileName);
-			FileWriter w = new FileWriter(f);
-			BufferedWriter bw = new BufferedWriter(w);
-			bw.write(content);
-			bw.close();
-			w.close();
-		} catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
-		}
-	}
-
-	public static void writeFile(String dir, String fileName, InputStream content) {
-		try {
-			File f = new File(dir, fileName);
-			OutputStream output = new FileOutputStream(f);
-			while(content.available()>0) {
-				int b = content.read();
-				output.write(b);
-			}
-			output.close();
-		} catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
-		}
-	}
-
 	protected void mkdir(File dir) {
 		dir.mkdirs();
 	}
@@ -785,7 +757,7 @@ public class BaseGoTest implements RuntimeTestSupport {
 		outputFileST.add("listenerName", listenerName);
 		outputFileST.add("visitorName", visitorName);
 		outputFileST.add("parserStartRuleName", parserStartRuleName.substring(0, 1).toUpperCase() + parserStartRuleName.substring(1) );
-		writeFile(overall_tmpdir, "Test.go", outputFileST.render());
+		writeFile(overall_tmpdir.toString(), "Test.go", outputFileST.render());
 	}
 
 
@@ -813,7 +785,7 @@ public class BaseGoTest implements RuntimeTestSupport {
 				+ "}\n"
 				+ "\n");
 		outputFileST.add("lexerName", lexerName);
-		writeFile(overall_tmpdir, "Test.go", outputFileST.render());
+		writeFile(overall_tmpdir.toString(), "Test.go", outputFileST.render());
 	}
 
 	public void writeRecognizer(String parserName, String lexerName,

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
@@ -81,6 +81,7 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 import static org.junit.Assert.assertArrayEquals;
 
 public class BaseJavaTest implements RuntimeTestSupport {
@@ -940,16 +941,6 @@ public class BaseJavaTest implements RuntimeTestSupport {
             hide.add(ttype);
         }
     }
-
-	public static void writeFile(String dir, String fileName, String content) {
-		try {
-			Utils.writeFile(dir+"/"+fileName, content, "UTF-8");
-		}
-		catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
-		}
-	}
 
 	protected void writeTestFile(String parserName,
 								 String lexerName,

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/browser/BaseBrowserTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/browser/BaseBrowserTest.java
@@ -72,6 +72,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static org.antlr.v4.test.runtime.BaseRuntimeTest.antlrOnString;
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -643,21 +644,6 @@ public abstract class BaseBrowserTest implements RuntimeTestSupport {
 		}
 		public void setTokenTypeChannel(int ttype, int channel) {
 			hide.add(ttype);
-		}
-	}
-
-	public static void writeFile(String dir, String fileName, String content) {
-		try {
-			File f = new File(dir, fileName);
-			FileWriter w = new FileWriter(f);
-			BufferedWriter bw = new BufferedWriter(w);
-			bw.write(content);
-			bw.close();
-			w.close();
-		}
-		catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
 		}
 	}
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/node/BaseNodeTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/node/BaseNodeTest.java
@@ -64,6 +64,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static org.antlr.v4.test.runtime.BaseRuntimeTest.antlrOnString;
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -650,35 +651,6 @@ public class BaseNodeTest implements RuntimeTestSupport {
 
 		public void setTokenTypeChannel(int ttype, int channel) {
 			hide.add(ttype);
-		}
-	}
-
-	public static void writeFile(String dir, String fileName, String content) {
-		try {
-			File f = new File(dir, fileName);
-			FileWriter w = new FileWriter(f);
-			BufferedWriter bw = new BufferedWriter(w);
-			bw.write(content);
-			bw.close();
-			w.close();
-		} catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
-		}
-	}
-
-	public static void writeFile(String dir, String fileName, InputStream content) {
-		try {
-			File f = new File(dir, fileName);
-			OutputStream output = new FileOutputStream(f);
-			while(content.available()>0) {
-				int b = content.read();
-				output.write(b);
-			}
-			output.close();
-		} catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
 		}
 	}
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python/BasePythonTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python/BasePythonTest.java
@@ -70,6 +70,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static org.antlr.v4.test.runtime.BaseRuntimeTest.antlrOnString;
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -766,21 +767,6 @@ public abstract class BasePythonTest implements RuntimeTestSupport {
 		}
 		public void setTokenTypeChannel(int ttype, int channel) {
 			hide.add(ttype);
-		}
-	}
-
-	public static void writeFile(String dir, String fileName, String content) {
-		try {
-			File f = new File(dir, fileName);
-			FileWriter w = new FileWriter(f);
-			BufferedWriter bw = new BufferedWriter(w);
-			bw.write(content);
-			bw.close();
-			w.close();
-		}
-		catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
 		}
 	}
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/BasePython2Test.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/BasePython2Test.java
@@ -9,6 +9,8 @@ package org.antlr.v4.test.runtime.python2;
 import org.antlr.v4.test.runtime.python.BasePythonTest;
 import org.stringtemplate.v4.ST;
 
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
+
 public class BasePython2Test extends BasePythonTest {
 
 	@Override

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/BasePython3Test.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/BasePython3Test.java
@@ -8,6 +8,8 @@ package org.antlr.v4.test.runtime.python3;
 import org.antlr.v4.test.runtime.python.BasePythonTest;
 import org.stringtemplate.v4.ST;
 
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
+
 public class BasePython3Test extends BasePythonTest {
 
 	@Override

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/BaseSwiftTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/BaseSwiftTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.antlr.v4.test.runtime.BaseRuntimeTest.antlrOnString;
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 import static org.junit.Assert.assertTrue;
 
 public class BaseSwiftTest implements RuntimeTestSupport {
@@ -362,20 +363,6 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 	public String execRecognizer() {
 		compile();
 		return execTest();
-	}
-
-	public static void writeFile(String dir, String fileName, String content) {
-		try {
-			File f = new File(dir, fileName);
-			FileWriter w = new FileWriter(f);
-			BufferedWriter bw = new BufferedWriter(w);
-			bw.write(content);
-			bw.close();
-			w.close();
-		} catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
-		}
 	}
 
 	protected void writeParserTestFile(String parserName,

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestCompositeGrammars.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestCompositeGrammars.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import java.io.File;
 
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -460,7 +461,7 @@ public class TestCompositeGrammars extends BaseJavaToolTest {
 		BaseRuntimeTest.mkdir(tmpdir);
 		writeFile(tmpdir, "Java.g4", slave);
 		String found = execParser("NewJava.g4", master, "NewJavaParser", "NewJavaLexer",
-		                          null, null, "compilationUnit", "package Foo;", debug);
+					  null, null, "compilationUnit", "package Foo;", debug);
 		assertEquals(null, found);
 		assertNull(stderrDuringParse);
 	}
@@ -488,7 +489,7 @@ public class TestCompositeGrammars extends BaseJavaToolTest {
 		BaseRuntimeTest.mkdir(tmpdir);
 		writeFile(tmpdir, "Java.g4", slave);
 		String found = execParser("T.g4", master, "TParser", "TLexer",
-		                          null, null, "s", "a=b", debug);
+					  null, null, "s", "a=b", debug);
 		assertEquals(null, found);
 		assertNull(stderrDuringParse);
 	}

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -78,6 +78,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.antlr.v4.runtime.misc.MurmurHash;
 
+import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
When writing tests for #276, I ran into an issue where Unicode values passed via `TestDescriptor`s randomly failed for some languages' runtimes, not not others.

When I investigated, I found many copy-pasted versions of the "write a Java `String` to disk" routine. Some of these explicitly converted to the String UTF-8, but many did not, which meant they didn't work if the system property `file.encoding` wasn't set to `utf-8` (and, let's be honest, nobody really sets this).

This PR addresses the issue by consolidating all runtime tests to use `BaseRuntimeTest.writeFile()`.