### PR TITLE
Fix JavaScript InputStream.getText() when input contains Unicode values > U+FFFF

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -28,6 +28,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 =====
 
 MIT License for codepointat.js from https://git.io/codepointat
+MIT License for fromcodepoint.js from https://git.io/vDW1m
 
 Copyright Mathias Bynens <https://mathiasbynens.be/>
 

--- a/runtime/JavaScript/src/antlr4/InputStream.js
+++ b/runtime/JavaScript/src/antlr4/InputStream.js
@@ -7,13 +7,14 @@
 
 var Token = require('./Token').Token;
 require('./polyfills/codepointat');
+require('./polyfills/fromcodepoint');
 
 // Vacuum all input from a string and then treat it like a buffer.
 
 function _loadString(stream, decodeToUnicodeCodePoints) {
 	stream._index = 0;
 	stream.data = [];
-	if (decodeToUnicodeCodePoints) {
+	if (stream.decodeToUnicodeCodePoints) {
 		for (var i = 0; i < stream.strdata.length; ) {
 			var codePoint = stream.strdata.codePointAt(i);
 			stream.data.push(codePoint);
@@ -36,7 +37,8 @@ function _loadString(stream, decodeToUnicodeCodePoints) {
 function InputStream(data, decodeToUnicodeCodePoints) {
 	this.name = "<empty>";
 	this.strdata = data;
-	_loadString(this, decodeToUnicodeCodePoints || false);
+	this.decodeToUnicodeCodePoints = decodeToUnicodeCodePoints || false;
+	_loadString(this);
 	return this;
 }
 
@@ -114,7 +116,15 @@ InputStream.prototype.getText = function(start, stop) {
 	if (start >= this._size) {
 		return "";
 	} else {
-		return this.strdata.slice(start, stop + 1);
+		if (this.decodeToUnicodeCodePoints) {
+			var result = "";
+			for (var i = start; i <= stop; i++) {
+				result += String.fromCodePoint(this.data[i]);
+			}
+			return result;
+		} else {
+			return this.strdata.slice(start, stop + 1);
+		}
 	}
 };
 

--- a/runtime/JavaScript/src/antlr4/index.js
+++ b/runtime/JavaScript/src/antlr4/index.js
@@ -5,6 +5,7 @@
 exports.atn = require('./atn/index');
 exports.codepointat = require('./polyfills/codepointat');
 exports.dfa = require('./dfa/index');
+exports.fromcodepoint = require('./polyfills/fromcodepoint');
 exports.tree = require('./tree/index');
 exports.error = require('./error/index');
 exports.Token = require('./Token').Token;

--- a/runtime/JavaScript/src/antlr4/polyfills/fromcodepoint.js
+++ b/runtime/JavaScript/src/antlr4/polyfills/fromcodepoint.js
@@ -1,0 +1,62 @@
+/*! https://mths.be/fromcodepoint v0.2.1 by @mathias */
+if (!String.fromCodePoint) {
+	(function() {
+		var defineProperty = (function() {
+			// IE 8 only supports `Object.defineProperty` on DOM elements
+			try {
+				var object = {};
+				var $defineProperty = Object.defineProperty;
+				var result = $defineProperty(object, object, object) && $defineProperty;
+			} catch(error) {}
+			return result;
+		}());
+		var stringFromCharCode = String.fromCharCode;
+		var floor = Math.floor;
+		var fromCodePoint = function(_) {
+			var MAX_SIZE = 0x4000;
+			var codeUnits = [];
+			var highSurrogate;
+			var lowSurrogate;
+			var index = -1;
+			var length = arguments.length;
+			if (!length) {
+				return '';
+			}
+			var result = '';
+			while (++index < length) {
+				var codePoint = Number(arguments[index]);
+				if (
+					!isFinite(codePoint) || // `NaN`, `+Infinity`, or `-Infinity`
+					codePoint < 0 || // not a valid Unicode code point
+					codePoint > 0x10FFFF || // not a valid Unicode code point
+					floor(codePoint) != codePoint // not an integer
+				) {
+					throw RangeError('Invalid code point: ' + codePoint);
+				}
+				if (codePoint <= 0xFFFF) { // BMP code point
+					codeUnits.push(codePoint);
+				} else { // Astral code point; split in surrogate halves
+					// https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+					codePoint -= 0x10000;
+					highSurrogate = (codePoint >> 10) + 0xD800;
+					lowSurrogate = (codePoint % 0x400) + 0xDC00;
+					codeUnits.push(highSurrogate, lowSurrogate);
+				}
+				if (index + 1 == length || codeUnits.length > MAX_SIZE) {
+					result += stringFromCharCode.apply(null, codeUnits);
+					codeUnits.length = 0;
+				}
+			}
+			return result;
+		};
+		if (defineProperty) {
+			defineProperty(String, 'fromCodePoint', {
+				'value': fromCodePoint,
+				'configurable': true,
+				'writable': true
+			});
+		} else {
+			String.fromCodePoint = fromCodePoint;
+		}
+	}());
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/antlr/antlr4/pull/1628 . 

When I added optional support to read in code points > U+FFFF to `InputStream`, I forgot to update `InputStream.getText()` to handle converting those code points back to UTF-16 for the Javascript `String`.

That meant the code which enabled the optional `decodeToUnicodeCodePoints` feature and then invoked `InputStream.getText()` would fail.

The root cause was that `this.strdata.slice(start, stop + 1)` was using the wrong units for the index; `this.strdata` uses UTF-16 for its indexes, but `start` and `stop` would be in Unicode code points.

This updates `InputStream.getText()` to work correctly if the `decodeToUnicodeCodePoints` flag is truthy. I imported the `String.fromCodePoint()` polyfill for backwards compatibility to convert Unicode code points to UTF-16 code units.