### PR TITLE
Python 2.7 InputStream: Properly support Unicode code points on Windows and macOS

### DIFF
--- a/runtime/Python2/src/antlr4/CodePoints.py
+++ b/runtime/Python2/src/antlr4/CodePoints.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2012-2016 The ANTLR Project. All rights reserved.
+# Use of this file is governed by the BSD 3-clause license that
+# can be found in the LICENSE.txt file in the project root.
+#
+
+from __future__ import unicode_literals
+import sys
+
+def is_leading_surrogate(code_unit):
+    return 0xD800 <= code_unit <= 0xDBFF
+
+def is_trailing_surrogate(code_unit):
+    return 0xDC00 <= code_unit <= 0xDFFF
+
+def decode_surrogate_pair(leading, trailing):
+    return ((leading - 0xD800) << 10) + (trailing - 0xDC00) + 0x10000
+
+def _from_unicode(unistr):
+    return [ord(c) for c in unistr]
+
+def _from_utf16(unistr):
+    assert sys.maxunicode == 0xFFFF
+    leading_surrogate = -1
+    for utf16 in unistr:
+        code_unit = ord(utf16)
+        if leading_surrogate == -1:
+            if is_leading_surrogate(code_unit):
+                leading_surrogate = code_unit
+            else:
+                yield code_unit
+        else:
+            if is_trailing_surrogate(code_unit):
+                # Valid surrogate pair
+                code_point = decode_surrogate_pair(leading_surrogate, code_unit)
+                yield code_point
+                leading_surrogate = -1
+            else:
+                # Leading surrogate without trailing surrogate
+                yield leading_surrogate
+                if is_leading_surrogate(code_unit):
+                    leading_surrogate = code_unit
+                else:
+                    yield code_point
+                    leading_surrogate = -1
+    # Dangling surrogate at end of input
+    if leading_surrogate != -1:
+        yield leading_surrogate
+
+def _to_utf16(code_points):
+    for code_point in code_points:
+        if code_point <= 0xFFFF:
+            yield unichr(code_point)
+        else:
+            base = code_point - 0x10000
+            high_surrogate = (base >> 10) + 0xD800
+            low_surrogate = (base & 0x3FF) + 0xDC00
+            yield unichr(high_surrogate)
+            yield unichr(low_surrogate)
+
+def _to_chars(code_points):
+    return [unichr(cp) for cp in code_points]
+
+if sys.maxunicode == 0xFFFF:
+    from_unicode = _from_utf16
+    to_chars = _to_utf16
+else:
+    assert sys.maxunicode == 0x10FFFF
+    from_unicode = _from_unicode
+    to_chars = _to_chars
+
+def to_unicode(code_points):
+    return u''.join(to_chars(code_points))

--- a/runtime/Python2/src/antlr4/CodePoints.py
+++ b/runtime/Python2/src/antlr4/CodePoints.py
@@ -17,7 +17,7 @@ def decode_surrogate_pair(leading, trailing):
     return ((leading - 0xD800) << 10) + (trailing - 0xDC00) + 0x10000
 
 def _from_unicode(unistr):
-    return [ord(c) for c in unistr]
+    return (ord(c) for c in unistr)
 
 def _from_utf16(unistr):
     assert sys.maxunicode == 0xFFFF
@@ -59,7 +59,7 @@ def _to_utf16(code_points):
             yield unichr(low_surrogate)
 
 def _to_chars(code_points):
-    return [unichr(cp) for cp in code_points]
+    return (unichr(cp) for cp in code_points)
 
 if sys.maxunicode == 0xFFFF:
     from_unicode = _from_utf16

--- a/runtime/Python2/src/antlr4/InputStream.py
+++ b/runtime/Python2/src/antlr4/InputStream.py
@@ -10,7 +10,8 @@ import unittest
 #  Vacuum all input from a string and then treat it like a buffer.
 #
 from antlr4.Token import Token
-
+from antlr4.CodePoints import from_unicode, to_unicode
+import sys
 
 class InputStream (object):
 
@@ -21,7 +22,7 @@ class InputStream (object):
 
     def _loadString(self):
         self._index = 0
-        self.data = [ord(c) for c in self.strdata]
+        self.data = list(from_unicode(self.strdata))
         self._size = len(self.data)
 
     @property
@@ -79,9 +80,9 @@ class InputStream (object):
         if stop >= self._size:
             stop = self._size-1
         if start >= self._size:
-            return ""
+            return u""
         else:
-            return self.strdata[start:stop+1]
+            return to_unicode(self.data[start:stop+1])
 
     def __str__(self):
         return unicode(self)


### PR DESCRIPTION
This is part of the work for #276.

Until Python 3.3, Python could be compiled in one of two modes (`sys.maxunicode == 0x10FFFF` or `sys.maxunicode == 0xFFFF`).

In particular, Python 2.7 on macOS and on Windows uses `0xFFFF`, where Python 2.7 on Linux as well as Python >= 3.3 globally use `0x10FFFF`.

The two modes behave VERY differently when looking at Unicode strings with code points > `U+FFFF`.

Python 2.7 on Linux:

```
>>> import sys
>>> hex(sys.maxunicode)
'0x10ffff'
>>> len(u'\U0001F40D')
1
>>> [c for c in u'\U0001F40D']
[u'\U0001f40d']
```

Python 2.7 on Windows:

```
>>> import sys
>>> hex(sys.maxunicode)
'0xffff'
>>> len(u'\U0001F40D')
2
>>> [c for c in u'\U0001F40D']
[u'\ud83d', u'\udc0d']
```

To handle this inconsistency, this PR introduces a new module `antlr4.CodePoints`, which I've separately open-sourced here:

https://pypi.python.org/pypi/codepoints/

and uses it as part of `InputStream` on Python 2.

Note that Python 3 doesn't need this, since we require 3.5 or later (which always uses `sys.maxunicode == 0x10FFFF`).