### PR TITLE
Update contributors.txt

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -136,3 +136,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/02/10, lionelplessis, Lionel Plessis, lionelplessis@users.noreply.github.com
 2017/02/14, lecode-official, David Neumann, david.neumann@lecode.de
 2017/02/14, xied75, Dong Xie, xied75@gmail.com
+2017/02/14, kohlsalem, Michael Kohl, michael@kohlsalem.com


### PR DESCRIPTION
[cut]
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
[/cut]
