### PR TITLE
C# support for lexer and parser output to a file

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CSharp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CSharp.test.stg
@@ -1,6 +1,6 @@
-writeln(s) ::= <<Console.WriteLine(<s>);>>
-write(s) ::= <<Console.Write(<s>);>>
-writeList(s) ::= <<Console.WriteLine(<s; separator="+">);>>
+writeln(s) ::= <<Output.WriteLine(<s>);>>
+write(s) ::= <<Output.Write(<s>);>>
+writeList(s) ::= <<Output.WriteLine(<s; separator="+">);>>
 
 False() ::= "false"
 
@@ -176,8 +176,14 @@ public class PositionAdjustingLexerATNSimulator : LexerATNSimulator {
 BasicListener(X) ::= <<
 @parser::members {
 public class LeafListener : TBaseListener {
+	private readonly TextWriter Output;
+
+	public LeafListener(TextWriter output) {
+		Output = output;
+	}
+
 	public override void VisitTerminal(ITerminalNode node) {
-		Console.WriteLine(node.Symbol.Text);
+		Output.WriteLine(node.Symbol.Text);
 	}
 }
 }
@@ -185,7 +191,7 @@ public class LeafListener : TBaseListener {
 
 WalkListener(s) ::= <<
 ParseTreeWalker walker = new ParseTreeWalker();
-walker.Walk(new LeafListener(), <s>);
+walker.Walk(new LeafListener(Output), <s>);
 >>
 
 TreeNodeWithAltNumField(X) ::= <<
@@ -204,6 +210,12 @@ public class MyRuleNode : ParserRuleContext {
 TokenGetterListener(X) ::= <<
 @parser::members {
 public class LeafListener : TBaseListener {
+	private readonly TextWriter Output;
+
+	public LeafListener(TextWriter output) {
+		Output = output;
+	}
+
 	public override void ExitA(TParser.AContext ctx) {
 		if (ctx.ChildCount==2)
 		{
@@ -214,11 +226,11 @@ public class LeafListener : TBaseListener {
 			}
 			sb.Length = sb.Length - 2;
 			sb.Append ("]");
-			Console.Write ("{0} {1} {2}", ctx.INT (0).Symbol.Text,
+			Output.Write ("{0} {1} {2}", ctx.INT (0).Symbol.Text,
 				ctx.INT (1).Symbol.Text, sb.ToString());
 		}
 		else
-			Console.WriteLine(ctx.ID().Symbol);
+			Output.WriteLine(ctx.ID().Symbol);
 	}
 }
 }
@@ -227,12 +239,18 @@ public class LeafListener : TBaseListener {
 RuleGetterListener(X) ::= <<
 @parser::members {
 public class LeafListener : TBaseListener {
+	private readonly TextWriter Output;
+
+	public LeafListener(TextWriter output) {
+		Output = output;
+	}
+
 	public override void ExitA(TParser.AContext ctx) {
 		if (ctx.ChildCount==2) {
-			Console.Write("{0} {1} {2}",ctx.b(0).Start.Text,
+			Output.Write("{0} {1} {2}",ctx.b(0).Start.Text,
 				ctx.b(1).Start.Text,ctx.b()[0].Start.Text);
 		} else
-			Console.WriteLine(ctx.b(0).Start.Text);
+			Output.WriteLine(ctx.b(0).Start.Text);
 	}
 }
 }
@@ -242,12 +260,18 @@ public class LeafListener : TBaseListener {
 LRListener(X) ::= <<
 @parser::members {
 public class LeafListener : TBaseListener {
+	private readonly TextWriter Output;
+
+	public LeafListener(TextWriter output) {
+		Output = output;
+	}
+
 	public override void ExitE(TParser.EContext ctx) {
 		if (ctx.ChildCount==3) {
-			Console.Write("{0} {1} {2}\n",ctx.e(0).Start.Text,
+			Output.Write("{0} {1} {2}\n",ctx.e(0).Start.Text,
 				ctx.e(1).Start.Text, ctx.e()[0].Start.Text);
 		} else
-			Console.WriteLine(ctx.INT().Symbol.Text);
+			Output.WriteLine(ctx.INT().Symbol.Text);
 	}
 }
 }
@@ -256,11 +280,17 @@ public class LeafListener : TBaseListener {
 LRWithLabelsListener(X) ::= <<
 @parser::members {
 public class LeafListener : TBaseListener {
+	private readonly TextWriter Output;
+
+	public LeafListener(TextWriter output) {
+		Output = output;
+	}
+
 	public override void ExitCall(TParser.CallContext ctx) {
-		Console.Write("{0} {1}",ctx.e().Start.Text,ctx.eList());
+		Output.Write("{0} {1}",ctx.e().Start.Text,ctx.eList());
 	}
 	public override void ExitInt(TParser.IntContext ctx) {
-		Console.WriteLine(ctx.INT().Symbol.Text);
+		Output.WriteLine(ctx.INT().Symbol.Text);
 	}
 }
 }
@@ -274,12 +304,12 @@ void foo() {
 }
 >>
 
-Declare_foo() ::= <<public void foo() {Console.WriteLine("foo");}>>
+Declare_foo() ::= <<public void foo() {Output.WriteLine("foo");}>>
 
 Invoke_foo() ::= "this.foo();"
 
 Declare_pred() ::= <<bool pred(bool v) {
-	Console.WriteLine("eval="+v.ToString().ToLower());
+	Output.WriteLine("eval="+v.ToString().ToLower());
 	return v;
 }
 >>

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Lexer.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Lexer.cs
@@ -3,6 +3,7 @@
  * can be found in the LICENSE.txt file in the project root.
  */
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Text;
 using Antlr4.Runtime;
@@ -32,6 +33,8 @@ namespace Antlr4.Runtime
         public const int MaxCharValue = '\uFFFE';
 
         private ICharStream _input;
+
+        protected readonly TextWriter Output;
 
 		private Tuple<ITokenSource, ICharStream> _tokenFactorySourcePair;
 
@@ -94,9 +97,12 @@ namespace Antlr4.Runtime
         /// </remarks>
 		private string _text;
 
-        public Lexer(ICharStream input)
+        public Lexer(ICharStream input) : this(input, Console.Out) { }
+
+        public Lexer(ICharStream input, TextWriter output)
         {
             this._input = input;
+            this.Output = output;
             this._tokenFactorySourcePair = Tuple.Create((ITokenSource)this, input);
         }
 

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
@@ -3,6 +3,7 @@
  * can be found in the LICENSE.txt file in the project root.
  */
 using System;
+using System.IO;
 using System.Text;
 using System.Collections.Generic;
 using Antlr4.Runtime.Atn;
@@ -21,14 +22,20 @@ namespace Antlr4.Runtime
 #if !PORTABLE
         public class TraceListener : IParseTreeListener
         {
+            private readonly TextWriter Output;
+
+            public TraceListener(TextWriter output) {
+                Output = output;
+            }
+
             public virtual void EnterEveryRule(ParserRuleContext ctx)
             {
-                System.Console.Out.WriteLine("enter   " + this._enclosing.RuleNames[ctx.RuleIndex] + ", LT(1)=" + this._enclosing._input.LT(1).Text);
+                Output.WriteLine("enter   " + this._enclosing.RuleNames[ctx.RuleIndex] + ", LT(1)=" + this._enclosing._input.LT(1).Text);
             }
 
             public virtual void ExitEveryRule(ParserRuleContext ctx)
             {
-                System.Console.Out.WriteLine("exit    " + this._enclosing.RuleNames[ctx.RuleIndex] + ", LT(1)=" + this._enclosing._input.LT(1).Text);
+                Output.WriteLine("exit    " + this._enclosing.RuleNames[ctx.RuleIndex] + ", LT(1)=" + this._enclosing._input.LT(1).Text);
             }
 
             public virtual void VisitErrorNode(IErrorNode node)
@@ -39,7 +46,7 @@ namespace Antlr4.Runtime
             {
                 ParserRuleContext parent = (ParserRuleContext)((IRuleNode)node.Parent).RuleContext;
                 IToken token = node.Symbol;
-                System.Console.Out.WriteLine("consume " + token + " rule " + this._enclosing.RuleNames[parent.RuleIndex]);
+                Output.WriteLine("consume " + token + " rule " + this._enclosing.RuleNames[parent.RuleIndex]);
             }
 
             internal TraceListener(Parser _enclosing)
@@ -161,9 +168,14 @@ namespace Antlr4.Runtime
         /// </remarks>
         private int _syntaxErrors;
 
-        public Parser(ITokenStream input)
+        protected readonly TextWriter Output;
+
+        public Parser(ITokenStream input) : this(input, Console.Out) { }
+
+        public Parser(ITokenStream input, TextWriter output)
         {
             TokenStream = input;
+            Output = output;
         }
 
         /// <summary>reset the parser's state</summary>
@@ -1143,10 +1155,10 @@ namespace Antlr4.Runtime
                 {
                     if (seenOne)
                     {
-                        System.Console.Out.WriteLine();
+                        Output.WriteLine();
                     }
-                    System.Console.Out.WriteLine("Decision " + dfa.decision + ":");
-                    System.Console.Out.Write(dfa.ToString(Vocabulary));
+                    Output.WriteLine("Decision " + dfa.decision + ":");
+                    Output.Write(dfa.ToString(Vocabulary));
                     seenOne = true;
                 }
             }

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -37,6 +37,7 @@ namespace <file.genPackage> {
 <endif>
 <namedActions.header>
 using System;
+using System.IO;
 using System.Text;
 using System.Diagnostics;
 using System.Collections.Generic;
@@ -357,8 +358,10 @@ case <f.ruleIndex> : return <f.name>_sempred(<if(!recog.modes)>(<f.ctxType>)<end
 >>
 
 parser_ctor(parser) ::= <<
-public <csIdentifier.(parser.name)>(ITokenStream input)
-	: base(input)
+	public <csIdentifier.(parser.name)>(ITokenStream input) : this(input, Console.Out) { }
+
+	public <csIdentifier.(parser.name)>(ITokenStream input, TextWriter output)
+	: base(input, output)
 {
 	Interpreter = new ParserATNSimulator(this, _ATN, decisionToDFA, sharedContextCache);
 }
@@ -958,6 +961,7 @@ namespace <file.genPackage> {
 <endif>
 <namedActions.header>
 using System;
+using System.IO;
 using System.Text;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Atn;
@@ -1001,7 +1005,10 @@ public partial class <csIdentifier.(lexer.name)> : <superClass; null="Lexer"> {
 	<namedActions.members>
 
 	public <csIdentifier.(lexer.name)>(ICharStream input)
-		: base(input)
+	: this(input, Console.Out) { }
+
+	public <csIdentifier.(lexer.name)>(ICharStream input, TextWriter output)
+	: base(input, output)
 	{
 		Interpreter = new LexerATNSimulator(this, _ATN, decisionToDFA, sharedContextCache);
 	}


### PR DESCRIPTION
This is part of the work for #276.

This is the same as https://github.com/antlr/antlr4/pull/1651 , but for C#.

It turns out C# on Windows writing to `Console.Out` has just as many problems with Unicode as Python < 3.6 does.

So, to work around these issues, this diff adds optional support to the C# `Lexer` and `Parser` for writing output to a file instead of hard-coding `Console.Out`.

A subsequent diff will use this work from the C# runtime tests.