### PR TITLE
 factor out the creation of error nodes and terminal nodes in the parser

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/ANTLRErrorStrategy.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ANTLRErrorStrategy.java
@@ -6,6 +6,8 @@
 
 package org.antlr.v4.runtime;
 
+import org.antlr.v4.runtime.tree.ErrorNode;
+
 /**
  * The interface for defining strategies to deal with syntax errors encountered
  * during a parse by ANTLR-generated parsers. We distinguish between three
@@ -89,8 +91,9 @@ public interface ANTLRErrorStrategy {
 	 * Tests whether or not {@code recognizer} is in the process of recovering
 	 * from an error. In error recovery mode, {@link Parser#consume} adds
 	 * symbols to the parse tree by calling
-	 * {@link ParserRuleContext#addErrorNode(Token)} instead of
-	 * {@link ParserRuleContext#addChild(Token)}.
+	 * {@link Parser#createErrorNode(ParserRuleContext, Token)} then
+	 * {@link ParserRuleContext#addErrorNode(ErrorNode)} instead of
+	 * {@link Parser#createTerminalNode(ParserRuleContext, Token)}.
 	 *
 	 * @param recognizer the parser instance
 	 * @return {@code true} if the parser is currently recovering from a parse

--- a/runtime/Java/src/org/antlr/v4/runtime/ParserInterpreter.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ParserInterpreter.java
@@ -414,7 +414,7 @@ public class ParserInterpreter extends Parser {
 				                             Token.DEFAULT_CHANNEL,
 				                            -1, -1, // invalid start/stop
 				                             tok.getLine(), tok.getCharPositionInLine());
-				_ctx.addErrorNode(errToken);
+				_ctx.addErrorNode(createErrorNode(_ctx,errToken));
 			}
 			else { // NoViableAlt
 				Token tok = e.getOffendingToken();
@@ -424,7 +424,7 @@ public class ParserInterpreter extends Parser {
 				                             Token.DEFAULT_CHANNEL,
 				                            -1, -1, // invalid start/stop
 				                             tok.getLine(), tok.getCharPositionInLine());
-				_ctx.addErrorNode(errToken);
+				_ctx.addErrorNode(createErrorNode(_ctx,errToken));
 			}
 		}
 	}
@@ -445,3 +445,4 @@ public class ParserInterpreter extends Parser {
 		return rootContext;
 	}
 }
+


### PR DESCRIPTION
The new methods act like a built-in factory during parse tree construction. In the end it is a fairly minor change, but since I moved some methods around in Parser, it looks bigger than it is. All I did was to convert `new TerminalNodeImpl` and `new ErrorNodeImpl` code to calls to the factory methods. I also cleaned up ParserRuleContext add child stuff.

@antlr/antlr-targets should consider updating their targets as it adds flexibility that will be handy in a future PR where I support tree construction that contains hidden text before/after nodes.