### PR TITLE
Support the Visitor Pattern for GoLang code generation

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -143,3 +143,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/03/03, chund, Christian Hund, christian.hund@gmail.com
 2017/03/15, robertvanderhulst, Robert van der Hulst, robert@xsharp.eu
 2017/03/28, cmd-johnson, Jonas Auer, jonas.auer.94@gmail.com
+2017/04/02, cyberfox, Morgan Schweers, cyberfox@gmail.com

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -135,6 +135,49 @@ import "github.com/antlr/antlr4/runtime/Go/antlr"
 
 type Base<file.grammarName>Visitor struct {
 	*antlr.BaseParseTreeVisitor
+	super <file.grammarName>Visitor
+}
+
+func (v *Base<file.grammarName>Visitor) SetSuper(newSuper <file.grammarName>Visitor) {
+	v.super = newSuper
+}
+
+func (v *Base<file.grammarName>Visitor) visitByName(name string, child antlr.RuleNode) {
+	var reified <file.grammarName>Visitor
+	if v.super == nil {
+		reified = v
+	} else {
+		reified = v.super
+	}
+
+	switch name {
+<file.visitorNames:{lname |
+	case "<lname>":
+		reified.Visit<lname; format="cap">(child.(*<lname; format="cap">Context))
+}; separator="\n">
+	}
+}
+
+func (v *Base<file.grammarName>Visitor) VisitChildren(node antlr.RuleNode) interface{} {
+	for i := 0; i \< node.GetChildCount(); i++ {
+		child := node.GetChild(i)
+		ruleChild, ok := child.(antlr.RuleNode)
+		if !ok {
+			terminalChild, ok := child.(antlr.TerminalNode)
+			if ok {
+				v.VisitTerminal(terminalChild)
+			} else {
+				errChild, ok := child.(antlr.ErrorNode)
+				if ok {
+					v.VisitErrorNode(errChild)
+				}
+			}
+		} else {
+			ruleType := ruleNames[ruleChild.GetRuleContext().GetRuleIndex()]
+			v.visitByName(ruleType, ruleChild)
+		}
+	}
+	return nil
 }
 
 <file.visitorNames:{lname |


### PR DESCRIPTION
The GoLang ANTLR4 parser did not seem to have all the pieces necessary to implement the visitor pattern over the resulting Tree.  This code attempts to resolve that, with two caveats.  The first is that I am only learning Go, so it may not be standard style.  The second is that it requires some extra work on the part of someone deriving a visitor.

After the visitor is generated, you can write code that looks like the following to get notified when sections of the parse tree are visited.  Let's say that the grammar is named `Piano`, and you want to be notified when `Sharps` are visited.

```Go
type PianoVisitor struct {
	parser.BasePianoVisitor
}

func NewPianoVisitor() *PianoVisitor {
	visitor := new(PianoVisitor)
	visitor.SetSuper(visitor)
	return visitor
}

func (v *PianoVisitor) VisitSharps(ctx *parser.SharpsContext) interface{} {
	fmt.Printf("In here: %s\n", ctx.GetText())
	return v.VisitChildren(ctx)
}
```
The initial calling function would look something like this:
```Go
func main() {
	input := antlr.NewFileStream(os.Args[1])
	lexer := parser.NewPianoLexer(input)
	stream := antlr.NewCommonTokenStream(lexer, 0)
	p := parser.NewPianoParser(stream)
	tree := p.Start()

	tree.Accept(NewPianoVisitor())
}
```
This is my first Go contribution, so I'm expecting that I'm getting some of the formatting or style wrong.

Thanks muchly for taking a look!