### PR TITLE
Channel parameter in c-tor is now a size_t - fixes #1827.

### DIFF
--- a/runtime/Cpp/runtime/src/CommonTokenStream.cpp
+++ b/runtime/Cpp/runtime/src/CommonTokenStream.cpp
@@ -9,12 +9,11 @@
 
 using namespace antlr4;
 
-CommonTokenStream::CommonTokenStream(TokenSource *tokenSource) : BufferedTokenStream(tokenSource) {
-  InitializeInstanceFields();
+CommonTokenStream::CommonTokenStream(TokenSource *tokenSource) : CommonTokenStream(tokenSource, Token::DEFAULT_CHANNEL) {
 }
 
-CommonTokenStream::CommonTokenStream(TokenSource *tokenSource, int channel) : BufferedTokenStream(tokenSource) {
-  this->channel = channel;
+CommonTokenStream::CommonTokenStream(TokenSource *tokenSource, size_t channel)
+: BufferedTokenStream(tokenSource), channel(channel) {
 }
 
 ssize_t CommonTokenStream::adjustSeekIndex(size_t i) {
@@ -76,8 +75,4 @@ int CommonTokenStream::getNumberOfOnChannelTokens() {
     }
   }
   return n;
-}
-
-void CommonTokenStream::InitializeInstanceFields() {
-  channel = Token::DEFAULT_CHANNEL;
 }

--- a/runtime/Cpp/runtime/src/CommonTokenStream.h
+++ b/runtime/Cpp/runtime/src/CommonTokenStream.h
@@ -34,16 +34,6 @@ namespace antlr4 {
    * channel.</p>
    */
   class ANTLR4CPP_PUBLIC CommonTokenStream : public BufferedTokenStream {
-  protected:
-    /**
-     * Specifies the channel to use for filtering tokens.
-     *
-     * <p>
-     * The default value is {@link Token#DEFAULT_CHANNEL}, which matches the
-     * default channel assigned to tokens created by the lexer.</p>
-     */
-    size_t channel;
-
   public:
     /**
      * Constructs a new {@link CommonTokenStream} using the specified token
@@ -63,21 +53,27 @@ namespace antlr4 {
      * @param tokenSource The token source.
      * @param channel The channel to use for filtering tokens.
      */
-    CommonTokenStream(TokenSource *tokenSource, int channel);
+    CommonTokenStream(TokenSource *tokenSource, size_t channel);
 
-  protected:
-    virtual ssize_t adjustSeekIndex(size_t i) override;
-
-    virtual Token* LB(size_t k) override;
-
-  public:
     virtual Token* LT(ssize_t k) override;
 
     /// Count EOF just once.
     virtual int getNumberOfOnChannelTokens();
+    
+  protected:
+    /**
+     * Specifies the channel to use for filtering tokens.
+     *
+     * <p>
+     * The default value is {@link Token#DEFAULT_CHANNEL}, which matches the
+     * default channel assigned to tokens created by the lexer.</p>
+     */
+    size_t channel;
 
-  private:
-    void InitializeInstanceFields();
+    virtual ssize_t adjustSeekIndex(size_t i) override;
+
+    virtual Token* LB(size_t k) override;
+
   };
 
 } // namespace antlr4


### PR DESCRIPTION
A bit cleanup on the way.