### PR TITLE
C#: Write test output to a file

### DIFF
--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/BaseErrorListener.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/BaseErrorListener.cs
@@ -6,6 +6,7 @@ using Antlr4.Runtime;
 using Antlr4.Runtime.Atn;
 using Antlr4.Runtime.Dfa;
 using Antlr4.Runtime.Sharpen;
+using System.IO;
 
 namespace Antlr4.Runtime
 {
@@ -19,7 +20,7 @@ namespace Antlr4.Runtime
     /// <author>Sam Harwell</author>
     public class BaseErrorListener : IParserErrorListener
     {
-        public virtual void SyntaxError(IRecognizer recognizer, IToken offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
+        public virtual void SyntaxError(TextWriter output, IRecognizer recognizer, IToken offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
         {
         }
 

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/ConsoleErrorListener.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/ConsoleErrorListener.cs
@@ -7,6 +7,7 @@
 
 using Antlr4.Runtime;
 using Antlr4.Runtime.Sharpen;
+using System.IO;
 
 namespace Antlr4.Runtime
 {
@@ -38,9 +39,9 @@ namespace Antlr4.Runtime
         /// line <em>line</em>:<em>charPositionInLine</em> <em>msg</em>
         /// </pre>
         /// </summary>
-        public virtual void SyntaxError(IRecognizer recognizer, Symbol offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
+        public virtual void SyntaxError(TextWriter output, IRecognizer recognizer, Symbol offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
         {
-            System.Console.Error.WriteLine("line " + line + ":" + charPositionInLine + " " + msg);
+            output.WriteLine("line " + line + ":" + charPositionInLine + " " + msg);
         }
     }
 }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/IAntlrErrorListener.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/IAntlrErrorListener.cs
@@ -4,6 +4,7 @@
  */
 using Antlr4.Runtime;
 using Antlr4.Runtime.Sharpen;
+using System.IO;
 
 namespace Antlr4.Runtime
 {
@@ -30,6 +31,9 @@ namespace Antlr4.Runtime
         /// in-line, without returning from the surrounding rule (via the single
         /// token insertion and deletion mechanism).</p>
         /// </remarks>
+        /// <param name="output">
+        /// Where the error should be written.
+        /// </param>
         /// <param name="recognizer">
         /// What parser got the error. From this
         /// object, you can access the context as well
@@ -52,6 +56,6 @@ namespace Antlr4.Runtime
         /// the parser was able to recover in line without exiting the
         /// surrounding rule.
         /// </param>
-        void SyntaxError(IRecognizer recognizer, TSymbol offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e);
+        void SyntaxError(TextWriter output, IRecognizer recognizer, TSymbol offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e);
     }
 }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/IAntlrErrorStrategy.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/IAntlrErrorStrategy.cs
@@ -5,6 +5,7 @@
 using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Sharpen;
+using System.IO;
 
 namespace Antlr4.Runtime
 {

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Lexer.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Lexer.cs
@@ -36,6 +36,8 @@ namespace Antlr4.Runtime
 
         protected readonly TextWriter Output;
 
+        protected readonly TextWriter ErrorOutput;
+
 		private Tuple<ITokenSource, ICharStream> _tokenFactorySourcePair;
 
         /// <summary>How to create token objects</summary>
@@ -97,12 +99,13 @@ namespace Antlr4.Runtime
         /// </remarks>
 		private string _text;
 
-        public Lexer(ICharStream input) : this(input, Console.Out) { }
+        public Lexer(ICharStream input) : this(input, Console.Out, Console.Error) { }
 
-        public Lexer(ICharStream input, TextWriter output)
+        public Lexer(ICharStream input, TextWriter output, TextWriter errorOutput)
         {
             this._input = input;
             this.Output = output;
+            this.ErrorOutput = errorOutput;
             this._tokenFactorySourcePair = Tuple.Create((ITokenSource)this, input);
         }
 
@@ -555,7 +558,7 @@ outer_continue: ;
             string text = _input.GetText(Interval.Of(_tokenStartCharIndex, _input.Index));
             string msg = "token recognition error at: '" + GetErrorDisplay(text) + "'";
             IAntlrErrorListener<int> listener = ErrorListenerDispatch;
-            listener.SyntaxError(this, 0, _tokenStartLine, _tokenStartColumn, msg, e);
+            listener.SyntaxError(ErrorOutput, this, 0, _tokenStartLine, _tokenStartColumn, msg, e);
         }
 
         public virtual string GetErrorDisplay(string s)

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
@@ -169,13 +169,15 @@ namespace Antlr4.Runtime
         private int _syntaxErrors;
 
         protected readonly TextWriter Output;
+        protected readonly TextWriter ErrorOutput;
 
-        public Parser(ITokenStream input) : this(input, Console.Out) { }
+        public Parser(ITokenStream input) : this(input, Console.Out, Console.Error) { }
 
-        public Parser(ITokenStream input, TextWriter output)
+        public Parser(ITokenStream input, TextWriter output, TextWriter errorOutput)
         {
             TokenStream = input;
             Output = output;
+            ErrorOutput = errorOutput;
         }
 
         /// <summary>reset the parser's state</summary>
@@ -688,7 +690,7 @@ namespace Antlr4.Runtime
                 charPositionInLine = offendingToken.Column;
             }
             IAntlrErrorListener<IToken> listener = ((IParserErrorListener)ErrorListenerDispatch);
-            listener.SyntaxError(this, offendingToken, line, charPositionInLine, msg, e);
+            listener.SyntaxError(ErrorOutput, this, offendingToken, line, charPositionInLine, msg, e);
         }
 
         /// <summary>

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/ProxyErrorListener.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/ProxyErrorListener.cs
@@ -4,6 +4,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.IO;
 namespace Antlr4.Runtime
 {
     /// <summary>
@@ -35,11 +36,11 @@ namespace Antlr4.Runtime
             }
         }
 
-        public virtual void SyntaxError(IRecognizer recognizer, Symbol offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
+        public virtual void SyntaxError(TextWriter output, IRecognizer recognizer, Symbol offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
         {
             foreach (IAntlrErrorListener<Symbol> listener in delegates)
             {
-                listener.SyntaxError(recognizer, offendingSymbol, line, charPositionInLine, msg, e);
+                listener.SyntaxError(output, recognizer, offendingSymbol, line, charPositionInLine, msg, e);
             }
         }
     }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Tree/Xpath/XPathLexerErrorListener.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Tree/Xpath/XPathLexerErrorListener.cs
@@ -5,12 +5,13 @@
 using Antlr4.Runtime;
 using Antlr4.Runtime.Sharpen;
 using Antlr4.Runtime.Tree.Xpath;
+using System.IO;
 
 namespace Antlr4.Runtime.Tree.Xpath
 {
     public class XPathLexerErrorListener : IAntlrErrorListener<int>
     {
-        public virtual void SyntaxError(IRecognizer recognizer, int offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
+        public virtual void SyntaxError(TextWriter output, IRecognizer recognizer, int offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
         {
         }
     }

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -358,10 +358,10 @@ case <f.ruleIndex> : return <f.name>_sempred(<if(!recog.modes)>(<f.ctxType>)<end
 >>
 
 parser_ctor(parser) ::= <<
-	public <csIdentifier.(parser.name)>(ITokenStream input) : this(input, Console.Out) { }
+	public <csIdentifier.(parser.name)>(ITokenStream input) : this(input, Console.Out, Console.Error) { }
 
-	public <csIdentifier.(parser.name)>(ITokenStream input, TextWriter output)
-	: base(input, output)
+	public <csIdentifier.(parser.name)>(ITokenStream input, TextWriter output, TextWriter errorOutput)
+	: base(input, output, errorOutput)
 {
 	Interpreter = new ParserATNSimulator(this, _ATN, decisionToDFA, sharedContextCache);
 }
@@ -1005,10 +1005,10 @@ public partial class <csIdentifier.(lexer.name)> : <superClass; null="Lexer"> {
 	<namedActions.members>
 
 	public <csIdentifier.(lexer.name)>(ICharStream input)
-	: this(input, Console.Out) { }
+	: this(input, Console.Out, Console.Error) { }
 
-	public <csIdentifier.(lexer.name)>(ICharStream input, TextWriter output)
-	: base(input, output)
+	public <csIdentifier.(lexer.name)>(ICharStream input, TextWriter output, TextWriter errorOutput)
+	: base(input, output, errorOutput)
 	{
 		Interpreter = new LexerATNSimulator(this, _ATN, decisionToDFA, sharedContextCache);
 	}


### PR DESCRIPTION
This is part of the work for #276.

This builds on #1652 to write C# test output and test error output to files instead of `Console.Out` and `Console.Error`.

This works around bugs with C# on Windows failing to write Unicode to `Console.Out` and `Console.Error`.

I also updated the C# tests to use the new `CodePointCharStream` to support Unicode code points > `U+FFFF`.