### PR TITLE
[dotnet] speed up tests; rename runtime dll ready for nuget

### DIFF
--- a/.travis/before-install-linux-dotnet.sh
+++ b/.travis/before-install-linux-dotnet.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
 sudo apt-get update
-sudo apt-get install dotnet-dev-1.0.1
+sudo apt-get install dotnet-dev-1.0.3
 
 # install mvn
 wget http://apache.mirrors.lucidnetworks.net/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz && \

--- a/.travis/before-install-osx-dotnet.sh
+++ b/.travis/before-install-osx-dotnet.sh
@@ -12,10 +12,10 @@ ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
 ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
 
 # download dotnet core
-curl https://download.microsoft.com/download/8/F/9/8F9659B9-E628-4D1A-B6BF-C3004C8C954B/dotnet-1.1.1-sdk-osx-x64.pkg -o /tmp/dotnet-1.1.1-sdk-osx-x64.pkg
+curl https://download.microsoft.com/download/1/1/4/114223DE-0AD6-4B8A-A8FB-164E5862AF6E/dotnet-dev-osx-x64.1.0.3.pkg -o /tmp/dotnet-dev-osx-x64.1.0.3.pkg
 
 # install dotnet core
-sudo installer -pkg /tmp/dotnet-1.1.1-sdk-osx-x64.pkg -target /
+sudo installer -pkg /tmp/dotnet-dev-osx-x64.1.0.3.pkg -target /
 
 # make the link
 ln -s /usr/local/share/dotnet/dotnet /usr/local/bin/

--- a/.travis/run-tests-dotnet.sh
+++ b/.travis/run-tests-dotnet.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 
+# we need to build the runtime before test run, since we used "--no-dependencies"
+# when we call dotnet cli for restore and build, in order to speed up
+
+dotnet restore ../runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.dotnet.csproj
+dotnet build -c Release ../runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.dotnet.csproj
+
+# call test
+
 mvn -q -Dparallel=classes -DthreadCount=4 -Dtest=csharp.* -Dantlr-csharp-netstandard=true test
 

--- a/.travis/run-tests-dotnet.sh
+++ b/.travis/run-tests-dotnet.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=csharp.* -Dantlr-csharp-netstandard=true test
+mvn -q -Dparallel=classes -DthreadCount=4 -Dtest=csharp.* -Dantlr-csharp-netstandard=true test
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
@@ -495,10 +495,6 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
             File runtimeProjFile = new File(runtimeProj.getFile());
             String runtimeProjPath = runtimeProjFile.getPath();
 
-            // check if runtime is built already
-            File dll = new File(runtimeProjFile.getParent() + "/bin/Release/netstandard1.3/Antlr4.Runtime.Core.dll");
-            String cliSwitch = (dll.exists() ? "--no-dependencies" : "");
-
             // add Runtime project reference
             String dotnetcli = locateTool("dotnet");
             String[] args = new String[] {
@@ -515,7 +511,7 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
                 dotnetcli,
                 "restore",
                 "Antlr4.Test.dotnet.csproj",
-                cliSwitch
+                "--no-dependencies"
             };
             success = runProcess(args, tmpdir);
 
@@ -526,7 +522,7 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
                 "Antlr4.Test.dotnet.csproj",
                 "-c",
                 "Release",
-                cliSwitch
+                "--no-dependencies"
             };
             success = runProcess(args, tmpdir);
         }

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
@@ -127,19 +127,6 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
 	/** Errors found while running antlr */
 	protected StringBuilder antlrToolErrors;
 
-	@org.junit.Rule
-	public final TestRule testWatcher = new TestWatcher() {
-
-		@Override
-		protected void succeeded(Description description) {
-			// remove tmpdir if no error.
-			if (!PRESERVE_TEST_DIR) {
-				eraseTempDir();
-			}
-		}
-
-	};
-
 	@Override
 	public void testSetUp() throws Exception {
 		if (CREATE_PER_TEST_DIRECTORIES) {
@@ -150,7 +137,7 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
 		else {
 			tmpdir = new File(BASE_TEST_DIR).getAbsolutePath();
 			if (!PRESERVE_TEST_DIR && new File(tmpdir).exists()) {
-				eraseFiles();
+				eraseDirectory(new File(tmpdir));
 			}
 		}
 		antlrToolErrors = new StringBuilder();
@@ -508,6 +495,10 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
             File runtimeProjFile = new File(runtimeProj.getFile());
             String runtimeProjPath = runtimeProjFile.getPath();
 
+            // check if runtime is built already
+            File dll = new File(runtimeProjFile.getParent() + "/bin/Release/netstandard1.3/Antlr4.Runtime.Core.dll");
+            String cliSwitch = (dll.exists() ? "--no-dependencies" : "");
+
             // add Runtime project reference
             String dotnetcli = locateTool("dotnet");
             String[] args = new String[] {
@@ -523,7 +514,8 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
             args = new String[] {
                 dotnetcli,
                 "restore",
-                "Antlr4.Test.dotnet.csproj"
+                "Antlr4.Test.dotnet.csproj",
+                cliSwitch
             };
             success = runProcess(args, tmpdir);
 
@@ -533,7 +525,8 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
                 "build",
                 "Antlr4.Test.dotnet.csproj",
                 "-c",
-                "Release"
+                "Release",
+                cliSwitch
             };
             success = runProcess(args, tmpdir);
         }
@@ -797,25 +790,30 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
 		}
 	}
 
-	protected void eraseFiles() {
-		if (tmpdir == null) {
-			return;
-		}
-
-		File tmpdirF = new File(tmpdir);
-		String[] files = tmpdirF.list();
-		if(files!=null) for(String file : files) {
-			new File(tmpdir+"/"+file).delete();
-		}
+	protected void eraseDirectory(File dir) {
+		File[] files = dir.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    eraseDirectory(file);
+                }
+                else {
+                    file.delete();
+                }
+            }
+        }
+        dir.delete();
 	}
 
 	@Override
 	public void eraseTempDir() {
-		File tmpdirF = new File(tmpdir);
-		if ( tmpdirF.exists() ) {
-			eraseFiles();
-			tmpdirF.delete();
-		}
+        if (!PRESERVE_TEST_DIR) {
+            File tmpdirF = new File(tmpdir);
+            if ( tmpdirF.exists() ) {
+                eraseDirectory(tmpdirF);
+                tmpdirF.delete();
+            }
+        }
 	}
 
 	public String getFirstLineOfException() {

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.dotnet.csproj
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.dotnet.csproj
@@ -1,16 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>4.7</VersionPrefix>
+    <Company>The ANTLR Organization</Company>
+    <Version>4.7.1</Version>
     <TargetFramework>netstandard1.3</TargetFramework>
     <DefineConstants>$(DefineConstants);DOTNETCORE;NET35PLUS;NET40PLUS;NET45PLUS</DefineConstants>
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1580</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>Antlr4.Runtime.Standard</AssemblyName>
+    <AssemblyName>Antlr4.Runtime.Core</AssemblyName>
     <AssemblyOriginatorKeyFile>../../Antlr4.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>Antlr4.Runtime.Standard</PackageId>
+    <PackageId>Antlr4.Runtime.Core</PackageId>
+    <Title>ANTLR 4 .NET Core Runtime</Title>
+    <Authors>Eric Vergnaud, Terence Parr, Sam Harwell</Authors>
+    <Description>The .NET Core C# ANTLR 4 runtime from the ANTLR Organization</Description>
+    <Copyright>Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.</Copyright>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageLicenseUrl>https://github.com/antlr/antlr4/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/antlr/antlr4</PackageProjectUrl>
+    <PackageIconUrl>https://raw.github.com/antlr/website-antlr4/master/images/icons/antlr.png</PackageIconUrl>
+    <PackageReleaseNotes>https://github.com/antlr/antlr4/releases</PackageReleaseNotes>
+    <PackageTags>antlr parsing grammar</PackageTags>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>


### PR DESCRIPTION
@parrt @ericvergnaud https://travis-ci.org/xied75/antlr4/builds/226855441

Renamed dll to Antlr4.Runtime.Core as Eric suggested.

dotnet test on Mac now able to finish successfully.

dotnet test on Linux runs faster.

The cmd to pack nuget package is ```dotnet pack Antlr4.Runtime.dotnet.csproj``` then we'll get a nupkg inside bin/

In fact we can push the nupkg automatically (nightly build would be great) if we want. Let me know.