### PR TITLE
A few last escapes: \p{EmojiPresentation=EmojiDefault} and \p{EmojiPresentation=TextDefault}

### DIFF
--- a/doc/lexer-rules.md
+++ b/doc/lexer-rules.md
@@ -66,6 +66,14 @@ Match that character or sequence of characters. E.g., ’while’ or ’=’.</t
 
 <p>As a shortcut for <tt>\p{Block=Latin_1_Supplement}</tt>, you can refer to blocks using <a href="http://www.unicode.org/Public/UCD/latest/ucd/Blocks.txt">Unicode block names</a> prefixed with <tt>In</tt> and with spaces changed to <tt>_</tt>. For example: <tt>\p{InLatin_1_Supplement}</tt>, <tt>\p{InYijing_Hexagram_Symbols}</tt>, and <tt>\p{InAncient_Greek_Numbers}</tt>.</p>
 
+<p>A few extra properties are supported:</p>
+<ul>
+<li><tt>\p{Extended_Pictographic}</tt> (see <a href="http://unicode.org/reports/tr35/">UTS #35</a>)</li>
+<li><tt>\p{EmojiPresentation=EmojiDefault}</tt> (code points which have colorful emoji-style presentation by default but which can also be displayed text-style)</li>
+<li><tt>\p{EmojiPresentation=TextDefault}</tt> (code points which have black-and-white text-style presentation by default but which can also be displayed emoji-style)</li>
+<li><tt>\p{EmojiPresentation=Text}</tt> (code points which have only black-and-white text-style and lack a colorful emoji-style presentation)</li>
+</ul>
+
 <p>Property names are <b>case-insensitive</b>, and <tt>_</tt> and <tt>-</tt> are treated identically</p>
 
 <p>Here are a few examples:</p>

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestUnicodeData.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestUnicodeData.java
@@ -176,6 +176,28 @@ public class TestUnicodeData {
 				UnicodeData.getPropertyCodePoints("Extended_Pictographic").contains('0'));
         }
 
+        @Test
+        public void emojiPresentation() {
+		assertTrue(
+				"U+1F4A9 PILE OF POO is in EmojiPresentation=EmojiDefault",
+				UnicodeData.getPropertyCodePoints("EmojiPresentation=EmojiDefault").contains(0x1F4A9));
+		assertFalse(
+				"0 is not in EmojiPresentation=EmojiDefault",
+				UnicodeData.getPropertyCodePoints("EmojiPresentation=EmojiDefault").contains('0'));
+		assertFalse(
+				"A is not in EmojiPresentation=EmojiDefault",
+				UnicodeData.getPropertyCodePoints("EmojiPresentation=EmojiDefault").contains('A'));
+		assertFalse(
+				"U+1F4A9 PILE OF POO is not in EmojiPresentation=TextDefault",
+				UnicodeData.getPropertyCodePoints("EmojiPresentation=TextDefault").contains(0x1F4A9));
+		assertTrue(
+				"0 is in EmojiPresentation=TextDefault",
+				UnicodeData.getPropertyCodePoints("EmojiPresentation=TextDefault").contains('0'));
+		assertFalse(
+				"A is not in EmojiPresentation=TextDefault",
+				UnicodeData.getPropertyCodePoints("EmojiPresentation=TextDefault").contains('A'));
+        }
+
 	@Test
 	public void testPropertyCaseInsensitivity() {
 		assertTrue(UnicodeData.getPropertyCodePoints("l").contains('x'));

--- a/tool/src/org/antlr/v4/unicode/UnicodeDataTemplateController.java
+++ b/tool/src/org/antlr/v4/unicode/UnicodeDataTemplateController.java
@@ -76,6 +76,7 @@ public abstract class UnicodeDataTemplateController {
 		addUnicodeBinaryPropertyCodesToCodePointRanges(propertyCodePointRanges);
 		addUnicodeIntPropertyCodesToCodePointRanges(propertyCodePointRanges);
 		addTR35ExtendedPictographicPropertyCodesToCodePointRanges(propertyCodePointRanges);
+		addEmojiPresentationPropertyCodesToCodePointRanges(propertyCodePointRanges);
 
 		Map<String, String> propertyAliases = new LinkedHashMap<>();
 		addUnicodeCategoryCodesToNames(propertyAliases);
@@ -348,6 +349,23 @@ public abstract class UnicodeDataTemplateController {
 		addUnicodeSetToIntervalSet(emojiNRKUnicodeSet, emojiNRKIntervalSet);
 		propertyCodePointRanges.put("EmojiNRK", emojiNRKIntervalSet);
 	}
+
+	private static void addEmojiPresentationPropertyCodesToCodePointRanges(Map<String, IntervalSet> propertyCodePointRanges) {
+		UnicodeSet emojiDefaultUnicodeSet = new UnicodeSet("[[\\p{Emoji=Yes}]&[\\p{Emoji_Presentation=Yes}]]");
+		IntervalSet emojiDefaultIntervalSet = new IntervalSet();
+		addUnicodeSetToIntervalSet(emojiDefaultUnicodeSet, emojiDefaultIntervalSet);
+		propertyCodePointRanges.put("EmojiPresentation=EmojiDefault", emojiDefaultIntervalSet);
+
+		UnicodeSet textDefaultUnicodeSet = new UnicodeSet("[[\\p{Emoji=Yes}]&[\\p{Emoji_Presentation=No}]]");
+		IntervalSet textDefaultIntervalSet = new IntervalSet();
+		addUnicodeSetToIntervalSet(textDefaultUnicodeSet, textDefaultIntervalSet);
+		propertyCodePointRanges.put("EmojiPresentation=TextDefault", textDefaultIntervalSet);
+
+		UnicodeSet textUnicodeSet = new UnicodeSet("[\\p{Emoji=No}]");
+		IntervalSet textIntervalSet = new IntervalSet();
+		addUnicodeSetToIntervalSet(textUnicodeSet, textIntervalSet);
+		propertyCodePointRanges.put("EmojiPresentation=Text", textIntervalSet);
+        }
 
 	private static void addIntPropertyAliases(int property, String namePrefix, Map<String, String> propertyAliases) {
 		String propertyName = getShortPropertyName(property);


### PR DESCRIPTION
To finish the Unicode grapheme cluster parser, we need a few more `\p` properties:

`\p{EmojiPresentation=EmojiDefault}`
`\p{EmojiPresentation=TextDefault}`
`\p{EmojiPresentation=Text}`

This data comes from ICU, but it uses an extended set syntax which ANTLR's `\p` escape doesn't currently support, so I'm including it as a specific escape.

I updated the docs and tests.