### PR TITLE
Go Target - make token source all public

### DIFF
--- a/runtime/Go/antlr/lexer.go
+++ b/runtime/Go/antlr/lexer.go
@@ -158,7 +158,7 @@ func (b *BaseLexer) GetTokenFactory() TokenFactory {
 	return b.factory
 }
 
-func (b *BaseLexer) setTokenFactory(f TokenFactory) {
+func (b *BaseLexer) SetTokenFactory(f TokenFactory) {
 	b.factory = f
 }
 

--- a/runtime/Go/antlr/parser.go
+++ b/runtime/Go/antlr/parser.go
@@ -321,8 +321,8 @@ func (p *BaseParser) GetTokenFactory() TokenFactory {
 }
 
 // Tell our token source and error strategy about a Newway to create tokens.//
-func (p *BaseParser) setTokenFactory(factory TokenFactory) {
-	p.input.GetTokenSource().setTokenFactory(factory)
+func (p *BaseParser) SetTokenFactory(factory TokenFactory) {
+	p.input.GetTokenSource().SetTokenFactory(factory)
 }
 
 // The ATN with bypass alternatives is expensive to create so we create it

--- a/runtime/Go/antlr/token_source.go
+++ b/runtime/Go/antlr/token_source.go
@@ -12,6 +12,6 @@ type TokenSource interface {
 	GetCharPositionInLine() int
 	GetInputStream() CharStream
 	GetSourceName() string
-	setTokenFactory(factory TokenFactory)
+	SetTokenFactory(factory TokenFactory)
 	GetTokenFactory() TokenFactory
 }


### PR DESCRIPTION
This change effects the Go Target only.
It makes all of the TokenSource signatures public so that an alternative, client code implementation can be provided.