### PR TITLE
Fixing Problems after Swift3.1 Release

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
@@ -123,7 +123,7 @@ open func emit() -> Token  {
 private func handleAcceptPositionForIdentifier() -> Bool {
 	let tokenText = getText()
 	var identifierLength = 0
-	while ((identifierLength \< tokenText.length)  &&  isIdentifierChar(tokenText[tokenText.characters.index(tokenText.startIndex, offsetBy: identifierLength)])) {
+	while ((identifierLength \< tokenText.characters.count)  &&  isIdentifierChar(tokenText[tokenText.characters.index(tokenText.startIndex, offsetBy: identifierLength)])) {
 		identifierLength += 1
 	}
 
@@ -137,8 +137,8 @@ private func handleAcceptPositionForIdentifier() -> Bool {
 }
 
 private func handleAcceptPositionForKeyword(_ keyword:String) -> Bool  {
-	if  getInputStream()!.index() > _tokenStartCharIndex + keyword.length   {
-		let offset = keyword.length  - 1
+	if  getInputStream()!.index() > _tokenStartCharIndex + keyword.characters.count   {
+		let offset = keyword.characters.count  - 1
 		(getInterpreter() as! PositionAdjustingLexerATNSimulator).resetAcceptPosition(getInputStream()!, _tokenStartCharIndex + offset, _tokenStartLine, _tokenStartCharPositionInLine + offset)
 		return true
 	}

--- a/runtime/Swift/Sources/Antlr4/CommonToken.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonToken.swift
@@ -246,14 +246,7 @@ public class CommonToken: WritableToken {
         if let r = r {
             typeString = r.getVocabulary().getDisplayName(type);
         }
-       return "[@"+getTokenIndex()+","+start+":"+stop+"='"+txt+"',<"+typeString+">"+channelStr+","+line+":"+getCharPositionInLine()+"]"
-//        let desc: StringBuilder = StringBuilder()
-//        desc.append("[@\(getTokenIndex()),")
-//        desc.append("\(start):\(stop)='\(txt)',")
-//        desc.append("<\(typeString)>\(channelStr),")
-//        desc.append("\(line):\(getCharPositionInLine())]")
-//
-//        return desc.toString()
+       return "[@\(getTokenIndex()),\(start):\(stop)='\(txt)',<\(typeString)>\(channelStr),\(line):\(getCharPositionInLine())]"
     }
     public var visited: Bool {
         get {

--- a/runtime/Swift/Sources/Antlr4/Lexer.swift
+++ b/runtime/Swift/Sources/Antlr4/Lexer.swift
@@ -129,9 +129,6 @@ open class Lexer: Recognizer<LexerATNSimulator>
                 _text = nil
                 repeat {
                     _type = CommonToken.INVALID_TYPE
-                    // print("nextToken line \(_tokenStartLine)" + " at \(try _input!.LA(1))" +
-                    //   " in mode \(mode)"  +
-                    //   " at index \(_input!.index())" );
                     var ttype: Int
                     do {
                         ttype = try getInterpreter().match(_input, _mode)
@@ -189,12 +186,10 @@ open class Lexer: Recognizer<LexerATNSimulator>
     open func popMode() throws -> Int {
         if _modeStack.isEmpty {
             throw ANTLRError.unsupportedOperation(msg: " EmptyStackException")
-            //RuntimeException(" EmptyStackException")
-            //throwException() /* throw EmptyStackException(); } */
         }
 
         if LexerATNSimulator.debug {
-            print("popMode back to \(_modeStack.peek())")
+            print("popMode back to \(String(describing: _modeStack.peek()))")
         }
         mode(_modeStack.pop())
         return _mode

--- a/runtime/Swift/Sources/Antlr4/Parser.swift
+++ b/runtime/Swift/Sources/Antlr4/Parser.swift
@@ -25,7 +25,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
 
         public func visitTerminal(_ node: TerminalNode) {
-            print("consume \(node.getSymbol()) rule \(host.getRuleNames()[host._ctx!.getRuleIndex()])")
+            print("consume \(String(describing: node.getSymbol())) rule \(host.getRuleNames()[host._ctx!.getRuleIndex()])")
         }
 
 

--- a/runtime/Swift/Sources/Antlr4/ParserRuleContext.swift
+++ b/runtime/Swift/Sources/Antlr4/ParserRuleContext.swift
@@ -329,7 +329,7 @@ open class ParserRuleContext: RuleContext {
         var rules: Array<String> = recognizer.getRuleInvocationStack(self)
         // Collections.reverse(rules);
         rules = rules.reversed()
-        return "ParserRuleContext\(rules){start= + \(start), stop=\(stop)}"
+        return "ParserRuleContext\(rules){start= + \(String(describing: start)), stop=\(String(describing: stop))}"
 
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/ArrayPredictionContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ArrayPredictionContext.swift
@@ -118,8 +118,6 @@ public func ==(lhs: ArrayPredictionContext, rhs: ArrayPredictionContext) -> Bool
         return false
     }
 
-    // return lhs.returnStates == rhs.returnStates && lhs.parents == rhs.parents
-
-    return ArrayEquals(lhs.returnStates, rhs.returnStates) && ArrayEquals(lhs.parents, rhs.parents)
+    return lhs.returnStates == rhs.returnStates && lhs.parents == rhs.parents
 }
 

--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
@@ -352,7 +352,7 @@ open class LexerATNSimulator: ATNSimulator {
     internal func accept(_ input: CharStream, _ lexerActionExecutor: LexerActionExecutor?,
         _ startIndex: Int, _ index: Int, _ line: Int, _ charPos: Int) throws {
             if LexerATNSimulator.debug {
-                print("ACTION \(lexerActionExecutor)\n")
+                print("ACTION \(String(describing: lexerActionExecutor))\n")
 
             }
 

--- a/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
@@ -1124,7 +1124,7 @@ open class ParserATNSimulator: ATNSimulator {
             let altToPred: [SemanticContext?]? = try configs.getPredsForAmbigAlts(ambigAlts,nalts)
 
             if debug {
-                print("getPredsForAmbigAlts result \(altToPred)")
+                print("getPredsForAmbigAlts result \(String(describing: altToPred))")
             }
             return altToPred
     }
@@ -1747,7 +1747,7 @@ open class ParserATNSimulator: ATNSimulator {
             }
 
             if debug {
-                print("config from pred transition=\(c)")
+                print("config from pred transition=\(String(describing: c))")
             }
             return c!
     }
@@ -1790,7 +1790,7 @@ open class ParserATNSimulator: ATNSimulator {
             }
 
             if debug {
-                print("config from pred transition=\(c)")
+                print("config from pred transition=\(String(describing: c))")
             }
             return c
     }
@@ -1798,7 +1798,7 @@ open class ParserATNSimulator: ATNSimulator {
 
     final func ruleTransition(_ config: ATNConfig, _ t: RuleTransition) -> ATNConfig {
         if debug {
-            print("CALL rule \(getRuleName(t.target.ruleIndex!)), ctx=\(config.context)")
+            print("CALL rule \(getRuleName(t.target.ruleIndex!)), ctx=\(String(describing: config.context))")
         }
 
         let returnState: ATNState = t.followState
@@ -1958,7 +1958,7 @@ open class ParserATNSimulator: ATNSimulator {
                           _ to: DFAState?) throws -> DFAState? {
         var to = to
         if debug {
-            print("EDGE \(from) -> \(to) upon \(getTokenName(t))")
+            print("EDGE \(String(describing: from)) -> \(String(describing: to)) upon \(getTokenName(t))")
         }
 
         if to == nil {

--- a/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
@@ -57,7 +57,7 @@ public class ProfilingATNSimulator: ParserATNSimulator {
         decisions[decision].timeInPrediction += (stop - start)
         decisions[decision].invocations += 1
 
-        var SLL_k: Int64 = _sllStopIndex - _startIndex + 1
+        var SLL_k: Int64 = Int64(_sllStopIndex - _startIndex + 1)
         decisions[decision].SLL_TotalLook += SLL_k
         decisions[decision].SLL_MinLook = decisions[decision].SLL_MinLook == 0 ? SLL_k : min(decisions[decision].SLL_MinLook, SLL_k)
         if SLL_k > decisions[decision].SLL_MaxLook {
@@ -67,7 +67,7 @@ public class ProfilingATNSimulator: ParserATNSimulator {
         }
 
         if _llStopIndex >= 0 {
-            var LL_k: Int64 = _llStopIndex - _startIndex + 1
+            var LL_k: Int64 = Int64(_llStopIndex - _startIndex + 1)
             decisions[decision].LL_TotalLook += LL_k
             decisions[decision].LL_MinLook = decisions[decision].LL_MinLook == 0 ? LL_k : min(decisions[decision].LL_MinLook, LL_k)
             if LL_k > decisions[decision].LL_MaxLook {

--- a/runtime/Swift/Sources/Antlr4/misc/BitSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/BitSet.swift
@@ -626,7 +626,7 @@ public class BitSet: Hashable, CustomStringConvertible {
             n = n - 2
             x = y
         }
-        return n - ((x << 1) >>> 31)
+        return Int(n - ((x << 1) >>> 31))
     }
 
     /// Returns the index of the first bit that is set to {@code false}
@@ -988,7 +988,7 @@ public class BitSet: Hashable, CustomStringConvertible {
         var i: Int = wordsInUse
         i -= 1
         while i >= 0 {
-             h ^= words[i] * (i + 1)
+             h ^= words[i] * Int64(i + 1)
              i -= 1
         }
 

--- a/runtime/Swift/Sources/Antlr4/misc/utils/CommonUtil.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/utils/CommonUtil.swift
@@ -16,22 +16,8 @@ func errPrint(_ msg: String) {
     fputs(msg + "\n", __stderrp)
 }
 
-public func +(lhs: String, rhs: Int) -> String {
-    return lhs + String(rhs)
-}
+infix operator >>> : BitwiseShiftPrecedence
 
-public func +(lhs: Int, rhs: String) -> String {
-    return String(lhs) + rhs
-}
-
-public func +(lhs: String, rhs: Token) -> String {
-    return lhs + rhs.description
-}
-
-public func +(lhs: Token, rhs: String) -> String {
-    return lhs.description + rhs
-}
-infix operator >>>  : BitwiseShiftPrecedence
 //infix operator >>> { associativity right precedence 160 }
 func >>>(lhs: Int32, rhs: Int32) -> Int32 {
     let left = UInt32(bitPattern: lhs)
@@ -56,19 +42,17 @@ func >>>(lhs: Int, rhs: Int) -> Int {
     return Int(bitPattern: left >> right)
 }
 
-
-public func synced(_ lock: AnyObject, closure: () -> ()) {
+func synced(_ lock: AnyObject, closure: () -> ()) {
     objc_sync_enter(lock)
     closure()
     objc_sync_exit(lock)
 }
 
-
-public func intChar2String(_ i: Int) -> String {
+func intChar2String(_ i: Int) -> String {
     return String(Character(integerLiteral: i))
 }
 
-public func log(_ message: String = "", file: String = #file, function: String = #function, lineNum: Int = #line) {
+func log(_ message: String = "", file: String = #file, function: String = #function, lineNum: Int = #line) {
 
     // #if DEBUG
     print("FILE: \(URL(fileURLWithPath: file).pathComponents.last!),FUNC: \(function), LINE: \(lineNum) MESSAGE: \(message)")
@@ -77,8 +61,7 @@ public func log(_ message: String = "", file: String = #file, function: String =
     //   #endif
 }
 
-
-public func RuntimeException(_ message: String = "", file: String = #file, function: String = #function, lineNum: Int = #line) {
+func RuntimeException(_ message: String = "", file: String = #file, function: String = #function, lineNum: Int = #line) {
     // #if DEBUG
     let info = "FILE: \(URL(fileURLWithPath: file).pathComponents.last!),FUNC: \(function), LINE: \(lineNum) MESSAGE: \(message)"
     //   #else
@@ -89,99 +72,37 @@ public func RuntimeException(_ message: String = "", file: String = #file, funct
 
 }
 
-
-public func toInt(_ c: Character) -> Int {
+func toInt(_ c: Character) -> Int {
     return c.unicodeValue
 }
 
-public func toInt32(_ data: [Character], _ offset: Int) -> Int {
+func toInt32(_ data: [Character], _ offset: Int) -> Int {
     return data[offset].unicodeValue | (data[offset + 1].unicodeValue << 16)
 }
 
-public func toLong(_ data: [Character], _ offset: Int) -> Int64 {
+func toLong(_ data: [Character], _ offset: Int) -> Int64 {
     let mask: Int64 = 0x00000000FFFFFFFF
     let lowOrder: Int64 = Int64(toInt32(data, offset)) & mask
     return lowOrder | Int64(toInt32(data, offset + 2) << 32)
 }
 
-public func toUUID(_ data: [Character], _ offset: Int) -> UUID {
+func toUUID(_ data: [Character], _ offset: Int) -> UUID {
     let leastSigBits: Int64 = toLong(data, offset)
     let mostSigBits: Int64 = toLong(data, offset + 4)
-    //TODO:NSUUID(mostSigBits, leastSigBits);
     return UUID(mostSigBits: mostSigBits, leastSigBits: leastSigBits)
 }
-public func == <Element : Equatable>(
-    lhs: Array<Element?>, rhs: Array<Element?>
-    ) -> Bool {
-        let lhsCount = lhs.count
-        if lhsCount != rhs.count {
-            return false
-        }
 
-        // Test referential equality.
-        if lhsCount == 0 || lhs._buffer.identity == rhs._buffer.identity {
-            return true
-        }
+func ==<T:Equatable>(_ lhs: [T?], _ rhs: [T?]) -> Bool {
 
-        var streamLHS = lhs.makeIterator()
-        var streamRHS = rhs.makeIterator()
-
-        var nextLHS = streamLHS.next()
-        while nextLHS != nil {
-            let nextRHS = streamRHS.next()
-            if nextLHS == nil && nextRHS != nil {
-                return false
-            }
-            else if nextRHS == nil && nextLHS != nil {
-                return false
-            }
-            else if nextLHS! != nextRHS! {
-                return false
-            }
-            nextLHS = streamLHS.next()
-        }
-
-        return true
-
-}
-public func ArrayEquals<T:Equatable>(_ a: [T], _ a2: [T]) -> Bool {
-
-    if a2.count != a.count {
+    if lhs.count != rhs.count {
         return false
     }
 
-    let length = a.count
-    for i in 0..<length {
-        if a[i] != a2[i] {
-            return false
-        }
-
-
-    }
-
-    return true
-}
-
-public func ArrayEquals<T:Equatable>(_ a: [T?], _ a2: [T?]) -> Bool {
-
-    if a2.count != a.count {
-        return false
-    }
-
-    let length = a.count
-
-    for i in 0..<length {
-        if a[i] == nil && a2[i] != nil {
-            return false
-        }
-        if a2[i] == nil && a[i] != nil {
-            return false
-        }
-        if a2[i] != nil && a[i] != nil && a[i]! != a2[i]! {
+    for i in 0..<lhs.count {
+        if lhs[i] != rhs[i] {
             return false
         }
     }
 
     return true
 }
-

--- a/runtime/Swift/Sources/Antlr4/misc/utils/CommonUtil.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/utils/CommonUtil.swift
@@ -16,9 +16,24 @@ func errPrint(_ msg: String) {
     fputs(msg + "\n", __stderrp)
 }
 
+public func +(lhs: String, rhs: Int) -> String {
+    return lhs + String(rhs)
+}
+
+public func +(lhs: Int, rhs: String) -> String {
+    return String(lhs) + rhs
+}
+
+public func +(lhs: String, rhs: Token) -> String {
+    return lhs + rhs.description
+}
+
+public func +(lhs: Token, rhs: String) -> String {
+    return lhs.description + rhs
+}
+
 infix operator >>> : BitwiseShiftPrecedence
 
-//infix operator >>> { associativity right precedence 160 }
 func >>>(lhs: Int32, rhs: Int32) -> Int32 {
     let left = UInt32(bitPattern: lhs)
     let right = UInt32(bitPattern: rhs) % 32

--- a/runtime/Swift/Tests/Antlr4Tests/VisitorTests.swift
+++ b/runtime/Swift/Tests/Antlr4Tests/VisitorTests.swift
@@ -6,7 +6,6 @@ import XCTest
 import Antlr4
 
 class VisitorTests: XCTestCase {
-
     ///
     /// This test verifies the basic behavior of visitors, with an emphasis on
     /// {@link AbstractParseTreeVisitor#visitTerminal}.


### PR DESCRIPTION
Swift 3.1 was [released](https://swift.org/blog/swift-3-1-released) on Mar. 27th.
The language change should be source compatible, but our implementation is using some language feature that's not guaranteed by the public API thus breaking the ANTLR4 Swift runtime build. This PR will fix those issues along with several warnings because of the language release.

The PR  #1793 removing StringExtension public modifier is breaking one unit test that uses the "length" method in the old string extension. The second commit will fix this issue by unwrapping the "length" method in the SwiftTest.stg file. We don't want to expose (those pretty generic) extensions inside Swift runtime but need to make sure our generated parsers (in a different module) still works.  