### PR TITLE
Fixed crash with multi threaded parsers warming up at the same time, fixes #1601

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
@@ -32,8 +32,7 @@ PredictionContextCache& ATNSimulator::getSharedContextCache() {
 }
 
 Ref<PredictionContext> ATNSimulator::getCachedContext(Ref<PredictionContext> const& context) {
-  // This function requires a lock as it might modify the cache, however the only path so far where it is called from
-  // (addDFAState -> optimizeConfigs) already has _stateLock aquired. Adding another lock here would then deadlock.
+  // This function must only be called with an active state lock, as we are going to change a shared structure.
   std::map<Ref<PredictionContext>, Ref<PredictionContext>> visited;
   return PredictionContext::getCachedContext(context, _sharedContextCache, visited);
 }

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -12,6 +12,7 @@
 #include "atn/SingletonPredictionContext.h"
 #include "atn/PredicateTransition.h"
 #include "atn/ActionTransition.h"
+#include "atn/TokensStartState.h"
 #include "misc/Interval.h"
 #include "dfa/DFA.h"
 #include "Lexer.h"
@@ -102,7 +103,7 @@ void LexerATNSimulator::clearDFA() {
 }
 
 size_t LexerATNSimulator::matchATN(CharStream *input) {
-  ATNState *startState = (ATNState *)atn.modeToStartState[_mode];
+  ATNState *startState = atn.modeToStartState[_mode];
 
   std::unique_ptr<ATNConfigSet> s0_closure = computeStartState(input, startState);
 

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
@@ -251,21 +251,21 @@ namespace atn {
 
     std::vector<dfa::DFA> &decisionToDFA;
 
+  private:
     /// <summary>
     /// SLL, LL, or LL + exact ambig detection? </summary>
-  private:
     PredictionMode mode;
 
+  protected:
     /// <summary>
     /// Each prediction operation uses a cache for merge of prediction contexts.
-    ///  Don't keep around as it wastes huge amounts of memory. The merge cache
-    ///  isn't synchronized but we're ok since two threads shouldn't reuse same
-    ///  parser/atnsim object because it can only handle one input at a time.
-    ///  This maps graphs a and b to merged result c. (a,b)->c. We can avoid
-    ///  the merge if we ever see a and b again.  Note that (b,a)->c should
-    ///  also be examined during cache lookup.
+    /// Don't keep around as it wastes huge amounts of memory. The merge cache
+    /// isn't synchronized but we're ok since two threads shouldn't reuse same
+    /// parser/atnsim object because it can only handle one input at a time.
+    /// This maps graphs a and b to merged result c. (a,b)->c. We can avoid
+    /// the merge if we ever see a and b again.  Note that (b,a)->c should
+    /// also be examined during cache lookup.
     /// </summary>
-  protected:
     PredictionContextMergeCache mergeCache;
 
     // LAME globals to avoid parameters!!!!! I need these down deep in predTransition
@@ -286,6 +286,7 @@ namespace atn {
     virtual void clearDFA() override;
     virtual size_t adaptivePredict(TokenStream *input, size_t decision, ParserRuleContext *outerContext);
 
+  protected:
     /// <summary>
     /// Performs ATN simulation to compute a predicted alternative based
     ///  upon the remaining input, but also updates the DFA cache to avoid
@@ -317,7 +318,6 @@ namespace atn {
     ///    conflict
     ///    conflict + preds
     /// </summary>
-  protected:
     virtual size_t execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream *input, size_t startIndex,
                            ParserRuleContext *outerContext);
 


### PR DESCRIPTION
The lock for the shared DFA state needs to protect a few more operations than just the addDFAState stuff and had to move up one call level. This in turn requires now 2 places where the lock must be aquired.