### PR TITLE
Ensure unit tests are run with file.encoding=UTF-8

### DIFF
--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -95,6 +95,8 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.19.1</version>
 				<configuration>
+					<!-- SUREFIRE-951: file.encoding cannot be set via systemPropertyVariables -->
+					<argLine>-Dfile.encoding=UTF-8</argLine>
 					<includes>
 						<include>**/csharp/Test*.java</include>
 						<include>**/java/Test*.java</include>

--- a/tool-testsuite/pom.xml
+++ b/tool-testsuite/pom.xml
@@ -59,6 +59,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.12.4</version>
         <configuration>
+          <!-- SUREFIRE-951: file.encoding cannot be set via systemPropertyVariables -->
+          <argLine>-Dfile.encoding=UTF-8</argLine>
           <includes>
             <include>**/Test*.java</include>
           </includes>


### PR DESCRIPTION
Previously, ANTLR's unit tests were run with the default encoding of the calling environment (which may or may not be UTF-8).

That affected all sorts of APIs, like `new String(byte[])`, making them behave unexpectedly if the encoding wasn't set to UTF-8 (e.g. on Windows).

This ensures we always run tests with `file.encoding` set to `UTF-8`.