### PR TITLE
[dotnet] NuGet packaging for .NET Core

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -145,3 +145,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/03/28, cmd-johnson, Jonas Auer, jonas.auer.94@gmail.com
 2017/04/12, lys0716, Yishuang Lu, luyscmu@gmail.com
 2017/05/11, jimallman, Jim Allman, jim@ibang.com
+2017/05/26, waf, Will Fuqua, wafuqua@gmail.com

--- a/doc/releasing-antlr.md
+++ b/doc/releasing-antlr.md
@@ -247,16 +247,13 @@ popd
 
 *Publishing to Nuget from Linux/MacOSX*
 
-**Getting ready to run Nuget**
+**Install the pre-requisites**
 
 Of course you need Mono and `nuget` to be installed. On mac:
 
-```bash
-brew install mono
-brew install nuget
-```
-
-Or, you can [download nuget.exe](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe).
+- mono - on mac, `brew install mono`
+- nuget - on mac, `brew install nuget` or you can [download nuget.exe](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe)
+- dotnet - follow [the instructions here](https://www.microsoft.com/net/core)
 
 From the shell on mac, you can check all is ok by typing
 
@@ -266,35 +263,22 @@ nuget
 
 This should display the nuget help. 
 
-**Creating the assembly**
+**Creating and packaging the assembly**
 
 ```bash
-$ cd runtime/CSharp/runtime/CSharp/Antlr4.Runtime
-$ xbuild /p:Configuration=Release Antlr4.Runtime.mono.csproj
+$ cd runtime/CSharp/runtime/CSharp
+$ ./build-nuget-package.sh
 ...
-		Copying file from '/Users/parrt/antlr/code/antlr4/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/obj/net20/Release/Antlr4.Runtime.Standard.dll' to '/Users/parrt/antlr/code/antlr4/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/lib/Release/Antlr4.Runtime.Standard.dll'
-Done building project "/Users/parrt/antlr/code/antlr4/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.mono.csproj".
-```
-
-Alternately, you may want to build ANTLR using Xamarin Studio Community (free).
-
-**Packaging for NuGet**
-
-```bash
-cd runtime/CSharp/runtime/CSharp
-```
-
-which is where the `Package.nuspec` file resides.
-
-Type the following command:
-
-```bash
-$ nuget pack Package.nuspec
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
 Attempting to build package from 'Package.nuspec'.
-Successfully created package '/Users/parrt/antlr/code/antlr4/runtime/CSharp/runtime/CSharp/Antlr4.Runtime.Standard.4.7.0.nupkg'.
+Successfully created package '/path/to/antlr/.../Antlr4.Runtime.Standard.4.7.0.nupkg'.
 ```
 
 This should display: Successfully created package *&lt;package-path>*
+
+Alternately, you may want to build ANTLR using Xamarin Studio Community (free).
 
 **Publishing to NuGet**
 

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.dotnet.csproj
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.dotnet.csproj
@@ -33,5 +33,15 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>lib\Debug</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>lib\Release</OutputPath>
+  </PropertyGroup>
 
 </Project>

--- a/runtime/CSharp/runtime/CSharp/Package.nuspec
+++ b/runtime/CSharp/runtime/CSharp/Package.nuspec
@@ -20,5 +20,6 @@
   </metadata>
   <files>
     <file src="Antlr4.Runtime/lib/Release/Antlr4.Runtime.Standard.dll" target="lib/net35/"/>
+    <file src="Antlr4.Runtime/lib/Release/netstandard1.3/Antlr4.Runtime.Core.dll" target="lib/netstandard/"/>
   </files>
 </package>

--- a/runtime/CSharp/runtime/CSharp/build-nuget-package.sh
+++ b/runtime/CSharp/runtime/CSharp/build-nuget-package.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Build a .NET 3.5 compatible DLL using mono
+# This step can be done by the `dotnet` cli once https://github.com/Microsoft/msbuild/issues/1333 is resolved.
+echo "Step 1: Building .NET 3.5 DLL"
+xbuild /p:Configuration=Release Antlr4.mono.sln
+
+# Build a .NET core DLL using the `dotnet` cli from microsoft
+echo "Step 2: Building .NET Core DLL"
+dotnet restore Antlr4.dotnet.sln
+dotnet build -c Release Antlr4.dotnet.sln
+
+echo "Step 3: Packaging both DLLs into a single nuget package"
+nuget pack Package.nuspec


### PR DESCRIPTION
This PR updates the nuspec file so the NuGet package includes the .NET Core DLL. The NuGet package has the following structure to support both .NET 3.5 and up, as well as .NET Core:

```
lib
├── net35
│   └── Antlr4.Runtime.Standard.dll
└── netstandard
    └── Antlr4.Runtime.Core.dll
```

I've verified that when the NuGet package is installed in .NET Framework projects ("normal" .NET), it references Antlr4.Runtime.Standard.dll, and in .NET Core projects it references Antlr4.Runtime.Core.dll.

For the build process, ideally to do a cross-platform build we could use a multi-targeting build with `dotnet`, the new command-line tool from Microsoft. However, due to https://github.com/Microsoft/msbuild/issues/1333 (a bug with msbuild core) we need to continue using mono to build .NET3.5, and `dotnet` to build .NET core. I've included a script that makes this easier, and updated the documentation. 

Please see the conversation from https://github.com/antlr/antlr4/pull/1229#issuecomment-304002438 for more context. /cc @ericvergnaud 