### PR TITLE
Remove unused C# runtime method Utils.ToCharArray

### DIFF
--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Misc/Utils.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Misc/Utils.cs
@@ -131,19 +131,5 @@ namespace Antlr4.Runtime.Misc
             }
             return m;
         }
-
-        public static char[] ToCharArray(ArrayList<int> data)
-        {
-            if (data == null)
-            {
-                return null;
-            }
-            char[] cdata = new char[data.Count];
-            for (int i = 0; i < data.Count; i++)
-            {
-                cdata[i] = (char)data[i];
-            }
-            return cdata;
-        }
     }
 }


### PR DESCRIPTION
When adding Unicode support to the C# runtime as part of #276, I found the C# runtime method `Utils.ToCharArray()` was unused.

Rather than add support for Unicode, this PR simply deletes the unused method.
