### PR TITLE
Add proper error handling semantics to FileStream.

### DIFF
--- a/runtime/Go/antlr/file_stream.go
+++ b/runtime/Go/antlr/file_stream.go
@@ -19,13 +19,19 @@ type FileStream struct {
 	filename string
 }
 
-func NewFileStream(fileName string) *FileStream {
+func NewFileStream(fileName string) (*FileStream, error) {
 
 	buf := bytes.NewBuffer(nil)
 
-	f, _ := os.Open(fileName) // Error handling elided for brevity.
-	io.Copy(buf, f)           // Error handling elided for brevity.
-	f.Close()
+	f, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	err = io.Copy(buf, f)
+	if err != nil {
+		return nil, er
+	}
 
 	fs := new(FileStream)
 
@@ -34,7 +40,7 @@ func NewFileStream(fileName string) *FileStream {
 
 	fs.InputStream = NewInputStream(s)
 
-	return fs
+	return fs, nil
 
 }
 


### PR DESCRIPTION
The previous implementation was swallowing any errors so it could be confusing.  For instance a missing file is treated as an empty string which successfully parses (when one would expect an error).

This will be an incompatible change and is probably best lumped in with the other incompatible changes coming up.
