### PR TITLE
Easy: Fix C# CodePointCharStream to actually work with code points > U+FFFF

### DIFF
--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/AntlrInputStream.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/AntlrInputStream.cs
@@ -302,12 +302,13 @@ namespace Antlr4.Runtime
         {
             this.data = new int[input.Length];
             int dataIdx = 0;
-            for (int i = 0; i < input.Length; i++) {
+            for (int i = 0; i < input.Length; ) {
                 var codePoint = Char.ConvertToUtf32(input, i);
                 data[dataIdx++] = codePoint;
                 if (dataIdx > data.Length) {
                     Array.Resize(ref data, data.Length * 2);
                 }
+                i += codePoint <= 0xFFFF ? 1 : 2;
             }
             this.n = dataIdx;
         }


### PR DESCRIPTION
When I got the tests running for C#, I found that my new class `CodePointCharStream` had a bug preventing it from working correctly with Unicode code points > U+FFFF:

```
  TestSets>BaseRuntimeTest.testOne:119->BaseRuntimeTest.testParser:170 expected:<null> but was:<
Unhandled Exception:
System.ArgumentException: Found a low surrogate char without a preceding high surrogate at index: 2. The input may not be in this e
ncoding, or may not contain valid Unicode (UTF-16) characters.
Parameter name: s   
  at System.Char.ConvertToUtf32 (System.String s, System.Int32 index) [0x00105] in <a8460a77e67a430a8486a9751162e5f4>:0
  at Antlr4.Runtime.CodePointCharStream..ctor (System.String input) [0x00020] in <e8faca77c4004290bfda247d286930a6>:0
  at Test.Main (System.String[] args) [0x0000e] in <705919cf5dfb4946aa318d140c00d9b7>:0
[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: Found a low surrogate char without a preceding high surrogate at index: 2. The input may not be in this encoding, or may not contain valid Unicode (UTF-16) characters.
Parameter name: s
  at System.Char.ConvertToUtf32 (System.String s, System.Int32 index) [0x00105] in <a8460a77e67a430a8486a9751162e5f4>:0
  at Antlr4.Runtime.CodePointCharStream..ctor (System.String input) [0x00020] in <e8faca77c4004290bfda247d286930a6>:0
  at Test.Main (System.String[] args) [0x0000e] in <705919cf5dfb4946aa318d140c00d9b7>:0
> 
```

The bug was that we were trying to convert *both* halves of a UTF-16 encoded surrogate pair to Unicode code points, which is of course an error.

This fixes the bug by ensuring we move forward 1 UTF-16 code unit for code points <= `U+FFFF`, and 2 code units for code points > `U+FFFF`.