### PR TITLE
Easy: Allow setting source name when creating CodePointCharStream from string

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/CharStreams.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CharStreams.java
@@ -32,6 +32,10 @@ public final class CharStreams {
 	 * for the Unicode code points in a Java {@link String}.
 	 */
 	public static CodePointCharStream createWithString(String s) {
+		return createWithString(s, IntStream.UNKNOWN_SOURCE_NAME);
+	}
+
+	public static CodePointCharStream createWithString(String s, String sourceName) {
 		// Initial guess assumes no code points > U+FFFF: one code
 		// point for each code unit in the string
 		IntBuffer codePointBuffer = IntBuffer.allocate(s.length());
@@ -49,7 +53,7 @@ public final class CharStreams {
 			stringIdx += Character.charCount(codePoint);
 		}
 		codePointBuffer.flip();
-		return new CodePointCharStream(codePointBuffer, IntStream.UNKNOWN_SOURCE_NAME);
+		return new CodePointCharStream(codePointBuffer, sourceName);
 	}
 
 	public static CodePointCharStream createWithUTF8(Path path) throws IOException {


### PR DESCRIPTION
We have a few tests which create a `CodePointCharStream` from a string and expect to set the source name. This updates the `CharStreams` API to make this possible.
