### PR TITLE
[CharStreams] Factor out Java 7 Path APIs into new PathCharStreams

### DIFF
--- a/doc/faq/general.md
+++ b/doc/faq/general.md
@@ -82,7 +82,7 @@ Make sure to use two-stage parsing. See example in [bug report](https://github.c
 
 ```Java
 
-CharStream input = CharStreams.fromPath(Paths.get(args[0]));
+CharStream input = PathCharStreams.fromPath(Paths.get(args[0]));
 ExprLexer lexer = new ExprLexer(input);
 CommonTokenStream tokens = new CommonTokenStream(lexer);
 ExprParser parser = new ExprParser(tokens);

--- a/doc/interpreters.md
+++ b/doc/interpreters.md
@@ -30,7 +30,7 @@ public static ParseTree parse(String fileName,
     throws IOException
 {
     final Grammar g = Grammar.load(combinedGrammarFileName);
-    LexerInterpreter lexEngine = g.createLexerInterpreter(CharStreams.fromPath(Paths.get(fileName)));
+    LexerInterpreter lexEngine = g.createLexerInterpreter(PathCharStreams.fromPath(Paths.get(fileName)));
     CommonTokenStream tokens = new CommonTokenStream(lexEngine);
     ParserInterpreter parser = g.createParserInterpreter(tokens);
     ParseTree t = parser.parse(g.getRule(startRule).index);
@@ -58,7 +58,7 @@ public static ParseTree parse(String fileNameToParse,
 {
     final LexerGrammar lg = (LexerGrammar) Grammar.load(lexerGrammarFileName);
     final Grammar pg = Grammar.load(parserGrammarFileName, lg);
-    CharStream input = CharStreams.fromPath(Paths.get(fileNameToParse));
+    CharStream input = PathCharStreams.fromPath(Paths.get(fileNameToParse));
     LexerInterpreter lexEngine = lg.createLexerInterpreter(input);
     CommonTokenStream tokens = new CommonTokenStream(lexEngine);
     ParserInterpreter parser = pg.createParserInterpreter(tokens);

--- a/doc/unicode.md
+++ b/doc/unicode.md
@@ -4,18 +4,18 @@ Prior to ANTLR 4.7, generated lexers in most targets only supported part of the 
 
 C++, Python, Go, and Swift APIs didn't need any API changes to support Unicode code points, so we decided to leave those class interfaces as-is. 
 
-Java, C#, and JavaScript runtimes required changes and, rather than break the previous interface, we deprecated them. (The *Java-target* deprecated `ANTLRInputStream` and `ANTLRFileStream` APIs only support Unicode code points up to `U+FFFF`.) Now, those targets must create `CharStream`s from input using `CharStreams.fromPath()`, `CharStreams.fromFileName()`, etc... 
+Java, C#, and JavaScript runtimes required changes and, rather than break the previous interface, we deprecated them. (The *Java-target* deprecated `ANTLRInputStream` and `ANTLRFileStream` APIs only support Unicode code points up to `U+FFFF`.) Now, those targets must create `CharStream`s from input using `PathCharStreams.fromPath()`, `CharStreams.fromFileName()`, etc...
 
 A big shout out to Ben Hamilton (github bhamiltoncx) for his superhuman
 efforts across all targets to get true support for U+10FFFF code points.
 
 ## Example
 
-The Java, C#, and JavaScript runtimes use the new factory style stream creation interface. For example, here is some sample Java code that uses `CharStreams.fromPath()`:
+The Java, C#, and JavaScript runtimes use the new factory style stream creation interface. For example, here is some sample Java code that uses `PathCharStreams.fromPath()`:
 
 ```java
 public static void main(String[] args) {
-  CharStream charStream = CharStreams.fromPath(Paths.get(args[0]));
+  CharStream charStream = PathCharStreams.fromPath(Paths.get(args[0]));
   Lexer lexer = new UnicodeLexer(charStream);
   CommonTokenStream tokens = new CommonTokenStream(lexer);
   tokens.fill();

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
@@ -922,7 +922,7 @@ public class BaseJavaTest implements RuntimeTestSupport {
 			"\n" +
 			"public class Test {\n" +
 			"    public static void main(String[] args) throws Exception {\n" +
-			"        CharStream input = CharStreams.fromPath(Paths.get(args[0]));\n" +
+			"        CharStream input = PathCharStreams.fromPath(Paths.get(args[0]));\n" +
 			"        <lexerName> lex = new <lexerName>(input);\n" +
 			"        CommonTokenStream tokens = new CommonTokenStream(lex);\n" +
 			"        <createParser>\n"+
@@ -979,7 +979,7 @@ public class BaseJavaTest implements RuntimeTestSupport {
 			"\n" +
 			"public class Test {\n" +
 			"    public static void main(String[] args) throws Exception {\n" +
-			"        CharStream input = CharStreams.fromPath(Paths.get(args[0]));\n" +
+			"        CharStream input = PathCharStreams.fromPath(Paths.get(args[0]));\n" +
 			"        <lexerName> lex = new <lexerName>(input);\n" +
 			"        CommonTokenStream tokens = new CommonTokenStream(lex);\n" +
 			"        tokens.fill();\n" +

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestCharStreams.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestCharStreams.java
@@ -8,6 +8,7 @@ package org.antlr.v4.test.runtime.java;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.PathCharStreams;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -53,7 +54,7 @@ public class TestCharStreams {
 	public void fromBMPUTF8PathHasExpectedSize() throws Exception {
 		Path p = folder.newFile().toPath();
 		Files.write(p, "hello".getBytes(StandardCharsets.UTF_8));
-		CharStream s = CharStreams.fromPath(p);
+		CharStream s = PathCharStreams.fromPath(p);
 		assertEquals(5, s.size());
 		assertEquals(0, s.index());
 		assertEquals("hello", s.toString());
@@ -64,7 +65,7 @@ public class TestCharStreams {
 	public void fromSMPUTF8PathHasExpectedSize() throws Exception {
 		Path p = folder.newFile().toPath();
 		Files.write(p, "hello \uD83C\uDF0E".getBytes(StandardCharsets.UTF_8));
-		CharStream s = CharStreams.fromPath(p);
+		CharStream s = PathCharStreams.fromPath(p);
 		assertEquals(7, s.size());
 		assertEquals(0, s.index());
 		assertEquals("hello \uD83C\uDF0E", s.toString());
@@ -207,7 +208,7 @@ public class TestCharStreams {
 	public void fromSMPUTF16LEPathSMPHasExpectedSize() throws Exception {
 		Path p = folder.newFile().toPath();
 		Files.write(p, "hello \uD83C\uDF0E".getBytes(StandardCharsets.UTF_16LE));
-		CharStream s = CharStreams.fromPath(p, StandardCharsets.UTF_16LE);
+		CharStream s = PathCharStreams.fromPath(p, StandardCharsets.UTF_16LE);
 		assertEquals(7, s.size());
 		assertEquals(0, s.index());
 		assertEquals("hello \uD83C\uDF0E", s.toString());
@@ -220,7 +221,7 @@ public class TestCharStreams {
 		// UTF-32 isn't popular enough to have an entry in StandardCharsets.
 		Charset c = Charset.forName("UTF-32LE");
 		Files.write(p, "hello \uD83C\uDF0E".getBytes(c));
-		CharStream s = CharStreams.fromPath(p, c);
+		CharStream s = PathCharStreams.fromPath(p, c);
 		assertEquals(7, s.size());
 		assertEquals(0, s.index());
 		assertEquals("hello \uD83C\uDF0E", s.toString());

--- a/runtime/Java/src/org/antlr/v4/runtime/CharStreams.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CharStreams.java
@@ -7,6 +7,7 @@
 package org.antlr.v4.runtime;
 
 import java.io.IOException;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.ByteBuffer;
@@ -18,9 +19,6 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /** This class represents the primary interface for creating {@link CharStream}s
  *  from a variety of sources as of 4.7.  The motivation was to support
@@ -61,39 +59,10 @@ import java.nio.file.Paths;
  *  @since 4.7
  */
 public final class CharStreams {
-	private static final int DEFAULT_BUFFER_SIZE = 4096;
+	static final int DEFAULT_BUFFER_SIZE = 4096;
 
 	// Utility class; do not construct.
 	private CharStreams() { }
-
-	/**
-	 * Creates a {@link CharStream} given a path to a UTF-8
-	 * encoded file on disk.
-	 *
-	 * Reads the entire contents of the file into the result before returning.
-	 */
-	public static CharStream fromPath(Path path) throws IOException {
-		return fromPath(path, StandardCharsets.UTF_8);
-	}
-
-	/**
-	 * Creates a {@link CharStream} given a path to a file on disk and the
-	 * charset of the bytes contained in the file.
-	 *
-	 * Reads the entire contents of the file into the result before returning.
-	 */
-	public static CharStream fromPath(Path path, Charset charset) throws IOException {
-		long size = Files.size(path);
-		try (ReadableByteChannel channel = Files.newByteChannel(path)) {
-			return fromChannel(
-				channel,
-				charset,
-				DEFAULT_BUFFER_SIZE,
-				CodingErrorAction.REPLACE,
-				path.toString(),
-				size);
-		}
-	}
 
 	/**
 	 * Creates a {@link CharStream} given a string containing a
@@ -102,7 +71,7 @@ public final class CharStreams {
 	 * Reads the entire contents of the file into the result before returning.
 	 */
 	public static CharStream fromFileName(String fileName) throws IOException {
-		return fromPath(Paths.get(fileName), StandardCharsets.UTF_8);
+		return fromFileName(fileName, StandardCharsets.UTF_8);
 	}
 
 	/**
@@ -113,7 +82,15 @@ public final class CharStreams {
 	 * Reads the entire contents of the file into the result before returning.
 	 */
 	public static CharStream fromFileName(String fileName, Charset charset) throws IOException {
-		return fromPath(Paths.get(fileName), charset);
+		try (FileInputStream fis = new FileInputStream(fileName)) {
+			return fromChannel(
+					fis.getChannel(),
+					charset,
+					DEFAULT_BUFFER_SIZE,
+					CodingErrorAction.REPLACE,
+					fileName,
+					fis.getChannel().size());
+		}
 	}
 
 

--- a/runtime/Java/src/org/antlr/v4/runtime/PathCharStreams.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/PathCharStreams.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+
+package org.antlr.v4.runtime;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+/** This class adds Java 7-friendly interfaces for creating {@link CharStream}s.
+ *
+ * This is in a separate class from {@link CharStreams} so it can be
+ * stripped entirely (e.g. using ProGuard) for Android (pre-Android O)
+ * and other clients which don't support Java 7 APIs.
+ *
+ * @see CharStreams
+ */
+public final class PathCharStreams {
+	// Utility class; do not construct.
+	private PathCharStreams() { }
+
+	/**
+	 * Creates a {@link CharStream} given a path to a UTF-8
+	 * encoded file on disk.
+	 *
+	 * Reads the entire contents of the file into the result before returning.
+	 */
+	public static CharStream fromPath(Path path) throws IOException {
+		return fromPath(path, StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Creates a {@link CharStream} given a path to a file on disk and the
+	 * charset of the bytes contained in the file.
+	 *
+	 * Reads the entire contents of the file into the result before returning.
+	 */
+	public static CharStream fromPath(Path path, Charset charset) throws IOException {
+		try (FileChannel channel = FileChannel.open(path)) {
+			return CharStreams.fromChannel(
+				channel,
+				charset,
+				CharStreams.DEFAULT_BUFFER_SIZE,
+				CodingErrorAction.REPLACE,
+				path.toString(),
+				channel.size());
+		}
+	}
+}

--- a/tool/src/org/antlr/v4/gui/TestRig.java
+++ b/tool/src/org/antlr/v4/gui/TestRig.java
@@ -8,6 +8,7 @@ package org.antlr.v4.gui;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.PathCharStreams;
 import org.antlr.v4.runtime.CommonToken;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.DiagnosticErrorListener;
@@ -159,7 +160,7 @@ public class TestRig {
 			return;
 		}
 		for (String inputFile : inputFiles) {
-	                CharStream charStream = CharStreams.fromPath(Paths.get(inputFile), charset);
+			CharStream charStream = PathCharStreams.fromPath(Paths.get(inputFile), charset);
 			if ( inputFiles.size()>1 ) {
 				System.err.println(inputFile);
 			}


### PR DESCRIPTION
I wanted to use the new ANTLR 4.7 runtime on Android, but when I tried to run Proguard on the result, I discovered that Android versions older than the "Android O" developer preview are missing the Java 7 `java.nio.file.Path` and related APIs.

Since these are just convenience APIs to wrap around the `Channel` APIs (which are present in all versions of Android), this PR refactors the Java 7-specific APIs into a new helper class `PathCharStreams` which is simple to exclude via a Proguard rule.