### PR TITLE
Support Unicode values > U+FFFF in C# runtime error messages

### DIFF
--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Lexer.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Lexer.cs
@@ -564,16 +564,17 @@ outer_continue: ;
         public virtual string GetErrorDisplay(string s)
         {
             StringBuilder buf = new StringBuilder();
-            foreach (char c in s.ToCharArray())
-            {
-                buf.Append(GetErrorDisplay(c));
+            for (var i = 0; i < s.Length; ) {
+                var codePoint = Char.ConvertToUtf32(s, i);
+                buf.Append(GetErrorDisplay(codePoint));
+                i += (codePoint > 0xFFFF) ? 2 : 1;
             }
             return buf.ToString();
         }
 
         public virtual string GetErrorDisplay(int c)
         {
-            string s = ((char)c).ToString();
+            string s;
             switch (c)
             {
                 case TokenConstants.EOF:
@@ -597,6 +598,12 @@ outer_continue: ;
                 case '\r':
                 {
                     s = "\\r";
+                    break;
+                }
+
+                default:
+                {
+                    s = Char.ConvertFromUtf32(c);
                     break;
                 }
             }


### PR DESCRIPTION
This is part of the work for #276.

When I added unit tests to cover error handling for Unicode values > `U+FFFF`, I found the C# runtime assumed that all code-points passed to `Lexer.GetErrorDisplay(int)` could be cast to a 16-bit `char`.

This was corrupting error messages for (valid) Unicode code points > U+FFFF.

To fix this, this PR changes the error message formatting logic to support Unicode code points > `U+FFFF`.