### PR TITLE
Fixed null pointer exception for JS target

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -138,3 +138,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/02/14, xied75, Dong Xie, xied75@gmail.com
 2017/02/20, Thomasb81, Thomas Burg, thomasb81@gmail.com
 2017/02/26, jvasileff, John Vasileff, john@vasileff.com
+2017/03/08, harry-tallbelt, Igor Vysokopoyasny, harry.tallbelt@gmail.com

--- a/runtime/JavaScript/src/antlr4/ParserRuleContext.js
+++ b/runtime/JavaScript/src/antlr4/ParserRuleContext.js
@@ -119,8 +119,11 @@ ParserRuleContext.prototype.addErrorNode = function(badToken) {
 
 ParserRuleContext.prototype.getChild = function(i, type) {
 	type = type || null;
+	if (this.children === null || i < 0 || i >= this.children.length) {
+		return null;
+	}
 	if (type === null) {
-		return this.children.length>=i ? this.children[i] : null;
+		return this.children[i];
 	} else {
 		for(var j=0; j<this.children.length; j++) {
 			var child = this.children[j];
@@ -138,6 +141,9 @@ ParserRuleContext.prototype.getChild = function(i, type) {
 
 
 ParserRuleContext.prototype.getToken = function(ttype, i) {
+	if (this.children === null || i < 0 || i >= this.children.length) {
+		return null;
+	}
 	for(var j=0; j<this.children.length; j++) {
 		var child = this.children[j];
 		if (child instanceof TerminalNode) {


### PR DESCRIPTION
For JavaScript target, `getToken` and `getChild` methods in `ParserRuleContext.js` did not check if `this.children` is `null` as code for Java target did. I added the two if statements Java implementation has in these methods.

For an example of where the problem arises, consider the rule

```
program : /* nothing */ | statements ;
```

If the input is empty (i.e. `statements` is not matched), the visitor's method

```
ProgramBaseVisitor.prototype.visitProgram = function(ctx) {
  return { statements: ctx.statements() ? this.visit(ctx.statements()) : [] }
}
```

fails on the `ctx.statements()` call, because of an attempt to access `this.children.length` in `ParserRuleContext.js`'s `getChild` method.

Meanwhile, the Java implementation of the same thing has no problem calling `ctx.statements()`.