### PR TITLE
added runtimeImport option

### DIFF
--- a/tool/src/org/antlr/v4/codegen/model/OutputFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/OutputFile.java
@@ -20,6 +20,7 @@ public abstract class OutputFile extends OutputModelObject {
 	public final String ANTLRVersion;
     public final String TokenLabelType;
     public final String InputSymbolType;
+	public final String antlrRuntimeImport; // from -DruntimeImport or options in grammars
 
     public OutputFile(OutputModelFactory factory, String fileName) {
         super(factory);
@@ -29,6 +30,7 @@ public abstract class OutputFile extends OutputModelObject {
 		ANTLRVersion = Tool.VERSION;
         TokenLabelType = g.getOptionString("TokenLabelType");
         InputSymbolType = TokenLabelType;
+		antlrRuntimeImport = factory.getGrammar().getOptionString("runtimeImport");
     }
 
 	public Map<String, Action> buildNamedActions(Grammar g) {

--- a/tool/src/org/antlr/v4/tool/Grammar.java
+++ b/tool/src/org/antlr/v4/tool/Grammar.java
@@ -82,6 +82,7 @@ public class Grammar implements AttributeResolver {
 		parserOptions.add("tokenVocab");
 		parserOptions.add("language");
 		parserOptions.add("exportMacro");
+		parserOptions.add("runtimeImport");		
 	}
 
 	public static final Set<String> lexerOptions = parserOptions;


### PR DESCRIPTION
This PR added an extra option to grammars to customise the import statement in the generated code. The import can be customised on the cmd line with -DruntimeImport or in the options section inside a grammar file.

This is currently only implemented in the Go target template. 
The Antlr Go runtime code could be more "go gettable".
See the closed issue https://github.com/antlr/antlr4/issues/1361 .
This option makes it easier to point at other Go runtime repos (eg https://github.com/wxio/antlr4-go)
