### PR TITLE
Python 3 codegen probably didn't mean to limit ATN segment size to 2 XOR 31

### DIFF
--- a/tool/src/org/antlr/v4/codegen/target/Python3Target.java
+++ b/tool/src/org/antlr/v4/codegen/target/Python3Target.java
@@ -56,7 +56,7 @@ public class Python3Target extends Target {
 	@Override
 	public int getSerializedATNSegmentLimit() {
 		// set to something stupid to avoid segmentation
-		return 2 ^ 31;
+		return Integer.MAX_VALUE;
 	}
 
 	@Override


### PR DESCRIPTION
Noticed this poking around in the Python 3 codegen. `2 ^ 31` is not 2<sup>31</sup>, it's 2 XOR 31, which is 29..
