### PR TITLE
IntervalSet perf: Use binary search for IntervalSet.contains(el)

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/misc/IntervalSet.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/IntervalSet.java
@@ -384,30 +384,24 @@ public class IntervalSet implements IntSet {
     @Override
     public boolean contains(int el) {
 		int n = intervals.size();
-		for (int i = 0; i < n; i++) {
-			Interval I = intervals.get(i);
+		int l = 0;
+		int r = n - 1;
+		// Binary search for the element in the (sorted,
+		// disjoint) array of intervals.
+		while (l <= r) {
+			int m = (l + r) / 2;
+			Interval I = intervals.get(m);
 			int a = I.a;
 			int b = I.b;
-			if ( el<a ) {
-				break; // list is sorted and el is before this interval; not here
-			}
-			if ( el>=a && el<=b ) {
-				return true; // found in this interval
+			if ( b<el ) {
+				l = m + 1;
+			} else if ( a>el ) {
+				r = m - 1;
+			} else { // el >= a && el <= b
+				return true;
 			}
 		}
 		return false;
-/*
-		for (ListIterator iter = intervals.listIterator(); iter.hasNext();) {
-            Interval I = (Interval) iter.next();
-            if ( el<I.a ) {
-                break; // list is sorted and el is before this interval; not here
-            }
-            if ( el>=I.a && el<=I.b ) {
-                return true; // found in this interval
-            }
-        }
-        return false;
-        */
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Using YourKit, I found the perf bottleneck in both `lex_legacy_grapheme_utf8` and `lex_new_grapheme_utf8` is the invocation of `IntervalSet.contains()` by `SetTransition`. (The new Unicode property sets `\p{Foo}` are quite large and contains lots of `Interval`s).

I can speed up the runtime of the grapheme lexer by almost 2x by using binary search instead of a linear scan in `IntervalSet.contains()` (this is trivial, since the set of intervals to search is already sorted and disjoint).

I'm not quite sure why this was a win for most things but negative for `udhr_hin.txt`. Still, a big enough win overall that it should be well worth it.

Before:

```
     lex_legacy_java_utf8 average time  1044us over 2000 runs of 29038 symbols
     lex_legacy_java_utf8 average time  1928us over 2000 runs of 29038 symbols DFA cleared
        lex_new_java_utf8 average time  1028us over 2000 runs of 29038 symbols
        lex_new_java_utf8 average time  1934us over 2000 runs of 29038 symbols DFA cleared

 lex_legacy_grapheme_utf8 average time 12249us over  400 runs of  6614 symbols from udhr_kor.txt
 lex_legacy_grapheme_utf8 average time 12216us over  400 runs of  6614 symbols from udhr_kor.txt DFA cleared
 lex_legacy_grapheme_utf8 average time 10964us over  400 runs of 13379 symbols from udhr_hin.txt
 lex_legacy_grapheme_utf8 average time 11036us over  400 runs of 13379 symbols from udhr_hin.txt DFA cleared
    lex_new_grapheme_utf8 average time 12175us over  400 runs of  6614 symbols from udhr_kor.txt
    lex_new_grapheme_utf8 average time 12275us over  400 runs of  6614 symbols from udhr_kor.txt DFA cleared
    lex_new_grapheme_utf8 average time 11112us over  400 runs of 13379 symbols from udhr_hin.txt
    lex_new_grapheme_utf8 average time 11162us over  400 runs of 13379 symbols from udhr_hin.txt DFA cleared
    lex_new_grapheme_utf8 average time   182us over  400 runs of    85 symbols from emoji.txt
    lex_new_grapheme_utf8 average time   193us over  400 runs of    85 symbols from emoji.txt DFA cleared
```

After:


```
     lex_legacy_java_utf8 average time  1044us over 2000 runs of 29038 symbols
     lex_legacy_java_utf8 average time  1916us over 2000 runs of 29038 symbols DFA cleared
        lex_new_java_utf8 average time  1018us over 2000 runs of 29038 symbols
        lex_new_java_utf8 average time  1937us over 2000 runs of 29038 symbols DFA cleared

 lex_legacy_grapheme_utf8 average time  7065us over  400 runs of  6614 symbols from udhr_kor.txt
 lex_legacy_grapheme_utf8 average time  7146us over  400 runs of  6614 symbols from udhr_kor.txt DFA cleared
 lex_legacy_grapheme_utf8 average time 13051us over  400 runs of 13379 symbols from udhr_hin.txt
 lex_legacy_grapheme_utf8 average time 13254us over  400 runs of 13379 symbols from udhr_hin.txt DFA cleared
    lex_new_grapheme_utf8 average time  7089us over  400 runs of  6614 symbols from udhr_kor.txt
    lex_new_grapheme_utf8 average time  7218us over  400 runs of  6614 symbols from udhr_kor.txt DFA cleared
    lex_new_grapheme_utf8 average time 12946us over  400 runs of 13379 symbols from udhr_hin.txt
    lex_new_grapheme_utf8 average time 13235us over  400 runs of 13379 symbols from udhr_hin.txt DFA cleared
    lex_new_grapheme_utf8 average time   141us over  400 runs of    85 symbols from emoji.txt
    lex_new_grapheme_utf8 average time   146us over  400 runs of    85 symbols from emoji.txt DFA cleared
```