### PR TITLE
Get rid of all (char) casts

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/RangeTransition.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/RangeTransition.java
@@ -34,6 +34,11 @@ public final class RangeTransition extends Transition {
 
 	@Override
 	public String toString() {
-		return "'"+(char)from+"'..'"+(char)to+"'";
+		return new StringBuilder("'")
+				.appendCodePoint(from)
+				.append("'..'")
+				.appendCodePoint(to)
+				.append("'")
+				.toString();
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/LexerDFASerializer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/LexerDFASerializer.java
@@ -16,6 +16,9 @@ public class LexerDFASerializer extends DFASerializer {
 	@Override
 
 	protected String getEdgeLabel(int i) {
-		return "'"+(char)i+"'";
+		return new StringBuilder("'")
+				.appendCodePoint(i)
+				.append("'")
+				.toString();
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/misc/IntervalSet.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/IntervalSet.java
@@ -505,11 +505,11 @@ public class IntervalSet implements IntSet {
 			int b = I.b;
 			if ( a==b ) {
 				if ( a==Token.EOF ) buf.append("<EOF>");
-				else if ( elemAreChar ) buf.append("'").append((char)a).append("'");
+				else if ( elemAreChar ) buf.append("'").appendCodePoint(a).append("'");
 				else buf.append(a);
 			}
 			else {
-				if ( elemAreChar ) buf.append("'").append((char)a).append("'..'").append((char)b).append("'");
+				if ( elemAreChar ) buf.append("'").appendCodePoint(a).append("'..'").appendCodePoint(b).append("'");
 				else buf.append(a).append("..").append(b);
 			}
 			if ( iter.hasNext() ) {

--- a/tool/src/org/antlr/v4/automata/ATNOptimizer.java
+++ b/tool/src/org/antlr/v4/automata/ATNOptimizer.java
@@ -18,6 +18,7 @@ import org.antlr.v4.runtime.atn.SetTransition;
 import org.antlr.v4.runtime.atn.Transition;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.misc.IntervalSet;
+import org.antlr.v4.misc.CharSupport;
 import org.antlr.v4.tool.ErrorType;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.Rule;
@@ -101,11 +102,11 @@ public class ATNOptimizer {
 					int maxElem = set.getMaxElement();
 					for (int k = minElem; k <= maxElem; k++) {
 						if (matchSet.contains(k)) {
-							char setMin = (char) set.getMinElement();
-							char setMax = (char) set.getMaxElement();
 							// TODO: Token is missing (i.e. position in source will not be displayed).
 							g.tool.errMgr.grammarError(ErrorType.CHARACTERS_COLLISION_IN_SET, g.fileName,
-							                           null, (char) minElem + "-" + (char) maxElem, "[" + setMin + "-" + setMax + "]");
+										   null,
+										   CharSupport.toRange(minElem, maxElem, CharSupport.ToRangeMode.NOT_BRACKETED),
+										   CharSupport.toRange(set.getMinElement(), set.getMaxElement(), CharSupport.ToRangeMode.BRACKETED));
 							break;
 						}
 					}

--- a/tool/src/org/antlr/v4/misc/CharSupport.java
+++ b/tool/src/org/antlr/v4/misc/CharSupport.java
@@ -19,6 +19,11 @@ public class CharSupport {
 	 */
 	public static String ANTLRLiteralCharValueEscape[] = new String[255];
 
+	public enum ToRangeMode {
+		BRACKETED,
+		NOT_BRACKETED,
+	};
+
 	static {
 		ANTLRLiteralEscapedCharValue['n'] = '\n';
 		ANTLRLiteralEscapedCharValue['r'] = '\r';
@@ -142,5 +147,19 @@ public class CharSupport {
 
 	public static String capitalize(String s) {
 		return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+	}
+
+	public static String toRange(int codePointStart, int codePointEnd, ToRangeMode mode) {
+		StringBuilder sb = new StringBuilder();
+		if (mode == ToRangeMode.BRACKETED) {
+			sb.append("[");
+		}
+		sb.appendCodePoint(codePointStart)
+			.append("-")
+			.appendCodePoint(codePointEnd);
+		if (mode == ToRangeMode.BRACKETED) {
+			sb.append("]");
+		}
+		return sb.toString();
 	}
 }

--- a/tool/src/org/antlr/v4/tool/DOTGenerator.java
+++ b/tool/src/org/antlr/v4/tool/DOTGenerator.java
@@ -92,7 +92,7 @@ public class DOTGenerator {
 					if ( target.stateNumber == Integer.MAX_VALUE ) continue;
 					int ttype = i-1; // we shift up for EOF as -1 for parser
 					String label = String.valueOf(ttype);
-					if ( isLexer ) label = "'"+getEdgeLabel(String.valueOf((char) i))+"'";
+					if ( isLexer ) label = "'"+getEdgeLabel(new StringBuilder().appendCodePoint(i).toString())+"'";
 					else if ( grammar!=null ) label = grammar.getTokenDisplayName(ttype);
 					ST st = stlib.getInstanceOf("edge");
 					st.add("label", label);
@@ -259,7 +259,7 @@ public class DOTGenerator {
 					edgeST = stlib.getInstanceOf("edge");
 					AtomTransition atom = (AtomTransition)edge;
 					String label = String.valueOf(atom.label);
-					if ( isLexer ) label = "'"+getEdgeLabel(String.valueOf((char)atom.label))+"'";
+					if ( isLexer ) label = "'"+getEdgeLabel(new StringBuilder().appendCodePoint(atom.label).toString())+"'";
 					else if ( grammar!=null ) label = grammar.getTokenDisplayName(atom.label);
 					edgeST.add("label", getEdgeLabel(label));
 				}


### PR DESCRIPTION
This is part of the work for #276.

There were a number of spots in the codebase which relied on `int` casts to `char`.

This replaces them with explicitly handling all `int`s as Unicode code points, rather than assuming they can be truncated to a 16-bit unsigned `char`.
