### PR TITLE
Fix TimeLexerSpeed when run from jar

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/perf/TimeLexerSpeed.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/perf/TimeLexerSpeed.java
@@ -1,48 +1,47 @@
 package org.antlr.v4.test.runtime.java.api.perf;
 
-import org.antlr.v4.runtime.ANTLRFileStream;
+import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.test.runtime.java.api.JavaLexer;
 
-import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
 /** Test how fast we can lex Java and some unicode graphemes using old and
- *  new unicode stream mechanism. It also tests load time for ASCII
- *  and unicode code points beyond 0xFFFF.
+ *  new unicode stream mechanism. It also tests load time for unicode code points beyond 0xFFFF.
  *
- *  Sample output on OS X with 4 GHz Intel Core i7 (us == microseconds, 1/1000 of a millisecond):
+ *  Sample output on Linux with Intel Xeon E5-2600 @ 2.20 GHz (us == microseconds, 1/1000 of a millisecond):
  *
- Warming up Java compiler....
-    load_legacy_java_ascii average time    53us over 3500 loads of 29038 symbols from Parser.java
-     load_legacy_java_utf8 average time    42us over 3500 loads of 29038 symbols from Parser.java
-     load_legacy_java_utf8 average time   121us over 3500 loads of 13379 symbols from udhr_hin.txt
-             load_new_utf8 average time   193us over 3500 loads of 29038 symbols from Parser.java
-             load_new_utf8 average time   199us over 3500 loads of 13379 symbols from udhr_hin.txt
+Warming up Java compiler....
+    load_legacy_java_utf8 average time   248us over 3500 loads of 29038 symbols from Parser.java
+    load_legacy_java_utf8 average time   301us over 3500 loads of 13379 symbols from udhr_hin.txt
+            load_new_utf8 average time   535us over 3500 loads of 29038 symbols from Parser.java
+            load_new_utf8 average time   420us over 3500 loads of 13379 symbols from udhr_hin.txt
 
-     lex_legacy_java_ascii average time   399us over 2000 runs of 29038 symbols
-     lex_legacy_java_ascii average time   918us over 2000 runs of 29038 symbols DFA cleared
-      lex_legacy_java_utf8 average time   377us over 2000 runs of 29038 symbols
-      lex_legacy_java_utf8 average time   925us over 2000 runs of 29038 symbols DFA cleared
-         lex_new_java_utf8 average time   460us over 2000 runs of 29038 symbols
-         lex_new_java_utf8 average time   989us over 2000 runs of 29038 symbols DFA cleared
+     lex_legacy_java_utf8 average time   625us over 2000 runs of 29038 symbols
+     lex_legacy_java_utf8 average time  1678us over 2000 runs of 29038 symbols DFA cleared
+        lex_new_java_utf8 average time   644us over 2000 runs of 29038 symbols
+        lex_new_java_utf8 average time  1534us over 2000 runs of 29038 symbols DFA cleared
 
-  lex_legacy_grapheme_utf8 average time  6862us over  400 runs of  6614 symbols from udhr_kor.txt
-  lex_legacy_grapheme_utf8 average time  7023us over  400 runs of  6614 symbols from udhr_kor.txt DFA cleared
-  lex_legacy_grapheme_utf8 average time  6290us over  400 runs of 13379 symbols from udhr_hin.txt
-  lex_legacy_grapheme_utf8 average time  6238us over  400 runs of 13379 symbols from udhr_hin.txt DFA cleared
-     lex_new_grapheme_utf8 average time  6863us over  400 runs of  6614 symbols from udhr_kor.txt
-     lex_new_grapheme_utf8 average time  7014us over  400 runs of  6614 symbols from udhr_kor.txt DFA cleared
-     lex_new_grapheme_utf8 average time  6187us over  400 runs of 13379 symbols from udhr_hin.txt
-     lex_new_grapheme_utf8 average time  6284us over  400 runs of 13379 symbols from udhr_hin.txt DFA cleared
-     lex_new_grapheme_utf8 average time    99us over  400 runs of    85 symbols from emoji.txt
-     lex_new_grapheme_utf8 average time   111us over  400 runs of    85 symbols from emoji.txt DFA cleared
+ lex_legacy_grapheme_utf8 average time 12950us over  400 runs of  6614 symbols from udhr_kor.txt
+ lex_legacy_grapheme_utf8 average time 11953us over  400 runs of  6614 symbols from udhr_kor.txt DFA cleared
+ lex_legacy_grapheme_utf8 average time 10144us over  400 runs of 13379 symbols from udhr_hin.txt
+ lex_legacy_grapheme_utf8 average time 11146us over  400 runs of 13379 symbols from udhr_hin.txt DFA cleared
+    lex_new_grapheme_utf8 average time 11914us over  400 runs of  6614 symbols from udhr_kor.txt
+    lex_new_grapheme_utf8 average time 12030us over  400 runs of  6614 symbols from udhr_kor.txt DFA cleared
+    lex_new_grapheme_utf8 average time 10400us over  400 runs of 13379 symbols from udhr_hin.txt
+    lex_new_grapheme_utf8 average time 10365us over  400 runs of 13379 symbols from udhr_hin.txt DFA cleared
+    lex_new_grapheme_utf8 average time   183us over  400 runs of    85 symbols from emoji.txt
+    lex_new_grapheme_utf8 average time   192us over  400 runs of    85 symbols from emoji.txt DFA cleared
  *
  *  The "DFA cleared" indicates that the lexer was returned to initial conditions
  *  before the tokenizing of each file.  As the ALL(*) lexer encounters new input,
@@ -71,18 +70,13 @@ public class TimeLexerSpeed { // don't call it Test else it'll run during "mvn t
 		tests.compilerWarmUp(100);
 
 		int n = 3500;
-		URL sampleJavaFile = TimeLexerSpeed.class.getClassLoader().getResource(Parser_java_file);
-		URL sampleFile = TimeLexerSpeed.class.getClassLoader().getResource(PerfDir+"/udhr_hin.txt");
-		tests.load_legacy_java_ascii(n);
-		tests.load_legacy_java_utf8(sampleJavaFile.getFile(), n);
-		tests.load_legacy_java_utf8(sampleFile.getFile(), n);
-		tests.load_new_utf8(sampleJavaFile.getFile(), n);
-		tests.load_new_utf8(sampleFile.getFile(), n);
+		tests.load_legacy_java_utf8(Parser_java_file, n);
+		tests.load_legacy_java_utf8(PerfDir+"/udhr_hin.txt", n);
+		tests.load_new_utf8(Parser_java_file, n);
+		tests.load_new_utf8(PerfDir+"/udhr_hin.txt", n);
 		System.out.println();
 
 		n = 2000;
-		tests.lex_legacy_java_ascii(n, false);
-		tests.lex_legacy_java_ascii(n, true);
 		tests.lex_legacy_java_utf8(n, false);
 		tests.lex_legacy_java_utf8(n, true);
 		tests.lex_new_java_utf8(n, false);
@@ -111,7 +105,6 @@ public class TimeLexerSpeed { // don't call it Test else it'll run during "mvn t
 		System.out.print('.');
 		lex_legacy_java_utf8(n, false);
 		System.out.print('.');
-		lex_legacy_java_ascii(n, false);
 		System.out.print('.');
 		lex_legacy_grapheme_utf8("udhr_hin.txt", n, false);
 		System.out.print('.');
@@ -120,131 +113,112 @@ public class TimeLexerSpeed { // don't call it Test else it'll run during "mvn t
 		output = true;
 	}
 
-	public void load_legacy_java_ascii(int n) throws Exception {
-		URL sampleJavaFile = TimeLexerSpeed.class.getClassLoader().getResource(Parser_java_file);
+	public void load_legacy_java_utf8(String resourceName, int n) throws Exception {
 		long start = System.nanoTime();
 		CharStream input = null;
 		for (int i = 0; i<n; i++) {
-			input = new ANTLRFileStream(sampleJavaFile.getFile());
+			try (InputStream is = TimeLexerSpeed.class.getClassLoader().getResourceAsStream(resourceName);
+			     InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+			     BufferedReader br = new BufferedReader(isr)) {
+				input = new ANTLRInputStream(br);
+			}
 		}
 		long stop = System.nanoTime();
 		long tus = (stop-start)/1000;
 		int size = input.size();
 		String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
 		if ( output ) System.out.printf("%25s average time %5dus over %4d loads of %5d symbols from %s\n",
-		                                currentMethodName,
-		                                tus/n,
-		                                n,
-		                                size,
-		                                basename(sampleJavaFile.getFile()));
-	}
-
-	public void load_legacy_java_utf8(String fileName, int n) throws Exception {
-		long start = System.nanoTime();
-		CharStream input = null;
-		for (int i = 0; i<n; i++) {
-			input = new ANTLRFileStream(fileName, "UTF-8");
-		}
-		long stop = System.nanoTime();
-		long tus = (stop-start)/1000;
-		int size = input.size();
-		String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
-		if ( output ) System.out.printf("%25s average time %5dus over %4d loads of %5d symbols from %s\n",
-		                                currentMethodName,
-		                                tus/n,
-		                                n,
-		                                size,
-		                                basename(fileName));
+						currentMethodName,
+						tus/n,
+						n,
+						size,
+						basename(resourceName));
 	}
 
 	public void load_new_utf8(String fileName, int n) throws Exception {
 		long start = System.nanoTime();
 		CharStream input = null;
 		for (int i = 0; i<n; i++) {
-			input = CharStreams.fromFileName(fileName);
+			try (InputStream is = TimeLexerSpeed.class.getClassLoader().getResourceAsStream(fileName)) {
+				input = CharStreams.fromStream(is);
+			}
 		}
 		long stop = System.nanoTime();
 		long tus = (stop-start)/1000;
 		int size = input.size();
 		String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
 		if ( output ) System.out.printf("%25s average time %5dus over %4d loads of %5d symbols from %s\n",
-		                                currentMethodName,
-		                                tus/n,
-		                                n,
-		                                size,
-		                                basename(fileName));
-	}
-
-	public void lex_legacy_java_ascii(int n, boolean clearLexerDFACache) throws Exception {
-		URL sampleJavaFile = TimeLexerSpeed.class.getClassLoader().getResource(Parser_java_file);
-		CharStream input = new ANTLRFileStream(sampleJavaFile.getFile());
-		JavaLexer lexer = new JavaLexer(input);
-		double avg = tokenize(lexer, n, clearLexerDFACache);
-		String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
-		if ( output ) System.out.printf("%25s average time %5dus over %4d runs of %5d symbols%s\n",
-		                                currentMethodName,
-		                                (int)avg,
-		                                n,
-		                                input.size(),
-		                                clearLexerDFACache ? " DFA cleared" : "");
+						currentMethodName,
+						tus/n,
+						n,
+						size,
+						basename(fileName));
 	}
 
 	public void lex_legacy_java_utf8(int n, boolean clearLexerDFACache) throws Exception {
-		URL sampleJavaFile = TimeLexerSpeed.class.getClassLoader().getResource(Parser_java_file);
-		CharStream input = new ANTLRFileStream(sampleJavaFile.getFile(), "UTF-8");
-		JavaLexer lexer = new JavaLexer(input);
-		double avg = tokenize(lexer, n, clearLexerDFACache);
-		String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
-		if ( output ) System.out.printf("%25s average time %5dus over %4d runs of %5d symbols%s\n",
-		                                currentMethodName,
-		                                (int)avg,
-		                                n,
-		                                input.size(),
-		                                clearLexerDFACache ? " DFA cleared" : "");
+		try (InputStream is = TimeLexerSpeed.class.getClassLoader().getResourceAsStream(Parser_java_file);
+		     InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+		     BufferedReader br = new BufferedReader(isr)) {
+			CharStream input = new ANTLRInputStream(br);
+			JavaLexer lexer = new JavaLexer(input);
+			double avg = tokenize(lexer, n, clearLexerDFACache);
+			String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
+			if ( output ) System.out.printf("%25s average time %5dus over %4d runs of %5d symbols%s\n",
+							currentMethodName,
+							(int)avg,
+							n,
+							input.size(),
+							clearLexerDFACache ? " DFA cleared" : "");
+		}
 	}
 
 	public void lex_new_java_utf8(int n, boolean clearLexerDFACache) throws Exception {
-		URL sampleJavaFile = TimeLexerSpeed.class.getClassLoader().getResource(Parser_java_file);
-		CharStream input = CharStreams.fromPath(Paths.get(sampleJavaFile.getFile()));
-		JavaLexer lexer = new JavaLexer(input);
-		double avg = tokenize(lexer, n, clearLexerDFACache);
-		String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
-		if ( output ) System.out.printf("%25s average time %5dus over %4d runs of %5d symbols%s\n",
-		                                currentMethodName,
-		                                (int)avg,
-		                                n,
-		                                input.size(),
-		                                clearLexerDFACache ? " DFA cleared" : "");
+		try (InputStream is = TimeLexerSpeed.class.getClassLoader().getResourceAsStream(Parser_java_file);) {
+			CharStream input = CharStreams.fromStream(is);
+			JavaLexer lexer = new JavaLexer(input);
+			double avg = tokenize(lexer, n, clearLexerDFACache);
+			String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
+			if ( output ) System.out.printf("%25s average time %5dus over %4d runs of %5d symbols%s\n",
+							currentMethodName,
+							(int)avg,
+							n,
+							input.size(),
+							clearLexerDFACache ? " DFA cleared" : "");
+		}
 	}
 
 	public void lex_legacy_grapheme_utf8(String fileName, int n, boolean clearLexerDFACache) throws Exception {
-		URL sampleFile = TimeLexerSpeed.class.getClassLoader().getResource(PerfDir+"/"+fileName);
-		CharStream input = new ANTLRFileStream(sampleFile.getFile(), "UTF-8");
-		graphemesLexer lexer = new graphemesLexer(input);
-		double avg = tokenize(lexer, n, clearLexerDFACache);
-		String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
-		if ( output ) System.out.printf("%25s average time %5dus over %4d runs of %5d symbols from %s%s\n",
-		                                currentMethodName,
-		                                (int)avg,
-		                                n,
-		                                input.size(),
-		                                fileName,
-		                                clearLexerDFACache ? " DFA cleared" : "");
+		try (InputStream is = TimeLexerSpeed.class.getClassLoader().getResourceAsStream(PerfDir+"/"+fileName);
+		     InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+		     BufferedReader br = new BufferedReader(isr)) {
+			CharStream input = new ANTLRInputStream(br);
+			graphemesLexer lexer = new graphemesLexer(input);
+			double avg = tokenize(lexer, n, clearLexerDFACache);
+			String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
+			if ( output ) System.out.printf("%25s average time %5dus over %4d runs of %5d symbols from %s%s\n",
+							currentMethodName,
+							(int)avg,
+							n,
+							input.size(),
+							fileName,
+							clearLexerDFACache ? " DFA cleared" : "");
+		}
 	}
 
 	public void lex_new_grapheme_utf8(String fileName, int n, boolean clearLexerDFACache) throws Exception {
-		URL sampleJavaFile = TimeLexerSpeed.class.getClassLoader().getResource(PerfDir+"/"+fileName);
-		CharStream input = CharStreams.fromPath(Paths.get(sampleJavaFile.getFile()));
-		graphemesLexer lexer = new graphemesLexer(input);
-		double avg = tokenize(lexer, n, clearLexerDFACache);
-		String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
-		if ( output ) System.out.printf("%25s average time %5dus over %4d runs of %5d symbols from %s%s\n",
-		                                currentMethodName,
-		                                (int)avg,
-		                                n,
-		                                input.size(),
-		                                fileName,
-		                                clearLexerDFACache ? " DFA cleared" : "");
+		try (InputStream is = TimeLexerSpeed.class.getClassLoader().getResourceAsStream(PerfDir+"/"+fileName)) {
+			CharStream input = CharStreams.fromStream(is);
+			graphemesLexer lexer = new graphemesLexer(input);
+			double avg = tokenize(lexer, n, clearLexerDFACache);
+			String currentMethodName = new Exception().getStackTrace()[0].getMethodName();
+			if ( output ) System.out.printf("%25s average time %5dus over %4d runs of %5d symbols from %s%s\n",
+							currentMethodName,
+							(int)avg,
+							n,
+							input.size(),
+							fileName,
+							clearLexerDFACache ? " DFA cleared" : "");
+		}
 	}
 
 	public double tokenize(Lexer lexer, int n, boolean clearLexerDFACache) {


### PR DESCRIPTION
This fixes the issue where we were passing URLs to APIs which expected filenames:

https://github.com/antlr/antlr4/pull/1781#issuecomment-288807273

I had to use the `Reader` API of `ANTLRInputStream` since the `InputStream` constructor constructs an `InputStreamReader()` without specifying a `Charset`.

That API sadly uses the default `Charset` from the test runner's environment, which is not necessarily UTF-8.

I also removed the ASCII time tests, since they were functionally identical to the UTF-8 test.

The timings are a bit different now, since we include time to read the file consistently across the `CharStream` implementations.