### PR TITLE
Fix for #1698

### DIFF
--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
@@ -203,12 +203,12 @@ void TokenStreamRewriter::Delete(Token *from, Token *to) {
 }
 
 void TokenStreamRewriter::Delete(const std::string &programName, size_t from, size_t to) {
-  std::String nullString;
+  std::string nullString;
   replace(programName, from, to, nullString);
 }
 
 void TokenStreamRewriter::Delete(const std::string &programName, Token *from, Token *to) {
-  std::String nullString;
+  std::string nullString;
   replace(programName, from, to, nullString);
 }
 

--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
@@ -203,11 +203,13 @@ void TokenStreamRewriter::Delete(Token *from, Token *to) {
 }
 
 void TokenStreamRewriter::Delete(const std::string &programName, size_t from, size_t to) {
-  replace(programName, from, to, nullptr);
+  std::String nullString;
+  replace(programName, from, to, nullString);
 }
 
 void TokenStreamRewriter::Delete(const std::string &programName, Token *from, Token *to) {
-  replace(programName, from, to, nullptr);
+  std::String nullString;
+  replace(programName, from, to, nullString);
 }
 
 size_t TokenStreamRewriter::getLastRewriteTokenIndex() {


### PR DESCRIPTION
Fix for https://github.com/antlr/antlr4/issues/1698
TokenStreamRewrite::replace expect a valid reference on std::string object. Not a null pointer.

