### PR TITLE
Fixing errors with Go runtime file_stream

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -144,3 +144,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/03/15, robertvanderhulst, Robert van der Hulst, robert@xsharp.eu
 2017/03/28, cmd-johnson, Jonas Auer, jonas.auer.94@gmail.com
 2017/04/12, lys0716, Yishuang Lu, luyscmu@gmail.com
+2017/05/07, pemcconnell, Peter McConnell, me@petermcconnell.com

--- a/runtime/Go/antlr/file_stream.go
+++ b/runtime/Go/antlr/file_stream.go
@@ -28,9 +28,9 @@ func NewFileStream(fileName string) (*FileStream, error) {
 		return nil, err
 	}
 	defer f.Close()
-	err = io.Copy(buf, f)
+	_, err = io.Copy(buf, f)
 	if err != nil {
-		return nil, er
+		return nil, err
 	}
 
 	fs := new(FileStream)


### PR DESCRIPTION
When trying to `go get` the Go runtime, I received two errors related to the `file_stream.go` file:

```
go get "github.com/antlr/antlr4/runtime/Go/antlr"
# github.com/antlr/antlr4/runtime/Go/antlr
/go/src/github.com/antlr/antlr4/runtime/Go/antlr/file_stream.go:31: multiple-value io.Copy() in single-value context
/go/src/github.com/antlr/antlr4/runtime/Go/antlr/file_stream.go:33: undefined: er
```

This PR fixes both of those errors and makes `go get "github.com/antlr/antlr4/runtime/Go/antlr"` work as expected