### PR TITLE
fix go runtime compile error

### DIFF
--- a/runtime/Go/antlr/file_stream.go
+++ b/runtime/Go/antlr/file_stream.go
@@ -28,9 +28,9 @@ func NewFileStream(fileName string) (*FileStream, error) {
 		return nil, err
 	}
 	defer f.Close()
-	err = io.Copy(buf, f)
+	_, err = io.Copy(buf, f)
 	if err != nil {
-		return nil, er
+		return nil, err
 	}
 
 	fs := new(FileStream)


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->
go runtime can not compile with error
![image](https://cloud.githubusercontent.com/assets/2957936/25982477/67a1ea32-370f-11e7-97df-2e82608360af.png)
