### PR TITLE
Fix listener example in C++ documentation.

### DIFF
--- a/doc/cpp-target.md
+++ b/doc/cpp-target.md
@@ -49,7 +49,7 @@ using namespace org::antlr::v4::runtime;
 
 class TreeShapeListener : public MyGrammarBaseListener {
 public:
-  void enterKey(Ref<ParserRuleContext> ctx) {
+  void enterKey(ParserRuleContext *ctx) override {
 	// Do something when entering the key rule.
   }
 };
@@ -72,7 +72,7 @@ int main(int argc, const char* argv[]) {
 
 ```
  
-This example assumes your grammar contains a parser rule named `key` for which the enterKey function was generated. The `Ref<>` template is an alias for `std::shared_ptr<>` to simplify the runtime source code which often makes use of smart pointers.
+This example assumes your grammar contains a parser rule named `key` for which the enterKey function was generated.
 
 ## Specialities of this ANTLR target
 


### PR DESCRIPTION
The listener example still refers to ```Ref<>``` and shared pointers, but in
reality the generated method does not pass a shared pointer. The actual
signature looks more like this:
```
  virtual void enterKey(ParserRuleContext * /*ctx*/) override { }
```
This change updates the example to match that signature, and removes a line
discussing ```Ref<>```. It also adds the ```override``` keyword in order to make the
user's code a little more robust against typos/changes in the grammar.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->