### PR TITLE
Go micro performance. lexer atn config using murmur hash 32.

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/BaseGoTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/BaseGoTest.java
@@ -165,6 +165,9 @@ public class BaseGoTest implements RuntimeTestSupport {
 	}
 
 	private static void copyFile(File source, File dest) throws IOException {
+		if ( source.isDirectory() ) {
+			return;
+		}
 		InputStream is = new FileInputStream(source);
 		OutputStream os = new FileOutputStream(dest);
 		byte[] buf = new byte[4 << 10];

--- a/runtime/Go/antlr/atn_config.go
+++ b/runtime/Go/antlr/atn_config.go
@@ -247,17 +247,17 @@ func NewLexerATNConfig1(state ATNState, alt int, context PredictionContext) *Lex
 	return &LexerATNConfig{BaseATNConfig: NewBaseATNConfig5(state, alt, context, SemanticContextNone)}
 }
 
-func (l *LexerATNConfig) Hash() string {
-	var f string
-
-	if l.passedThroughNonGreedyDecision {
-		f = "1"
-	} else {
-		f = "0"
-	}
-
-	return fmt.Sprintf("%v%v%v%v%v%v", l.state.GetStateNumber(), l.alt, l.context, l.semanticContext, f, l.lexerActionExecutor)
-}
+// func (l *LexerATNConfig) Hash() string {
+// 	var f string
+//
+// 	if l.passedThroughNonGreedyDecision {
+// 		f = "1"
+// 	} else {
+// 		f = "0"
+// 	}
+//
+// 	return fmt.Sprintf("%v%v%v%v%v%v", l.state.GetStateNumber(), l.alt, l.context, l.semanticContext, f, l.lexerActionExecutor)
+// }
 
 func (l *LexerATNConfig) equals(other interface{}) bool {
 	var othert, ok = other.(*LexerATNConfig)
@@ -283,6 +283,24 @@ func (l *LexerATNConfig) equals(other interface{}) bool {
 	}
 
 	return l.BaseATNConfig.equals(othert.BaseATNConfig)
+}
+
+func (l *LexerATNConfig) HashCode() int {
+	var f int
+	if l.passedThroughNonGreedyDecision {
+		f = 1
+	} else {
+		f = 0
+	}
+	h := initHash(7)
+	h = update(h, l.state.HashCode())
+	h = update(h, l.alt)
+	h = update(h, l.context.HashCode())
+	h = update(h, l.semanticContext.HashCode())
+	h = update(h, f)
+	h = update(h, l.lexerActionExecutor.HashCode())
+	h = finish(h, 6)
+	return h
 }
 
 func checkNonGreedyDecision(source *LexerATNConfig, target ATNState) bool {

--- a/runtime/Go/antlr/atn_config_set.go
+++ b/runtime/Go/antlr/atn_config_set.go
@@ -95,7 +95,7 @@ type BaseATNConfigSet struct {
 func NewBaseATNConfigSet(fullCtx bool) *BaseATNConfigSet {
 	return &BaseATNConfigSet{
 		cachedHashString: "-1",
-		configLookup:     NewSet(hashATNConfig, equalATNConfigs),
+		configLookup:     NewSet(hashATNConfig, nil, equalATNConfigs),
 		fullCtx:          fullCtx,
 	}
 }
@@ -147,7 +147,7 @@ func (b *BaseATNConfigSet) Add(config ATNConfig, mergeCache *DoubleDict) bool {
 }
 
 func (b *BaseATNConfigSet) GetStates() *Set {
-	states := NewSet(nil, nil)
+	states := NewSet(nil, nil, nil)
 
 	for i := 0; i < len(b.configs); i++ {
 		states.add(b.configs[i].GetState())
@@ -277,7 +277,7 @@ func (b *BaseATNConfigSet) Clear() {
 
 	b.configs = make([]ATNConfig, 0)
 	b.cachedHashString = "-1"
-	b.configLookup = NewSet(hashATNConfig, equalATNConfigs)
+	b.configLookup = NewSet(hashATNConfig, nil, equalATNConfigs)
 }
 
 func (b *BaseATNConfigSet) FullContext() bool {
@@ -359,7 +359,7 @@ type OrderedATNConfigSet struct {
 func NewOrderedATNConfigSet() *OrderedATNConfigSet {
 	b := NewBaseATNConfigSet(false)
 
-	b.configLookup = NewSet(nil, nil)
+	b.configLookup = NewSet(nil, nil, nil)
 
 	return &OrderedATNConfigSet{BaseATNConfigSet: b}
 }

--- a/runtime/Go/antlr/atn_state.go
+++ b/runtime/Go/antlr/atn_state.go
@@ -49,6 +49,7 @@ type ATNState interface {
 	AddTransition(Transition, int)
 
 	String() string
+	HashCode() int
 }
 
 type BaseATNState struct {
@@ -120,6 +121,10 @@ func (as *BaseATNState) GetNextTokenWithinRule() *IntervalSet {
 
 func (as *BaseATNState) SetNextTokenWithinRule(v *IntervalSet) {
 	as.NextTokenWithinRule = v
+}
+
+func (as *BaseATNState) HashCode() int {
+	return as.stateNumber
 }
 
 func (as *BaseATNState) String() string {

--- a/runtime/Go/antlr/dfa_state.go
+++ b/runtime/Go/antlr/dfa_state.go
@@ -92,7 +92,7 @@ func NewDFAState(stateNumber int, configs ATNConfigSet) *DFAState {
 
 // GetAltSet gets the set of all alts mentioned by all ATN configurations in d.
 func (d *DFAState) GetAltSet() *Set {
-	alts := NewSet(nil, nil)
+	alts := NewSet(nil, nil, nil)
 
 	if d.configs != nil {
 		for _, c := range d.configs.GetItems() {

--- a/runtime/Go/antlr/lexer_action.go
+++ b/runtime/Go/antlr/lexer_action.go
@@ -22,6 +22,7 @@ type LexerAction interface {
 	getIsPositionDependent() bool
 	execute(lexer Lexer)
 	Hash() string
+	HashCode() int
 	equals(other LexerAction) bool
 }
 
@@ -49,6 +50,10 @@ func (b *BaseLexerAction) getActionType() int {
 
 func (b *BaseLexerAction) getIsPositionDependent() bool {
 	return b.isPositionDependent
+}
+
+func (b *BaseLexerAction) HashCode() int {
+	return b.actionType
 }
 
 func (b *BaseLexerAction) Hash() string {

--- a/runtime/Go/antlr/lexer_action_executor.go
+++ b/runtime/Go/antlr/lexer_action_executor.go
@@ -14,6 +14,7 @@ package antlr
 type LexerActionExecutor struct {
 	lexerActions     []LexerAction
 	cachedHashString string
+	cachedHash       int
 }
 
 func NewLexerActionExecutor(lexerActions []LexerAction) *LexerActionExecutor {
@@ -30,8 +31,10 @@ func NewLexerActionExecutor(lexerActions []LexerAction) *LexerActionExecutor {
 	// of the performance-critical {@link LexerATNConfig//hashCode} operation.
 
 	var s string
+	l.cachedHash = initHash(57)
 	for _, a := range lexerActions {
 		s += a.Hash()
+		l.cachedHash = update(l.cachedHash, a.HashCode())
 	}
 
 	l.cachedHashString = s // "".join([str(la) for la in
@@ -159,6 +162,13 @@ func (l *LexerActionExecutor) execute(lexer Lexer, input CharStream, startIndex 
 
 func (l *LexerActionExecutor) Hash() string {
 	return l.cachedHashString
+}
+
+func (l *LexerActionExecutor) HashCode() int {
+	if l == nil {
+		return 61
+	}
+	return l.cachedHash
 }
 
 func (l *LexerActionExecutor) equals(other interface{}) bool {

--- a/runtime/Go/antlr/lexer_atn_simulator.go
+++ b/runtime/Go/antlr/lexer_atn_simulator.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	LexerATNSimulatorDebug    = false
+	LexerATNSimulatorDebug = false
 	LexerATNSimulatorDFADebug = false
 
 	LexerATNSimulatorMinDFAEdge = 0
@@ -311,7 +311,7 @@ func (l *LexerATNSimulator) accept(input CharStream, lexerActionExecutor *LexerA
 }
 
 func (l *LexerATNSimulator) getReachableTarget(trans Transition, t int) ATNState {
-	if trans.Matches(t, 0, LexerMaxCharValue) {
+	if trans.Matches(t, 0, 0xFFFE) {
 		return trans.getTarget()
 	}
 
@@ -461,7 +461,7 @@ func (l *LexerATNSimulator) getEpsilonTarget(input CharStream, config *LexerATNC
 		trans.getSerializationType() == TransitionRANGE ||
 		trans.getSerializationType() == TransitionSET {
 		if treatEOFAsEpsilon {
-			if trans.Matches(TokenEOF, 0, LexerMaxCharValue) {
+			if trans.Matches(TokenEOF, 0, 0xFFFF) {
 				cfg = NewLexerATNConfig4(config, trans.getTarget())
 			}
 		}

--- a/runtime/Go/antlr/ll1_analyzer.go
+++ b/runtime/Go/antlr/ll1_analyzer.go
@@ -38,7 +38,7 @@ func (la *LL1Analyzer) getDecisionLookahead(s ATNState) []*IntervalSet {
 	look := make([]*IntervalSet, count)
 	for alt := 0; alt < count; alt++ {
 		look[alt] = NewIntervalSet()
-		lookBusy := NewSet(nil, nil)
+		lookBusy := NewSet(nil, nil, nil)
 		seeThruPreds := false // fail to get lookahead upon pred
 		la.look1(s.GetTransitions()[alt].getTarget(), nil, BasePredictionContextEMPTY, look[alt], lookBusy, NewBitSet(), seeThruPreds, false)
 		// Wipe out lookahead for la alternative if we found nothing
@@ -75,7 +75,7 @@ func (la *LL1Analyzer) Look(s, stopState ATNState, ctx RuleContext) *IntervalSet
 	if ctx != nil {
 		lookContext = predictionContextFromRuleContext(s.GetATN(), ctx)
 	}
-	la.look1(s, stopState, lookContext, r, NewSet(nil, nil), NewBitSet(), seeThruPreds, true)
+	la.look1(s, stopState, lookContext, r, NewSet(nil, nil, nil), NewBitSet(), seeThruPreds, true)
 	return r
 }
 

--- a/runtime/Go/antlr/parser_atn_simulator.go
+++ b/runtime/Go/antlr/parser_atn_simulator.go
@@ -568,7 +568,7 @@ func (p *ParserATNSimulator) computeReachSet(closure ATNConfigSet, t int, fullCt
 	//
 	if reach == nil {
 		reach = NewBaseATNConfigSet(fullCtx)
-		closureBusy := NewSet(nil, nil)
+		closureBusy := NewSet(nil, nil, nil)
 		treatEOFAsEpsilon := t == TokenEOF
 		for k := 0; k < len(intermediate.configs); k++ {
 			p.closure(intermediate.configs[k], reach, closureBusy, false, fullCtx, treatEOFAsEpsilon)
@@ -665,7 +665,7 @@ func (p *ParserATNSimulator) computeStartState(a ATNState, ctx RuleContext, full
 	for i := 0; i < len(a.GetTransitions()); i++ {
 		target := a.GetTransitions()[i].getTarget()
 		c := NewBaseATNConfig6(target, i+1, initialContext)
-		closureBusy := NewSet(nil, nil)
+		closureBusy := NewSet(nil, nil, nil)
 		p.closure(c, configs, closureBusy, true, fullCtx, false)
 	}
 	return configs

--- a/runtime/Go/antlr/prediction_context.go
+++ b/runtime/Go/antlr/prediction_context.go
@@ -28,6 +28,7 @@ var (
 
 type PredictionContext interface {
 	Hash() string
+	HashCode() int
 	GetParent(int) PredictionContext
 	getReturnState(int) int
 	equals(PredictionContext) bool
@@ -204,6 +205,23 @@ func (b *BaseSingletonPredictionContext) Hash() string {
 	return b.cachedHashString
 }
 
+func (b *BaseSingletonPredictionContext) HashCode() int {
+	up := 0
+	if b.parentCtx != nil {
+		up = b.parentCtx.HashCode()
+	}
+
+	if up == 0 {
+		if b.returnState == BasePredictionContextEmptyReturnState {
+			up += 1 //TODO what should this be
+		}
+		up += b.returnState
+		return up
+	}
+	up += b.returnState
+	return up
+}
+
 func (b *BaseSingletonPredictionContext) String() string {
 	var up string
 
@@ -320,6 +338,26 @@ func (a *ArrayPredictionContext) equals(other PredictionContext) bool {
 		otherP := other.(*ArrayPredictionContext)
 		return &a.returnStates == &otherP.returnStates && &a.parents == &otherP.parents
 	}
+}
+
+func (a *ArrayPredictionContext) HashCode() int {
+	if a.isEmpty() {
+		return 19 //TODO what to return here, some prime is probably ol
+	}
+	v := 0
+	for i := 0; i < len(a.returnStates); i++ {
+		if a.returnStates[i] == BasePredictionContextEmptyReturnState {
+			v += (i * 23) //TODO what #
+			continue
+		}
+		v += a.returnStates[i]
+		if a.parents[i] != nil {
+			v += (27 * a.parents[i].HashCode())
+		} else {
+			v += 31
+		}
+	}
+	return v
 }
 
 func (a *ArrayPredictionContext) String() string {

--- a/runtime/Go/antlr/semantic_context.go
+++ b/runtime/Go/antlr/semantic_context.go
@@ -22,6 +22,8 @@ type SemanticContext interface {
 
 	evaluate(parser Recognizer, outerContext RuleContext) bool
 	evalPrecedence(parser Recognizer, outerContext RuleContext) SemanticContext
+
+	HashCode() int
 	String() string
 }
 
@@ -109,6 +111,10 @@ func (p *Predicate) equals(other interface{}) bool {
 	}
 }
 
+func (p *Predicate) HashCode() int {
+	return p.ruleIndex*43 + p.predIndex*47
+}
+
 func (p *Predicate) String() string {
 	return "{" + strconv.Itoa(p.ruleIndex) + ":" + strconv.Itoa(p.predIndex) + "}?"
 }
@@ -155,6 +161,10 @@ func (p *PrecedencePredicate) equals(other interface{}) bool {
 	}
 }
 
+func (p *PrecedencePredicate) HashCode() int {
+	return p.precedence * 51
+}
+
 func (p *PrecedencePredicate) String() string {
 	return "{" + strconv.Itoa(p.precedence) + ">=prec}?"
 }
@@ -180,7 +190,7 @@ type AND struct {
 
 func NewAND(a, b SemanticContext) *AND {
 
-	operands := NewSet(nil, nil)
+	operands := NewSet(nil, nil, nil)
 	if aa, ok := a.(*AND); ok {
 		for _, o := range aa.opnds {
 			operands.add(o)
@@ -295,6 +305,21 @@ func (a *AND) evalPrecedence(parser Recognizer, outerContext RuleContext) Semant
 	return result
 }
 
+func (a *AND) HashCode() int {
+	v := 37
+	for _, o := range a.opnds {
+		v += o.HashCode()
+	}
+	return v
+}
+func (a *OR) HashCode() int {
+	v := 41
+	for _, o := range a.opnds {
+		v += o.HashCode()
+	}
+	return v
+}
+
 func (a *AND) String() string {
 	s := ""
 
@@ -320,7 +345,7 @@ type OR struct {
 
 func NewOR(a, b SemanticContext) *OR {
 
-	operands := NewSet(nil, nil)
+	operands := NewSet(nil, nil, nil)
 	if aa, ok := a.(*OR); ok {
 		for _, o := range aa.opnds {
 			operands.add(o)

--- a/runtime/Go/antlr/token.go
+++ b/runtime/Go/antlr/token.go
@@ -14,6 +14,10 @@ type TokenSourceCharStreamPair struct {
 	charStream  CharStream
 }
 
+func NewTokenSourceCharStreamPair(source TokenSource, stream CharStream) *TokenSourceCharStreamPair {
+	return &TokenSourceCharStreamPair{source, stream}
+}
+
 // A token has properties: text, type, line, character position in the line
 // (so we can ignore tabs), token channel, index, and source from which
 // we obtained this token.
@@ -204,7 +208,7 @@ func (c *CommonToken) String() string {
 		ch = ""
 	}
 
-	return "[@" + strconv.Itoa(c.tokenIndex) + "," + strconv.Itoa(c.start) + ":" + strconv.Itoa(c.stop) + "='" +
+	return "[" + "channel:" + strconv.Itoa(c.channel) + " @" + strconv.Itoa(c.tokenIndex) + "," + strconv.Itoa(c.start) + ":" + strconv.Itoa(c.stop) + "='" +
 		txt + "',<" + strconv.Itoa(c.tokenType) + ">" +
 		ch + "," + strconv.Itoa(c.line) + ":" + strconv.Itoa(c.column) + "]"
 }

--- a/runtime/Go/antlr/token.go
+++ b/runtime/Go/antlr/token.go
@@ -208,7 +208,7 @@ func (c *CommonToken) String() string {
 		ch = ""
 	}
 
-	return "[" + "channel:" + strconv.Itoa(c.channel) + " @" + strconv.Itoa(c.tokenIndex) + "," + strconv.Itoa(c.start) + ":" + strconv.Itoa(c.stop) + "='" +
+	return "[@" + strconv.Itoa(c.tokenIndex) + "," + strconv.Itoa(c.start) + ":" + strconv.Itoa(c.stop) + "='" +
 		txt + "',<" + strconv.Itoa(c.tokenType) + ">" +
 		ch + "," + strconv.Itoa(c.line) + ":" + strconv.Itoa(c.column) + "]"
 }

--- a/runtime/Go/antlr/utils.go
+++ b/runtime/Go/antlr/utils.go
@@ -49,22 +49,33 @@ func (s *IntStack) Push(e int) {
 }
 
 type Set struct {
-	data           map[string][]interface{}
-	hashFunction   func(interface{}) string
-	equalsFunction func(interface{}, interface{}) bool
+	setData map[int][]interface{}
+	// stringhashFunction func(interface{}) string
+	hashcodeFunction func(interface{}) int
+	equalsFunction   func(interface{}, interface{}) bool
 }
 
-func NewSet(hashFunction func(interface{}) string, equalsFunction func(interface{}, interface{}) bool) *Set {
+func NewSet(
+	hashFunction func(interface{}) string,
+	hashcodeFunction func(interface{}) int,
+	equalsFunction func(interface{}, interface{}) bool) *Set {
 
 	s := new(Set)
 
-	s.data = make(map[string][]interface{})
+	s.setData = make(map[int][]interface{})
 
-	if hashFunction == nil {
-		s.hashFunction = standardHashFunction
+	// could be nil
+	if hashcodeFunction != nil {
+		s.hashcodeFunction = hashcodeFunction
 	} else {
-		s.hashFunction = hashFunction
+		s.hashcodeFunction = standardHashFunction
 	}
+
+	// if hashFunction == nil {
+	// 	s.hashFunction = standardHashFunction
+	// } else {
+	// 	s.stringhashFunction = hashFunction
+	// }
 
 	if equalsFunction == nil {
 		s.equalsFunction = standardEqualsFunction
@@ -87,11 +98,16 @@ func standardEqualsFunction(a interface{}, b interface{}) bool {
 	return ac.equals(bc)
 }
 
-func standardHashFunction(a interface{}) string {
-	h, ok := a.(Hasher)
+func standardHashFunction(a interface{}) int {
+	if h, ok := a.(HashCodeer); ok {
+		return h.HashCode()
+	}
 
-	if ok {
-		return h.Hash()
+	if h, ok := a.(Hasher); ok {
+		s := h.Hash()
+		ha := fnv.New32a()
+		ha.Write([]byte((s)))
+		return int(ha.Sum32())
 	}
 
 	panic("Not Hasher")
@@ -110,25 +126,21 @@ func standardHashFunction(a interface{}) string {
 type Hasher interface {
 	Hash() string
 }
-
-func hashCode(s string) string {
-	h := fnv.New32a()
-	h.Write([]byte((s)))
-	return fmt.Sprint(h.Sum32())
+type HashCodeer interface {
+	HashCode() int
 }
 
 func (s *Set) length() int {
-	return len(s.data)
+	return len(s.setData)
 }
 
 func (s *Set) add(value interface{}) interface{} {
 
-	hash := s.hashFunction(value)
-	key := "hash_" + hashCode(hash)
+	key := s.hashcodeFunction(value)
 
-	values := s.data[key]
+	values := s.setData[key]
 
-	if s.data[key] != nil {
+	if s.setData[key] != nil {
 
 		for i := 0; i < len(values); i++ {
 			if s.equalsFunction(value, values[i]) {
@@ -136,22 +148,25 @@ func (s *Set) add(value interface{}) interface{} {
 			}
 		}
 
-		s.data[key] = append(s.data[key], value)
+		s.setData[key] = append(s.setData[key], value)
 		return value
 	}
 
-	s.data[key] = []interface{}{value}
+	v := make([]interface{}, 1, 10)
+	v[0] = value
+	s.setData[key] = v
+
+	// s.setData[key] = []interface{}{value}
 	return value
 }
 
 func (s *Set) contains(value interface{}) bool {
 
-	hash := s.hashFunction(value)
-	key := "hash_" + hashCode(hash)
+	key := s.hashcodeFunction(value)
 
-	values := s.data[key]
+	values := s.setData[key]
 
-	if s.data[key] != nil {
+	if s.setData[key] != nil {
 		for i := 0; i < len(values); i++ {
 			if s.equalsFunction(value, values[i]) {
 				return true
@@ -164,10 +179,10 @@ func (s *Set) contains(value interface{}) bool {
 func (s *Set) values() []interface{} {
 	l := make([]interface{}, 0)
 
-	for key := range s.data {
-		if strings.Index(key, "hash_") == 0 {
-			l = append(l, s.data[key]...)
-		}
+	for key := range s.setData {
+		// if strings.Index(key, "hash_") == 0 {
+		l = append(l, s.setData[key]...)
+		// }
 	}
 	return l
 }
@@ -176,7 +191,7 @@ func (s *Set) String() string {
 
 	r := ""
 
-	for _, av := range s.data {
+	for _, av := range s.setData {
 		for _, v := range av {
 			r += fmt.Sprint(v)
 		}
@@ -214,7 +229,7 @@ func (b *BitSet) remove(value int) {
 }
 
 func (b *BitSet) contains(value int) bool {
-	return b.data[value] == true
+	return b.data[value]
 }
 
 func (b *BitSet) values() []int {
@@ -384,4 +399,37 @@ func TitleCase(str string) string {
 	//		return strings.ToUpper(s[0:1]) + s[1:2]
 	//	})
 
+}
+
+// murmur hash
+const (
+	c1_32 = 0xCC9E2D51
+	c2_32 = 0x1B873593
+	n1_32 = 0xE6546B64
+)
+
+func initHash(seed int) int {
+	return seed
+}
+
+func update(h1 int, k1 int) int {
+	k1 *= c1_32
+	k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
+	k1 *= c2_32
+
+	h1 ^= k1
+	h1 = (h1 << 13) | (h1 >> 19) // rotl32(h1, 13)
+	h1 = h1*5 + 0xe6546b64
+	return h1
+}
+
+func finish(h1 int, numberOfWords int) int {
+	h1 ^= (numberOfWords * 4)
+	h1 ^= h1 >> 16
+	h1 *= 0x85ebca6b
+	h1 ^= h1 >> 13
+	h1 *= 0xc2b2ae35
+	h1 ^= h1 >> 16
+
+	return h1
 }


### PR DESCRIPTION
The Go target needs some TLC at both a micro and macro level. A a micro level the lexer (and probably the parser) is slow, around 40x slower than a hand rolled one. Where the cpp target is only around 40% slower (see https://github.com/antlr/antlr4/issues/1540 & https://github.com/pboyer/antlr4/issues/92). At a macro level the LR optimisation (see https://github.com/antlr/antlr4/issues/192) have not been ported to the Go runtime.

This PR changed the LexerATNConfig hash code from a string that was hashed with fnv to hashcode ints that are murmur32 hashed. This gives about a 30% (benchmark number below) improvement (if implemented correctly), so there is still low hanging fruit in the 40x slow down. I intend to revisit this when I have some time or performance becomes an issue. My currently environment doesn't support profiling, which is probably an effective way of finding micro issues. Anyone interested in helping with this, I would be more than happy to collaborate.

@parrt and @sharwell any gotchas in implementing the LR changes?

**Comments**
**Benchmarking** - At this point in Antlr4's maturity it would be nice to have a benchmarking framework to complement  the unit testing framework. Go's benchmarking is an extension of testing and by the looks of it was influenced by [caliper](https://github.com/google/caliper), a Java benchmarking framework. Any suggestion of similar tools for the other targets and what such a framework might look like? Do any travis add-ins support reporting on benchmark data?

**Code coverage** - Whilst looking at the Go and Java code I came across another micro issue. In the Java runtime the `boolean add(T t)` in `Array2DHashSet` class will always return true (ie new element added), this behaviour also exists in the Go runtime. This doesn't effect behaviour, but without benchmarking it is difficult to tell the benefit from fixing it or replacing it with a hash set from a thirdparty library (eg [guava](https://github.com/google/guava) r19 is java 1.7 compatible). It wouldn't be a surprise if many micro issues exist across the runtime code bases. In this case the code in question dates back to 2012. So a deeper question is how to find them. The first answer that springs to mind is code coverage. Has anyone setup code coverage on Antlr4 using one of the travis add-ins? What other tools and techniques might be of interest?

Cheers
Gary

Go benchmarking numbers for this PR (see [modified dgraph benchmark](https://github.com/millergarym/dgraph/blob/bench-antlr4/antlr4go/lexer/benchmark_test.go))
@ashishne thought this might interest you.
before
```
bash-3.2$ go test -test.run=XXX -v  -benchtime=2s -bench . -cpuprofile cprof.prof
BenchmarkQuery/q1.1-12             10000            398395 ns/op
BenchmarkQuery/q1.2-12             10000            432751 ns/op
BenchmarkQuery/q2.1-12             10000            446644 ns/op
BenchmarkQuery/q2.2-12              5000            514398 ns/op
BenchmarkQuery/q3.1-12              5000            490114 ns/op
BenchmarkQuery/q3.2-12              5000            504340 ns/op
BenchmarkQuery/q4.1-12              5000            537611 ns/op
BenchmarkQuery/q4.2-12              5000            552284 ns/op
BenchmarkQuery/q5.1-12              5000            538648 ns/op
BenchmarkQuery/q5.2-12              5000            552259 ns/op
```

after
```
bash-3.2$ go test -test.run=XXX -v  -benchtime=2s -bench .
BenchmarkQuery/q1.1-12             10000            277898 ns/op
BenchmarkQuery/q1.2-12             10000            299240 ns/op
BenchmarkQuery/q2.1-12             10000            307816 ns/op
BenchmarkQuery/q2.2-12             10000            351049 ns/op
BenchmarkQuery/q3.1-12             10000            336241 ns/op
BenchmarkQuery/q3.2-12             10000            352299 ns/op
BenchmarkQuery/q4.1-12             10000            374569 ns/op
BenchmarkQuery/q4.2-12             10000            384309 ns/op
BenchmarkQuery/q5.1-12             10000            374470 ns/op
BenchmarkQuery/q5.2-12             10000            386929 ns/op
```

From https://github.com/antlr/antlr4/issues/1540
```
query$ gotb -test.run=XXX -benchtime=2s -v
BenchmarkQueryParse/spielberg:handwitten:-4               100000         46918 ns/op
BenchmarkQueryParse/spielberg:antlr:-4                      2000       1741364 ns/op
BenchmarkQueryParse/tomhanks:handwitten:-4                100000         25982 ns/op
BenchmarkQueryParse/tomhanks:antlr:-4                       2000       1654579 ns/op
BenchmarkQueryParse/nestedquery:handwritten:-4             30000         73053 ns/op
BenchmarkQueryParse/nestedquery:antlr:-4                    1000       3385005 ns/op
PASS
ok      github.com/dgraph-io/dgraph/query    21.922s
```