### PR TITLE
Use murmur hash in Go target

### DIFF
--- a/runtime/Go/antlr/atn_config.go
+++ b/runtime/Go/antlr/atn_config.go
@@ -6,7 +6,6 @@ package antlr
 
 import (
 	"fmt"
-	"strconv"
 )
 
 type Comparable interface {
@@ -171,11 +170,11 @@ func (b *BaseATNConfig) equals(o interface{}) bool {
 
 // TODO(pboyer) not altogether clear why this is needed
 func (b *BaseATNConfig) shortHash() int {
-	h := initMurmurHash(7)
-	h = updateMurmurHash(h, b.state.GetStateNumber())
-	h = updateMurmurHash(h, b.alt)
-	h = updateMurmurHash(h, b.semanticContext.Hash())
-	return finishMurmurHash(h, 3)
+	h := murmurInit(7)
+	h = murmurUpdate(h, b.state.GetStateNumber())
+	h = murmurUpdate(h, b.alt)
+	h = murmurUpdate(h, b.semanticContext.Hash())
+	return murmurFinish(h, 3)
 }
 
 func (b *BaseATNConfig) Hash() int {
@@ -186,12 +185,12 @@ func (b *BaseATNConfig) Hash() int {
 		c = b.context.Hash()
 	}
 
-	h := initMurmurHash(7)
-	h = updateMurmurHash(h, b.state.GetStateNumber())
-	h = updateMurmurHash(h, b.alt)
-	h = updateMurmurHash(h, c)
-	h = updateMurmurHash(h, b.semanticContext.Hash())
-	return finishMurmurHash(h, 4)
+	h := murmurInit(7)
+	h = murmurUpdate(h, b.state.GetStateNumber())
+	h = murmurUpdate(h, b.alt)
+	h = murmurUpdate(h, c)
+	h = murmurUpdate(h, b.semanticContext.Hash())
+	return murmurFinish(h, 4)
 }
 
 func (b *BaseATNConfig) String() string {
@@ -265,14 +264,14 @@ func (l *LexerATNConfig) Hash() int {
 		f = 0
 	}
 
-	h := initMurmurHash(7)
-	h = updateMurmurHash(h, l.state.Hash())
-	h = updateMurmurHash(h, l.alt)
-	h = updateMurmurHash(h, l.context.Hash())
-	h = updateMurmurHash(h, l.semanticContext.Hash())
-	h = updateMurmurHash(h, f)
-	h = updateMurmurHash(h, l.lexerActionExecutor.Hash())
-	return finishMurmurHash(h, 6)
+	h := murmurInit(7)
+	h = murmurUpdate(h, l.state.Hash())
+	h = murmurUpdate(h, l.alt)
+	h = murmurUpdate(h, l.context.Hash())
+	h = murmurUpdate(h, l.semanticContext.Hash())
+	h = murmurUpdate(h, f)
+	h = murmurUpdate(h, l.lexerActionExecutor.Hash())
+	return murmurFinish(h, 6)
 }
 
 func (l *LexerATNConfig) equals(other interface{}) bool {

--- a/runtime/Go/antlr/atn_config.go
+++ b/runtime/Go/antlr/atn_config.go
@@ -7,7 +7,6 @@ package antlr
 import (
 	"fmt"
 	"strconv"
-	"golang.autodesk.com/ts/go/test/fixedbugs/issue4932.dir"
 )
 
 type Comparable interface {

--- a/runtime/Go/antlr/atn_config.go
+++ b/runtime/Go/antlr/atn_config.go
@@ -7,6 +7,7 @@ package antlr
 import (
 	"fmt"
 	"strconv"
+	"golang.autodesk.com/ts/go/test/fixedbugs/issue4932.dir"
 )
 
 type Comparable interface {
@@ -37,7 +38,7 @@ type ATNConfig interface {
 	getPrecedenceFilterSuppressed() bool
 	setPrecedenceFilterSuppressed(bool)
 
-	shortHash() string
+	shortHash() int
 }
 
 type BaseATNConfig struct {
@@ -121,6 +122,7 @@ func (b *BaseATNConfig) GetAlt() int {
 func (b *BaseATNConfig) SetContext(v PredictionContext) {
 	b.context = v
 }
+
 func (b *BaseATNConfig) GetContext() PredictionContext {
 	return b.context
 }
@@ -168,20 +170,29 @@ func (b *BaseATNConfig) equals(o interface{}) bool {
 	return nums && alts && cons && sups && equal
 }
 
-func (b *BaseATNConfig) shortHash() string {
-	return strconv.Itoa(b.state.GetStateNumber()) + "/" + strconv.Itoa(b.alt) + "/" + b.semanticContext.String()
+// TODO(pboyer) not altogether clear why this is needed
+func (b *BaseATNConfig) shortHash() int {
+	h := initMurmurHash(7)
+	h = updateMurmurHash(h, b.state.GetStateNumber())
+	h = updateMurmurHash(h, b.alt)
+	h = updateMurmurHash(h, b.semanticContext.Hash())
+	return finishMurmurHash(h, 3)
 }
 
-func (b *BaseATNConfig) Hash() string {
-	var c string
-
+func (b *BaseATNConfig) Hash() int {
+	var c int
 	if b.context == nil {
-		c = ""
+		c = 0
 	} else {
 		c = b.context.Hash()
 	}
 
-	return strconv.Itoa(b.state.GetStateNumber()) + "/" + strconv.Itoa(b.alt) + "/" + c + "/" + b.semanticContext.String()
+	h := initMurmurHash(7)
+	h = updateMurmurHash(h, b.state.GetStateNumber())
+	h = updateMurmurHash(h, b.alt)
+	h = updateMurmurHash(h, c)
+	h = updateMurmurHash(h, b.semanticContext.Hash())
+	return finishMurmurHash(h, 4)
 }
 
 func (b *BaseATNConfig) String() string {
@@ -247,16 +258,22 @@ func NewLexerATNConfig1(state ATNState, alt int, context PredictionContext) *Lex
 	return &LexerATNConfig{BaseATNConfig: NewBaseATNConfig5(state, alt, context, SemanticContextNone)}
 }
 
-func (l *LexerATNConfig) Hash() string {
-	var f string
-
+func (l *LexerATNConfig) Hash() int {
+	var f int
 	if l.passedThroughNonGreedyDecision {
-		f = "1"
+		f = 1
 	} else {
-		f = "0"
+		f = 0
 	}
 
-	return fmt.Sprintf("%v%v%v%v%v%v", l.state.GetStateNumber(), l.alt, l.context, l.semanticContext, f, l.lexerActionExecutor)
+	h := initMurmurHash(7)
+	h = updateMurmurHash(h, l.state.Hash())
+	h = updateMurmurHash(h, l.alt)
+	h = updateMurmurHash(h, l.context.Hash())
+	h = updateMurmurHash(h, l.semanticContext.Hash())
+	h = updateMurmurHash(h, f)
+	h = updateMurmurHash(h, l.lexerActionExecutor.Hash())
+	return finishMurmurHash(h, 6)
 }
 
 func (l *LexerATNConfig) equals(other interface{}) bool {

--- a/runtime/Go/antlr/atn_config.go
+++ b/runtime/Go/antlr/atn_config.go
@@ -168,7 +168,6 @@ func (b *BaseATNConfig) equals(o interface{}) bool {
 	return nums && alts && cons && sups && equal
 }
 
-// TODO(pboyer) not altogether clear why this is needed
 func (b *BaseATNConfig) shortHash() int {
 	h := murmurInit(7)
 	h = murmurUpdate(h, b.state.GetStateNumber())

--- a/runtime/Go/antlr/atn_config_set.go
+++ b/runtime/Go/antlr/atn_config_set.go
@@ -9,10 +9,10 @@ import "fmt"
 type ATNConfigSet interface {
 	Hasher
 
-	Add(ATNConfig, *DoubleDict) bool
+	Add(ATNConfig, *doubleDict) bool
 	AddAll([]ATNConfig) bool
 
-	GetStates() *Set
+	GetStates() *set
 	GetPredicates() []SemanticContext
 	GetItems() []ATNConfig
 
@@ -33,8 +33,8 @@ type ATNConfigSet interface {
 	ReadOnly() bool
 	SetReadOnly(bool)
 
-	GetConflictingAlts() *BitSet
-	SetConflictingAlts(*BitSet)
+	GetConflictingAlts() *bitSet
+	SetConflictingAlts(*bitSet)
 
 	FullContext() bool
 
@@ -56,7 +56,7 @@ type BaseATNConfigSet struct {
 	// effectively doubles the number of objects associated with ATNConfigs. All
 	// keys are hashed by (s, i, _, pi), not including the context. Wiped out when
 	// read-only because a set becomes a DFA state.
-	configLookup *Set
+	configLookup *set
 
 	// configs is the added elements.
 	configs []ATNConfig
@@ -64,7 +64,7 @@ type BaseATNConfigSet struct {
 	// TODO: These fields make me pretty uncomfortable, but it is nice to pack up
 	// info together because it saves recomputation. Can we track conflicts as they
 	// are added to save scanning configs later?
-	conflictingAlts *BitSet
+	conflictingAlts *bitSet
 
 	// dipsIntoOuterContext is used by parsers and lexers. In a lexer, it indicates
 	// we hit a pred while computing a closure operation. Do not make a DFA state
@@ -95,7 +95,7 @@ type BaseATNConfigSet struct {
 func NewBaseATNConfigSet(fullCtx bool) *BaseATNConfigSet {
 	return &BaseATNConfigSet{
 		cachedHash:   -1,
-		configLookup: NewSet(hashATNConfig, equalATNConfigs),
+		configLookup: newSet(hashATNConfig, equalATNConfigs),
 		fullCtx:      fullCtx,
 	}
 }
@@ -104,7 +104,7 @@ func NewBaseATNConfigSet(fullCtx bool) *BaseATNConfigSet {
 // ATNConfig.state, i is the ATNConfig.alt, and pi is the
 // ATNConfig.semanticContext. We use (s,i,pi) as the key. Updates
 // dipsIntoOuterContext and hasSemanticContext when necessary.
-func (b *BaseATNConfigSet) Add(config ATNConfig, mergeCache *DoubleDict) bool {
+func (b *BaseATNConfigSet) Add(config ATNConfig, mergeCache *doubleDict) bool {
 	if b.readOnly {
 		panic("set is read-only")
 	}
@@ -146,8 +146,8 @@ func (b *BaseATNConfigSet) Add(config ATNConfig, mergeCache *DoubleDict) bool {
 	return true
 }
 
-func (b *BaseATNConfigSet) GetStates() *Set {
-	states := NewSet(nil, nil)
+func (b *BaseATNConfigSet) GetStates() *set {
+	states := newSet(nil, nil)
 
 	for i := 0; i < len(b.configs); i++ {
 		states.add(b.configs[i].GetState())
@@ -281,7 +281,7 @@ func (b *BaseATNConfigSet) Clear() {
 
 	b.configs = make([]ATNConfig, 0)
 	b.cachedHash = -1
-	b.configLookup = NewSet(hashATNConfig, equalATNConfigs)
+	b.configLookup = newSet(hashATNConfig, equalATNConfigs)
 }
 
 func (b *BaseATNConfigSet) FullContext() bool {
@@ -304,11 +304,11 @@ func (b *BaseATNConfigSet) SetUniqueAlt(v int) {
 	b.uniqueAlt = v
 }
 
-func (b *BaseATNConfigSet) GetConflictingAlts() *BitSet {
+func (b *BaseATNConfigSet) GetConflictingAlts() *bitSet {
 	return b.conflictingAlts
 }
 
-func (b *BaseATNConfigSet) SetConflictingAlts(v *BitSet) {
+func (b *BaseATNConfigSet) SetConflictingAlts(v *bitSet) {
 	b.conflictingAlts = v
 }
 
@@ -363,12 +363,12 @@ type OrderedATNConfigSet struct {
 func NewOrderedATNConfigSet() *OrderedATNConfigSet {
 	b := NewBaseATNConfigSet(false)
 
-	b.configLookup = NewSet(nil, nil)
+	b.configLookup = newSet(nil, nil)
 
 	return &OrderedATNConfigSet{BaseATNConfigSet: b}
 }
 
-func hashATNConfig(c interface{}) string {
+func hashATNConfig(c interface{}) int {
 	return c.(ATNConfig).shortHash()
 }
 

--- a/runtime/Go/antlr/atn_config_set.go
+++ b/runtime/Go/antlr/atn_config_set.go
@@ -49,7 +49,7 @@ type ATNConfigSet interface {
 // about its elements and can combine similar configurations using a
 // graph-structured stack.
 type BaseATNConfigSet struct {
-	cachedHash   int
+	cachedHash int
 
 	// configLookup is used to determine whether two BaseATNConfigSets are equal. We
 	// need all configurations with the same (s, i, _, semctx) to be equal. A key
@@ -59,7 +59,7 @@ type BaseATNConfigSet struct {
 	configLookup *Set
 
 	// configs is the added elements.
-	configs      []ATNConfig
+	configs []ATNConfig
 
 	// TODO: These fields make me pretty uncomfortable, but it is nice to pack up
 	// info together because it saves recomputation. Can we track conflicts as they
@@ -84,19 +84,19 @@ type BaseATNConfigSet struct {
 	// allow any code to manipulate the set if true because DFA states will point at
 	// sets and those must not change. It not protect other fields; conflictingAlts
 	// in particular, which is assigned after readOnly.
-	readOnly     bool
+	readOnly bool
 
 	// TODO: These fields make me pretty uncomfortable, but it is nice to pack up
 	// info together because it saves recomputation. Can we track conflicts as they
 	// are added to save scanning configs later?
-	uniqueAlt    int
+	uniqueAlt int
 }
 
 func NewBaseATNConfigSet(fullCtx bool) *BaseATNConfigSet {
 	return &BaseATNConfigSet{
-		cachedHash: -1,
-		configLookup:     NewSet(hashATNConfig, equalATNConfigs),
-		fullCtx:          fullCtx,
+		cachedHash:   -1,
+		configLookup: NewSet(hashATNConfig, equalATNConfigs),
+		fullCtx:      fullCtx,
 	}
 }
 

--- a/runtime/Go/antlr/atn_config_set.go
+++ b/runtime/Go/antlr/atn_config_set.go
@@ -49,7 +49,7 @@ type ATNConfigSet interface {
 // about its elements and can combine similar configurations using a
 // graph-structured stack.
 type BaseATNConfigSet struct {
-	cachedHashString string
+	cachedHash   int
 
 	// configLookup is used to determine whether two BaseATNConfigSets are equal. We
 	// need all configurations with the same (s, i, _, semctx) to be equal. A key
@@ -59,7 +59,7 @@ type BaseATNConfigSet struct {
 	configLookup *Set
 
 	// configs is the added elements.
-	configs []ATNConfig
+	configs      []ATNConfig
 
 	// TODO: These fields make me pretty uncomfortable, but it is nice to pack up
 	// info together because it saves recomputation. Can we track conflicts as they
@@ -84,17 +84,17 @@ type BaseATNConfigSet struct {
 	// allow any code to manipulate the set if true because DFA states will point at
 	// sets and those must not change. It not protect other fields; conflictingAlts
 	// in particular, which is assigned after readOnly.
-	readOnly bool
+	readOnly     bool
 
 	// TODO: These fields make me pretty uncomfortable, but it is nice to pack up
 	// info together because it saves recomputation. Can we track conflicts as they
 	// are added to save scanning configs later?
-	uniqueAlt int
+	uniqueAlt    int
 }
 
 func NewBaseATNConfigSet(fullCtx bool) *BaseATNConfigSet {
 	return &BaseATNConfigSet{
-		cachedHashString: "-1",
+		cachedHash: -1,
 		configLookup:     NewSet(hashATNConfig, equalATNConfigs),
 		fullCtx:          fullCtx,
 	}
@@ -120,7 +120,7 @@ func (b *BaseATNConfigSet) Add(config ATNConfig, mergeCache *DoubleDict) bool {
 	existing := b.configLookup.add(config).(ATNConfig)
 
 	if existing == config {
-		b.cachedHashString = "-1"
+		b.cachedHash = -1
 		b.configs = append(b.configs, config) // Track order here
 
 		return true
@@ -224,26 +224,30 @@ func (b *BaseATNConfigSet) Equals(other interface{}) bool {
 		b.dipsIntoOuterContext == other2.dipsIntoOuterContext
 }
 
-func (b *BaseATNConfigSet) Hash() string {
+func (b *BaseATNConfigSet) Hash() int {
 	if b.readOnly {
-		if b.cachedHashString == "-1" {
-			b.cachedHashString = b.hashConfigs()
+		if b.cachedHash == -1 {
+			b.cachedHash = b.hashConfigs()
 		}
 
-		return b.cachedHashString
+		return b.cachedHash
 	}
 
 	return b.hashConfigs()
 }
 
-func (b *BaseATNConfigSet) hashConfigs() string {
-	s := ""
+func (b *BaseATNConfigSet) hashConfigs() int {
+	h := 1
 
 	for _, c := range b.configs {
-		s += fmt.Sprint(c)
+		h += 31 * h
+
+		if c != nil {
+			h += c.Hash()
+		}
 	}
 
-	return s
+	return h
 }
 
 func (b *BaseATNConfigSet) Length() int {
@@ -276,7 +280,7 @@ func (b *BaseATNConfigSet) Clear() {
 	}
 
 	b.configs = make([]ATNConfig, 0)
-	b.cachedHashString = "-1"
+	b.cachedHash = -1
 	b.configLookup = NewSet(hashATNConfig, equalATNConfigs)
 }
 

--- a/runtime/Go/antlr/atn_deserializer.go
+++ b/runtime/Go/antlr/atn_deserializer.go
@@ -98,7 +98,7 @@ func (a *ATNDeserializer) DeserializeFromUInt16(data []uint16) *ATN {
 	sets = a.readSets(atn, sets, a.readInt)
 	// Next, if the ATN was serialized with the Unicode SMP feature,
 	// deserialize sets with 32-bit arguments <= U+10FFFF.
-	if (a.isFeatureSupported(AddedUnicodeSMP, a.uuid)) {
+	if a.isFeatureSupported(AddedUnicodeSMP, a.uuid) {
 		sets = a.readSets(atn, sets, a.readInt32)
 	}
 

--- a/runtime/Go/antlr/atn_deserializer.go
+++ b/runtime/Go/antlr/atn_deserializer.go
@@ -656,14 +656,6 @@ func (a *ATNDeserializer) readInt32() int {
 	return low | (high << 16)
 }
 
-//TODO
-//func (a *ATNDeserializer) readLong() int64 {
-//    panic("Not implemented")
-//    var low = a.readInt32()
-//    var high = a.readInt32()
-//    return (low & 0x00000000FFFFFFFF) | (high << int32)
-//}
-
 func createByteToHex() []string {
 	bth := make([]string, 256)
 
@@ -806,16 +798,16 @@ func (a *ATNDeserializer) lexerActionFactory(typeIndex, data1, data2 int) LexerA
 		return NewLexerModeAction(data1)
 
 	case LexerActionTypeMore:
-		return LexerMoreActionINSTANCE
+		return LexerMoreActionInstance
 
 	case LexerActionTypePopMode:
-		return LexerPopModeActionINSTANCE
+		return LexerPopModeActionInstance
 
 	case LexerActionTypePushMode:
 		return NewLexerPushModeAction(data1)
 
 	case LexerActionTypeSkip:
-		return LexerSkipActionINSTANCE
+		return LexerSkipActionInstance
 
 	case LexerActionTypeType:
 		return NewLexerTypeAction(data1)

--- a/runtime/Go/antlr/atn_state.go
+++ b/runtime/Go/antlr/atn_state.go
@@ -28,6 +28,8 @@ const (
 var ATNStateInitialNumTransitions = 4
 
 type ATNState interface {
+	Hasher
+
 	GetEpsilonOnlyTransitions() bool
 
 	GetRuleIndex() int
@@ -151,6 +153,10 @@ func (as *BaseATNState) AddTransition(trans Transition, index int) {
 		as.transitions = append(as.transitions[:index], append([]Transition{trans}, as.transitions[index:]...)...)
 		// TODO: as.transitions.splice(index, 1, trans)
 	}
+}
+
+func (as *BaseATNState) Hash() int {
+	return as.stateNumber
 }
 
 type BasicState struct {

--- a/runtime/Go/antlr/dfa.go
+++ b/runtime/Go/antlr/dfa.go
@@ -76,7 +76,7 @@ func (d *DFA) setPrecedenceStartState(precedence int, startState *DFAState) {
 // true or nil otherwise, and d.precedenceDfa is updated.
 func (d *DFA) setPrecedenceDfa(precedenceDfa bool) {
 	if d.precedenceDfa != precedenceDfa {
-		d.states = make(map[string]*DFAState)
+		d.states = make(map[int]*DFAState)
 
 		if precedenceDfa {
 			precedenceState := NewDFAState(-1, NewBaseATNConfigSet(false))

--- a/runtime/Go/antlr/dfa.go
+++ b/runtime/Go/antlr/dfa.go
@@ -14,7 +14,7 @@ type DFA struct {
 
 	// states is all the DFA states. Use Map to get the old state back; Set can only
 	// indicate whether it is there.
-	states map[string]*DFAState
+	states map[int]*DFAState
 
 	s0 *DFAState
 
@@ -27,7 +27,7 @@ func NewDFA(atnStartState DecisionState, decision int) *DFA {
 	return &DFA{
 		atnStartState: atnStartState,
 		decision:      decision,
-		states:        make(map[string]*DFAState),
+		states:        make(map[int]*DFAState),
 	}
 }
 
@@ -93,7 +93,7 @@ func (d *DFA) setPrecedenceDfa(precedenceDfa bool) {
 	}
 }
 
-func (d *DFA) GetStates() map[string]*DFAState {
+func (d *DFA) GetStates() map[int]*DFAState {
 	return d.states
 }
 

--- a/runtime/Go/antlr/dfa_state.go
+++ b/runtime/Go/antlr/dfa_state.go
@@ -6,7 +6,6 @@ package antlr
 
 import (
 	"fmt"
-	"strconv"
 )
 
 // PredPrediction maps a predicate to a predicted alternative.
@@ -91,8 +90,8 @@ func NewDFAState(stateNumber int, configs ATNConfigSet) *DFAState {
 }
 
 // GetAltSet gets the set of all alts mentioned by all ATN configurations in d.
-func (d *DFAState) GetAltSet() *Set {
-	alts := NewSet(nil, nil)
+func (d *DFAState) GetAltSet() *set {
+	alts := newSet(nil, nil)
 
 	if d.configs != nil {
 		for _, c := range d.configs.GetItems() {
@@ -137,7 +136,7 @@ func (d *DFAState) String() string {
 }
 
 func (d *DFAState) Hash() int {
-	h := initMurmurHash(7)
-	h = updateMurmurHash(h, d.configs.Hash())
-	return finishMurmurHash(h, 1)
+	h := murmurInit(7)
+	h = murmurUpdate(h, d.configs.Hash())
+	return murmurFinish(h, 1)
 }

--- a/runtime/Go/antlr/dfa_state.go
+++ b/runtime/Go/antlr/dfa_state.go
@@ -137,7 +137,7 @@ func (d *DFAState) String() string {
 }
 
 func (d *DFAState) Hash() int {
-	h := initMurmurHash(7);
-	h = updateMurmurHash(h, d.configs.Hash());
-	return finishMurmurHash(h, 1);
+	h := initMurmurHash(7)
+	h = updateMurmurHash(h, d.configs.Hash())
+	return finishMurmurHash(h, 1)
 }

--- a/runtime/Go/antlr/dfa_state.go
+++ b/runtime/Go/antlr/dfa_state.go
@@ -133,19 +133,11 @@ func (d *DFAState) equals(other interface{}) bool {
 }
 
 func (d *DFAState) String() string {
-	return strconv.Itoa(d.stateNumber) + ":" + d.Hash()
+	return fmt.Sprintf("%d:%d", d.stateNumber, d.Hash())
 }
 
-func (d *DFAState) Hash() string {
-	var s string
-
-	if d.isAcceptState {
-		if d.predicates != nil {
-			s = "=>" + fmt.Sprint(d.predicates)
-		} else {
-			s = "=>" + fmt.Sprint(d.prediction)
-		}
-	}
-
-	return fmt.Sprint(d.configs) + s
+func (d *DFAState) Hash() int {
+	h := initMurmurHash(7);
+	h = updateMurmurHash(h, d.configs.Hash());
+	return finishMurmurHash(h, 1);
 }

--- a/runtime/Go/antlr/diagnostic_error_listener.go
+++ b/runtime/Go/antlr/diagnostic_error_listener.go
@@ -42,7 +42,7 @@ func NewDiagnosticErrorListener(exactOnly bool) *DiagnosticErrorListener {
 	return n
 }
 
-func (d *DiagnosticErrorListener) ReportAmbiguity(recognizer Parser, dfa *DFA, startIndex, stopIndex int, exact bool, ambigAlts *BitSet, configs ATNConfigSet) {
+func (d *DiagnosticErrorListener) ReportAmbiguity(recognizer Parser, dfa *DFA, startIndex, stopIndex int, exact bool, ambigAlts *bitSet, configs ATNConfigSet) {
 	if d.exactOnly && !exact {
 		return
 	}
@@ -55,7 +55,7 @@ func (d *DiagnosticErrorListener) ReportAmbiguity(recognizer Parser, dfa *DFA, s
 	recognizer.NotifyErrorListeners(msg, nil, nil)
 }
 
-func (d *DiagnosticErrorListener) ReportAttemptingFullContext(recognizer Parser, dfa *DFA, startIndex, stopIndex int, conflictingAlts *BitSet, configs ATNConfigSet) {
+func (d *DiagnosticErrorListener) ReportAttemptingFullContext(recognizer Parser, dfa *DFA, startIndex, stopIndex int, conflictingAlts *bitSet, configs ATNConfigSet) {
 
 	msg := "reportAttemptingFullContext d=" +
 		d.getDecisionDescription(recognizer, dfa) +
@@ -98,11 +98,11 @@ func (d *DiagnosticErrorListener) getDecisionDescription(recognizer Parser, dfa 
 // @return Returns {@code ReportedAlts} if it is not {@code nil}, otherwise
 // returns the set of alternatives represented in {@code configs}.
 //
-func (d *DiagnosticErrorListener) getConflictingAlts(ReportedAlts *BitSet, set ATNConfigSet) *BitSet {
+func (d *DiagnosticErrorListener) getConflictingAlts(ReportedAlts *bitSet, set ATNConfigSet) *bitSet {
 	if ReportedAlts != nil {
 		return ReportedAlts
 	}
-	result := NewBitSet()
+	result := newBitSet()
 	for _, c := range set.GetItems() {
 		result.add(c.GetAlt())
 	}

--- a/runtime/Go/antlr/error_listener.go
+++ b/runtime/Go/antlr/error_listener.go
@@ -51,7 +51,7 @@ func NewConsoleErrorListener() *ConsoleErrorListener {
 //
 // Provides a default instance of {@link ConsoleErrorListener}.
 //
-var ConsoleErrorListenerINSTANCE = NewConsoleErrorListener()
+var ConsoleErrorListenerInstance = NewConsoleErrorListener()
 
 //
 // {@inheritDoc}

--- a/runtime/Go/antlr/error_listener.go
+++ b/runtime/Go/antlr/error_listener.go
@@ -16,8 +16,8 @@ import (
 
 type ErrorListener interface {
 	SyntaxError(recognizer Recognizer, offendingSymbol interface{}, line, column int, msg string, e RecognitionException)
-	ReportAmbiguity(recognizer Parser, dfa *DFA, startIndex, stopIndex int, exact bool, ambigAlts *BitSet, configs ATNConfigSet)
-	ReportAttemptingFullContext(recognizer Parser, dfa *DFA, startIndex, stopIndex int, conflictingAlts *BitSet, configs ATNConfigSet)
+	ReportAmbiguity(recognizer Parser, dfa *DFA, startIndex, stopIndex int, exact bool, ambigAlts *bitSet, configs ATNConfigSet)
+	ReportAttemptingFullContext(recognizer Parser, dfa *DFA, startIndex, stopIndex int, conflictingAlts *bitSet, configs ATNConfigSet)
 	ReportContextSensitivity(recognizer Parser, dfa *DFA, startIndex, stopIndex, prediction int, configs ATNConfigSet)
 }
 
@@ -31,10 +31,10 @@ func NewDefaultErrorListener() *DefaultErrorListener {
 func (d *DefaultErrorListener) SyntaxError(recognizer Recognizer, offendingSymbol interface{}, line, column int, msg string, e RecognitionException) {
 }
 
-func (d *DefaultErrorListener) ReportAmbiguity(recognizer Parser, dfa *DFA, startIndex, stopIndex int, exact bool, ambigAlts *BitSet, configs ATNConfigSet) {
+func (d *DefaultErrorListener) ReportAmbiguity(recognizer Parser, dfa *DFA, startIndex, stopIndex int, exact bool, ambigAlts *bitSet, configs ATNConfigSet) {
 }
 
-func (d *DefaultErrorListener) ReportAttemptingFullContext(recognizer Parser, dfa *DFA, startIndex, stopIndex int, conflictingAlts *BitSet, configs ATNConfigSet) {
+func (d *DefaultErrorListener) ReportAttemptingFullContext(recognizer Parser, dfa *DFA, startIndex, stopIndex int, conflictingAlts *bitSet, configs ATNConfigSet) {
 }
 
 func (d *DefaultErrorListener) ReportContextSensitivity(recognizer Parser, dfa *DFA, startIndex, stopIndex, prediction int, configs ATNConfigSet) {
@@ -89,13 +89,13 @@ func (p *ProxyErrorListener) SyntaxError(recognizer Recognizer, offendingSymbol 
 	}
 }
 
-func (p *ProxyErrorListener) ReportAmbiguity(recognizer Parser, dfa *DFA, startIndex, stopIndex int, exact bool, ambigAlts *BitSet, configs ATNConfigSet) {
+func (p *ProxyErrorListener) ReportAmbiguity(recognizer Parser, dfa *DFA, startIndex, stopIndex int, exact bool, ambigAlts *bitSet, configs ATNConfigSet) {
 	for _, d := range p.delegates {
 		d.ReportAmbiguity(recognizer, dfa, startIndex, stopIndex, exact, ambigAlts, configs)
 	}
 }
 
-func (p *ProxyErrorListener) ReportAttemptingFullContext(recognizer Parser, dfa *DFA, startIndex, stopIndex int, conflictingAlts *BitSet, configs ATNConfigSet) {
+func (p *ProxyErrorListener) ReportAttemptingFullContext(recognizer Parser, dfa *DFA, startIndex, stopIndex int, conflictingAlts *bitSet, configs ATNConfigSet) {
 	for _, d := range p.delegates {
 		d.ReportAttemptingFullContext(recognizer, dfa, startIndex, stopIndex, conflictingAlts, configs)
 	}

--- a/runtime/Go/antlr/lexer.go
+++ b/runtime/Go/antlr/lexer.go
@@ -31,12 +31,12 @@ type Lexer interface {
 type BaseLexer struct {
 	*BaseRecognizer
 
-	Interpreter         ILexerATNSimulator
-	TokenStartCharIndex int
-	TokenStartLine      int
-	TokenStartColumn    int
-	ActionType          int
-	Virt                Lexer // The most derived lexer implementation. Allows virtual method calls.
+	Interpreter            ILexerATNSimulator
+	TokenStartCharIndex    int
+	TokenStartLine         int
+	TokenStartColumn       int
+	ActionType             int
+	Virt                   Lexer // The most derived lexer implementation. Allows virtual method calls.
 
 	input                  CharStream
 	factory                TokenFactory
@@ -45,7 +45,7 @@ type BaseLexer struct {
 	hitEOF                 bool
 	channel                int
 	thetype                int
-	modeStack              IntStack
+	modeStack              intStack
 	mode                   int
 	text                   string
 }
@@ -258,7 +258,7 @@ func (b *BaseLexer) pushMode(m int) {
 	if LexerATNSimulatorDebug {
 		fmt.Println("pushMode " + strconv.Itoa(m))
 	}
-	b.modeStack.Push(b.mode)
+	b.modeStack.push(b.mode)
 	b.mode = m
 }
 
@@ -269,7 +269,7 @@ func (b *BaseLexer) popMode() int {
 	if LexerATNSimulatorDebug {
 		fmt.Println("popMode back to " + fmt.Sprint(b.modeStack[0:len(b.modeStack)-1]))
 	}
-	i, _ := b.modeStack.Pop()
+	i, _ := b.modeStack.pop()
 	b.mode = i
 	return b.mode
 }

--- a/runtime/Go/antlr/lexer_action.go
+++ b/runtime/Go/antlr/lexer_action.go
@@ -4,7 +4,10 @@
 
 package antlr
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 const (
 	LexerActionTypeChannel  = 0 //The type of a {@link LexerChannelAction} action.
@@ -18,10 +21,11 @@ const (
 )
 
 type LexerAction interface {
+	Hasher
+
 	getActionType() int
 	getIsPositionDependent() bool
 	execute(lexer Lexer)
-	Hash() string
 	equals(other LexerAction) bool
 }
 
@@ -51,8 +55,8 @@ func (b *BaseLexerAction) getIsPositionDependent() bool {
 	return b.isPositionDependent
 }
 
-func (b *BaseLexerAction) Hash() string {
-	return strconv.Itoa(b.actionType)
+func (b *BaseLexerAction) Hash() int {
+	return b.actionType
 }
 
 func (b *BaseLexerAction) equals(other LexerAction) bool {
@@ -75,7 +79,7 @@ func NewLexerSkipAction() *LexerSkipAction {
 }
 
 // Provides a singleton instance of l parameterless lexer action.
-var LexerSkipActionINSTANCE = NewLexerSkipAction()
+var LexerSkipActionInstance = NewLexerSkipAction()
 
 func (l *LexerSkipAction) execute(lexer Lexer) {
 	lexer.Skip()
@@ -104,8 +108,11 @@ func (l *LexerTypeAction) execute(lexer Lexer) {
 	lexer.setType(l.thetype)
 }
 
-func (l *LexerTypeAction) Hash() string {
-	return strconv.Itoa(l.actionType) + strconv.Itoa(l.thetype)
+func (l *LexerTypeAction) Hash() int {
+	h := initMurmurHash(0)
+	h = updateMurmurHash(h, l.actionType)
+	h = updateMurmurHash(h, l.thetype)
+	return finishMurmurHash(h, 2)
 }
 
 func (l *LexerTypeAction) equals(other LexerAction) bool {
@@ -119,7 +126,7 @@ func (l *LexerTypeAction) equals(other LexerAction) bool {
 }
 
 func (l *LexerTypeAction) String() string {
-	return "actionType(" + strconv.Itoa(l.thetype) + ")"
+	return fmt.Sprintf("actionType(%d)", l.thetype)
 }
 
 // Implements the {@code pushMode} lexer action by calling
@@ -145,8 +152,11 @@ func (l *LexerPushModeAction) execute(lexer Lexer) {
 	lexer.pushMode(l.mode)
 }
 
-func (l *LexerPushModeAction) Hash() string {
-	return strconv.Itoa(l.actionType) + strconv.Itoa(l.mode)
+func (l *LexerPushModeAction) Hash() int {
+	h := initMurmurHash(0)
+	h = updateMurmurHash(h, l.actionType)
+	h = updateMurmurHash(h, l.mode)
+	return finishMurmurHash(h, 2)
 }
 
 func (l *LexerPushModeAction) equals(other LexerAction) bool {
@@ -160,7 +170,7 @@ func (l *LexerPushModeAction) equals(other LexerAction) bool {
 }
 
 func (l *LexerPushModeAction) String() string {
-	return "pushMode(" + strconv.Itoa(l.mode) + ")"
+	return fmt.Sprintf("pushMode(%d)", l.mode)
 }
 
 // Implements the {@code popMode} lexer action by calling {@link Lexer//popMode}.
@@ -180,7 +190,7 @@ func NewLexerPopModeAction() *LexerPopModeAction {
 	return l
 }
 
-var LexerPopModeActionINSTANCE = NewLexerPopModeAction()
+var LexerPopModeActionInstance = NewLexerPopModeAction()
 
 // <p>This action is implemented by calling {@link Lexer//popMode}.</p>
 func (l *LexerPopModeAction) execute(lexer Lexer) {
@@ -207,7 +217,7 @@ func NewLexerMoreAction() *LexerMoreAction {
 	return l
 }
 
-var LexerMoreActionINSTANCE = NewLexerMoreAction()
+var LexerMoreActionInstance = NewLexerMoreAction()
 
 // <p>This action is implemented by calling {@link Lexer//popMode}.</p>
 func (l *LexerMoreAction) execute(lexer Lexer) {
@@ -239,8 +249,11 @@ func (l *LexerModeAction) execute(lexer Lexer) {
 	lexer.setMode(l.mode)
 }
 
-func (l *LexerModeAction) Hash() string {
-	return strconv.Itoa(l.actionType) + strconv.Itoa(l.mode)
+func (l *LexerModeAction) Hash() int {
+	h := initMurmurHash(0)
+	h = updateMurmurHash(h, l.actionType)
+	h = updateMurmurHash(h, l.mode)
+	return finishMurmurHash(h, 2)
 }
 
 func (l *LexerModeAction) equals(other LexerAction) bool {
@@ -254,7 +267,7 @@ func (l *LexerModeAction) equals(other LexerAction) bool {
 }
 
 func (l *LexerModeAction) String() string {
-	return "mode(" + strconv.Itoa(l.mode) + ")"
+	return fmt.Sprintf("mode(%d)", l.mode)
 }
 
 // Executes a custom lexer action by calling {@link Recognizer//action} with the
@@ -294,8 +307,12 @@ func (l *LexerCustomAction) execute(lexer Lexer) {
 	lexer.Action(nil, l.ruleIndex, l.actionIndex)
 }
 
-func (l *LexerCustomAction) Hash() string {
-	return strconv.Itoa(l.actionType) + strconv.Itoa(l.ruleIndex) + strconv.Itoa(l.actionIndex)
+func (l *LexerCustomAction) Hash() int {
+	h := initMurmurHash(0)
+	h = updateMurmurHash(h, l.actionType)
+	h = updateMurmurHash(h, l.ruleIndex)
+	h = updateMurmurHash(h, l.actionIndex)
+	return finishMurmurHash(h, 3)
 }
 
 func (l *LexerCustomAction) equals(other LexerAction) bool {
@@ -331,8 +348,11 @@ func (l *LexerChannelAction) execute(lexer Lexer) {
 	lexer.setChannel(l.channel)
 }
 
-func (l *LexerChannelAction) Hash() string {
-	return strconv.Itoa(l.actionType) + strconv.Itoa(l.channel)
+func (l *LexerChannelAction) Hash() int {
+	h := initMurmurHash(0)
+	h = updateMurmurHash(h, l.actionType)
+	h = updateMurmurHash(h, l.channel)
+	return finishMurmurHash(h, 2)
 }
 
 func (l *LexerChannelAction) equals(other LexerAction) bool {
@@ -396,8 +416,12 @@ func (l *LexerIndexedCustomAction) execute(lexer Lexer) {
 	l.lexerAction.execute(lexer)
 }
 
-func (l *LexerIndexedCustomAction) Hash() string {
-	return strconv.Itoa(l.actionType) + strconv.Itoa(l.offset) + l.lexerAction.Hash()
+func (l *LexerIndexedCustomAction) Hash() int {
+	h := initMurmurHash(0)
+	h = updateMurmurHash(h, l.actionType)
+	h = updateMurmurHash(h, l.offset)
+	h = updateMurmurHash(h, l.lexerAction.Hash())
+	return finishMurmurHash(h, 3)
 }
 
 func (l *LexerIndexedCustomAction) equals(other LexerAction) bool {

--- a/runtime/Go/antlr/lexer_action.go
+++ b/runtime/Go/antlr/lexer_action.go
@@ -109,10 +109,10 @@ func (l *LexerTypeAction) execute(lexer Lexer) {
 }
 
 func (l *LexerTypeAction) Hash() int {
-	h := initMurmurHash(0)
-	h = updateMurmurHash(h, l.actionType)
-	h = updateMurmurHash(h, l.thetype)
-	return finishMurmurHash(h, 2)
+	h := murmurInit(0)
+	h = murmurUpdate(h, l.actionType)
+	h = murmurUpdate(h, l.thetype)
+	return murmurFinish(h, 2)
 }
 
 func (l *LexerTypeAction) equals(other LexerAction) bool {
@@ -153,10 +153,10 @@ func (l *LexerPushModeAction) execute(lexer Lexer) {
 }
 
 func (l *LexerPushModeAction) Hash() int {
-	h := initMurmurHash(0)
-	h = updateMurmurHash(h, l.actionType)
-	h = updateMurmurHash(h, l.mode)
-	return finishMurmurHash(h, 2)
+	h := murmurInit(0)
+	h = murmurUpdate(h, l.actionType)
+	h = murmurUpdate(h, l.mode)
+	return murmurFinish(h, 2)
 }
 
 func (l *LexerPushModeAction) equals(other LexerAction) bool {
@@ -250,10 +250,10 @@ func (l *LexerModeAction) execute(lexer Lexer) {
 }
 
 func (l *LexerModeAction) Hash() int {
-	h := initMurmurHash(0)
-	h = updateMurmurHash(h, l.actionType)
-	h = updateMurmurHash(h, l.mode)
-	return finishMurmurHash(h, 2)
+	h := murmurInit(0)
+	h = murmurUpdate(h, l.actionType)
+	h = murmurUpdate(h, l.mode)
+	return murmurFinish(h, 2)
 }
 
 func (l *LexerModeAction) equals(other LexerAction) bool {
@@ -308,11 +308,11 @@ func (l *LexerCustomAction) execute(lexer Lexer) {
 }
 
 func (l *LexerCustomAction) Hash() int {
-	h := initMurmurHash(0)
-	h = updateMurmurHash(h, l.actionType)
-	h = updateMurmurHash(h, l.ruleIndex)
-	h = updateMurmurHash(h, l.actionIndex)
-	return finishMurmurHash(h, 3)
+	h := murmurInit(0)
+	h = murmurUpdate(h, l.actionType)
+	h = murmurUpdate(h, l.ruleIndex)
+	h = murmurUpdate(h, l.actionIndex)
+	return murmurFinish(h, 3)
 }
 
 func (l *LexerCustomAction) equals(other LexerAction) bool {
@@ -349,10 +349,10 @@ func (l *LexerChannelAction) execute(lexer Lexer) {
 }
 
 func (l *LexerChannelAction) Hash() int {
-	h := initMurmurHash(0)
-	h = updateMurmurHash(h, l.actionType)
-	h = updateMurmurHash(h, l.channel)
-	return finishMurmurHash(h, 2)
+	h := murmurInit(0)
+	h = murmurUpdate(h, l.actionType)
+	h = murmurUpdate(h, l.channel)
+	return murmurFinish(h, 2)
 }
 
 func (l *LexerChannelAction) equals(other LexerAction) bool {
@@ -417,11 +417,11 @@ func (l *LexerIndexedCustomAction) execute(lexer Lexer) {
 }
 
 func (l *LexerIndexedCustomAction) Hash() int {
-	h := initMurmurHash(0)
-	h = updateMurmurHash(h, l.actionType)
-	h = updateMurmurHash(h, l.offset)
-	h = updateMurmurHash(h, l.lexerAction.Hash())
-	return finishMurmurHash(h, 3)
+	h := murmurInit(0)
+	h = murmurUpdate(h, l.actionType)
+	h = murmurUpdate(h, l.offset)
+	h = murmurUpdate(h, l.lexerAction.Hash())
+	return murmurFinish(h, 3)
 }
 
 func (l *LexerIndexedCustomAction) equals(other LexerAction) bool {

--- a/runtime/Go/antlr/lexer_action_executor.go
+++ b/runtime/Go/antlr/lexer_action_executor.go
@@ -13,7 +13,7 @@ package antlr
 
 type LexerActionExecutor struct {
 	lexerActions     []LexerAction
-	cachedHashString string
+	cachedHash int
 }
 
 func NewLexerActionExecutor(lexerActions []LexerAction) *LexerActionExecutor {
@@ -28,13 +28,11 @@ func NewLexerActionExecutor(lexerActions []LexerAction) *LexerActionExecutor {
 
 	// Caches the result of {@link //hashCode} since the hash code is an element
 	// of the performance-critical {@link LexerATNConfig//hashCode} operation.
-
-	var s string
+	h := initMurmurHash(0)
 	for _, a := range lexerActions {
-		s += a.Hash()
+		h = updateMurmurHash(h, a.Hash())
 	}
-
-	l.cachedHashString = s // "".join([str(la) for la in
+	l.cachedHash = finishMurmurHash(h, len(lexerActions));
 
 	return l
 }
@@ -157,8 +155,8 @@ func (l *LexerActionExecutor) execute(lexer Lexer, input CharStream, startIndex 
 	}
 }
 
-func (l *LexerActionExecutor) Hash() string {
-	return l.cachedHashString
+func (l *LexerActionExecutor) Hash() int {
+	return l.cachedHash
 }
 
 func (l *LexerActionExecutor) equals(other interface{}) bool {
@@ -167,7 +165,7 @@ func (l *LexerActionExecutor) equals(other interface{}) bool {
 	} else if _, ok := other.(*LexerActionExecutor); !ok {
 		return false
 	} else {
-		return l.cachedHashString == other.(*LexerActionExecutor).cachedHashString &&
+		return l.cachedHash == other.(*LexerActionExecutor).cachedHash &&
 			&l.lexerActions == &other.(*LexerActionExecutor).lexerActions
 	}
 }

--- a/runtime/Go/antlr/lexer_action_executor.go
+++ b/runtime/Go/antlr/lexer_action_executor.go
@@ -12,8 +12,8 @@ package antlr
 // not cause bloating of the {@link DFA} created for the lexer.</p>
 
 type LexerActionExecutor struct {
-	lexerActions     []LexerAction
-	cachedHash int
+	lexerActions []LexerAction
+	cachedHash   int
 }
 
 func NewLexerActionExecutor(lexerActions []LexerAction) *LexerActionExecutor {
@@ -32,7 +32,7 @@ func NewLexerActionExecutor(lexerActions []LexerAction) *LexerActionExecutor {
 	for _, a := range lexerActions {
 		h = updateMurmurHash(h, a.Hash())
 	}
-	l.cachedHash = finishMurmurHash(h, len(lexerActions));
+	l.cachedHash = finishMurmurHash(h, len(lexerActions))
 
 	return l
 }

--- a/runtime/Go/antlr/lexer_action_executor.go
+++ b/runtime/Go/antlr/lexer_action_executor.go
@@ -28,11 +28,11 @@ func NewLexerActionExecutor(lexerActions []LexerAction) *LexerActionExecutor {
 
 	// Caches the result of {@link //hashCode} since the hash code is an element
 	// of the performance-critical {@link LexerATNConfig//hashCode} operation.
-	h := initMurmurHash(0)
+	h := murmurInit(0)
 	for _, a := range lexerActions {
-		h = updateMurmurHash(h, a.Hash())
+		h = murmurUpdate(h, a.Hash())
 	}
-	l.cachedHash = finishMurmurHash(h, len(lexerActions))
+	l.cachedHash = murmurFinish(h, len(lexerActions))
 
 	return l
 }

--- a/runtime/Go/antlr/lexer_atn_simulator.go
+++ b/runtime/Go/antlr/lexer_atn_simulator.go
@@ -35,7 +35,7 @@ type LexerATNSimulator struct {
 
 	recog              Lexer
 	predictionMode     int
-	mergeCache         DoubleDict
+	mergeCache         doubleDict
 	startIndex         int
 	Line               int
 	CharPositionInLine int

--- a/runtime/Go/antlr/ll1_analyzer.go
+++ b/runtime/Go/antlr/ll1_analyzer.go
@@ -38,9 +38,9 @@ func (la *LL1Analyzer) getDecisionLookahead(s ATNState) []*IntervalSet {
 	look := make([]*IntervalSet, count)
 	for alt := 0; alt < count; alt++ {
 		look[alt] = NewIntervalSet()
-		lookBusy := NewSet(nil, nil)
+		lookBusy := newSet(nil, nil)
 		seeThruPreds := false // fail to get lookahead upon pred
-		la.look1(s.GetTransitions()[alt].getTarget(), nil, BasePredictionContextEMPTY, look[alt], lookBusy, NewBitSet(), seeThruPreds, false)
+		la.look1(s.GetTransitions()[alt].getTarget(), nil, BasePredictionContextEMPTY, look[alt], lookBusy, newBitSet(), seeThruPreds, false)
 		// Wipe out lookahead for la alternative if we found nothing
 		// or we had a predicate when we !seeThruPreds
 		if look[alt].length() == 0 || look[alt].contains(LL1AnalyzerHitPred) {
@@ -75,7 +75,7 @@ func (la *LL1Analyzer) Look(s, stopState ATNState, ctx RuleContext) *IntervalSet
 	if ctx != nil {
 		lookContext = predictionContextFromRuleContext(s.GetATN(), ctx)
 	}
-	la.look1(s, stopState, lookContext, r, NewSet(nil, nil), NewBitSet(), seeThruPreds, true)
+	la.look1(s, stopState, lookContext, r, newSet(nil, nil), newBitSet(), seeThruPreds, true)
 	return r
 }
 
@@ -109,7 +109,7 @@ func (la *LL1Analyzer) Look(s, stopState ATNState, ctx RuleContext) *IntervalSet
 // outermost context is reached. This parameter has no effect if {@code ctx}
 // is {@code nil}.
 
-func (la *LL1Analyzer) look2(s, stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy *Set, calledRuleStack *BitSet, seeThruPreds, addEOF bool, i int) {
+func (la *LL1Analyzer) look2(s, stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy *set, calledRuleStack *bitSet, seeThruPreds, addEOF bool, i int) {
 
 	returnState := la.atn.states[ctx.getReturnState(i)]
 
@@ -126,7 +126,7 @@ func (la *LL1Analyzer) look2(s, stopState ATNState, ctx PredictionContext, look 
 
 }
 
-func (la *LL1Analyzer) look1(s, stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy *Set, calledRuleStack *BitSet, seeThruPreds, addEOF bool) {
+func (la *LL1Analyzer) look1(s, stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy *set, calledRuleStack *bitSet, seeThruPreds, addEOF bool) {
 
 	c := NewBaseATNConfig6(s, 0, ctx)
 
@@ -201,7 +201,7 @@ func (la *LL1Analyzer) look1(s, stopState ATNState, ctx PredictionContext, look 
 	}
 }
 
-func (la *LL1Analyzer) look3(stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy *Set, calledRuleStack *BitSet, seeThruPreds, addEOF bool, t1 *RuleTransition) {
+func (la *LL1Analyzer) look3(stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy *set, calledRuleStack *bitSet, seeThruPreds, addEOF bool, t1 *RuleTransition) {
 
 	newContext := SingletonBasePredictionContextCreate(ctx, t1.followState.GetStateNumber())
 

--- a/runtime/Go/antlr/parser.go
+++ b/runtime/Go/antlr/parser.go
@@ -40,12 +40,12 @@ type BaseParser struct {
 
 	input           TokenStream
 	errHandler      ErrorStrategy
-	precedenceStack IntStack
+	precedenceStack intStack
 	ctx             ParserRuleContext
 
-	tracer         *TraceListener
-	parseListeners []ParseTreeListener
-	_SyntaxErrors  int
+	tracer          *TraceListener
+	parseListeners  []ParseTreeListener
+	_SyntaxErrors   int
 }
 
 // p.is all the parsing support code essentially most of it is error
@@ -62,7 +62,7 @@ func NewBaseParser(input TokenStream) *BaseParser {
 	// instance of {@link DefaultErrorStrategy}.
 	p.errHandler = NewDefaultErrorStrategy()
 	p.precedenceStack = make([]int, 0)
-	p.precedenceStack.Push(0)
+	p.precedenceStack.push(0)
 	// The {@link ParserRuleContext} object for the currently executing rule.
 	// p.is always non-nil during the parsing process.
 	p.ctx = nil
@@ -104,7 +104,7 @@ func (p *BaseParser) reset() {
 	p._SyntaxErrors = 0
 	p.SetTrace(nil)
 	p.precedenceStack = make([]int, 0)
-	p.precedenceStack.Push(0)
+	p.precedenceStack.push(0)
 	if p.Interpreter != nil {
 		p.Interpreter.reset()
 	}
@@ -508,7 +508,7 @@ func (p *BaseParser) GetPrecedence() int {
 
 func (p *BaseParser) EnterRecursionRule(localctx ParserRuleContext, state, ruleIndex, precedence int) {
 	p.SetState(state)
-	p.precedenceStack.Push(precedence)
+	p.precedenceStack.push(precedence)
 	p.ctx = localctx
 	p.ctx.SetStart(p.input.LT(1))
 	if p.parseListeners != nil {
@@ -538,7 +538,7 @@ func (p *BaseParser) PushNewRecursionContext(localctx ParserRuleContext, state, 
 }
 
 func (p *BaseParser) UnrollRecursionContexts(parentCtx ParserRuleContext) {
-	p.precedenceStack.Pop()
+	p.precedenceStack.pop()
 	p.ctx.SetStop(p.input.LT(-1))
 	retCtx := p.ctx // save current ctx (return value)
 	// unroll so ctx is as it was before call to recursive method

--- a/runtime/Go/antlr/parser_atn_simulator.go
+++ b/runtime/Go/antlr/parser_atn_simulator.go
@@ -783,7 +783,7 @@ func (p *ParserATNSimulator) getPredsForAmbigAlts(ambigAlts *BitSet, configs ATN
 	altToPred := make([]SemanticContext, nalts+1)
 	for _, c := range configs.GetItems() {
 		if ambigAlts.contains(c.GetAlt()) {
-			altToPred[c.GetAlt()] = SemanticContextorContext(altToPred[c.GetAlt()], c.GetSemanticContext())
+			altToPred[c.GetAlt()] = SemanticContextOr(altToPred[c.GetAlt()], c.GetSemanticContext())
 		}
 	}
 	nPredAlts := 0
@@ -1174,7 +1174,7 @@ func (p *ParserATNSimulator) precedenceTransition(config ATNConfig,
 				c = NewBaseATNConfig4(config, pt.getTarget()) // no pred context
 			}
 		} else {
-			newSemCtx := SemanticContextandContext(config.GetSemanticContext(), pt.getPredicate())
+			newSemCtx := SemanticContextAnd(config.GetSemanticContext(), pt.getPredicate())
 			c = NewBaseATNConfig3(config, pt.getTarget(), newSemCtx)
 		}
 	} else {
@@ -1210,7 +1210,7 @@ func (p *ParserATNSimulator) predTransition(config ATNConfig, pt *PredicateTrans
 				c = NewBaseATNConfig4(config, pt.getTarget()) // no pred context
 			}
 		} else {
-			newSemCtx := SemanticContextandContext(config.GetSemanticContext(), pt.getPredicate())
+			newSemCtx := SemanticContextAnd(config.GetSemanticContext(), pt.getPredicate())
 			c = NewBaseATNConfig3(config, pt.getTarget(), newSemCtx)
 		}
 	} else {

--- a/runtime/Go/antlr/parser_atn_simulator.go
+++ b/runtime/Go/antlr/parser_atn_simulator.go
@@ -25,7 +25,7 @@ type ParserATNSimulator struct {
 	input          TokenStream
 	startIndex     int
 	dfa            *DFA
-	mergeCache     *DoubleDict
+	mergeCache     *doubleDict
 	outerContext   ParserRuleContext
 }
 
@@ -489,7 +489,7 @@ func (p *ParserATNSimulator) computeReachSet(closure ATNConfigSet, t int, fullCt
 		fmt.Println("in computeReachSet, starting closure: " + closure.String())
 	}
 	if p.mergeCache == nil {
-		p.mergeCache = NewDoubleDict()
+		p.mergeCache = newDoubleDict()
 	}
 	intermediate := NewBaseATNConfigSet(fullCtx)
 
@@ -568,7 +568,7 @@ func (p *ParserATNSimulator) computeReachSet(closure ATNConfigSet, t int, fullCt
 	//
 	if reach == nil {
 		reach = NewBaseATNConfigSet(fullCtx)
-		closureBusy := NewSet(nil, nil)
+		closureBusy := newSet(nil, nil)
 		treatEOFAsEpsilon := t == TokenEOF
 		for k := 0; k < len(intermediate.configs); k++ {
 			p.closure(intermediate.configs[k], reach, closureBusy, false, fullCtx, treatEOFAsEpsilon)
@@ -665,7 +665,7 @@ func (p *ParserATNSimulator) computeStartState(a ATNState, ctx RuleContext, full
 	for i := 0; i < len(a.GetTransitions()); i++ {
 		target := a.GetTransitions()[i].getTarget()
 		c := NewBaseATNConfig6(target, i+1, initialContext)
-		closureBusy := NewSet(nil, nil)
+		closureBusy := newSet(nil, nil)
 		p.closure(c, configs, closureBusy, true, fullCtx, false)
 	}
 	return configs
@@ -778,7 +778,7 @@ func (p *ParserATNSimulator) getReachableTarget(trans Transition, ttype int) ATN
 	return nil
 }
 
-func (p *ParserATNSimulator) getPredsForAmbigAlts(ambigAlts *BitSet, configs ATNConfigSet, nalts int) []SemanticContext {
+func (p *ParserATNSimulator) getPredsForAmbigAlts(ambigAlts *bitSet, configs ATNConfigSet, nalts int) []SemanticContext {
 
 	altToPred := make([]SemanticContext, nalts+1)
 	for _, c := range configs.GetItems() {
@@ -805,7 +805,7 @@ func (p *ParserATNSimulator) getPredsForAmbigAlts(ambigAlts *BitSet, configs ATN
 	return altToPred
 }
 
-func (p *ParserATNSimulator) getPredicatePredictions(ambigAlts *BitSet, altToPred []SemanticContext) []*PredPrediction {
+func (p *ParserATNSimulator) getPredicatePredictions(ambigAlts *bitSet, altToPred []SemanticContext) []*PredPrediction {
 	pairs := make([]*PredPrediction, 0)
 	containsPredicate := false
 	for i := 1; i < len(altToPred); i++ {
@@ -943,8 +943,8 @@ func (p *ParserATNSimulator) splitAccordingToSemanticValidity(configs ATNConfigS
 //  then we stop at the first predicate that evaluates to true. This
 //  includes pairs with nil predicates.
 //
-func (p *ParserATNSimulator) evalSemanticContext(predPredictions []*PredPrediction, outerContext ParserRuleContext, complete bool) *BitSet {
-	predictions := NewBitSet()
+func (p *ParserATNSimulator) evalSemanticContext(predPredictions []*PredPrediction, outerContext ParserRuleContext, complete bool) *bitSet {
+	predictions := newBitSet()
 	for i := 0; i < len(predPredictions); i++ {
 		pair := predPredictions[i]
 		if pair.pred == SemanticContextNone {
@@ -972,13 +972,13 @@ func (p *ParserATNSimulator) evalSemanticContext(predPredictions []*PredPredicti
 	return predictions
 }
 
-func (p *ParserATNSimulator) closure(config ATNConfig, configs ATNConfigSet, closureBusy *Set, collectPredicates, fullCtx, treatEOFAsEpsilon bool) {
+func (p *ParserATNSimulator) closure(config ATNConfig, configs ATNConfigSet, closureBusy *set, collectPredicates, fullCtx, treatEOFAsEpsilon bool) {
 	initialDepth := 0
 	p.closureCheckingStopState(config, configs, closureBusy, collectPredicates,
 		fullCtx, initialDepth, treatEOFAsEpsilon)
 }
 
-func (p *ParserATNSimulator) closureCheckingStopState(config ATNConfig, configs ATNConfigSet, closureBusy *Set, collectPredicates, fullCtx bool, depth int, treatEOFAsEpsilon bool) {
+func (p *ParserATNSimulator) closureCheckingStopState(config ATNConfig, configs ATNConfigSet, closureBusy *set, collectPredicates, fullCtx bool, depth int, treatEOFAsEpsilon bool) {
 
 	if ParserATNSimulatorDebug {
 		fmt.Println("closure(" + config.String() + ")")
@@ -1033,7 +1033,7 @@ func (p *ParserATNSimulator) closureCheckingStopState(config ATNConfig, configs 
 }
 
 // Do the actual work of walking epsilon edges//
-func (p *ParserATNSimulator) closureWork(config ATNConfig, configs ATNConfigSet, closureBusy *Set, collectPredicates, fullCtx bool, depth int, treatEOFAsEpsilon bool) {
+func (p *ParserATNSimulator) closureWork(config ATNConfig, configs ATNConfigSet, closureBusy *set, collectPredicates, fullCtx bool, depth int, treatEOFAsEpsilon bool) {
 	state := config.GetState()
 	// optimization
 	if !state.GetEpsilonOnlyTransitions() {
@@ -1231,7 +1231,7 @@ func (p *ParserATNSimulator) ruleTransition(config ATNConfig, t *RuleTransition)
 	return NewBaseATNConfig1(config, t.getTarget(), newContext)
 }
 
-func (p *ParserATNSimulator) getConflictingAlts(configs ATNConfigSet) *BitSet {
+func (p *ParserATNSimulator) getConflictingAlts(configs ATNConfigSet) *bitSet {
 	altsets := PredictionModegetConflictingAltSubsets(configs)
 	return PredictionModeGetAlts(altsets)
 }
@@ -1272,10 +1272,10 @@ func (p *ParserATNSimulator) getConflictingAlts(configs ATNConfigSet) *BitSet {
 // that we still need to pursue.
 //
 
-func (p *ParserATNSimulator) getConflictingAltsOrUniqueAlt(configs ATNConfigSet) *BitSet {
-	var conflictingAlts *BitSet
+func (p *ParserATNSimulator) getConflictingAltsOrUniqueAlt(configs ATNConfigSet) *bitSet {
+	var conflictingAlts *bitSet
 	if configs.GetUniqueAlt() != ATNInvalidAltNumber {
-		conflictingAlts = NewBitSet()
+		conflictingAlts = newBitSet()
 		conflictingAlts.add(configs.GetUniqueAlt())
 	} else {
 		conflictingAlts = configs.GetConflictingAlts()
@@ -1437,7 +1437,7 @@ func (p *ParserATNSimulator) addDFAState(dfa *DFA, D *DFAState) *DFAState {
 	return D
 }
 
-func (p *ParserATNSimulator) ReportAttemptingFullContext(dfa *DFA, conflictingAlts *BitSet, configs ATNConfigSet, startIndex, stopIndex int) {
+func (p *ParserATNSimulator) ReportAttemptingFullContext(dfa *DFA, conflictingAlts *bitSet, configs ATNConfigSet, startIndex, stopIndex int) {
 	if ParserATNSimulatorDebug || ParserATNSimulatorRetryDebug {
 		interval := NewInterval(startIndex, stopIndex+1)
 		fmt.Println("ReportAttemptingFullContext decision=" + strconv.Itoa(dfa.decision) + ":" + configs.String() +
@@ -1461,7 +1461,7 @@ func (p *ParserATNSimulator) ReportContextSensitivity(dfa *DFA, prediction int, 
 
 // If context sensitive parsing, we know it's ambiguity not conflict//
 func (p *ParserATNSimulator) ReportAmbiguity(dfa *DFA, D *DFAState, startIndex, stopIndex int,
-	exact bool, ambigAlts *BitSet, configs ATNConfigSet) {
+	exact bool, ambigAlts *bitSet, configs ATNConfigSet) {
 	if ParserATNSimulatorDebug || ParserATNSimulatorRetryDebug {
 		interval := NewInterval(startIndex, stopIndex+1)
 		fmt.Println("ReportAmbiguity " + ambigAlts.String() + ":" + configs.String() +

--- a/runtime/Go/antlr/prediction_context.go
+++ b/runtime/Go/antlr/prediction_context.go
@@ -58,16 +58,16 @@ func (b *BasePredictionContext) Hash() int {
 	return b.cachedHash
 }
 
-func calculateHash(parent PredictionContext, returnState int) string {
-	h := initMurmurHash(1)
-	h = updateMurmurHash(h, parent.Hash())
-	h = updateMurmurHash(h, returnState)
-	return finishMurmurHash(h, 2)
+func calculateHash(parent PredictionContext, returnState int) int {
+	h := murmurInit(1)
+	h = murmurUpdate(h, parent.Hash())
+	h = murmurUpdate(h, returnState)
+	return murmurFinish(h, 2)
 }
 
 func calculateEmptyHash() int {
-	h := initMurmurHash(1)
-	return finishMurmurHash(h, 0)
+	h := murmurInit(1)
+	return murmurFinish(h, 0)
 }
 
 // Used to cache {@link BasePredictionContext} objects. Its used for the shared
@@ -122,7 +122,7 @@ type BaseSingletonPredictionContext struct {
 func NewBaseSingletonPredictionContext(parent PredictionContext, returnState int) *BaseSingletonPredictionContext {
 
 	s := new(BaseSingletonPredictionContext)
-	s.BasePredictionContext = NewBasePredictionContext("")
+	s.BasePredictionContext = NewBasePredictionContext(0)
 
 	if parent != nil {
 		s.cachedHash = calculateHash(parent, returnState)
@@ -254,7 +254,7 @@ func NewArrayPredictionContext(parents []PredictionContext, returnStates []int) 
 	// returnState == {@link //EmptyReturnState}.
 
 	c := new(ArrayPredictionContext)
-	c.BasePredictionContext = NewBasePredictionContext("")
+	c.BasePredictionContext = NewBasePredictionContext(0)
 
 	for i := range parents {
 		c.cachedHash += calculateHash(parents[i], returnStates[i])
@@ -362,7 +362,7 @@ func calculateListsHash(parents []BasePredictionContext, returnStates []int) str
 	return s
 }
 
-func merge(a, b PredictionContext, rootIsWildcard bool, mergeCache *DoubleDict) PredictionContext {
+func merge(a, b PredictionContext, rootIsWildcard bool, mergeCache *doubleDict) PredictionContext {
 	// share same graph if both same
 	if a == b {
 		return a
@@ -425,13 +425,13 @@ func merge(a, b PredictionContext, rootIsWildcard bool, mergeCache *DoubleDict) 
 // otherwise false to indicate a full-context merge
 // @param mergeCache
 // /
-func mergeSingletons(a, b *BaseSingletonPredictionContext, rootIsWildcard bool, mergeCache *DoubleDict) PredictionContext {
+func mergeSingletons(a, b *BaseSingletonPredictionContext, rootIsWildcard bool, mergeCache *doubleDict) PredictionContext {
 	if mergeCache != nil {
-		previous := mergeCache.Get(a.Hash(), b.Hash())
+		previous := mergeCache.get(a.Hash(), b.Hash())
 		if previous != nil {
 			return previous.(PredictionContext)
 		}
-		previous = mergeCache.Get(b.Hash(), a.Hash())
+		previous = mergeCache.get(b.Hash(), a.Hash())
 		if previous != nil {
 			return previous.(PredictionContext)
 		}
@@ -585,13 +585,13 @@ func mergeRoot(a, b SingletonPredictionContext, rootIsWildcard bool) PredictionC
 // {@link SingletonBasePredictionContext}.<br>
 // <embed src="images/ArrayMerge_EqualTop.svg" type="image/svg+xml"/></p>
 // /
-func mergeArrays(a, b *ArrayPredictionContext, rootIsWildcard bool, mergeCache *DoubleDict) PredictionContext {
+func mergeArrays(a, b *ArrayPredictionContext, rootIsWildcard bool, mergeCache *doubleDict) PredictionContext {
 	if mergeCache != nil {
-		previous := mergeCache.Get(a.Hash(), b.Hash())
+		previous := mergeCache.get(a.Hash(), b.Hash())
 		if previous != nil {
 			return previous.(PredictionContext)
 		}
-		previous = mergeCache.Get(b.Hash(), a.Hash())
+		previous = mergeCache.get(b.Hash(), a.Hash())
 		if previous != nil {
 			return previous.(PredictionContext)
 		}

--- a/runtime/Go/antlr/prediction_mode.go
+++ b/runtime/Go/antlr/prediction_mode.go
@@ -376,7 +376,7 @@ func PredictionModeallConfigsInRuleStopStates(configs ATNConfigSet) bool {
 // we need exact ambiguity detection when the sets look like
 // {@code A={{1,2}}} or {@code {{1,2},{1,2}}}, etc...</p>
 //
-func PredictionModeresolvesToJustOneViableAlt(altsets []*BitSet) int {
+func PredictionModeresolvesToJustOneViableAlt(altsets []*bitSet) int {
 	return PredictionModegetSingleViableAlt(altsets)
 }
 
@@ -388,7 +388,7 @@ func PredictionModeresolvesToJustOneViableAlt(altsets []*BitSet) int {
 // @return {@code true} if every {@link BitSet} in {@code altsets} has
 // {@link BitSet//cardinality cardinality} &gt 1, otherwise {@code false}
 //
-func PredictionModeallSubsetsConflict(altsets []*BitSet) bool {
+func PredictionModeallSubsetsConflict(altsets []*bitSet) bool {
 	return !PredictionModehasNonConflictingAltSet(altsets)
 }
 
@@ -400,7 +400,7 @@ func PredictionModeallSubsetsConflict(altsets []*BitSet) bool {
 // @return {@code true} if {@code altsets} contains a {@link BitSet} with
 // {@link BitSet//cardinality cardinality} 1, otherwise {@code false}
 //
-func PredictionModehasNonConflictingAltSet(altsets []*BitSet) bool {
+func PredictionModehasNonConflictingAltSet(altsets []*bitSet) bool {
 	for i := 0; i < len(altsets); i++ {
 		alts := altsets[i]
 		if alts.length() == 1 {
@@ -418,7 +418,7 @@ func PredictionModehasNonConflictingAltSet(altsets []*BitSet) bool {
 // @return {@code true} if {@code altsets} contains a {@link BitSet} with
 // {@link BitSet//cardinality cardinality} &gt 1, otherwise {@code false}
 //
-func PredictionModehasConflictingAltSet(altsets []*BitSet) bool {
+func PredictionModehasConflictingAltSet(altsets []*bitSet) bool {
 	for i := 0; i < len(altsets); i++ {
 		alts := altsets[i]
 		if alts.length() > 1 {
@@ -435,8 +435,8 @@ func PredictionModehasConflictingAltSet(altsets []*BitSet) bool {
 // @return {@code true} if every member of {@code altsets} is equal to the
 // others, otherwise {@code false}
 //
-func PredictionModeallSubsetsEqual(altsets []*BitSet) bool {
-	var first *BitSet
+func PredictionModeallSubsetsEqual(altsets []*bitSet) bool {
+	var first *bitSet
 
 	for i := 0; i < len(altsets); i++ {
 		alts := altsets[i]
@@ -457,7 +457,7 @@ func PredictionModeallSubsetsEqual(altsets []*BitSet) bool {
 //
 // @param altsets a collection of alternative subsets
 //
-func PredictionModegetUniqueAlt(altsets []*BitSet) int {
+func PredictionModegetUniqueAlt(altsets []*bitSet) int {
 	all := PredictionModeGetAlts(altsets)
 	if all.length() == 1 {
 		return all.minValue()
@@ -473,8 +473,8 @@ func PredictionModegetUniqueAlt(altsets []*BitSet) int {
 // @param altsets a collection of alternative subsets
 // @return the set of represented alternatives in {@code altsets}
 //
-func PredictionModeGetAlts(altsets []*BitSet) *BitSet {
-	all := NewBitSet()
+func PredictionModeGetAlts(altsets []*bitSet) *bitSet {
+	all := newBitSet()
 	for _, alts := range altsets {
 		all.or(alts)
 	}
@@ -490,20 +490,20 @@ func PredictionModeGetAlts(altsets []*BitSet) *BitSet {
 // alt and not pred
 // </pre>
 //
-func PredictionModegetConflictingAltSubsets(configs ATNConfigSet) []*BitSet {
-	configToAlts := make(map[string]*BitSet)
+func PredictionModegetConflictingAltSubsets(configs ATNConfigSet) []*bitSet {
+	configToAlts := make(map[string]*bitSet)
 
 	for _, c := range configs.GetItems() {
 		key := "key_" + strconv.Itoa(c.GetState().GetStateNumber()) + "/" + c.GetContext().String()
 		alts := configToAlts[key]
 		if alts == nil {
-			alts = NewBitSet()
+			alts = newBitSet()
 			configToAlts[key] = alts
 		}
 		alts.add(c.GetAlt())
 	}
 
-	values := make([]*BitSet, 0)
+	values := make([]*bitSet, 0)
 
 	for k := range configToAlts {
 		if strings.Index(k, "key_") != 0 {
@@ -522,16 +522,16 @@ func PredictionModegetConflictingAltSubsets(configs ATNConfigSet) []*BitSet {
 // map[c.{@link ATNConfig//state state}] U= c.{@link ATNConfig//alt alt}
 // </pre>
 //
-func PredictionModeGetStateToAltMap(configs ATNConfigSet) *AltDict {
-	m := NewAltDict()
+func PredictionModeGetStateToAltMap(configs ATNConfigSet) *altDict {
+	m := newAltDict()
 
 	for _, c := range configs.GetItems() {
 		alts := m.Get(c.GetState().String())
 		if alts == nil {
-			alts = NewBitSet()
+			alts = newBitSet()
 			m.put(c.GetState().String(), alts)
 		}
-		alts.(*BitSet).add(c.GetAlt())
+		alts.(*bitSet).add(c.GetAlt())
 	}
 	return m
 }
@@ -539,14 +539,14 @@ func PredictionModeGetStateToAltMap(configs ATNConfigSet) *AltDict {
 func PredictionModehasStateAssociatedWithOneAlt(configs ATNConfigSet) bool {
 	values := PredictionModeGetStateToAltMap(configs).values()
 	for i := 0; i < len(values); i++ {
-		if values[i].(*BitSet).length() == 1 {
+		if values[i].(*bitSet).length() == 1 {
 			return true
 		}
 	}
 	return false
 }
 
-func PredictionModegetSingleViableAlt(altsets []*BitSet) int {
+func PredictionModegetSingleViableAlt(altsets []*bitSet) int {
 	result := ATNInvalidAltNumber
 
 	for i := 0; i < len(altsets); i++ {

--- a/runtime/Go/antlr/recognizer.go
+++ b/runtime/Go/antlr/recognizer.go
@@ -40,7 +40,7 @@ type BaseRecognizer struct {
 
 func NewBaseRecognizer() *BaseRecognizer {
 	rec := new(BaseRecognizer)
-	rec.listeners = []ErrorListener{ConsoleErrorListenerINSTANCE}
+	rec.listeners = []ErrorListener{ConsoleErrorListenerInstance}
 	rec.state = -1
 	return rec
 }
@@ -110,7 +110,6 @@ func (b *BaseRecognizer) SetState(v int) {
 // <p>Used for XPath and tree pattern compilation.</p>
 //
 func (b *BaseRecognizer) GetRuleIndexMap() map[string]int {
-
 	panic("Method not defined!")
 	//    var ruleNames = b.GetRuleNames()
 	//    if (ruleNames==nil) {

--- a/runtime/Go/antlr/semantic_context.go
+++ b/runtime/Go/antlr/semantic_context.go
@@ -101,11 +101,11 @@ func (p *Predicate) Hash() int {
 		c = 1
 	}
 
-	h := initMurmurHash(0)
-	h = updateMurmurHash(h, p.ruleIndex)
-	h = updateMurmurHash(h, p.predIndex)
-	h = updateMurmurHash(h, c)
-	return finishMurmurHash(h, 3)
+	h := murmurInit(0)
+	h = murmurUpdate(h, p.ruleIndex)
+	h = murmurUpdate(h, p.predIndex)
+	h = murmurUpdate(h, c)
+	return murmurFinish(h, 3)
 }
 
 func (p *Predicate) equals(other interface{}) bool {
@@ -170,7 +170,7 @@ func (p *PrecedencePredicate) String() string {
 	return "{" + strconv.Itoa(p.precedence) + ">=prec}?"
 }
 
-func PrecedencePredicatefilterPrecedencePredicates(set *Set) []*PrecedencePredicate {
+func PrecedencePredicatefilterPrecedencePredicates(set *set) []*PrecedencePredicate {
 	result := make([]*PrecedencePredicate, 0)
 
 	for _, v := range set.values() {
@@ -190,7 +190,7 @@ type AND struct {
 }
 
 func NewAND(a, b SemanticContext) *AND {
-	operands := NewSet(nil, nil)
+	operands := newSet(nil, nil)
 	if aa, ok := a.(*AND); ok {
 		for _, o := range aa.opnds {
 			operands.add(o)
@@ -248,11 +248,11 @@ func (a *AND) equals(other interface{}) bool {
 }
 
 func (a *AND) Hash() int {
-	h := initMurmurHash(0) // Init with a value different from OR
+	h := murmurInit(0) // Init with a value different from OR
 	for _, op := range a.opnds {
-		h = updateMurmurHash(h, op.Hash())
+		h = murmurUpdate(h, op.Hash())
 	}
-	return finishMurmurHash(h, len(a.opnds))
+	return murmurFinish(h, len(a.opnds))
 }
 
 //
@@ -334,7 +334,7 @@ type OR struct {
 
 func NewOR(a, b SemanticContext) *OR {
 
-	operands := NewSet(nil, nil)
+	operands := newSet(nil, nil)
 	if aa, ok := a.(*OR); ok {
 		for _, o := range aa.opnds {
 			operands.add(o)
@@ -393,11 +393,11 @@ func (o *OR) equals(other interface{}) bool {
 }
 
 func (o *OR) Hash() int {
-	h := initMurmurHash(1) // Init with a value different from AND
+	h := murmurInit(1) // Init with a value different from AND
 	for _, op := range o.opnds {
-		h = updateMurmurHash(h, op.Hash())
+		h = murmurUpdate(h, op.Hash())
 	}
-	return finishMurmurHash(h, len(o.opnds))
+	return murmurFinish(h, len(o.opnds))
 }
 
 // <p>

--- a/runtime/Go/antlr/semantic_context.go
+++ b/runtime/Go/antlr/semantic_context.go
@@ -153,7 +153,7 @@ func (p *PrecedencePredicate) compareTo(other *PrecedencePredicate) int {
 }
 
 func (p *PrecedencePredicate) Hash() int {
-	return 31 + p.precedence;
+	return 31 + p.precedence
 }
 
 func (p *PrecedencePredicate) equals(other interface{}) bool {

--- a/runtime/Go/antlr/utils.go
+++ b/runtime/Go/antlr/utils.go
@@ -30,34 +30,34 @@ func intMax(a, b int) int {
 
 // A simple integer stack
 
-type IntStack []int
+type intStack []int
 
-var ErrEmptyStack = errors.New("Stack is empty")
+var errEmptyStack = errors.New("Stack is empty")
 
-func (s *IntStack) Pop() (int, error) {
+func (s *intStack) pop() (int, error) {
 	l := len(*s) - 1
 	if l < 0 {
-		return 0, ErrEmptyStack
+		return 0, errEmptyStack
 	}
 	v := (*s)[l]
 	*s = (*s)[0:l]
 	return v, nil
 }
 
-func (s *IntStack) Push(e int) {
+func (s *intStack) push(e int) {
 	*s = append(*s, e)
 }
 
-type Set struct {
+type set struct {
 	data           map[int][]interface{}
 	hashFunction   func(interface{}) int
 	equalsFunction func(interface{}, interface{}) bool
 }
 
-func NewSet(hashFunction func(interface{}) string, equalsFunction func(interface{}, interface{}) bool) *Set {
-	s := new(Set)
+func newSet(hashFunction func(interface{}) int, equalsFunction func(interface{}, interface{}) bool) *set {
+	s := new(set)
 
-	s.data = make(map[string][]interface{})
+	s.data = make(map[int][]interface{})
 
 	if hashFunction == nil {
 		s.hashFunction = hasherHash
@@ -66,7 +66,7 @@ func NewSet(hashFunction func(interface{}) string, equalsFunction func(interface
 	}
 
 	if equalsFunction == nil {
-		s.equalsFunction = standardEqualsFunction
+		s.equalsFunction = comparableHash
 	} else {
 		s.equalsFunction = equalsFunction
 	}
@@ -74,7 +74,7 @@ func NewSet(hashFunction func(interface{}) string, equalsFunction func(interface
 	return s
 }
 
-func standardEqualsFunction(a interface{}, b interface{}) bool {
+func comparableHash(a interface{}, b interface{}) bool {
 
 	ac, oka := a.(Comparable)
 	bc, okb := b.(Comparable)
@@ -86,7 +86,7 @@ func standardEqualsFunction(a interface{}, b interface{}) bool {
 	return ac.equals(bc)
 }
 
-func hasherHash(a interface{}) string {
+func hasherHash(a interface{}) int {
 	h, ok := a.(Hasher)
 
 	if ok {
@@ -106,15 +106,13 @@ func hashCode(s string) int {
 	return int(h.Sum32())
 }
 
-func (s *Set) length() int {
+func (s *set) length() int {
 	return len(s.data)
 }
 
-func (s *Set) add(value interface{}) interface{} {
+func (s *set) add(value interface{}) interface{} {
 
-	hash := s.hashFunction(value)
-	key := hashCode(hash)
-
+	key := s.hashFunction(value)
 	values := s.data[key]
 
 	if s.data[key] != nil {
@@ -133,10 +131,8 @@ func (s *Set) add(value interface{}) interface{} {
 	return value
 }
 
-func (s *Set) contains(value interface{}) bool {
-
-	hash := s.hashFunction(value)
-	key := hashCode(hash)
+func (s *set) contains(value interface{}) bool {
+	key := s.hashFunction(value)
 
 	values := s.data[key]
 
@@ -150,18 +146,16 @@ func (s *Set) contains(value interface{}) bool {
 	return false
 }
 
-func (s *Set) values() []interface{} {
-	l := make([]interface{}, 0)
+func (s *set) values() []interface{} {
+	l := make([]interface{}, 10)
 
 	for key := range s.data {
-		if strings.Index(key, "hash_") == 0 {
-			l = append(l, s.data[key]...)
-		}
+		l = append(l, s.data[key]...)
 	}
 	return l
 }
 
-func (s *Set) String() string {
+func (s *set) String() string {
 	r := ""
 
 	for _, av := range s.data {
@@ -173,39 +167,39 @@ func (s *Set) String() string {
 	return r
 }
 
-type BitSet struct {
+type bitSet struct {
 	data map[int]bool
 }
 
-func NewBitSet() *BitSet {
-	b := new(BitSet)
+func newBitSet() *bitSet {
+	b := new(bitSet)
 	b.data = make(map[int]bool)
 	return b
 }
 
-func (b *BitSet) add(value int) {
+func (b *bitSet) add(value int) {
 	b.data[value] = true
 }
 
-func (b *BitSet) clear(index int) {
+func (b *bitSet) clear(index int) {
 	delete(b.data, index)
 }
 
-func (b *BitSet) or(set *BitSet) {
+func (b *bitSet) or(set *bitSet) {
 	for k := range set.data {
 		b.add(k)
 	}
 }
 
-func (b *BitSet) remove(value int) {
+func (b *bitSet) remove(value int) {
 	delete(b.data, value)
 }
 
-func (b *BitSet) contains(value int) bool {
+func (b *bitSet) contains(value int) bool {
 	return b.data[value] == true
 }
 
-func (b *BitSet) values() []int {
+func (b *bitSet) values() []int {
 	ks := make([]int, len(b.data))
 	i := 0
 	for k := range b.data {
@@ -216,7 +210,7 @@ func (b *BitSet) values() []int {
 	return ks
 }
 
-func (b *BitSet) minValue() int {
+func (b *bitSet) minValue() int {
 	min := 2147483647
 
 	for k := range b.data {
@@ -228,8 +222,8 @@ func (b *BitSet) minValue() int {
 	return min
 }
 
-func (b *BitSet) equals(other interface{}) bool {
-	otherBitSet, ok := other.(*BitSet)
+func (b *bitSet) equals(other interface{}) bool {
+	otherBitSet, ok := other.(*bitSet)
 	if !ok {
 		return false
 	}
@@ -247,11 +241,11 @@ func (b *BitSet) equals(other interface{}) bool {
 	return true
 }
 
-func (b *BitSet) length() int {
+func (b *bitSet) length() int {
 	return len(b.data)
 }
 
-func (b *BitSet) String() string {
+func (b *bitSet) String() string {
 	vals := b.values()
 	valsS := make([]string, len(vals))
 
@@ -261,27 +255,27 @@ func (b *BitSet) String() string {
 	return "{" + strings.Join(valsS, ", ") + "}"
 }
 
-type AltDict struct {
+type altDict struct {
 	data map[string]interface{}
 }
 
-func NewAltDict() *AltDict {
-	d := new(AltDict)
+func newAltDict() *altDict {
+	d := new(altDict)
 	d.data = make(map[string]interface{})
 	return d
 }
 
-func (a *AltDict) Get(key string) interface{} {
+func (a *altDict) Get(key string) interface{} {
 	key = "k-" + key
 	return a.data[key]
 }
 
-func (a *AltDict) put(key string, value interface{}) {
+func (a *altDict) put(key string, value interface{}) {
 	key = "k-" + key
 	a.data[key] = value
 }
 
-func (a *AltDict) values() []interface{} {
+func (a *altDict) values() []interface{} {
 	vs := make([]interface{}, len(a.data))
 	i := 0
 	for _, v := range a.data {
@@ -291,17 +285,17 @@ func (a *AltDict) values() []interface{} {
 	return vs
 }
 
-type DoubleDict struct {
-	data map[string]map[string]interface{}
+type doubleDict struct {
+	data map[int]map[int]interface{}
 }
 
-func NewDoubleDict() *DoubleDict {
-	dd := new(DoubleDict)
+func newDoubleDict() *doubleDict {
+	dd := new(doubleDict)
 	dd.data = make(map[int]map[int]interface{})
 	return dd
 }
 
-func (d *DoubleDict) Get(a, b int) interface{} {
+func (d *doubleDict) get(a, b int) interface{} {
 	data := d.data[a]
 
 	if data == nil {
@@ -311,11 +305,11 @@ func (d *DoubleDict) Get(a, b int) interface{} {
 	return data[b]
 }
 
-func (d *DoubleDict) set(a, b int, o interface{}) {
+func (d *doubleDict) set(a, b int, o interface{}) {
 	data := d.data[a]
 
 	if data == nil {
-		data = make(map[string]interface{})
+		data = make(map[int]interface{})
 		d.data[a] = data
 	}
 
@@ -367,11 +361,11 @@ const (
 	n1_32 = 0xE6546B64
 )
 
-func initMurmurHash(seed int) int {
+func murmurInit(seed int) int {
 	return seed
 }
 
-func updateMurmurHash(h1 int, k1 int) int {
+func murmurUpdate(h1 int, k1 int) int {
 	k1 *= c1_32
 	k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
 	k1 *= c2_32
@@ -382,7 +376,7 @@ func updateMurmurHash(h1 int, k1 int) int {
 	return h1
 }
 
-func finishMurmurHash(h1 int, numberOfWords int) int {
+func murmurFinish(h1 int, numberOfWords int) int {
 	h1 ^= (numberOfWords * 4)
 	h1 ^= h1 >> 16
 	h1 *= 0x85ebca6b

--- a/runtime/Go/antlr/utils.go
+++ b/runtime/Go/antlr/utils.go
@@ -360,7 +360,6 @@ func PrintArrayJavaStyle(sa []string) string {
 	return buffer.String()
 }
 
-
 // murmur hash
 const (
 	c1_32 = 0xCC9E2D51


### PR DESCRIPTION
This pull request continues the work that @millergarym started with some refinement and cleanup.

I generally followed the pattern established by @sharwell in the Java runtime. That is, I often adopted the same initialization number as he did.

In this PR, I started some work to reduced the visibility of various internal data structures in the `antlr` package, so this PR is technically API breaking. I plan a follow up PR that takes the API scope reduction further.