### PR TITLE
Add EOF check for recover method in Lexer

### DIFF
--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Lexer.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Lexer.cs
@@ -632,7 +632,10 @@ outer_continue: ;
             //System.out.println("consuming char "+(char)input.LA(1)+" during recovery");
             //re.printStackTrace();
             // TODO: Do we lose character or line position information?
-            _input.Consume();
+            if (_input.LA(1) != IntStreamConstants.EOF)
+            {
+                _input.Consume();
+            }
         }
     }
 }

--- a/runtime/Cpp/runtime/src/Lexer.cpp
+++ b/runtime/Cpp/runtime/src/Lexer.cpp
@@ -274,7 +274,9 @@ std::string Lexer::getErrorDisplay(const std::string &s) {
 
 void Lexer::recover(RecognitionException * /*re*/) {
   // TO_DO: Do we lose character or line position information?
-  _input->consume();
+  if (_input->LA(1) != EOF) {
+    _input->consume();
+  }
 }
 
 size_t Lexer::getNumberOfSyntaxErrors() {

--- a/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
@@ -405,6 +405,8 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 		//System.out.println("consuming char "+(char)input.LA(1)+" during recovery");
 		//re.printStackTrace();
 		// TODO: Do we lose character or line position information?
-		_input.consume();
+		if (_input.LA(1) != IntStream.EOF) {
+			_input.consume();
+		}
 	}
 }

--- a/runtime/Swift/Sources/Antlr4/Lexer.swift
+++ b/runtime/Swift/Sources/Antlr4/Lexer.swift
@@ -414,6 +414,8 @@ open class Lexer: Recognizer<LexerATNSimulator>
         //System.out.println("consuming char "+(char)input.LA(1)+" during recovery");
         //re.printStackTrace();
         // TODO: Do we lose character or line position information?
-        try _input!.consume()
+        if try _input!.LA(1) != BufferedTokenStream.EOF {
+            try _input!.consume()
+        }
     }
 }


### PR DESCRIPTION
We have two recover() methods in some Lexer(Lexer.go, Lexer.py). But only one method check EOF for the input. Added EOF check for another one(Lexer.java, Lexer.cpp, Lexer.swift, Lexer.cs).

Signed-off-by: Yishuang Lu <luyscmu@gmail.com>