### PR TITLE
New C# CharStreams static factory class

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
@@ -725,13 +725,11 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
 				"\n" +
 				"public class Test {\n" +
 				"    public static void Main(string[] args) {\n" +
-				"        string inputData = File.ReadAllText(args[0], Encoding.UTF8);\n" +
+				"        var input = CharStreams.fromPath(args[0]);\n" +
                 "        using (FileStream fsOut = new FileStream(args[1], FileMode.Create, FileAccess.Write))\n" +
                 "        using (FileStream fsErr = new FileStream(args[2], FileMode.Create, FileAccess.Write))\n" +
 				"        using (TextWriter output = new StreamWriter(fsOut),\n" +
 				"                          errorOutput = new StreamWriter(fsErr)) {\n" +
-				"                CodePointCharStream input = new CodePointCharStream(inputData);\n" +
-				"                input.name = args[0];\n" +
 				"                <lexerName> lex = new <lexerName>(input, output, errorOutput);\n" +
 				"                CommonTokenStream tokens = new CommonTokenStream(lex);\n" +
 				"                <createParser>\n"+
@@ -780,8 +778,7 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
 				"\n" +
 				"public class Test {\n" +
 				"    public static void Main(string[] args) {\n" +
-				"        string inputData = File.ReadAllText(args[0], Encoding.UTF8);\n" +
-				"        ICharStream input = new CodePointCharStream(inputData);\n" +
+				"        var input = CharStreams.fromPath(args[0]);\n" +
                 "        using (FileStream fsOut = new FileStream(args[1], FileMode.Create, FileAccess.Write))\n" +
                 "        using (FileStream fsErr = new FileStream(args[2], FileMode.Create, FileAccess.Write))\n" +
 				"        using (TextWriter output = new StreamWriter(fsOut),\n" +

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.mono.csproj
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.mono.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Atn\ATNDeserializationOptions.cs" />
     <Compile Include="Atn\ATNDeserializer.cs" />
     <Compile Include="Atn\ConflictInfo.cs" />
+    <Compile Include="CharStreams.cs" />
     <Compile Include="Dfa\AcceptStateInfo.cs" />
     <Compile Include="IVocabulary.cs" />
     <Compile Include="Vocabulary.cs" />

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.vs2013.csproj
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.vs2013.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Atn\ATNDeserializationOptions.cs" />
     <Compile Include="Atn\ATNDeserializer.cs" />
     <Compile Include="Atn\ConflictInfo.cs" />
+    <Compile Include="CharStreams.cs" />
     <Compile Include="Dfa\AbstractEdgeMap.cs" />
     <Compile Include="Dfa\AcceptStateInfo.cs" />
     <Compile Include="Dfa\ArrayEdgeMap.cs" />

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CharStreams.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CharStreams.cs
@@ -1,0 +1,93 @@
+/* Copyright (c) 2012-2016 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using System.IO;
+using System.Text;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using Antlr4.Runtime.Sharpen;
+
+namespace Antlr4.Runtime
+{
+    /// <summary>Utility class to create <see cref="ICharStream"/>s from various sources of
+    /// string data.
+    ///
+    /// The methods in this utility class support the full range of
+    /// Unicode code points up to U+10FFFF, unlike <see cref="AntlrInputStream"/>,
+    /// which is limited to 16-bit Unicode code units up to U+FFFF.
+    /// </summary>
+    public static class CharStreams
+    {
+        /// <summary>Creates an <see cref="ICharStream"/> given a path to a UTF-8
+        /// encoded file on disk.
+        ///
+        /// Reads the entire contents of the file into the result before returning.
+        /// </summary>
+        public static ICharStream fromPath(string path)
+        {
+            return fromPath(path, Encoding.UTF8);
+        }
+
+        /// <summary>Creates an <see cref="ICharStream"/> given a path to a
+        /// file on disk and the encoding of the bytes contained in the file.
+        ///
+        /// Reads the entire contents of the file into the result before returning.
+        /// </summary>
+        public static ICharStream fromPath(string path, Encoding encoding)
+        {
+            var pathContents = File.ReadAllText(path, encoding);
+            var result = new CodePointCharStream(pathContents);
+            result.name = path;
+            return result;
+        }
+
+        /// <summary>Creates an <see cref="ICharStream"/> given an opened
+        /// <see cref="TextReader"/>.
+        ///
+        /// Reads the entire contents of the TextReader then closes the reader before returning.
+        /// </summary>
+        public static ICharStream fromTextReader(TextReader textReader)
+        {
+            try {
+                var textReaderContents = textReader.ReadToEnd();
+                return new CodePointCharStream(textReaderContents);
+            } finally {
+                textReader.Dispose();
+            }
+        }
+
+        /// <summary>Creates an <see cref="ICharStream"/> given an opened
+        /// <see cref="Stream"/> from which UTF-8 encoded bytes can be read.
+        ///
+        /// Reads the entire contents of the stream into the result then
+        /// closes the stream before returning.
+        /// </summary>
+        public static ICharStream fromStream(Stream stream)
+        {
+            return fromStream(stream, Encoding.UTF8);
+        }
+
+        /// <summary>Creates an <see cref="ICharStream"/> given an opened
+        /// <see cref="Stream"/> as well as the encoding of the bytes
+        /// to be read from the stream.
+        ///
+        /// Reads the entire contents of the stream into the result then
+        /// closes the stream before returning.
+        /// </summary>
+        public static ICharStream fromStream(Stream stream, Encoding encoding)
+        {
+            using (StreamReader sr = new StreamReader(stream, encoding, false)) {
+                return fromTextReader(sr);
+            }
+        }
+
+        /// <summary>Creates an <see cref="ICharStream"/> given a <see cref="string"/>.
+        /// </summary>
+        public static ICharStream fromstring(string s)
+        {
+            return new CodePointCharStream(s);
+        }
+    }
+}


### PR DESCRIPTION
Based on the discussion at https://github.com/antlr/antlr4/pull/1771#issuecomment-287627618 , this brings the Java runtime's `CharStreams` factory API to C#.

I updated `BaseCSharpTest` to make use of the new API to illustrate how it works.