### PR TITLE
Fix double-free bug in example code.

### DIFF
--- a/doc/cpp-target.md
+++ b/doc/cpp-target.md
@@ -63,7 +63,8 @@ int main(int argc, const char* argv[]) {
   CommonTokenStream tokens(&lexer);
   MyGrammarParser parser(&tokens);
 
-  Ref<tree::ParseTree> tree = parser.key();
+  // MyGrammarParser owns this pointer.
+  tree::ParseTree *tree = parser.key();
   Ref<TreeShapeListener> listener(new TreeShapeListener());
   tree::ParseTreeWalker::DEFAULT->walk(listener, tree);
 


### PR DESCRIPTION
MyGrammarParser owns the pointer returned by parser.key(). That pointer is
ultimately deallocated by Parser::~Parser() via that method's call to
_tracker.reset(). Taking ownership via Ref<tree::ParseTree> would lead to
a double-free bug.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->