### PR TITLE
Add `new` keyword to return proper InputStreams

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -144,3 +144,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/03/15, robertvanderhulst, Robert van der Hulst, robert@xsharp.eu
 2017/03/28, cmd-johnson, Jonas Auer, jonas.auer.94@gmail.com
 2017/04/12, lys0716, Yishuang Lu, luyscmu@gmail.com
+2017/05/11, jimallman, Jim Allman, jim@ibang.com

--- a/runtime/JavaScript/src/antlr4/CharStreams.js
+++ b/runtime/JavaScript/src/antlr4/CharStreams.js
@@ -30,7 +30,7 @@ var CharStreams = {
   fromBlob: function(blob, encoding, onLoad, onError) {
     var reader = FileReader();
     reader.onload = function(e) {
-      var is = InputStream(e.target.result, true);
+      var is = new InputStream(e.target.result, true);
       onLoad(is);
     };
     reader.onerror = onError;
@@ -53,7 +53,7 @@ var CharStreams = {
     fs.readFile(path, encoding, function(err, data) {
       var is = null;
       if (data !== null) {
-        is = InputStream(data, true);
+        is = new InputStream(data, true);
       }
       callback(err, is);
     });

--- a/runtime/JavaScript/src/antlr4/CharStreams.js
+++ b/runtime/JavaScript/src/antlr4/CharStreams.js
@@ -18,7 +18,7 @@ var fs = isNodeJs ? require("fs") : null;
 var CharStreams = {
   // Creates an InputStream from a string.
   fromString: function(str) {
-    return InputStream(str, true);
+    return new InputStream(str, true);
   },
 
   // Asynchronously creates an InputStream from a blob given the
@@ -41,7 +41,7 @@ var CharStreams = {
   // encoding of the bytes in that buffer (defaults to 'utf8' if
   // encoding is null).
   fromBuffer: function(buffer, encoding) {
-    return InputStream(buffer.toString(encoding), true);
+    return new InputStream(buffer.toString(encoding), true);
   },
 
   // Asynchronously creates an InputStream from a file on disk given
@@ -64,7 +64,7 @@ var CharStreams = {
   // 'utf8' if encoding is null).
   fromPathSync: function(path, encoding) {
     var data = fs.readFileSync(path, encoding);
-    return InputStream(data, true);
+    return new InputStream(data, true);
   }
 };
 


### PR DESCRIPTION
Currently the JS runtime `CharStreams.fromString` sometimes returns (and mangles) the global `window` object instead of returning a proper InputStream. This is prevented by using the `new` keyword in this and similar helper methods.

@bhamiltoncx, please take a look. Perhaps I'm doing something wrong... if so, I'm happy to be mistaken!