### PR TITLE
Make ParseTreeWalker::DEFAULT provide an IterativeParseTreeWalker

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -146,3 +146,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/04/12, lys0716, Yishuang Lu, luyscmu@gmail.com
 2017/05/11, jimallman, Jim Allman, jim@ibang.com
 2017/05/26, waf, Will Fuqua, wafuqua@gmail.com
+2017/05/29, kosak, Corey Kosak, kosak@kosak.com

--- a/runtime/Cpp/runtime/src/tree/ParseTreeWalker.cpp
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeWalker.cpp
@@ -14,7 +14,8 @@
 using namespace antlr4::tree;
 using namespace antlrcpp;
 
-ParseTreeWalker ParseTreeWalker::DEFAULT = IterativeParseTreeWalker();
+static IterativeParseTreeWalker defaultWalker;
+ParseTreeWalker &ParseTreeWalker::DEFAULT = defaultWalker;
 
 void ParseTreeWalker::walk(ParseTreeListener *listener, ParseTree *t) const {
   if (is<ErrorNode *>(t)) {

--- a/runtime/Cpp/runtime/src/tree/ParseTreeWalker.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeWalker.h
@@ -12,7 +12,7 @@ namespace tree {
 
   class ANTLR4CPP_PUBLIC ParseTreeWalker {
   public:
-    static ParseTreeWalker DEFAULT;
+    static ParseTreeWalker &DEFAULT;
 
     virtual ~ParseTreeWalker() {};
 


### PR DESCRIPTION
as intended.

The existing code intended for ParseTreeWalker::DEFAULT to provide a
IterativeParseTreeWalker. However, the implementation initialized
ParseTreeWalker::DEFAULT by doing a (value) copy of an
IterativeParseTreeWalker, which sliced the object and therefore,
unfortunately, transformed it back into a regular ParseTreeWalker.

This change implements the desired behavior. Furthermore by making DEFAULT
a reference, we are able to preserve the interface to existing code.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->