### PR TITLE
UnicodeData: Also support Unicode blocks

### DIFF
--- a/tool-codegen/src/main/string-template/unicodedata.st
+++ b/tool-codegen/src/main/string-template/unicodedata.st
@@ -41,12 +41,16 @@ static private void addProperty<k>() {
               addPropertyAliases();
        }
 
+       private static String normalize(String propertyCodeOrAlias) {
+               return propertyCodeOrAlias.toLowerCase(Locale.US).replace('-', '_');
+       }
+
        /**
         * Given a Unicode property (general category code, binary property name, or script name),
         * returns the {@link IntervalSet} of Unicode code point ranges which have that property.
         */
        public static IntervalSet getPropertyCodePoints(String propertyCodeOrAlias) {
-              String normalizedPropertyCodeOrAlias = propertyCodeOrAlias.toLowerCase(Locale.US);
+              String normalizedPropertyCodeOrAlias = normalize(propertyCodeOrAlias);
               IntervalSet result = propertyCodePointRanges.get(normalizedPropertyCodeOrAlias);
               if (result == null) {
                  String propertyCode = propertyAliases.get(normalizedPropertyCodeOrAlias);

--- a/tool-codegen/src/org/antlr/v4/unicode/UnicodeDataTemplateController.java
+++ b/tool-codegen/src/org/antlr/v4/unicode/UnicodeDataTemplateController.java
@@ -75,11 +75,13 @@ public abstract class UnicodeDataTemplateController {
 		addUnicodeCategoryCodesToCodePointRanges(propertyCodePointRanges);
 		addUnicodeBinaryPropertyCodesToCodePointRanges(propertyCodePointRanges);
 		addUnicodeScriptCodesToCodePointRanges(propertyCodePointRanges);
+		addUnicodeBlocksToCodePointRanges(propertyCodePointRanges);
 
 		Map<String, String> propertyAliases = new LinkedHashMap<>();
 		addUnicodeCategoryCodesToNames(propertyAliases);
 		addUnicodeBinaryPropertyCodesToNames(propertyAliases);
 		addUnicodeScriptCodesToNames(propertyAliases);
+		addUnicodeBlocksToNames(propertyAliases);
 
 		Map<String, Object> properties = new LinkedHashMap<>();
 		properties.put("propertyCodePointRanges", propertyCodePointRanges);
@@ -171,17 +173,17 @@ public abstract class UnicodeDataTemplateController {
 		}
 	}
 
-	private static void addUnicodeScriptCodesToCodePointRanges(Map<String, IntervalSet> propertyCodePointRanges) {
-		for (int script = UCharacter.getIntPropertyMinValue(UProperty.SCRIPT);
-		     script <= UCharacter.getIntPropertyMaxValue(UProperty.SCRIPT);
-		     script++) {
+	private static void addIntPropertyRanges(int property, String namePrefix, Map<String, IntervalSet> propertyCodePointRanges) {
+		for (int propertyValue = UCharacter.getIntPropertyMinValue(property);
+		     propertyValue <= UCharacter.getIntPropertyMaxValue(property);
+		     propertyValue++) {
 			UnicodeSet set = new UnicodeSet();
-			set.applyIntPropertyValue(UProperty.SCRIPT, script);
-			String scriptName = UCharacter.getPropertyValueName(UProperty.SCRIPT, script, UProperty.NameChoice.SHORT);
-			IntervalSet intervalSet = propertyCodePointRanges.get(scriptName);
+			set.applyIntPropertyValue(property, propertyValue);
+			String propertyName = namePrefix + UCharacter.getPropertyValueName(property, propertyValue, UProperty.NameChoice.SHORT);
+			IntervalSet intervalSet = propertyCodePointRanges.get(propertyName);
 			if (intervalSet == null) {
 				intervalSet = new IntervalSet();
-				propertyCodePointRanges.put(scriptName, intervalSet);
+				propertyCodePointRanges.put(propertyName, intervalSet);
 			}
 			for (UnicodeSet.EntryRange range : set.ranges()) {
 				intervalSet.add(range.codepoint, range.codepointEnd);
@@ -189,16 +191,24 @@ public abstract class UnicodeDataTemplateController {
 		}
 	}
 
-	private static void addUnicodeScriptCodesToNames(Map<String, String> propertyAliases) {
-		for (int script = UCharacter.getIntPropertyMinValue(UProperty.SCRIPT);
-		     script <= UCharacter.getIntPropertyMaxValue(UProperty.SCRIPT);
-		     script++) {
-			String propertyName = UCharacter.getPropertyValueName(UProperty.SCRIPT, script, UProperty.NameChoice.SHORT);
+	private static void addUnicodeScriptCodesToCodePointRanges(Map<String, IntervalSet> propertyCodePointRanges) {
+		addIntPropertyRanges(UProperty.SCRIPT, "", propertyCodePointRanges);
+	}
+
+	private static void addUnicodeBlocksToCodePointRanges(Map<String, IntervalSet> propertyCodePointRanges) {
+		addIntPropertyRanges(UProperty.BLOCK, "In", propertyCodePointRanges);
+	}
+
+	private static void addIntPropertyAliases(int property, String namePrefix, Map<String, String> propertyAliases) {
+		for (int propertyValue = UCharacter.getIntPropertyMinValue(property);
+		     propertyValue <= UCharacter.getIntPropertyMaxValue(property);
+		     propertyValue++) {
+			String propertyName = namePrefix + UCharacter.getPropertyValueName(property, propertyValue, UProperty.NameChoice.SHORT);
 			int nameChoice = UProperty.NameChoice.LONG;
 			String alias;
 			while (true) {
 				try {
-					alias = UCharacter.getPropertyValueName(UProperty.SCRIPT, script, nameChoice);
+					alias = namePrefix + UCharacter.getPropertyValueName(property, propertyValue, nameChoice);
 				} catch (IllegalArgumentException e) {
 					// No more aliases.
 					break;
@@ -208,5 +218,13 @@ public abstract class UnicodeDataTemplateController {
 				nameChoice++;
 			}
 		}
+	}
+
+	private static void addUnicodeScriptCodesToNames(Map<String, String> propertyAliases) {
+		addIntPropertyAliases(UProperty.SCRIPT, "", propertyAliases);
+	}
+
+	private static void addUnicodeBlocksToNames(Map<String, String> propertyAliases) {
+		addIntPropertyAliases(UProperty.BLOCK, "In", propertyAliases);
 	}
 }

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestUnicodeData.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestUnicodeData.java
@@ -109,11 +109,30 @@ public class TestUnicodeData {
 	}
 
 	@Test
+	public void testUnicodeBlocks() {
+		assertTrue(UnicodeData.getPropertyCodePoints("InASCII").contains('0'));
+		assertTrue(UnicodeData.getPropertyCodePoints("InCJK").contains(0x4E04));
+		assertTrue(UnicodeData.getPropertyCodePoints("InCyrillic").contains(0x0404));
+		assertTrue(UnicodeData.getPropertyCodePoints("InMisc_Pictographs").contains(0x1F4A9));
+	}
+
+	@Test
+	public void testUnicodeBlockAliases() {
+		assertTrue(UnicodeData.getPropertyCodePoints("InBasic_Latin").contains('0'));
+		assertTrue(UnicodeData.getPropertyCodePoints("InMiscellaneous_Mathematical_Symbols_B").contains(0x29BE));
+	}
+
+	@Test
 	public void testPropertyCaseInsensitivity() {
 		assertTrue(UnicodeData.getPropertyCodePoints("l").contains('x'));
 		assertFalse(UnicodeData.getPropertyCodePoints("l").contains('0'));
 		assertTrue(UnicodeData.getPropertyCodePoints("common").contains('0'));
 		assertTrue(UnicodeData.getPropertyCodePoints("Alnum").contains('0'));
+	}
+
+	@Test
+	public void testPropertyDashSameAsUnderscore() {
+		assertTrue(UnicodeData.getPropertyCodePoints("InLatin-1").contains('\u00F0'));
 	}
 
 	@Test


### PR DESCRIPTION
This is split off from the WIP PR #1688.

This extends the `UnicodeData` code-generated class to support Unicode blocks in addition to general categories, scripts, binary properties.

I added tests to cover the new functionality.

Since Unicode block names overlap with script names, I prefix the block name with `In`: `\p{InBlockName}`.

I also made it so `-` and `_` are treated the same.
