### PR TITLE
C++ runtime changes for high warning levels

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -148,3 +148,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/05/11, jimallman, Jim Allman, jim@ibang.com
 2017/05/26, waf, Will Fuqua, wafuqua@gmail.com
 2017/05/29, kosak, Corey Kosak, kosak@kosak.com
+2017/06/10, jm-mikkelsen, Jan Martin Mikkelsen, janm@transactionware.com

--- a/runtime/Cpp/runtime/src/ANTLRErrorListener.cpp
+++ b/runtime/Cpp/runtime/src/ANTLRErrorListener.cpp
@@ -1,0 +1,5 @@
+#include "ANTLRErrorListener.h"
+
+antlr4::ANTLRErrorListener::~ANTLRErrorListener()
+{
+}

--- a/runtime/Cpp/runtime/src/ANTLRErrorListener.h
+++ b/runtime/Cpp/runtime/src/ANTLRErrorListener.h
@@ -16,7 +16,7 @@ namespace antlr4 {
   /// How to emit recognition errors (an interface in Java).
   class ANTLR4CPP_PUBLIC ANTLRErrorListener {
   public:
-    virtual ~ANTLRErrorListener() {};
+    virtual ~ANTLRErrorListener();
 
     /// <summary>
     /// Upon syntax error, notify any interested parties. This is not how to

--- a/runtime/Cpp/runtime/src/ANTLRErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/ANTLRErrorStrategy.cpp
@@ -1,0 +1,5 @@
+#include "ANTLRErrorStrategy.h"
+
+antlr4::ANTLRErrorStrategy::~ANTLRErrorStrategy()
+{
+}

--- a/runtime/Cpp/runtime/src/ANTLRErrorStrategy.h
+++ b/runtime/Cpp/runtime/src/ANTLRErrorStrategy.h
@@ -32,7 +32,7 @@ namespace antlr4 {
     /// <summary>
     /// Reset the error handler state for the specified {@code recognizer}. </summary>
     /// <param name="recognizer"> the parser instance </param>
-    virtual ~ANTLRErrorStrategy() {};
+    virtual ~ANTLRErrorStrategy();
 
     virtual void reset(Parser *recognizer) = 0;
 

--- a/runtime/Cpp/runtime/src/ANTLRInputStream.cpp
+++ b/runtime/Cpp/runtime/src/ANTLRInputStream.cpp
@@ -71,7 +71,7 @@ size_t ANTLRInputStream::LA(ssize_t i) {
     return 0; // undefined
   }
 
-  ssize_t position = (ssize_t)p;
+  ssize_t position = static_cast<ssize_t>(p);
   if (i < 0) {
     i++; // e.g., translate LA(-1) to use offset i=0; then _data[p+0-1]
     if ((position + i - 1) < 0) {
@@ -79,11 +79,11 @@ size_t ANTLRInputStream::LA(ssize_t i) {
     }
   }
 
-  if ((position + i - 1) >= (ssize_t)_data.size()) {
+  if ((position + i - 1) >= static_cast<ssize_t>(_data.size())) {
     return IntStream::EOF;
   }
 
-  return _data[(size_t)(position + i - 1)];
+  return _data[static_cast<size_t>((position + i - 1))];
 }
 
 size_t ANTLRInputStream::LT(ssize_t i) {
@@ -123,8 +123,8 @@ std::string ANTLRInputStream::getText(const Interval &interval) {
     return "";
   }
 
-  size_t start = interval.a;
-  size_t stop = interval.b;
+  size_t start = static_cast<size_t>(interval.a);
+  size_t stop = static_cast<size_t>(interval.b);
 
 
   if (stop >= _data.size()) {

--- a/runtime/Cpp/runtime/src/BailErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/BailErrorStrategy.cpp
@@ -18,7 +18,7 @@ void BailErrorStrategy::recover(Parser *recognizer, std::exception_ptr e) {
     context->exception = e;
     if (context->parent == nullptr)
       break;
-    context = (ParserRuleContext *)context->parent;
+    context = static_cast<ParserRuleContext *>(context->parent);
   } while (true);
 
   try {
@@ -42,7 +42,7 @@ Token* BailErrorStrategy::recoverInline(Parser *recognizer)  {
     context->exception = exception;
     if (context->parent == nullptr)
       break;
-    context = (ParserRuleContext *)context->parent;
+    context = static_cast<ParserRuleContext *>(context->parent);
   } while (true);
 
   try {

--- a/runtime/Cpp/runtime/src/BufferedTokenStream.cpp
+++ b/runtime/Cpp/runtime/src/BufferedTokenStream.cpp
@@ -96,7 +96,7 @@ size_t BufferedTokenStream::fetch(size_t n) {
     std::unique_ptr<Token> t(_tokenSource->nextToken());
 
     if (is<WritableToken *>(t.get())) {
-      (static_cast<WritableToken *>(t.get()))->setTokenIndex((int)_tokens.size());
+      (static_cast<WritableToken *>(t.get()))->setTokenIndex(_tokens.size());
     }
 
     _tokens.push_back(std::move(t));
@@ -272,7 +272,7 @@ ssize_t BufferedTokenStream::previousTokenOnChannel(size_t i, size_t channel) {
     }
 
     if (i == 0)
-      return i;
+      break;
     i--;
   }
   return i;
@@ -289,7 +289,7 @@ std::vector<Token *> BufferedTokenStream::getHiddenTokensToRight(size_t tokenInd
   size_t from = tokenIndex + 1;
   // if none onchannel to right, nextOnChannel=-1 so set to = last token
   if (nextOnChannel == -1) {
-    to = (ssize_t)size() - 1;
+    to = static_cast<ssize_t>(size() - 1);
   } else {
     to = nextOnChannel;
   }
@@ -313,11 +313,11 @@ std::vector<Token *> BufferedTokenStream::getHiddenTokensToLeft(size_t tokenInde
   }
 
   ssize_t prevOnChannel = previousTokenOnChannel(tokenIndex - 1, Lexer::DEFAULT_TOKEN_CHANNEL);
-  if (prevOnChannel == (ssize_t)tokenIndex - 1) {
+  if (prevOnChannel == static_cast<ssize_t>(tokenIndex - 1)) {
     return { };
   }
   // if none onchannel to left, prevOnChannel=-1 then from=0
-  size_t from = (size_t)(prevOnChannel + 1);
+  size_t from = static_cast<size_t>(prevOnChannel + 1);
   size_t to = tokenIndex - 1;
 
   return filterForChannel(from, to, channel);
@@ -336,7 +336,7 @@ std::vector<Token *> BufferedTokenStream::filterForChannel(size_t from, size_t t
         hidden.push_back(t);
       }
     } else {
-      if (t->getChannel() == (size_t)channel) {
+      if (t->getChannel() == static_cast<size_t>(channel)) {
         hidden.push_back(t);
       }
     }

--- a/runtime/Cpp/runtime/src/CharStream.h
+++ b/runtime/Cpp/runtime/src/CharStream.h
@@ -13,7 +13,7 @@ namespace antlr4 {
   /// A source of characters for an ANTLR lexer.
   class ANTLR4CPP_PUBLIC CharStream : public IntStream {
   public:
-    virtual ~CharStream() = 0;
+    virtual ~CharStream();
 
     /// This method returns the text for a range of characters within this input
     /// stream. This method is guaranteed to not throw an exception if the

--- a/runtime/Cpp/runtime/src/CommonToken.cpp
+++ b/runtime/Cpp/runtime/src/CommonToken.cpp
@@ -35,7 +35,7 @@ CommonToken::CommonToken(std::pair<TokenSource*, CharStream*> source, size_t typ
   _start = start;
   _stop = stop;
   if (_source.first != nullptr) {
-    _line = (int)source.first->getLine();
+    _line = static_cast<int>(source.first->getLine());
     _charPositionInLine = source.first->getCharPositionInLine();
   }
 }

--- a/runtime/Cpp/runtime/src/CommonTokenFactory.cpp
+++ b/runtime/Cpp/runtime/src/CommonTokenFactory.cpp
@@ -13,7 +13,7 @@ using namespace antlr4;
 
 const Ref<TokenFactory<CommonToken>> CommonTokenFactory::DEFAULT = std::make_shared<CommonTokenFactory>();
 
-CommonTokenFactory::CommonTokenFactory(bool copyText_in) : copyText(copyText_in) {
+CommonTokenFactory::CommonTokenFactory(bool copyText_) : copyText(copyText_) {
 }
 
 CommonTokenFactory::CommonTokenFactory() : CommonTokenFactory(false) {

--- a/runtime/Cpp/runtime/src/CommonTokenFactory.cpp
+++ b/runtime/Cpp/runtime/src/CommonTokenFactory.cpp
@@ -13,7 +13,7 @@ using namespace antlr4;
 
 const Ref<TokenFactory<CommonToken>> CommonTokenFactory::DEFAULT = std::make_shared<CommonTokenFactory>();
 
-CommonTokenFactory::CommonTokenFactory(bool copyText) : copyText(copyText) {
+CommonTokenFactory::CommonTokenFactory(bool copyText_in) : copyText(copyText_in) {
 }
 
 CommonTokenFactory::CommonTokenFactory() : CommonTokenFactory(false) {

--- a/runtime/Cpp/runtime/src/CommonTokenStream.cpp
+++ b/runtime/Cpp/runtime/src/CommonTokenStream.cpp
@@ -12,8 +12,8 @@ using namespace antlr4;
 CommonTokenStream::CommonTokenStream(TokenSource *tokenSource) : CommonTokenStream(tokenSource, Token::DEFAULT_CHANNEL) {
 }
 
-CommonTokenStream::CommonTokenStream(TokenSource *tokenSource, size_t channel_in)
-: BufferedTokenStream(tokenSource), channel(channel_in) {
+CommonTokenStream::CommonTokenStream(TokenSource *tokenSource, size_t channel_)
+: BufferedTokenStream(tokenSource), channel(channel_) {
 }
 
 ssize_t CommonTokenStream::adjustSeekIndex(size_t i) {

--- a/runtime/Cpp/runtime/src/CommonTokenStream.cpp
+++ b/runtime/Cpp/runtime/src/CommonTokenStream.cpp
@@ -12,8 +12,8 @@ using namespace antlr4;
 CommonTokenStream::CommonTokenStream(TokenSource *tokenSource) : CommonTokenStream(tokenSource, Token::DEFAULT_CHANNEL) {
 }
 
-CommonTokenStream::CommonTokenStream(TokenSource *tokenSource, size_t channel)
-: BufferedTokenStream(tokenSource), channel(channel) {
+CommonTokenStream::CommonTokenStream(TokenSource *tokenSource, size_t channel_in)
+: BufferedTokenStream(tokenSource), channel(channel_in) {
 }
 
 ssize_t CommonTokenStream::adjustSeekIndex(size_t i) {
@@ -25,7 +25,7 @@ Token* CommonTokenStream::LB(size_t k) {
     return nullptr;
   }
 
-  ssize_t i = (ssize_t)_p;
+  ssize_t i = static_cast<ssize_t>(_p);
   size_t n = 1;
   // find k good tokens looking backwards
   while (n <= k) {
@@ -46,7 +46,7 @@ Token* CommonTokenStream::LT(ssize_t k) {
     return nullptr;
   }
   if (k < 0) {
-    return LB((size_t)-k);
+    return LB(static_cast<size_t>(-k));
   }
   size_t i = _p;
   ssize_t n = 1; // we know tokens[p] is a good one

--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
@@ -62,18 +62,18 @@ void DefaultErrorStrategy::reportError(Parser *recognizer, const RecognitionExce
 
   beginErrorCondition(recognizer);
   if (is<const NoViableAltException *>(&e)) {
-    reportNoViableAlternative(recognizer, (const NoViableAltException &)e);
+    reportNoViableAlternative(recognizer, static_cast<const NoViableAltException &>(e));
   } else if (is<const InputMismatchException *>(&e)) {
-    reportInputMismatch(recognizer, (const InputMismatchException &)e);
+    reportInputMismatch(recognizer, static_cast<const InputMismatchException &>(e));
   } else if (is<const FailedPredicateException *>(&e)) {
-    reportFailedPredicate(recognizer, (const FailedPredicateException &)e);
+    reportFailedPredicate(recognizer, static_cast<const FailedPredicateException &>(e));
   } else if (is<const RecognitionException *>(&e)) {
     recognizer->notifyErrorListeners(e.getOffendingToken(), e.what(), std::current_exception());
   }
 }
 
 void DefaultErrorStrategy::recover(Parser *recognizer, std::exception_ptr /*e*/) {
-  if (lastErrorIndex == (int)recognizer->getInputStream()->index() &&
+  if (lastErrorIndex == static_cast<int>(recognizer->getInputStream()->index()) &&
       lastErrorStates.contains(recognizer->getState())) {
 
     // uh oh, another error at same token index and previously-visited
@@ -82,7 +82,7 @@ void DefaultErrorStrategy::recover(Parser *recognizer, std::exception_ptr /*e*/)
     // at least to prevent an infinite loop; this is a failsafe.
     recognizer->consume();
   }
-  lastErrorIndex = (int)recognizer->getInputStream()->index();
+  lastErrorIndex = static_cast<int>(recognizer->getInputStream()->index());
   lastErrorStates.add(recognizer->getState());
   misc::IntervalSet followSet = getErrorRecoverySet(recognizer);
   consumeUntil(recognizer, followSet);
@@ -312,7 +312,7 @@ misc::IntervalSet DefaultErrorStrategy::getErrorRecoverySet(Parser *recognizer) 
 
     if (ctx->parent == nullptr)
       break;
-    ctx = (RuleContext *)ctx->parent;
+    ctx = static_cast<RuleContext *>(ctx->parent);
   }
   recoverSet.remove(Token::EPSILON);
 

--- a/runtime/Cpp/runtime/src/DiagnosticErrorListener.cpp
+++ b/runtime/Cpp/runtime/src/DiagnosticErrorListener.cpp
@@ -17,7 +17,7 @@ using namespace antlr4;
 DiagnosticErrorListener::DiagnosticErrorListener() : DiagnosticErrorListener(true) {
 }
 
-DiagnosticErrorListener::DiagnosticErrorListener(bool exactOnly) : exactOnly(exactOnly) {
+DiagnosticErrorListener::DiagnosticErrorListener(bool exactOnly_in) : exactOnly(exactOnly_in) {
 }
 
 void DiagnosticErrorListener::reportAmbiguity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
@@ -53,7 +53,7 @@ void DiagnosticErrorListener::reportContextSensitivity(Parser *recognizer, const
 
 std::string DiagnosticErrorListener::getDecisionDescription(Parser *recognizer, const dfa::DFA &dfa) {
   size_t decision = dfa.decision;
-  size_t ruleIndex = ((atn::ATNState*)dfa.atnStartState)->ruleIndex;
+  size_t ruleIndex = (reinterpret_cast<atn::ATNState*>(dfa.atnStartState))->ruleIndex;
 
   const std::vector<std::string>& ruleNames = recognizer->getRuleNames();
   if (ruleIndex == INVALID_INDEX || ruleIndex >= ruleNames.size()) {

--- a/runtime/Cpp/runtime/src/DiagnosticErrorListener.cpp
+++ b/runtime/Cpp/runtime/src/DiagnosticErrorListener.cpp
@@ -17,7 +17,7 @@ using namespace antlr4;
 DiagnosticErrorListener::DiagnosticErrorListener() : DiagnosticErrorListener(true) {
 }
 
-DiagnosticErrorListener::DiagnosticErrorListener(bool exactOnly_in) : exactOnly(exactOnly_in) {
+DiagnosticErrorListener::DiagnosticErrorListener(bool exactOnly_) : exactOnly(exactOnly_) {
 }
 
 void DiagnosticErrorListener::reportAmbiguity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,

--- a/runtime/Cpp/runtime/src/Exceptions.cpp
+++ b/runtime/Cpp/runtime/src/Exceptions.cpp
@@ -23,11 +23,42 @@ const char* IOException::what() const NOEXCEPT {
   return _message.c_str();
 }
 
-IllegalStateException::~IllegalStateException() = default;
-IllegalArgumentException::~IllegalArgumentException() = default;
-NullPointerException::~NullPointerException() = default;
-IndexOutOfBoundsException::~IndexOutOfBoundsException() = default;
-UnsupportedOperationException::~UnsupportedOperationException() = default;
-EmptyStackException::~EmptyStackException() = default;
-CancellationException::~CancellationException() = default;
-ParseCancellationException::~ParseCancellationException() = default;
+//------------------ IllegalStateException -----------------------------------------------------------------------------
+
+IllegalStateException::~IllegalStateException() {
+}
+
+//------------------ IllegalArgumentException --------------------------------------------------------------------------
+
+IllegalArgumentException::~IllegalArgumentException() {
+}
+
+//------------------ NullPointerException ------------------------------------------------------------------------------
+
+NullPointerException::~NullPointerException() {
+}
+
+//------------------ IndexOutOfBoundsException -------------------------------------------------------------------------
+
+IndexOutOfBoundsException::~IndexOutOfBoundsException() {
+}
+
+//------------------ UnsupportedOperationException ---------------------------------------------------------------------
+
+UnsupportedOperationException::~UnsupportedOperationException() {
+}
+
+//------------------ EmptyStackException -------------------------------------------------------------------------------
+
+EmptyStackException::~EmptyStackException() {
+}
+
+//------------------ CancellationException -----------------------------------------------------------------------------
+
+CancellationException::~CancellationException() {
+}
+
+//------------------ ParseCancellationException ------------------------------------------------------------------------
+
+ParseCancellationException::~ParseCancellationException() {
+}

--- a/runtime/Cpp/runtime/src/Exceptions.cpp
+++ b/runtime/Cpp/runtime/src/Exceptions.cpp
@@ -22,3 +22,12 @@ IOException::IOException(const std::string &msg) : std::exception(), _message(ms
 const char* IOException::what() const NOEXCEPT {
   return _message.c_str();
 }
+
+IllegalStateException::~IllegalStateException() = default;
+IllegalArgumentException::~IllegalArgumentException() = default;
+NullPointerException::~NullPointerException() = default;
+IndexOutOfBoundsException::~IndexOutOfBoundsException() = default;
+UnsupportedOperationException::~UnsupportedOperationException() = default;
+EmptyStackException::~EmptyStackException() = default;
+CancellationException::~CancellationException() = default;
+ParseCancellationException::~ParseCancellationException() = default;

--- a/runtime/Cpp/runtime/src/Exceptions.h
+++ b/runtime/Cpp/runtime/src/Exceptions.h
@@ -21,32 +21,51 @@ namespace antlr4 {
 
   class ANTLR4CPP_PUBLIC IllegalStateException : public RuntimeException {
   public:
-    IllegalStateException(const std::string &msg = "") : RuntimeException(msg) {};
+    IllegalStateException(const std::string &msg = "") : RuntimeException(msg) {}
+    IllegalStateException(IllegalStateException const&) = default;
+    ~IllegalStateException();
+    IllegalStateException& operator=(IllegalStateException const&) = default;
   };
 
   class ANTLR4CPP_PUBLIC IllegalArgumentException : public RuntimeException {
   public:
-    IllegalArgumentException(const std::string &msg = "") : RuntimeException(msg) {};
+    IllegalArgumentException(IllegalArgumentException const&) = default;
+    IllegalArgumentException(const std::string &msg = "") : RuntimeException(msg) {}
+    ~IllegalArgumentException();
+    IllegalArgumentException& operator=(IllegalArgumentException const&) = default;
   };
 
   class ANTLR4CPP_PUBLIC NullPointerException : public RuntimeException {
   public:
-    NullPointerException(const std::string &msg = "") : RuntimeException(msg) {};
+    NullPointerException(const std::string &msg = "") : RuntimeException(msg) {}
+    NullPointerException(NullPointerException const&) = default;
+    ~NullPointerException();
+    NullPointerException& operator=(NullPointerException const&) = default;
   };
 
   class ANTLR4CPP_PUBLIC IndexOutOfBoundsException : public RuntimeException {
   public:
-    IndexOutOfBoundsException(const std::string &msg = "") : RuntimeException(msg) {};
+    IndexOutOfBoundsException(const std::string &msg = "") : RuntimeException(msg) {}
+    IndexOutOfBoundsException(IndexOutOfBoundsException const&) = default;
+    ~IndexOutOfBoundsException();
+    IndexOutOfBoundsException& operator=(IndexOutOfBoundsException const&) = default;
   };
 
   class ANTLR4CPP_PUBLIC UnsupportedOperationException : public RuntimeException {
   public:
-    UnsupportedOperationException(const std::string &msg = "") : RuntimeException(msg) {};
+    UnsupportedOperationException(const std::string &msg = "") : RuntimeException(msg) {}
+    UnsupportedOperationException(UnsupportedOperationException const&) = default;
+    ~UnsupportedOperationException();
+    UnsupportedOperationException& operator=(UnsupportedOperationException const&) = default;
+
   };
 
   class ANTLR4CPP_PUBLIC EmptyStackException : public RuntimeException {
   public:
-    EmptyStackException(const std::string &msg = "") : RuntimeException(msg) {};
+    EmptyStackException(const std::string &msg = "") : RuntimeException(msg) {}
+    EmptyStackException(EmptyStackException const&) = default;
+    ~EmptyStackException();
+    EmptyStackException& operator=(EmptyStackException const&) = default;
   };
 
   // IOException is not a runtime exception (in the java hierarchy).
@@ -63,12 +82,18 @@ namespace antlr4 {
 
   class ANTLR4CPP_PUBLIC CancellationException : public IllegalStateException {
   public:
-    CancellationException(const std::string &msg = "") : IllegalStateException(msg) {};
+    CancellationException(const std::string &msg = "") : IllegalStateException(msg) {}
+    CancellationException(CancellationException const&) = default;
+    ~CancellationException();
+    CancellationException& operator=(CancellationException const&) = default;
   };
 
   class ANTLR4CPP_PUBLIC ParseCancellationException : public CancellationException {
   public:
-    ParseCancellationException(const std::string &msg = "") : CancellationException(msg) {};
+    ParseCancellationException(const std::string &msg = "") : CancellationException(msg) {}
+    ParseCancellationException(ParseCancellationException const&) = default;
+    ~ParseCancellationException();
+    ParseCancellationException& operator=(ParseCancellationException const&) = default;
   };
 
 } // namespace antlr4

--- a/runtime/Cpp/runtime/src/FailedPredicateException.cpp
+++ b/runtime/Cpp/runtime/src/FailedPredicateException.cpp
@@ -28,8 +28,8 @@ FailedPredicateException::FailedPredicateException(Parser *recognizer, const std
   atn::ATNState *s = recognizer->getInterpreter<atn::ATNSimulator>()->atn.states[recognizer->getState()];
   atn::Transition *transition = s->transitions[0];
   if (is<atn::PredicateTransition*>(transition)) {
-    _ruleIndex = ((atn::PredicateTransition *)transition)->ruleIndex;
-    _predicateIndex = ((atn::PredicateTransition *)transition)->predIndex;
+    _ruleIndex = static_cast<atn::PredicateTransition *>(transition)->ruleIndex;
+    _predicateIndex = static_cast<atn::PredicateTransition *>(transition)->predIndex;
   } else {
     _ruleIndex = 0;
     _predicateIndex = 0;

--- a/runtime/Cpp/runtime/src/InputMismatchException.cpp
+++ b/runtime/Cpp/runtime/src/InputMismatchException.cpp
@@ -13,3 +13,7 @@ InputMismatchException::InputMismatchException(Parser *recognizer)
   : RecognitionException(recognizer, recognizer->getInputStream(), recognizer->getContext(),
                          recognizer->getCurrentToken()) {
 }
+
+InputMismatchException::~InputMismatchException()
+{
+}

--- a/runtime/Cpp/runtime/src/InputMismatchException.cpp
+++ b/runtime/Cpp/runtime/src/InputMismatchException.cpp
@@ -14,6 +14,5 @@ InputMismatchException::InputMismatchException(Parser *recognizer)
                          recognizer->getCurrentToken()) {
 }
 
-InputMismatchException::~InputMismatchException()
-{
+InputMismatchException::~InputMismatchException() {
 }

--- a/runtime/Cpp/runtime/src/InputMismatchException.h
+++ b/runtime/Cpp/runtime/src/InputMismatchException.h
@@ -16,6 +16,9 @@ namespace antlr4 {
   class ANTLR4CPP_PUBLIC InputMismatchException : public RecognitionException {
   public:
     InputMismatchException(Parser *recognizer);
+    InputMismatchException(InputMismatchException const&) = default;
+    ~InputMismatchException();
+    InputMismatchException& operator=(InputMismatchException const&) = default;
   };
 
 } // namespace antlr4

--- a/runtime/Cpp/runtime/src/IntStream.cpp
+++ b/runtime/Cpp/runtime/src/IntStream.cpp
@@ -8,3 +8,5 @@
 using namespace antlr4;
 
 const std::string IntStream::UNKNOWN_SOURCE_NAME = "<unknown>";
+
+IntStream::~IntStream() = default;

--- a/runtime/Cpp/runtime/src/IntStream.h
+++ b/runtime/Cpp/runtime/src/IntStream.h
@@ -27,7 +27,7 @@ namespace antlr4 {
   /// </summary>
   class ANTLR4CPP_PUBLIC IntStream {
   public:
-    static const size_t EOF = (size_t)-1;
+    static const size_t EOF = std::numeric_limits<size_t>::max();
 
     /// The value returned by <seealso cref="#LA LA()"/> when the end of the stream is
     /// reached.
@@ -40,7 +40,7 @@ namespace antlr4 {
     /// </summary>
     static const std::string UNKNOWN_SOURCE_NAME;
 
-    virtual ~IntStream() {};
+    virtual ~IntStream();
 
     /// <summary>
     /// Consumes the current symbol in the stream. This method has the following

--- a/runtime/Cpp/runtime/src/Lexer.h
+++ b/runtime/Cpp/runtime/src/Lexer.h
@@ -19,8 +19,8 @@ namespace antlr4 {
   class ANTLR4CPP_PUBLIC Lexer : public Recognizer, public TokenSource {
   public:
     static const size_t DEFAULT_MODE = 0;
-    static const size_t MORE = std::numeric_limits<size_t>::max() - 1;
-    static const size_t SKIP = std::numeric_limits<size_t>::max() - 2;
+    static const size_t MORE = static_cast<size_t>(-2);
+    static const size_t SKIP = static_cast<size_t>(-3);
 
     static const size_t DEFAULT_TOKEN_CHANNEL = Token::DEFAULT_CHANNEL;
     static const size_t HIDDEN = Token::HIDDEN_CHANNEL;

--- a/runtime/Cpp/runtime/src/Lexer.h
+++ b/runtime/Cpp/runtime/src/Lexer.h
@@ -19,8 +19,8 @@ namespace antlr4 {
   class ANTLR4CPP_PUBLIC Lexer : public Recognizer, public TokenSource {
   public:
     static const size_t DEFAULT_MODE = 0;
-    static const size_t MORE = (size_t)-2;
-    static const size_t SKIP = (size_t)-3;
+    static const size_t MORE = std::numeric_limits<size_t>::max() - 1;
+    static const size_t SKIP = std::numeric_limits<size_t>::max() - 2;
 
     static const size_t DEFAULT_TOKEN_CHANNEL = Token::DEFAULT_CHANNEL;
     static const size_t HIDDEN = Token::HIDDEN_CHANNEL;

--- a/runtime/Cpp/runtime/src/LexerNoViableAltException.cpp
+++ b/runtime/Cpp/runtime/src/LexerNoViableAltException.cpp
@@ -28,7 +28,7 @@ atn::ATNConfigSet* LexerNoViableAltException::getDeadEndConfigs() {
 std::string LexerNoViableAltException::toString() {
   std::string symbol;
   if (_startIndex < getInputStream()->size()) {
-    symbol = ((CharStream *)getInputStream())->getText(misc::Interval(_startIndex, _startIndex));
+    symbol = static_cast<CharStream *>(getInputStream())->getText(misc::Interval(_startIndex, _startIndex));
     symbol = antlrcpp::escapeWhitespace(symbol, false);
   }
   std::string format = "LexerNoViableAltException('" + symbol + "')";

--- a/runtime/Cpp/runtime/src/ListTokenSource.cpp
+++ b/runtime/Cpp/runtime/src/ListTokenSource.cpp
@@ -11,7 +11,7 @@
 
 using namespace antlr4;
 
-ListTokenSource::ListTokenSource(std::vector<std::unique_ptr<Token>> tokens_in) : ListTokenSource(std::move(tokens_in), "") {
+ListTokenSource::ListTokenSource(std::vector<std::unique_ptr<Token>> tokens_) : ListTokenSource(std::move(tokens_), "") {
 }
 
 ListTokenSource::ListTokenSource(std::vector<std::unique_ptr<Token>> tokens_, const std::string &sourceName_)

--- a/runtime/Cpp/runtime/src/ListTokenSource.cpp
+++ b/runtime/Cpp/runtime/src/ListTokenSource.cpp
@@ -11,7 +11,7 @@
 
 using namespace antlr4;
 
-ListTokenSource::ListTokenSource(std::vector<std::unique_ptr<Token>> tokens) : ListTokenSource(std::move(tokens), "") {
+ListTokenSource::ListTokenSource(std::vector<std::unique_ptr<Token>> tokens_in) : ListTokenSource(std::move(tokens_in), "") {
 }
 
 ListTokenSource::ListTokenSource(std::vector<std::unique_ptr<Token>> tokens_, const std::string &sourceName_)
@@ -32,7 +32,7 @@ ListTokenSource::ListTokenSource(std::vector<std::unique_ptr<Token>> tokens_, co
 
     size_t stop = std::max(INVALID_INDEX, start - 1);
     tokens.emplace_back((_factory->create({ this, getInputStream() }, Token::EOF, "EOF",
-      Token::DEFAULT_CHANNEL, start, stop, (int)lastToken->getLine(), lastToken->getCharPositionInLine())));
+      Token::DEFAULT_CHANNEL, start, stop, static_cast<int>(lastToken->getLine()), lastToken->getCharPositionInLine())));
   }
 }
 

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -36,8 +36,7 @@ std::map<std::vector<uint16_t>, atn::ATN> Parser::bypassAltsAtnCache;
 Parser::TraceListener::TraceListener(Parser *outerInstance_) : outerInstance(outerInstance_) {
 }
 
-Parser::TraceListener::~TraceListener()
-{
+Parser::TraceListener::~TraceListener() {
 }
 
 void Parser::TraceListener::enterEveryRule(ParserRuleContext *ctx) {
@@ -60,8 +59,7 @@ void Parser::TraceListener::exitEveryRule(ParserRuleContext *ctx) {
 
 Parser::TrimToSizeListener Parser::TrimToSizeListener::INSTANCE;
 
-Parser::TrimToSizeListener::~TrimToSizeListener()
-{
+Parser::TrimToSizeListener::~TrimToSizeListener() {
 }
 
 void Parser::TrimToSizeListener::enterEveryRule(ParserRuleContext * /*ctx*/) {

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -33,7 +33,11 @@ using namespace antlrcpp;
 
 std::map<std::vector<uint16_t>, atn::ATN> Parser::bypassAltsAtnCache;
 
-Parser::TraceListener::TraceListener(Parser *outerInstance) : outerInstance(outerInstance) {
+Parser::TraceListener::TraceListener(Parser *outerInstance_in) : outerInstance(outerInstance_in) {
+}
+
+Parser::TraceListener::~TraceListener()
+{
 }
 
 void Parser::TraceListener::enterEveryRule(ParserRuleContext *ctx) {
@@ -55,6 +59,10 @@ void Parser::TraceListener::exitEveryRule(ParserRuleContext *ctx) {
 }
 
 Parser::TrimToSizeListener Parser::TrimToSizeListener::INSTANCE;
+
+Parser::TrimToSizeListener::~TrimToSizeListener()
+{
+}
 
 void Parser::TrimToSizeListener::enterEveryRule(ParserRuleContext * /*ctx*/) {
 }

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -33,7 +33,7 @@ using namespace antlrcpp;
 
 std::map<std::vector<uint16_t>, atn::ATN> Parser::bypassAltsAtnCache;
 
-Parser::TraceListener::TraceListener(Parser *outerInstance_in) : outerInstance(outerInstance_in) {
+Parser::TraceListener::TraceListener(Parser *outerInstance_) : outerInstance(outerInstance_) {
 }
 
 Parser::TraceListener::~TraceListener()

--- a/runtime/Cpp/runtime/src/Parser.h
+++ b/runtime/Cpp/runtime/src/Parser.h
@@ -21,7 +21,7 @@ namespace antlr4 {
     class TraceListener : public tree::ParseTreeListener {
     public:
       TraceListener(Parser *outerInstance);
-      virtual ~TraceListener() {};
+      virtual ~TraceListener();
 
       virtual void enterEveryRule(ParserRuleContext *ctx) override;
       virtual void visitTerminal(tree::TerminalNode *node) override;
@@ -36,7 +36,7 @@ namespace antlr4 {
     public:
       static TrimToSizeListener INSTANCE;
 
-      virtual ~TrimToSizeListener() {};
+      virtual ~TrimToSizeListener();
 
       virtual void enterEveryRule(ParserRuleContext *ctx) override;
       virtual void visitTerminal(tree::TerminalNode *node) override;
@@ -375,7 +375,7 @@ namespace antlr4 {
      */
     bool isTrace() const;
 
-    tree::ParseTreeTracker& getTreeTracker() { return _tracker; };
+    tree::ParseTreeTracker& getTreeTracker() { return _tracker; }
 
     /** How to create a token leaf node associated with a parent.
      *  Typically, the terminal node to create is not a function of the parent

--- a/runtime/Cpp/runtime/src/ParserInterpreter.cpp
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.cpp
@@ -174,19 +174,19 @@ void ParserInterpreter::visitState(atn::ATNState *p) {
         // We are at the start of a left recursive rule's (...)* loop
         // and we're not taking the exit branch of loop.
         InterpreterRuleContext *localctx = createInterpreterRuleContext(_parentContextStack.top().first,
-          _parentContextStack.top().second, (int)_ctx->getRuleIndex());
-        pushNewRecursionContext(localctx, _atn.ruleToStartState[p->ruleIndex]->stateNumber, (int)_ctx->getRuleIndex());
+          _parentContextStack.top().second, static_cast<int>(_ctx->getRuleIndex()));
+        pushNewRecursionContext(localctx, _atn.ruleToStartState[p->ruleIndex]->stateNumber, static_cast<int>(_ctx->getRuleIndex()));
       }
       break;
 
     case atn::Transition::ATOM:
-      match((int)((atn::AtomTransition*)(transition))->_label);
+      match(static_cast<int>(static_cast<atn::AtomTransition*>(transition)->_label));
       break;
 
     case atn::Transition::RANGE:
     case atn::Transition::SET:
     case atn::Transition::NOT_SET:
-      if (!transition->matches((int)_input->LA(1), Token::MIN_USER_TOKEN_TYPE, Lexer::MAX_CHAR_VALUE)) {
+      if (!transition->matches(static_cast<int>(_input->LA(1)), Token::MIN_USER_TOKEN_TYPE, Lexer::MAX_CHAR_VALUE)) {
         recoverInline();
       }
       matchWildcard();
@@ -198,11 +198,11 @@ void ParserInterpreter::visitState(atn::ATNState *p) {
 
     case atn::Transition::RULE:
     {
-      atn::RuleStartState *ruleStartState = (atn::RuleStartState*)(transition->target);
+      atn::RuleStartState *ruleStartState = static_cast<atn::RuleStartState*>(transition->target);
       size_t ruleIndex = ruleStartState->ruleIndex;
       InterpreterRuleContext *newctx = createInterpreterRuleContext(_ctx, p->stateNumber, ruleIndex);
       if (ruleStartState->isLeftRecursiveRule) {
-        enterRecursionRule(newctx, ruleStartState->stateNumber, ruleIndex, ((atn::RuleTransition*)(transition))->precedence);
+        enterRecursionRule(newctx, ruleStartState->stateNumber, ruleIndex, static_cast<atn::RuleTransition*>(transition)->precedence);
       } else {
         enterRule(newctx, transition->target->stateNumber, ruleIndex);
       }
@@ -211,7 +211,7 @@ void ParserInterpreter::visitState(atn::ATNState *p) {
 
     case atn::Transition::PREDICATE:
     {
-      atn::PredicateTransition *predicateTransition = (atn::PredicateTransition*)(transition);
+      atn::PredicateTransition *predicateTransition = static_cast<atn::PredicateTransition*>(transition);
       if (!sempred(_ctx, predicateTransition->ruleIndex, predicateTransition->predIndex)) {
         throw FailedPredicateException(this);
       }
@@ -220,15 +220,15 @@ void ParserInterpreter::visitState(atn::ATNState *p) {
 
     case atn::Transition::ACTION:
     {
-      atn::ActionTransition *actionTransition = (atn::ActionTransition*)(transition);
+      atn::ActionTransition *actionTransition = static_cast<atn::ActionTransition*>(transition);
       action(_ctx, actionTransition->ruleIndex, actionTransition->actionIndex);
     }
       break;
 
     case atn::Transition::PRECEDENCE:
     {
-      if (!precpred(_ctx, ((atn::PrecedencePredicateTransition*)(transition))->precedence)) {
-        throw FailedPredicateException(this, "precpred(_ctx, " + std::to_string(((atn::PrecedencePredicateTransition*)(transition))->precedence) +  ")");
+      if (!precpred(_ctx, static_cast<atn::PrecedencePredicateTransition*>(transition)->precedence)) {
+        throw FailedPredicateException(this, "precpred(_ctx, " + std::to_string(static_cast<atn::PrecedencePredicateTransition*>(transition)->precedence) +  ")");
       }
     }
       break;
@@ -283,7 +283,7 @@ void ParserInterpreter::recover(RecognitionException &e) {
   if (_input->index() == i) {
     // no input consumed, better add an error node
     if (is<InputMismatchException *>(&e)) {
-      InputMismatchException &ime = (InputMismatchException&)e;
+      InputMismatchException &ime = static_cast<InputMismatchException&>(e);
       Token *tok = e.getOffendingToken();
       size_t expectedTokenType = ime.getExpectedTokens().getMinElement(); // get any element
       _errorToken = getTokenFactory()->create({ tok->getTokenSource(), tok->getTokenSource()->getInputStream() },

--- a/runtime/Cpp/runtime/src/RecognitionException.cpp
+++ b/runtime/Cpp/runtime/src/RecognitionException.cpp
@@ -27,8 +27,7 @@ RecognitionException::RecognitionException(const std::string &message, Recognize
   }
 }
 
-RecognitionException::~RecognitionException()
-{
+RecognitionException::~RecognitionException() {
 }
 
 size_t RecognitionException::getOffendingState() const {

--- a/runtime/Cpp/runtime/src/RecognitionException.cpp
+++ b/runtime/Cpp/runtime/src/RecognitionException.cpp
@@ -27,6 +27,10 @@ RecognitionException::RecognitionException(const std::string &message, Recognize
   }
 }
 
+RecognitionException::~RecognitionException()
+{
+}
+
 size_t RecognitionException::getOffendingState() const {
   return _offendingState;
 }

--- a/runtime/Cpp/runtime/src/RecognitionException.h
+++ b/runtime/Cpp/runtime/src/RecognitionException.h
@@ -33,7 +33,9 @@ namespace antlr4 {
                          Token *offendingToken = nullptr);
     RecognitionException(const std::string &message, Recognizer *recognizer, IntStream *input,
                          ParserRuleContext *ctx, Token *offendingToken = nullptr);
-    ~RecognitionException() {}
+    RecognitionException(RecognitionException const&) = default;
+    ~RecognitionException();
+    RecognitionException& operator=(RecognitionException const&) = default;
 
     /// Get the ATN state number the parser was in at the time the error
     /// occurred. For NoViableAltException and

--- a/runtime/Cpp/runtime/src/Recognizer.cpp
+++ b/runtime/Cpp/runtime/src/Recognizer.cpp
@@ -27,6 +27,10 @@ Recognizer::Recognizer() {
   _proxListener.addErrorListener(&ConsoleErrorListener::INSTANCE);
 }
 
+Recognizer::~Recognizer()
+{
+}
+
 dfa::Vocabulary const& Recognizer::getVocabulary() const {
   static dfa::Vocabulary vocabulary = dfa::Vocabulary::fromTokenNames(getTokenNames());
   return vocabulary;

--- a/runtime/Cpp/runtime/src/Recognizer.cpp
+++ b/runtime/Cpp/runtime/src/Recognizer.cpp
@@ -27,8 +27,7 @@ Recognizer::Recognizer() {
   _proxListener.addErrorListener(&ConsoleErrorListener::INSTANCE);
 }
 
-Recognizer::~Recognizer()
-{
+Recognizer::~Recognizer() {
 }
 
 dfa::Vocabulary const& Recognizer::getVocabulary() const {

--- a/runtime/Cpp/runtime/src/Recognizer.h
+++ b/runtime/Cpp/runtime/src/Recognizer.h
@@ -11,10 +11,13 @@ namespace antlr4 {
 
   class ANTLR4CPP_PUBLIC Recognizer {
   public:
-    static const size_t EOF = (size_t)-1;
+    static const size_t EOF = std::numeric_limits<size_t>::max();
 
     Recognizer();
-    virtual ~Recognizer() {};
+    Recognizer(Recognizer const&) = delete;
+    virtual ~Recognizer();
+
+    Recognizer& operator=(Recognizer const&) = delete;
 
     /** Used to print out token names like ID during debugging and
      *  error reporting.  The generated parsers implement a method

--- a/runtime/Cpp/runtime/src/RuleContext.cpp
+++ b/runtime/Cpp/runtime/src/RuleContext.cpp
@@ -19,10 +19,10 @@ RuleContext::RuleContext() {
   InitializeInstanceFields();
 }
 
-RuleContext::RuleContext(RuleContext *parent, size_t invokingState_in) {
+RuleContext::RuleContext(RuleContext *parent_, size_t invokingState_) {
   InitializeInstanceFields();
-  this->parent = parent;
-  this->invokingState = invokingState_in;
+  this->parent = parent_;
+  this->invokingState = invokingState_;
 }
 
 int RuleContext::depth() {

--- a/runtime/Cpp/runtime/src/RuleContext.cpp
+++ b/runtime/Cpp/runtime/src/RuleContext.cpp
@@ -19,10 +19,10 @@ RuleContext::RuleContext() {
   InitializeInstanceFields();
 }
 
-RuleContext::RuleContext(RuleContext *parent, size_t invokingState) {
+RuleContext::RuleContext(RuleContext *parent, size_t invokingState_in) {
   InitializeInstanceFields();
   this->parent = parent;
-  this->invokingState = invokingState;
+  this->invokingState = invokingState_in;
 }
 
 int RuleContext::depth() {
@@ -31,7 +31,7 @@ int RuleContext::depth() {
   while (true) {
     if (p->parent == nullptr)
       break;
-    p = (RuleContext *)p->parent;
+    p = static_cast<RuleContext *>(p->parent);
     n++;
   }
   return n;
@@ -112,7 +112,7 @@ std::string RuleContext::toString(const std::vector<std::string> &ruleNames, Rul
 
     if (currentParent->parent == nullptr) // No parent anymore.
       break;
-    currentParent = (RuleContext *)currentParent->parent;
+    currentParent = static_cast<RuleContext *>(currentParent->parent);
     if (!ruleNames.empty() || !currentParent->isEmpty()) {
       ss << " ";
     }

--- a/runtime/Cpp/runtime/src/Token.cpp
+++ b/runtime/Cpp/runtime/src/Token.cpp
@@ -1,0 +1,5 @@
+#include "Token.h"
+
+antlr4::Token::~Token()
+{
+}

--- a/runtime/Cpp/runtime/src/Token.cpp
+++ b/runtime/Cpp/runtime/src/Token.cpp
@@ -1,5 +1,4 @@
 #include "Token.h"
 
-antlr4::Token::~Token()
-{
+antlr4::Token::~Token() {
 }

--- a/runtime/Cpp/runtime/src/Token.h
+++ b/runtime/Cpp/runtime/src/Token.h
@@ -18,11 +18,11 @@ namespace antlr4 {
 
     /// During lookahead operations, this "token" signifies we hit rule end ATN state
     /// and did not follow it despite needing to.
-    static const size_t EPSILON = (size_t)-2;
+    static const size_t EPSILON = std::numeric_limits<size_t>::max() - 1;
     static const size_t MIN_USER_TOKEN_TYPE = 1;
     static const size_t EOF = IntStream::EOF;
 
-    virtual ~Token() {};
+    virtual ~Token();
 
     /// All tokens go to the parser (unless skip() is called in that rule)
     /// on a particular "channel".  The parser tunes to a particular channel

--- a/runtime/Cpp/runtime/src/TokenFactory.h
+++ b/runtime/Cpp/runtime/src/TokenFactory.h
@@ -15,7 +15,7 @@ namespace antlr4 {
   template<typename Symbol>
   class ANTLR4CPP_PUBLIC TokenFactory {
   public:
-    virtual ~TokenFactory() {};
+    virtual ~TokenFactory() {}
 
     /// This is the method used to create tokens in the lexer and in the
     /// error handling strategy. If text!=null, than the start and stop positions

--- a/runtime/Cpp/runtime/src/TokenSource.cpp
+++ b/runtime/Cpp/runtime/src/TokenSource.cpp
@@ -1,5 +1,4 @@
 #include "TokenSource.h"
 
-antlr4::TokenSource::~TokenSource()
-{
+antlr4::TokenSource::~TokenSource() {
 }

--- a/runtime/Cpp/runtime/src/TokenSource.cpp
+++ b/runtime/Cpp/runtime/src/TokenSource.cpp
@@ -1,0 +1,5 @@
+#include "TokenSource.h"
+
+antlr4::TokenSource::~TokenSource()
+{
+}

--- a/runtime/Cpp/runtime/src/TokenSource.h
+++ b/runtime/Cpp/runtime/src/TokenSource.h
@@ -26,7 +26,7 @@ namespace antlr4 {
   /// </summary>
   class ANTLR4CPP_PUBLIC TokenSource {
   public:
-    virtual ~TokenSource() {};
+    virtual ~TokenSource();
 
     /// Return a <seealso cref="Token"/> object from your input stream (usually a
     /// <seealso cref="CharStream"/>). Do not fail/return upon lexing error; keep chewing

--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
@@ -14,19 +14,23 @@ using namespace antlr4;
 
 using antlr4::misc::Interval;
 
-TokenStreamRewriter::RewriteOperation::RewriteOperation(TokenStreamRewriter *outerInstance, size_t index)
-  : outerInstance(outerInstance) {
+TokenStreamRewriter::RewriteOperation::RewriteOperation(TokenStreamRewriter *outerInstance_in, size_t index_in)
+  : outerInstance(outerInstance_in) {
 
   InitializeInstanceFields();
-  this->index = index;
+  this->index = index_in;
 }
 
-TokenStreamRewriter::RewriteOperation::RewriteOperation(TokenStreamRewriter *outerInstance, size_t index,
-  const std::string& text) : outerInstance(outerInstance) {
+TokenStreamRewriter::RewriteOperation::RewriteOperation(TokenStreamRewriter *outerInstance_in, size_t index_in,
+  const std::string& text_in) : outerInstance(outerInstance_in) {
 
   InitializeInstanceFields();
-  this->index = index;
-  this->text = text;
+  this->index = index_in;
+  this->text = text_in;
+}
+
+TokenStreamRewriter::RewriteOperation::~RewriteOperation()
+{
 }
 
 size_t TokenStreamRewriter::RewriteOperation::execute(std::string * /*buf*/) {
@@ -45,8 +49,8 @@ void TokenStreamRewriter::RewriteOperation::InitializeInstanceFields() {
   index = 0;
 }
 
-TokenStreamRewriter::InsertBeforeOp::InsertBeforeOp(TokenStreamRewriter *outerInstance, size_t index, const std::string& text)
-: RewriteOperation(outerInstance, index, text), outerInstance(outerInstance) {
+TokenStreamRewriter::InsertBeforeOp::InsertBeforeOp(TokenStreamRewriter *outerInstance_in, size_t index_in, const std::string& text_in)
+: RewriteOperation(outerInstance_in, index_in, text_in), outerInstance(outerInstance_in) {
 }
 
 size_t TokenStreamRewriter::InsertBeforeOp::execute(std::string *buf) {
@@ -57,8 +61,8 @@ size_t TokenStreamRewriter::InsertBeforeOp::execute(std::string *buf) {
   return index + 1;
 }
 
-TokenStreamRewriter::ReplaceOp::ReplaceOp(TokenStreamRewriter *outerInstance, size_t from, size_t to, const std::string& text)
-: RewriteOperation(outerInstance, from, text), outerInstance(outerInstance) {
+TokenStreamRewriter::ReplaceOp::ReplaceOp(TokenStreamRewriter *outerInstance_in, size_t from, size_t to, const std::string& text)
+: RewriteOperation(outerInstance_in, from, text), outerInstance(outerInstance_in) {
 
   InitializeInstanceFields();
   lastIndex = to;
@@ -84,7 +88,7 @@ void TokenStreamRewriter::ReplaceOp::InitializeInstanceFields() {
 
 const std::string TokenStreamRewriter::DEFAULT_PROGRAM_NAME = "default";
 
-TokenStreamRewriter::TokenStreamRewriter(TokenStream *tokens) : tokens(tokens) {
+TokenStreamRewriter::TokenStreamRewriter(TokenStream *tokens_in) : tokens(tokens_in) {
   _programs[DEFAULT_PROGRAM_NAME].reserve(PROGRAM_INIT_SIZE);
 }
 
@@ -413,10 +417,10 @@ std::string TokenStreamRewriter::catOpText(std::string *a, std::string *b) {
   std::string x = "";
   std::string y = "";
   if (a != nullptr) {
-    x = std::string(*a);
+    x = *a;
   }
   if (b != nullptr) {
-    y = std::string(*b);
+    y = *b;
   }
   return x + y;
 }

--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
@@ -14,19 +14,19 @@ using namespace antlr4;
 
 using antlr4::misc::Interval;
 
-TokenStreamRewriter::RewriteOperation::RewriteOperation(TokenStreamRewriter *outerInstance_in, size_t index_in)
-  : outerInstance(outerInstance_in) {
+TokenStreamRewriter::RewriteOperation::RewriteOperation(TokenStreamRewriter *outerInstance_, size_t index_)
+  : outerInstance(outerInstance_) {
 
   InitializeInstanceFields();
-  this->index = index_in;
+  this->index = index_;
 }
 
-TokenStreamRewriter::RewriteOperation::RewriteOperation(TokenStreamRewriter *outerInstance_in, size_t index_in,
-  const std::string& text_in) : outerInstance(outerInstance_in) {
+TokenStreamRewriter::RewriteOperation::RewriteOperation(TokenStreamRewriter *outerInstance_, size_t index_,
+  const std::string& text_) : outerInstance(outerInstance_) {
 
   InitializeInstanceFields();
-  this->index = index_in;
-  this->text = text_in;
+  this->index = index_;
+  this->text = text_;
 }
 
 TokenStreamRewriter::RewriteOperation::~RewriteOperation()
@@ -49,8 +49,8 @@ void TokenStreamRewriter::RewriteOperation::InitializeInstanceFields() {
   index = 0;
 }
 
-TokenStreamRewriter::InsertBeforeOp::InsertBeforeOp(TokenStreamRewriter *outerInstance_in, size_t index_in, const std::string& text_in)
-: RewriteOperation(outerInstance_in, index_in, text_in), outerInstance(outerInstance_in) {
+TokenStreamRewriter::InsertBeforeOp::InsertBeforeOp(TokenStreamRewriter *outerInstance_, size_t index_, const std::string& text_)
+: RewriteOperation(outerInstance_, index_, text_), outerInstance(outerInstance_) {
 }
 
 size_t TokenStreamRewriter::InsertBeforeOp::execute(std::string *buf) {
@@ -61,8 +61,8 @@ size_t TokenStreamRewriter::InsertBeforeOp::execute(std::string *buf) {
   return index + 1;
 }
 
-TokenStreamRewriter::ReplaceOp::ReplaceOp(TokenStreamRewriter *outerInstance_in, size_t from, size_t to, const std::string& text)
-: RewriteOperation(outerInstance_in, from, text), outerInstance(outerInstance_in) {
+TokenStreamRewriter::ReplaceOp::ReplaceOp(TokenStreamRewriter *outerInstance_, size_t from, size_t to, const std::string& text)
+: RewriteOperation(outerInstance_, from, text), outerInstance(outerInstance_) {
 
   InitializeInstanceFields();
   lastIndex = to;
@@ -88,7 +88,7 @@ void TokenStreamRewriter::ReplaceOp::InitializeInstanceFields() {
 
 const std::string TokenStreamRewriter::DEFAULT_PROGRAM_NAME = "default";
 
-TokenStreamRewriter::TokenStreamRewriter(TokenStream *tokens_in) : tokens(tokens_in) {
+TokenStreamRewriter::TokenStreamRewriter(TokenStream *tokens_) : tokens(tokens_) {
   _programs[DEFAULT_PROGRAM_NAME].reserve(PROGRAM_INIT_SIZE);
 }
 

--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.h
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.h
@@ -164,7 +164,7 @@ namespace antlr4 {
 
       RewriteOperation(TokenStreamRewriter *outerInstance, size_t index);
       RewriteOperation(TokenStreamRewriter *outerInstance, size_t index, const std::string& text);
-      virtual ~RewriteOperation() {};
+      virtual ~RewriteOperation();
 
       /// Execute the rewrite operation by possibly adding to the buffer.
       /// Return the index of the next token to operate on.

--- a/runtime/Cpp/runtime/src/Vocabulary.cpp
+++ b/runtime/Cpp/runtime/src/Vocabulary.cpp
@@ -22,8 +22,7 @@ Vocabulary::Vocabulary(const std::vector<std::string> &literalNames,
   // See note here on -1 part: https://github.com/antlr/antlr4/pull/1146
 }
 
-Vocabulary::~Vocabulary()
-{
+Vocabulary::~Vocabulary() {
 }
 
 Vocabulary Vocabulary::fromTokenNames(const std::vector<std::string> &tokenNames) {

--- a/runtime/Cpp/runtime/src/Vocabulary.cpp
+++ b/runtime/Cpp/runtime/src/Vocabulary.cpp
@@ -22,6 +22,10 @@ Vocabulary::Vocabulary(const std::vector<std::string> &literalNames,
   // See note here on -1 part: https://github.com/antlr/antlr4/pull/1146
 }
 
+Vocabulary::~Vocabulary()
+{
+}
+
 Vocabulary Vocabulary::fromTokenNames(const std::vector<std::string> &tokenNames) {
   if (tokenNames.empty()) {
     return EMPTY_VOCABULARY;

--- a/runtime/Cpp/runtime/src/Vocabulary.h
+++ b/runtime/Cpp/runtime/src/Vocabulary.h
@@ -14,7 +14,9 @@ namespace dfa {
   /// interface.
   class ANTLR4CPP_PUBLIC Vocabulary {
   public:
-    virtual ~Vocabulary() {};
+    Vocabulary(Vocabulary const&) = default;
+    virtual ~Vocabulary();
+    Vocabulary& operator=(Vocabulary const&) = default;
 
     /// Gets an empty <seealso cref="Vocabulary"/> instance.
     ///
@@ -24,7 +26,7 @@ namespace dfa {
     /// except <seealso cref="Token#EOF"/>.</para>
     static const Vocabulary EMPTY_VOCABULARY;
 
-    Vocabulary() {};
+    Vocabulary() {}
 
     /// <summary>
     /// Constructs a new instance of <seealso cref="Vocabulary"/> from the specified

--- a/runtime/Cpp/runtime/src/WritableToken.cpp
+++ b/runtime/Cpp/runtime/src/WritableToken.cpp
@@ -1,5 +1,4 @@
 #include "WritableToken.h"
 
-antlr4::WritableToken::~WritableToken()
-{
+antlr4::WritableToken::~WritableToken() {
 }

--- a/runtime/Cpp/runtime/src/WritableToken.cpp
+++ b/runtime/Cpp/runtime/src/WritableToken.cpp
@@ -1,0 +1,5 @@
+#include "WritableToken.h"
+
+antlr4::WritableToken::~WritableToken()
+{
+}

--- a/runtime/Cpp/runtime/src/WritableToken.h
+++ b/runtime/Cpp/runtime/src/WritableToken.h
@@ -11,6 +11,7 @@ namespace antlr4 {
 
   class ANTLR4CPP_PUBLIC WritableToken : public Token {
   public:
+    virtual ~WritableToken();
     virtual void setText(const std::string &text) = 0;
     virtual void setType(size_t ttype) = 0;
     virtual void setLine(size_t line) = 0;

--- a/runtime/Cpp/runtime/src/antlr4-common.h
+++ b/runtime/Cpp/runtime/src/antlr4-common.h
@@ -77,7 +77,7 @@
 
   class ANTLR4CPP_PUBLIC std::exception; // Needed for VS 2015.
 
-#elif __APPLE__
+#elif defined(__APPLE__)
   typedef std::u32string UTF32String;
 
   #define GUID_CFUUID

--- a/runtime/Cpp/runtime/src/antlr4-common.h
+++ b/runtime/Cpp/runtime/src/antlr4-common.h
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <limits.h>
 #include <list>
 #include <map>
@@ -76,7 +77,7 @@
   class ANTLR4CPP_PUBLIC std::exception; // Needed for VS 2015.
 #endif
 
-#elif __APPLE__
+#elif defined(__APPLE__)
   #define GUID_CFUUID
   #if __GNUC__ >= 4
     #define ANTLR4CPP_PUBLIC __attribute__ ((visibility ("default")))
@@ -120,5 +121,5 @@
 #undef EOF
 #endif
 
-#define INVALID_INDEX (size_t)-1
+#define INVALID_INDEX std::numeric_limits<size_t>::max()
 template<class T> using Ref = std::shared_ptr<T>;

--- a/runtime/Cpp/runtime/src/atn/ATN.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATN.cpp
@@ -88,10 +88,10 @@ misc::IntervalSet ATN::nextTokens(ATNState *s, RuleContext *ctx) const {
 }
 
 misc::IntervalSet& ATN::nextTokens(ATNState *s) const {
-  if (s->nextTokenWithinRule.isEmpty()) {
-    auto candidate = nextTokens(s, nullptr);
-    if (!candidate.isEmpty() || !s->nextTokenWithinRule.isReadOnly()) {
-      s->nextTokenWithinRule = candidate;
+  if (!s->nextTokenWithinRule.isReadOnly()) {
+    std::unique_lock<std::mutex> lock { _mutex };
+    if (!s->nextTokenWithinRule.isReadOnly()) {
+      s->nextTokenWithinRule = nextTokens(s, nullptr);
       s->nextTokenWithinRule.setReadOnly(true);
     }
   }

--- a/runtime/Cpp/runtime/src/atn/ATN.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATN.cpp
@@ -89,8 +89,11 @@ misc::IntervalSet ATN::nextTokens(ATNState *s, RuleContext *ctx) const {
 
 misc::IntervalSet& ATN::nextTokens(ATNState *s) const {
   if (s->nextTokenWithinRule.isEmpty()) {
-    s->nextTokenWithinRule = nextTokens(s, nullptr);
-    s->nextTokenWithinRule.setReadOnly(true);
+    auto candidate = nextTokens(s, nullptr);
+    if (!candidate.isEmpty() || !s->nextTokenWithinRule.isReadOnly()) {
+      s->nextTokenWithinRule = candidate;
+      s->nextTokenWithinRule.setReadOnly(true);
+    }
   }
   return s->nextTokenWithinRule;
 }

--- a/runtime/Cpp/runtime/src/atn/ATN.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATN.cpp
@@ -36,7 +36,7 @@ ATN::ATN(ATN &&other) {
   modeToStartState = std::move(other.modeToStartState);
 }
 
-ATN::ATN(ATNType grammarType_in, size_t maxTokenType_in) : grammarType(grammarType_in), maxTokenType(maxTokenType_in) {
+ATN::ATN(ATNType grammarType_, size_t maxTokenType_) : grammarType(grammarType_), maxTokenType(maxTokenType_) {
 }
 
 ATN::~ATN() {

--- a/runtime/Cpp/runtime/src/atn/ATN.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATN.cpp
@@ -36,7 +36,7 @@ ATN::ATN(ATN &&other) {
   modeToStartState = std::move(other.modeToStartState);
 }
 
-ATN::ATN(ATNType grammarType, size_t maxTokenType) : grammarType(grammarType), maxTokenType(maxTokenType) {
+ATN::ATN(ATNType grammarType_in, size_t maxTokenType_in) : grammarType(grammarType_in), maxTokenType(maxTokenType_in) {
 }
 
 ATN::~ATN() {

--- a/runtime/Cpp/runtime/src/atn/ATN.h
+++ b/runtime/Cpp/runtime/src/atn/ATN.h
@@ -103,6 +103,9 @@ namespace atn {
     virtual misc::IntervalSet getExpectedTokens(size_t stateNumber, RuleContext *context) const;
 
     std::string toString() const;
+
+  private:
+    mutable std::mutex _mutex;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
@@ -13,19 +13,19 @@ using namespace antlr4::atn;
 
 const size_t ATNConfig::SUPPRESS_PRECEDENCE_FILTER = 0x40000000;
 
-ATNConfig::ATNConfig(ATNState *state, size_t alt, Ref<PredictionContext> const& context)
-  : ATNConfig(state, alt, context, SemanticContext::NONE) {
+ATNConfig::ATNConfig(ATNState *state_in, size_t alt_in, Ref<PredictionContext> const& context_in)
+  : ATNConfig(state_in, alt_in, context_in, SemanticContext::NONE) {
 }
 
-ATNConfig::ATNConfig(ATNState *state, size_t alt, Ref<PredictionContext> const& context, Ref<SemanticContext> const& semanticContext)
-  : state(state), alt(alt), context(context), semanticContext(semanticContext) {
+ATNConfig::ATNConfig(ATNState *state_in, size_t alt_in, Ref<PredictionContext> const& context_in, Ref<SemanticContext> const& semanticContext_in)
+  : state(state_in), alt(alt_in), context(context_in), semanticContext(semanticContext_in) {
   reachesIntoOuterContext = 0;
 }
 
 ATNConfig::ATNConfig(Ref<ATNConfig> const& c) : ATNConfig(c, c->state, c->context, c->semanticContext) {
 }
 
-ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state) : ATNConfig(c, state, c->context, c->semanticContext) {
+ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state_in) : ATNConfig(c, state_in, c->context, c->semanticContext) {
 }
 
 ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<SemanticContext> const& semanticContext)

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
@@ -13,19 +13,19 @@ using namespace antlr4::atn;
 
 const size_t ATNConfig::SUPPRESS_PRECEDENCE_FILTER = 0x40000000;
 
-ATNConfig::ATNConfig(ATNState *state_in, size_t alt_in, Ref<PredictionContext> const& context_in)
-  : ATNConfig(state_in, alt_in, context_in, SemanticContext::NONE) {
+ATNConfig::ATNConfig(ATNState *state_, size_t alt_, Ref<PredictionContext> const& context_)
+  : ATNConfig(state_, alt_, context_, SemanticContext::NONE) {
 }
 
-ATNConfig::ATNConfig(ATNState *state_in, size_t alt_in, Ref<PredictionContext> const& context_in, Ref<SemanticContext> const& semanticContext_in)
-  : state(state_in), alt(alt_in), context(context_in), semanticContext(semanticContext_in) {
+ATNConfig::ATNConfig(ATNState *state_, size_t alt_, Ref<PredictionContext> const& context_, Ref<SemanticContext> const& semanticContext_)
+  : state(state_), alt(alt_), context(context_), semanticContext(semanticContext_) {
   reachesIntoOuterContext = 0;
 }
 
 ATNConfig::ATNConfig(Ref<ATNConfig> const& c) : ATNConfig(c, c->state, c->context, c->semanticContext) {
 }
 
-ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state_in) : ATNConfig(c, state_in, c->context, c->semanticContext) {
+ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state_) : ATNConfig(c, state_, c->context, c->semanticContext) {
 }
 
 ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<SemanticContext> const& semanticContext)

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.h
@@ -85,7 +85,9 @@ namespace atn {
     ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> const& context);
     ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> const& context, Ref<SemanticContext> const& semanticContext);
 
+    ATNConfig(ATNConfig const&) = default;
     virtual ~ATNConfig();
+    ATNConfig& operator=(ATNConfig const&) = default;
 
     virtual size_t hashCode() const;
 

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializationOptions.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializationOptions.cpp
@@ -18,8 +18,7 @@ ATNDeserializationOptions::ATNDeserializationOptions(ATNDeserializationOptions *
   this->generateRuleBypassTransitions = options->generateRuleBypassTransitions;
 }
 
-ATNDeserializationOptions::~ATNDeserializationOptions()
-{
+ATNDeserializationOptions::~ATNDeserializationOptions() {
 }
 
 const ATNDeserializationOptions& ATNDeserializationOptions::getDefaultOptions() {

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializationOptions.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializationOptions.cpp
@@ -18,6 +18,10 @@ ATNDeserializationOptions::ATNDeserializationOptions(ATNDeserializationOptions *
   this->generateRuleBypassTransitions = options->generateRuleBypassTransitions;
 }
 
+ATNDeserializationOptions::~ATNDeserializationOptions()
+{
+}
+
 const ATNDeserializationOptions& ATNDeserializationOptions::getDefaultOptions() {
   return defaultOptions;
 }

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializationOptions.h
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializationOptions.h
@@ -21,7 +21,9 @@ namespace atn {
   public:
     ATNDeserializationOptions();
     ATNDeserializationOptions(ATNDeserializationOptions *options);
-    virtual ~ATNDeserializationOptions() {};
+    ATNDeserializationOptions(ATNDeserializationOptions const&) = default;
+    virtual ~ATNDeserializationOptions();
+    ATNDeserializationOptions& operator=(ATNDeserializationOptions const&) = default;
 
     static const ATNDeserializationOptions& getDefaultOptions();
 

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
@@ -110,8 +110,7 @@ ATNDeserializer::ATNDeserializer(): ATNDeserializer(ATNDeserializationOptions::g
 ATNDeserializer::ATNDeserializer(const ATNDeserializationOptions& dso): deserializationOptions(dso) {
 }
 
-ATNDeserializer::~ATNDeserializer()
-{
+ATNDeserializer::~ATNDeserializer() {
 }
 
 /**

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
@@ -51,6 +51,8 @@
 
 #include "atn/ATNDeserializer.h"
 
+#include <string>
+
 using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlrcpp;
@@ -106,6 +108,10 @@ ATNDeserializer::ATNDeserializer(): ATNDeserializer(ATNDeserializationOptions::g
 }
 
 ATNDeserializer::ATNDeserializer(const ATNDeserializationOptions& dso): deserializationOptions(dso) {
+}
+
+ATNDeserializer::~ATNDeserializer()
+{
 }
 
 /**

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.h
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.h
@@ -21,7 +21,7 @@ namespace atn {
 
     ATNDeserializer();
     ATNDeserializer(const ATNDeserializationOptions& dso);
-    virtual ~ATNDeserializer() {};
+    virtual ~ATNDeserializer();
 
     static Guid toUUID(const unsigned short *data, size_t offset);
 

--- a/runtime/Cpp/runtime/src/atn/ATNSerializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNSerializer.cpp
@@ -50,6 +50,8 @@ ATNSerializer::ATNSerializer(ATN *atn, const std::vector<std::string> &tokenName
   _tokenNames = tokenNames;
 }
 
+ATNSerializer::~ATNSerializer() { }
+
 std::vector<size_t> ATNSerializer::serialize() {
   std::vector<size_t> data;
   data.push_back(ATNDeserializer::SERIALIZED_VERSION);

--- a/runtime/Cpp/runtime/src/atn/ATNSerializer.h
+++ b/runtime/Cpp/runtime/src/atn/ATNSerializer.h
@@ -14,7 +14,7 @@ namespace atn {
 
     ATNSerializer(ATN *atn);
     ATNSerializer(ATN *atn, const std::vector<std::string> &tokenNames);
-    virtual ~ATNSerializer() {};
+    virtual ~ATNSerializer();
 
     /// <summary>
     /// Serialize state descriptors, edge descriptors, and decision->state map

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
@@ -23,6 +23,10 @@ ATNSimulator::ATNSimulator(const ATN &atn, PredictionContextCache &sharedContext
 : atn(atn), _sharedContextCache(sharedContextCache) {
 }
 
+ATNSimulator::~ATNSimulator()
+{
+}
+
 void ATNSimulator::clearDFA() {
   throw UnsupportedOperationException("This ATN simulator does not support clearing the DFA.");
 }

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
@@ -23,8 +23,7 @@ ATNSimulator::ATNSimulator(const ATN &atn, PredictionContextCache &sharedContext
 : atn(atn), _sharedContextCache(sharedContextCache) {
 }
 
-ATNSimulator::~ATNSimulator()
-{
+ATNSimulator::~ATNSimulator() {
 }
 
 void ATNSimulator::clearDFA() {

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.h
@@ -20,7 +20,7 @@ namespace atn {
     const ATN &atn;
 
     ATNSimulator(const ATN &atn, PredictionContextCache &sharedContextCache);
-    virtual ~ATNSimulator() {};
+    virtual ~ATNSimulator();
 
     virtual void reset() = 0;
 

--- a/runtime/Cpp/runtime/src/atn/ATNState.h
+++ b/runtime/Cpp/runtime/src/atn/ATNState.h
@@ -77,7 +77,7 @@ namespace atn {
     virtual ~ATNState();
 
     static const size_t INITIAL_NUM_TRANSITIONS = 4;
-    static const size_t INVALID_STATE_NUMBER = (size_t)-1;
+    static const size_t INVALID_STATE_NUMBER = std::numeric_limits<size_t>::max();
 
     enum {
       ATN_INVALID_TYPE = 0,

--- a/runtime/Cpp/runtime/src/atn/AbstractPredicateTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/AbstractPredicateTransition.cpp
@@ -10,6 +10,5 @@ using namespace antlr4::atn;
 AbstractPredicateTransition::AbstractPredicateTransition(ATNState *target) : Transition(target) {
 }
 
-AbstractPredicateTransition::~AbstractPredicateTransition()
-{
+AbstractPredicateTransition::~AbstractPredicateTransition() {
 }

--- a/runtime/Cpp/runtime/src/atn/AbstractPredicateTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/AbstractPredicateTransition.cpp
@@ -9,3 +9,7 @@ using namespace antlr4::atn;
 
 AbstractPredicateTransition::AbstractPredicateTransition(ATNState *target) : Transition(target) {
 }
+
+AbstractPredicateTransition::~AbstractPredicateTransition()
+{
+}

--- a/runtime/Cpp/runtime/src/atn/AbstractPredicateTransition.h
+++ b/runtime/Cpp/runtime/src/atn/AbstractPredicateTransition.h
@@ -16,6 +16,7 @@ namespace atn {
 
   public:
     AbstractPredicateTransition(ATNState *target);
+    ~AbstractPredicateTransition();
 
   };
 

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
@@ -21,6 +21,10 @@ ArrayPredictionContext::ArrayPredictionContext(std::vector<Ref<PredictionContext
     assert(returnStates.size() > 0);
 }
 
+ArrayPredictionContext::~ArrayPredictionContext()
+{
+}
+
 bool ArrayPredictionContext::isEmpty() const {
   // Since EMPTY_RETURN_STATE can only appear in the last position, we don't need to verify that size == 1.
   return returnStates[0] == EMPTY_RETURN_STATE;

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
@@ -21,8 +21,7 @@ ArrayPredictionContext::ArrayPredictionContext(std::vector<Ref<PredictionContext
     assert(returnStates.size() > 0);
 }
 
-ArrayPredictionContext::~ArrayPredictionContext()
-{
+ArrayPredictionContext::~ArrayPredictionContext() {
 }
 
 bool ArrayPredictionContext::isEmpty() const {

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.h
@@ -27,7 +27,7 @@ namespace atn {
 
     ArrayPredictionContext(Ref<SingletonPredictionContext> const& a);
     ArrayPredictionContext(std::vector<Ref<PredictionContext>> const& parents_, std::vector<size_t> const& returnStates);
-    virtual ~ArrayPredictionContext() {};
+    virtual ~ArrayPredictionContext();
 
     virtual bool isEmpty() const override;
     virtual size_t size() const override;

--- a/runtime/Cpp/runtime/src/atn/BlockStartState.cpp
+++ b/runtime/Cpp/runtime/src/atn/BlockStartState.cpp
@@ -1,0 +1,5 @@
+#include "BlockStartState.h"
+
+antlr4::atn::BlockStartState::~BlockStartState()
+{
+}

--- a/runtime/Cpp/runtime/src/atn/BlockStartState.cpp
+++ b/runtime/Cpp/runtime/src/atn/BlockStartState.cpp
@@ -1,5 +1,4 @@
 #include "BlockStartState.h"
 
-antlr4::atn::BlockStartState::~BlockStartState()
-{
+antlr4::atn::BlockStartState::~BlockStartState() {
 }

--- a/runtime/Cpp/runtime/src/atn/BlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/BlockStartState.h
@@ -13,6 +13,7 @@ namespace atn {
   ///  The start of a regular {@code (...)} block.
   class ANTLR4CPP_PUBLIC BlockStartState : public DecisionState {
   public:
+    ~BlockStartState();
     BlockEndState *endState = nullptr;
   };
 

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
@@ -25,6 +25,10 @@ using namespace antlrcpp;
 LL1Analyzer::LL1Analyzer(const ATN &atn) : _atn(atn) {
 }
 
+LL1Analyzer::~LL1Analyzer()
+{
+}
+
 std::vector<misc::IntervalSet> LL1Analyzer::getDecisionLookahead(ATNState *s) const {
   std::vector<misc::IntervalSet> look;
 

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
@@ -25,8 +25,7 @@ using namespace antlrcpp;
 LL1Analyzer::LL1Analyzer(const ATN &atn) : _atn(atn) {
 }
 
-LL1Analyzer::~LL1Analyzer()
-{
+LL1Analyzer::~LL1Analyzer() {
 }
 
 std::vector<misc::IntervalSet> LL1Analyzer::getDecisionLookahead(ATNState *s) const {

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.h
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.h
@@ -22,7 +22,7 @@ namespace atn {
     const atn::ATN &_atn;
 
     LL1Analyzer(const atn::ATN &atn);
-    virtual ~LL1Analyzer() {};
+    virtual ~LL1Analyzer();
 
     /// <summary>
     /// Calculates the SLL(1) expected lookahead set for each outgoing transition

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -31,6 +31,10 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlrcpp;
 
+LexerATNSimulator::SimState::~SimState()
+{
+}
+
 void LexerATNSimulator::SimState::reset() {
   index = INVALID_INDEX;
   line = 0;
@@ -82,8 +86,6 @@ size_t LexerATNSimulator::match(CharStream *input, size_t mode) {
   } else {
     return execATN(input, dfa.s0);
   }
-
-  return Token::EOF;
 }
 
 void LexerATNSimulator::reset() {

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -31,8 +31,7 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlrcpp;
 
-LexerATNSimulator::SimState::~SimState()
-{
+LexerATNSimulator::SimState::~SimState() {
 }
 
 void LexerATNSimulator::SimState::reset() {

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
@@ -17,7 +17,7 @@ namespace atn {
   protected:
     class SimState {
     public:
-      virtual ~SimState() {};
+      virtual ~SimState();
 
     protected:
       size_t index;

--- a/runtime/Cpp/runtime/src/atn/LexerAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerAction.cpp
@@ -1,5 +1,4 @@
 #include "LexerAction.h"
 
-antlr4::atn::LexerAction::~LexerAction()
-{
+antlr4::atn::LexerAction::~LexerAction() {
 }

--- a/runtime/Cpp/runtime/src/atn/LexerAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerAction.cpp
@@ -1,0 +1,5 @@
+#include "LexerAction.h"
+
+antlr4::atn::LexerAction::~LexerAction()
+{
+}

--- a/runtime/Cpp/runtime/src/atn/LexerAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerAction.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "atn/LexerActionType.h"
+#include "antlr4-common.h"
 
 namespace antlr4 {
 namespace atn {
@@ -20,7 +21,7 @@ namespace atn {
   /// </summary>
   class ANTLR4CPP_PUBLIC LexerAction {
   public:
-    virtual ~LexerAction() {};
+    virtual ~LexerAction();
 
     /// <summary>
     /// Gets the serialization type of the lexer action.

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
@@ -19,8 +19,7 @@ LexerActionExecutor::LexerActionExecutor(const std::vector<Ref<LexerAction>> &le
   : _lexerActions(lexerActions), _hashCode(generateHashCode()) {
 }
 
-LexerActionExecutor::~LexerActionExecutor()
-{
+LexerActionExecutor::~LexerActionExecutor() {
 }
 
 Ref<LexerActionExecutor> LexerActionExecutor::append(Ref<LexerActionExecutor> const& lexerActionExecutor,

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
@@ -19,6 +19,10 @@ LexerActionExecutor::LexerActionExecutor(const std::vector<Ref<LexerAction>> &le
   : _lexerActions(lexerActions), _hashCode(generateHashCode()) {
 }
 
+LexerActionExecutor::~LexerActionExecutor()
+{
+}
+
 Ref<LexerActionExecutor> LexerActionExecutor::append(Ref<LexerActionExecutor> const& lexerActionExecutor,
                                                      Ref<LexerAction> const& lexerAction) {
   if (lexerActionExecutor == nullptr) {

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
@@ -23,7 +23,7 @@ namespace atn {
     /// Constructs an executor for a sequence of <seealso cref="LexerAction"/> actions. </summary>
     /// <param name="lexerActions"> The lexer actions to execute. </param>
     LexerActionExecutor(const std::vector<Ref<LexerAction>> &lexerActions);
-    virtual ~LexerActionExecutor() {};
+    virtual ~LexerActionExecutor();
 
     /// <summary>
     /// Creates a <seealso cref="LexerActionExecutor"/> which executes the actions for

--- a/runtime/Cpp/runtime/src/atn/LexerActionType.h
+++ b/runtime/Cpp/runtime/src/atn/LexerActionType.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace antlr4 {
 namespace atn {
 
@@ -14,7 +16,7 @@ namespace atn {
   /// @author Sam Harwell
   /// @since 4.2
   /// </summary>
-  enum class ANTLR4CPP_PUBLIC LexerActionType : size_t {
+  enum class LexerActionType : size_t {
     /// <summary>
     /// The type of a <seealso cref="LexerChannelAction"/> action.
     /// </summary>

--- a/runtime/Cpp/runtime/src/atn/LexerActionType.h
+++ b/runtime/Cpp/runtime/src/atn/LexerActionType.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include "antlr4-common.h"
 
 namespace antlr4 {
 namespace atn {

--- a/runtime/Cpp/runtime/src/atn/LexerActionType.h
+++ b/runtime/Cpp/runtime/src/atn/LexerActionType.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <cstddef>
+#include <stddef.h>
 
 namespace antlr4 {
 namespace atn {

--- a/runtime/Cpp/runtime/src/atn/ParseInfo.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParseInfo.cpp
@@ -13,6 +13,10 @@ using namespace antlr4::atn;
 ParseInfo::ParseInfo(ProfilingATNSimulator *atnSimulator) : _atnSimulator(atnSimulator) {
 }
 
+ParseInfo::~ParseInfo()
+{
+}
+
 std::vector<DecisionInfo> ParseInfo::getDecisionInfo() {
   return _atnSimulator->getDecisionInfo();
 }

--- a/runtime/Cpp/runtime/src/atn/ParseInfo.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParseInfo.cpp
@@ -13,8 +13,7 @@ using namespace antlr4::atn;
 ParseInfo::ParseInfo(ProfilingATNSimulator *atnSimulator) : _atnSimulator(atnSimulator) {
 }
 
-ParseInfo::~ParseInfo()
-{
+ParseInfo::~ParseInfo() {
 }
 
 std::vector<DecisionInfo> ParseInfo::getDecisionInfo() {

--- a/runtime/Cpp/runtime/src/atn/ParseInfo.h
+++ b/runtime/Cpp/runtime/src/atn/ParseInfo.h
@@ -17,7 +17,10 @@ namespace atn {
   class ANTLR4CPP_PUBLIC ParseInfo {
   public:
     ParseInfo(ProfilingATNSimulator *atnSimulator);
-    virtual ~ParseInfo() {};
+    ParseInfo(ParseInfo const&) = default;
+    virtual ~ParseInfo();
+
+    ParseInfo& operator=(ParseInfo const&) = default;
 
     /// <summary>
     /// Gets an array of <seealso cref="DecisionInfo"/> instances containing the profiling

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.h
@@ -31,7 +31,7 @@ namespace atn {
     // ml: originally Integer.MAX_VALUE, which would be (size_t)-1 for us, but this is already used in places where
     //     -1 is converted to unsigned, so we use a different value here. Any value does the job provided it doesn't
     //     conflict with real return states.
-    static const size_t EMPTY_RETURN_STATE = (size_t)-10;
+    static const size_t EMPTY_RETURN_STATE = std::numeric_limits<size_t>::max() - 9;
 
   private:
     static const size_t INITIAL_HASH = 1;

--- a/runtime/Cpp/runtime/src/atn/RuleTransition.h
+++ b/runtime/Cpp/runtime/src/atn/RuleTransition.h
@@ -25,6 +25,8 @@ namespace atn {
     RuleTransition(RuleStartState *ruleStart, size_t ruleIndex, ATNState *followState);
 
     RuleTransition(RuleStartState *ruleStart, size_t ruleIndex, int precedence, ATNState *followState);
+    RuleTransition(RuleTransition const&) = delete;
+    RuleTransition& operator=(RuleTransition const&) = delete;
 
     virtual SerializationType getSerializationType() const override;
 

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
@@ -13,6 +13,10 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlrcpp;
 
+SemanticContext::~SemanticContext()
+{
+}
+
 //------------------ Predicate -----------------------------------------------------------------------------------------
 
 SemanticContext::Predicate::Predicate() : Predicate(INVALID_INDEX, INVALID_INDEX, false) {
@@ -365,4 +369,8 @@ std::vector<Ref<SemanticContext::PrecedencePredicate>> SemanticContext::filterPr
   }
 
   return result;
+}
+
+SemanticContext::Operator::~Operator()
+{
 }

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
@@ -13,10 +13,6 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlrcpp;
 
-SemanticContext::~SemanticContext()
-{
-}
-
 //------------------ Predicate -----------------------------------------------------------------------------------------
 
 SemanticContext::Predicate::Predicate() : Predicate(INVALID_INDEX, INVALID_INDEX, false) {
@@ -315,6 +311,9 @@ std::string SemanticContext::OR::toString() const {
 
 const Ref<SemanticContext> SemanticContext::NONE = std::make_shared<Predicate>(INVALID_INDEX, INVALID_INDEX, false);
 
+SemanticContext::~SemanticContext() {
+}
+
 bool SemanticContext::operator != (const SemanticContext &other) const {
   return !(*this == other);
 }
@@ -371,6 +370,8 @@ std::vector<Ref<SemanticContext::PrecedencePredicate>> SemanticContext::filterPr
   return result;
 }
 
-SemanticContext::Operator::~Operator()
-{
+
+//------------------ Operator -----------------------------------------------------------------------------------------
+
+SemanticContext::Operator::~Operator() {
 }

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.h
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.h
@@ -43,7 +43,7 @@ namespace atn {
      */
     static const Ref<SemanticContext> NONE;
 
-    virtual ~SemanticContext() {};
+    virtual ~SemanticContext();
 
     virtual size_t hashCode() const = 0;
     virtual std::string toString() const = 0;
@@ -144,6 +144,8 @@ namespace atn {
    */
   class ANTLR4CPP_PUBLIC SemanticContext::Operator : public SemanticContext {
   public:
+    ~Operator();
+
     /**
      * Gets the operands for the semantic context operator.
      *

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.h
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.h
@@ -144,7 +144,7 @@ namespace atn {
    */
   class ANTLR4CPP_PUBLIC SemanticContext::Operator : public SemanticContext {
   public:
-    ~Operator();
+    virtual ~Operator() override;
 
     /**
      * Gets the operands for the semantic context operator.

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
@@ -15,6 +15,10 @@ SingletonPredictionContext::SingletonPredictionContext(Ref<PredictionContext> co
   assert(returnState != ATNState::INVALID_STATE_NUMBER);
 }
 
+SingletonPredictionContext::~SingletonPredictionContext()
+{
+}
+
 Ref<SingletonPredictionContext> SingletonPredictionContext::create(Ref<PredictionContext> const& parent, size_t returnState) {
 
   if (returnState == EMPTY_RETURN_STATE && parent) {

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
@@ -15,8 +15,7 @@ SingletonPredictionContext::SingletonPredictionContext(Ref<PredictionContext> co
   assert(returnState != ATNState::INVALID_STATE_NUMBER);
 }
 
-SingletonPredictionContext::~SingletonPredictionContext()
-{
+SingletonPredictionContext::~SingletonPredictionContext() {
 }
 
 Ref<SingletonPredictionContext> SingletonPredictionContext::create(Ref<PredictionContext> const& parent, size_t returnState) {

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.h
@@ -21,7 +21,7 @@ namespace atn {
     const size_t returnState;
 
     SingletonPredictionContext(Ref<PredictionContext> const& parent, size_t returnState);
-    virtual ~SingletonPredictionContext() {};
+    virtual ~SingletonPredictionContext();
 
     static Ref<SingletonPredictionContext> create(Ref<PredictionContext> const& parent, size_t returnState);
 

--- a/runtime/Cpp/runtime/src/atn/Transition.cpp
+++ b/runtime/Cpp/runtime/src/atn/Transition.cpp
@@ -25,8 +25,7 @@ Transition::Transition(ATNState *target) {
   this->target = target;
 }
 
-Transition::~Transition()
-{
+Transition::~Transition() {
 }
 
 bool Transition::isEpsilon() const {

--- a/runtime/Cpp/runtime/src/atn/Transition.cpp
+++ b/runtime/Cpp/runtime/src/atn/Transition.cpp
@@ -25,6 +25,10 @@ Transition::Transition(ATNState *target) {
   this->target = target;
 }
 
+Transition::~Transition()
+{
+}
+
 bool Transition::isEpsilon() const {
   return false;
 }

--- a/runtime/Cpp/runtime/src/atn/Transition.h
+++ b/runtime/Cpp/runtime/src/atn/Transition.h
@@ -45,7 +45,7 @@ namespace atn {
     // ml: this is a reference into the ATN.
     ATNState *target;
 
-    virtual ~Transition() {};
+    virtual ~Transition();
 
   protected:
     Transition(ATNState *target);
@@ -67,6 +67,9 @@ namespace atn {
     virtual bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const = 0;
 
     virtual std::string toString() const;
+
+    Transition(Transition const&) = delete;
+    Transition& operator=(Transition const&) = delete;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/dfa/DFASerializer.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFASerializer.cpp
@@ -17,8 +17,7 @@ DFASerializer::DFASerializer(const DFA *dfa, const std::vector<std::string>& tok
 DFASerializer::DFASerializer(const DFA *dfa, const Vocabulary &vocabulary) : _dfa(dfa), _vocabulary(vocabulary) {
 }
 
-DFASerializer::~DFASerializer()
-{
+DFASerializer::~DFASerializer() {
 }
 
 std::string DFASerializer::toString() const {

--- a/runtime/Cpp/runtime/src/dfa/DFASerializer.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFASerializer.cpp
@@ -17,6 +17,10 @@ DFASerializer::DFASerializer(const DFA *dfa, const std::vector<std::string>& tok
 DFASerializer::DFASerializer(const DFA *dfa, const Vocabulary &vocabulary) : _dfa(dfa), _vocabulary(vocabulary) {
 }
 
+DFASerializer::~DFASerializer()
+{
+}
+
 std::string DFASerializer::toString() const {
   if (_dfa->s0 == nullptr) {
     return "";

--- a/runtime/Cpp/runtime/src/dfa/DFASerializer.h
+++ b/runtime/Cpp/runtime/src/dfa/DFASerializer.h
@@ -15,7 +15,7 @@ namespace dfa {
   public:
     DFASerializer(const DFA *dfa, const std::vector<std::string>& tnames);
     DFASerializer(const DFA *dfa, const Vocabulary &vocabulary);
-    virtual ~DFASerializer() {};
+    virtual ~DFASerializer();
 
     virtual std::string toString() const;
 

--- a/runtime/Cpp/runtime/src/dfa/DFAState.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.cpp
@@ -18,8 +18,7 @@ DFAState::PredPrediction::PredPrediction(const Ref<SemanticContext> &pred, int a
   this->alt = alt;
 }
 
-DFAState::PredPrediction::~PredPrediction()
-{
+DFAState::PredPrediction::~PredPrediction() {
 }
 
 std::string DFAState::PredPrediction::toString() {

--- a/runtime/Cpp/runtime/src/dfa/DFAState.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.cpp
@@ -18,6 +18,10 @@ DFAState::PredPrediction::PredPrediction(const Ref<SemanticContext> &pred, int a
   this->alt = alt;
 }
 
+DFAState::PredPrediction::~PredPrediction()
+{
+}
+
 std::string DFAState::PredPrediction::toString() {
   return std::string("(") + pred->toString() + ", " + std::to_string(alt) + ")";
 }

--- a/runtime/Cpp/runtime/src/dfa/DFAState.h
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.h
@@ -43,7 +43,7 @@ namespace dfa {
       int alt;
 
       PredPrediction(const Ref<atn::SemanticContext> &pred, int alt);
-      virtual ~PredPrediction() {};
+      virtual ~PredPrediction();
 
       virtual std::string toString();
 

--- a/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.cpp
+++ b/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.cpp
@@ -12,8 +12,7 @@ using namespace antlr4::dfa;
 LexerDFASerializer::LexerDFASerializer(DFA *dfa) : DFASerializer(dfa, Vocabulary::EMPTY_VOCABULARY) {
 }
 
-LexerDFASerializer::~LexerDFASerializer()
-{
+LexerDFASerializer::~LexerDFASerializer() {
 }
 
 std::string LexerDFASerializer::getEdgeLabel(size_t i) const {

--- a/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.cpp
+++ b/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.cpp
@@ -12,6 +12,10 @@ using namespace antlr4::dfa;
 LexerDFASerializer::LexerDFASerializer(DFA *dfa) : DFASerializer(dfa, Vocabulary::EMPTY_VOCABULARY) {
 }
 
+LexerDFASerializer::~LexerDFASerializer()
+{
+}
+
 std::string LexerDFASerializer::getEdgeLabel(size_t i) const {
   return std::string("'") + static_cast<char>(i) + "'";
 }

--- a/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.h
+++ b/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.h
@@ -13,7 +13,7 @@ namespace dfa {
   class ANTLR4CPP_PUBLIC LexerDFASerializer : public DFASerializer {
   public:
     LexerDFASerializer(DFA *dfa);
-    virtual ~LexerDFASerializer() {};
+    virtual ~LexerDFASerializer();
 
   protected:
     virtual std::string getEdgeLabel(size_t i) const override;

--- a/runtime/Cpp/runtime/src/misc/Interval.cpp
+++ b/runtime/Cpp/runtime/src/misc/Interval.cpp
@@ -7,6 +7,7 @@
 
 using namespace antlr4::misc;
 
+Interval::~Interval() = default;
 
 size_t antlr4::misc::numericToSymbol(ssize_t v) {
   return (size_t)v;

--- a/runtime/Cpp/runtime/src/misc/Interval.h
+++ b/runtime/Cpp/runtime/src/misc/Interval.h
@@ -28,7 +28,9 @@ namespace misc {
     Interval();
     explicit Interval(size_t a_, size_t b_); // For unsigned -> signed mappings.
     Interval(ssize_t a_, ssize_t b_);
-    virtual ~Interval() {};
+    Interval(Interval const&) = default;
+    virtual ~Interval();
+    Interval& operator=(Interval const&) = default;
 
     /// return number of elements between a and b inclusively. x..x is length 1.
     ///  if b < a, then length is 0.  9..10 has length 2.

--- a/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
@@ -46,6 +46,21 @@ IntervalSet::IntervalSet(int n, ...) : IntervalSet() {
   }
 }
 
+IntervalSet::~IntervalSet()
+{
+}
+
+IntervalSet& IntervalSet::operator=(const IntervalSet& other)
+{
+  if (_readonly) {
+    throw IllegalStateException("can't alter read only IntervalSet");
+  }
+
+  _intervals.clear();
+
+  return addAll(other);
+}
+
 IntervalSet IntervalSet::of(ssize_t a) {
   return IntervalSet({ Interval(a, a) });
 }

--- a/runtime/Cpp/runtime/src/misc/IntervalSet.h
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "misc/Interval.h"
+#include <atomic>
 
 namespace antlr4 {
 namespace misc {
@@ -30,7 +31,7 @@ namespace misc {
   protected:
     /// The list of sorted, disjoint intervals.
     std::vector<Interval> _intervals;
-    bool _readonly;
+    std::atomic<bool> _readonly;
 
   public:
     IntervalSet();

--- a/runtime/Cpp/runtime/src/misc/IntervalSet.h
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.h
@@ -38,7 +38,9 @@ namespace misc {
     IntervalSet(const IntervalSet &set);
     IntervalSet(int numArgs, ...);
 
-    virtual ~IntervalSet() {}
+    virtual ~IntervalSet();
+
+    IntervalSet& operator=(const IntervalSet &set);
 
     /// Create a set with a single element, el.
     static IntervalSet of(ssize_t a);

--- a/runtime/Cpp/runtime/src/misc/MurmurHash.cpp
+++ b/runtime/Cpp/runtime/src/misc/MurmurHash.cpp
@@ -57,7 +57,7 @@ size_t MurmurHash::initialize(size_t seed) {
   return seed;
 }
 
-#if _WIN32 || _WIN64
+#if defined(_WIN32) || defined(_WIN64)
   #if _WIN64
     #define ENVIRONMENT64
   #else
@@ -65,8 +65,8 @@ size_t MurmurHash::initialize(size_t seed) {
   #endif
 #endif
 
-#if __GNUC__
-  #if __x86_64__ || __ppc64__
+#if defined(__GNUC__)
+  #if defined(__x86_64__) || defined(__ppc64__)
     #define ENVIRONMENT64
   #else
     #define ENVIRONMENT32

--- a/runtime/Cpp/runtime/src/misc/Predicate.cpp
+++ b/runtime/Cpp/runtime/src/misc/Predicate.cpp
@@ -1,5 +1,4 @@
 #include "misc/Predicate.h"
 
-antlr4::misc::Predicate::~Predicate()
-{
+antlr4::misc::Predicate::~Predicate() {
 }

--- a/runtime/Cpp/runtime/src/misc/Predicate.cpp
+++ b/runtime/Cpp/runtime/src/misc/Predicate.cpp
@@ -1,0 +1,5 @@
+#include "misc/Predicate.h"
+
+antlr4::misc::Predicate::~Predicate()
+{
+}

--- a/runtime/Cpp/runtime/src/misc/Predicate.h
+++ b/runtime/Cpp/runtime/src/misc/Predicate.h
@@ -5,12 +5,14 @@
 
 #pragma once
 
+#include "antlr4-common.h"
+
 namespace antlr4 {
 namespace misc {
 
   class ANTLR4CPP_PUBLIC Predicate {
   public:
-    virtual ~Predicate() {};
+    virtual ~Predicate();
 
     virtual bool test(tree::ParseTree *t) = 0;
   };

--- a/runtime/Cpp/runtime/src/support/Any.cpp
+++ b/runtime/Cpp/runtime/src/support/Any.cpp
@@ -1,0 +1,10 @@
+#include "Any.h"
+
+antlrcpp::Any::~Any()
+{
+    delete _ptr;
+}
+
+antlrcpp::Any::Base::~Base()
+{
+}

--- a/runtime/Cpp/runtime/src/support/Any.cpp
+++ b/runtime/Cpp/runtime/src/support/Any.cpp
@@ -5,6 +5,5 @@ antlrcpp::Any::~Any()
     delete _ptr;
 }
 
-antlrcpp::Any::Base::~Base()
-{
+antlrcpp::Any::Base::~Base() {
 }

--- a/runtime/Cpp/runtime/src/support/Any.h
+++ b/runtime/Cpp/runtime/src/support/Any.h
@@ -92,9 +92,7 @@ struct Any
     return *this;
   }
 
-  virtual ~Any() {
-    delete _ptr;
-  }
+  virtual ~Any();
 
   virtual bool equals(Any other) const {
     return _ptr == other._ptr;
@@ -102,7 +100,7 @@ struct Any
 
 private:
   struct Base {
-    virtual ~Base() { }
+    virtual ~Base();
     virtual Base* clone() const = 0;
   };
 

--- a/runtime/Cpp/runtime/src/support/CPPUtils.h
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.h
@@ -22,8 +22,7 @@ namespace antlrcpp {
   struct FinalAction {
     FinalAction(std::function<void ()> f) : _cleanUp { f } {}
     FinalAction(FinalAction &&other) :
-	_cleanUp(std::move(other._cleanUp)), _enabled(other._enabled)
-    {
+	_cleanUp(std::move(other._cleanUp)), _enabled(other._enabled) {
       other._enabled = false; // Don't trigger the lambda after ownership has moved.
     }
     ~FinalAction() { if (_enabled) _cleanUp(); }

--- a/runtime/Cpp/runtime/src/support/CPPUtils.h
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.h
@@ -21,14 +21,14 @@ namespace antlrcpp {
   // Using RAII + a lambda to implement a "finally" replacement.
   struct FinalAction {
     FinalAction(std::function<void ()> f) : _cleanUp { f } {}
-    FinalAction(FinalAction &&other) {
-      _cleanUp = other._cleanUp;
-      _enabled = other._enabled;
+    FinalAction(FinalAction &&other) :
+	_cleanUp(std::move(other._cleanUp)), _enabled(other._enabled)
+    {
       other._enabled = false; // Don't trigger the lambda after ownership has moved.
     }
     ~FinalAction() { if (_enabled) _cleanUp(); }
 
-    void disable() { _enabled = false; };
+    void disable() { _enabled = false; }
   private:
     std::function<void ()> _cleanUp;
     bool _enabled {true};
@@ -52,7 +52,7 @@ namespace antlrcpp {
     std::stringstream ss;
     // typeid gives the mangled class name, but that's all what's possible
     // in a portable way.
-    ss << typeid(o).name() << "@" << std::hex << (size_t)&o;
+    ss << typeid(o).name() << "@" << std::hex << reinterpret_cast<uintptr_t>(&o);
     return ss.str();
   }
 

--- a/runtime/Cpp/runtime/src/support/StringUtils.h
+++ b/runtime/Cpp/runtime/src/support/StringUtils.h
@@ -24,7 +24,7 @@ namespace antlrcpp {
     // Don't make the converter static or we have to serialize access to it.
     UTF32Converter converter;
 
-    #if _MSC_VER >= 1900 && _MSC_VER < 2000
+    #if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
       auto p = reinterpret_cast<const int32_t *>(data.data());
       return converter.to_bytes(p, p + data.size());
     #else
@@ -36,7 +36,7 @@ namespace antlrcpp {
   {
     UTF32Converter converter;
 
-    #if _MSC_VER >= 1900 && _MSC_VER < 2000
+    #if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
       auto r = converter.from_bytes(first, last);
       i32string s = reinterpret_cast<const int32_t *>(r.data());
     #else

--- a/runtime/Cpp/runtime/src/support/StringUtils.h
+++ b/runtime/Cpp/runtime/src/support/StringUtils.h
@@ -11,9 +11,11 @@ namespace antlrcpp {
   // For all conversions utf8 <-> utf32.
   // VS 2015 and VS 2017 have different bugs in std::codecvt_utf8<char32_t> (VS 2013 works fine).
 #if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
-  static std::wstring_convert<std::codecvt_utf8<__int32>, __int32> utfConverter;
+  using UtfConverterType = std::wstring_convert<std::codecvt_utf8<__int32>, __int32>;
+  using UtfConverterWide = std::u32string;
 #else
-  static std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> utfConverter;
+  using UtfConverterType = std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t>;
+  using UtfConverterWide = std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t>::wide_string;
 #endif
 
   //the conversion functions fails in VS2017, so we explicitly use a workaround
@@ -22,20 +24,20 @@ namespace antlrcpp {
   {
     #if defined(_MSC_VER) && _MSC_VER > 1900 && _MSC_VER < 2000
       auto p = reinterpret_cast<const int32_t *>(_data.data());
-      return antlrcpp::utfConverter.to_bytes(p, p + _data.size());
+      return UtfConverterType().to_bytes(p, p + _data.size());
     #else
-      return antlrcpp::utfConverter.to_bytes(_data);
+      return UtfConverterType().to_bytes(_data);
     #endif
   }
 
-  inline auto utf8_to_utf32(const char* first, const char* last)
+  inline UtfConverterWide utf8_to_utf32(const char* first, const char* last)
   {
     #if defined(_MSC_VER) && _MSC_VER > 1900 && _MSC_VER < 2000
-      auto r = antlrcpp::utfConverter.from_bytes(first, last);
+      auto r = UtfConverterType().from_bytes(first, last);
       std::u32string s = reinterpret_cast<const char32_t *>(r.data());
       return s;
     #else
-      return antlrcpp::utfConverter.from_bytes(first, last);
+      return UtfConverterType().from_bytes(first, last);
     #endif
   }
 

--- a/runtime/Cpp/runtime/src/support/StringUtils.h
+++ b/runtime/Cpp/runtime/src/support/StringUtils.h
@@ -20,7 +20,7 @@ namespace antlrcpp {
   template<typename T>
   inline std::string utf32_to_utf8(T _data)
   {
-    #if _MSC_VER > 1900 && _MSC_VER < 2000
+    #if defined(_MSC_VER) && _MSC_VER > 1900 && _MSC_VER < 2000
       auto p = reinterpret_cast<const int32_t *>(_data.data());
       return antlrcpp::utfConverter.to_bytes(p, p + _data.size());
     #else
@@ -30,7 +30,7 @@ namespace antlrcpp {
 
   inline auto utf8_to_utf32(const char* first, const char* last)
   {
-    #if _MSC_VER > 1900 && _MSC_VER < 2000
+    #if defined(_MSC_VER) && _MSC_VER > 1900 && _MSC_VER < 2000
       auto r = antlrcpp::utfConverter.from_bytes(first, last);
       std::u32string s = reinterpret_cast<const char32_t *>(r.data());
       return s;

--- a/runtime/Cpp/runtime/src/support/guid.cpp
+++ b/runtime/Cpp/runtime/src/support/guid.cpp
@@ -99,7 +99,7 @@ Guid::Guid(const uint16_t *bytes, bool reverse)
 }
 
 // converts a single hex char to a number (0 - 15)
-unsigned char hexDigitToChar(char ch)
+static unsigned char hexDigitToChar(char ch)
 {
   if (ch > 47 && ch < 58)
     return (unsigned char)(ch - 48);
@@ -114,7 +114,7 @@ unsigned char hexDigitToChar(char ch)
 }
 
 // converts the two hexadecimal characters to an unsigned char (a byte)
-unsigned char hexPairToChar(char a, char b)
+static unsigned char hexPairToChar(char a, char b)
 {
   return hexDigitToChar(a) * 16 + hexDigitToChar(b);
 }

--- a/runtime/Cpp/runtime/src/support/guid.h
+++ b/runtime/Cpp/runtime/src/support/guid.h
@@ -68,10 +68,10 @@ public:
   bool operator!=(const Guid &other) const;
 
   const std::string toString() const;
-  std::vector<unsigned char>::const_iterator begin() { return _bytes.begin(); };
-  std::vector<unsigned char>::const_iterator end() { return _bytes.end(); };
-  std::vector<unsigned char>::const_reverse_iterator rbegin() { return _bytes.rbegin(); };
-  std::vector<unsigned char>::const_reverse_iterator rend() { return _bytes.rend(); };
+  std::vector<unsigned char>::const_iterator begin() { return _bytes.begin(); }
+  std::vector<unsigned char>::const_iterator end() { return _bytes.end(); }
+  std::vector<unsigned char>::const_reverse_iterator rbegin() { return _bytes.rbegin(); }
+  std::vector<unsigned char>::const_reverse_iterator rend() { return _bytes.rend(); }
 
 
 private:

--- a/runtime/Cpp/runtime/src/tree/ErrorNode.cpp
+++ b/runtime/Cpp/runtime/src/tree/ErrorNode.cpp
@@ -1,0 +1,5 @@
+#include "tree/ErrorNode.h"
+
+antlr4::tree::ErrorNode::~ErrorNode()
+{
+}

--- a/runtime/Cpp/runtime/src/tree/ErrorNode.cpp
+++ b/runtime/Cpp/runtime/src/tree/ErrorNode.cpp
@@ -1,5 +1,4 @@
 #include "tree/ErrorNode.h"
 
-antlr4::tree::ErrorNode::~ErrorNode()
-{
+antlr4::tree::ErrorNode::~ErrorNode() {
 }

--- a/runtime/Cpp/runtime/src/tree/ErrorNode.h
+++ b/runtime/Cpp/runtime/src/tree/ErrorNode.h
@@ -11,6 +11,8 @@ namespace antlr4 {
 namespace tree {
 
   class ANTLR4CPP_PUBLIC ErrorNode : public virtual TerminalNode {
+  public:
+    ~ErrorNode() override;
   };
 
 } // namespace tree

--- a/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.cpp
+++ b/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.cpp
@@ -15,6 +15,9 @@ using namespace antlr4::tree;
 ErrorNodeImpl::ErrorNodeImpl(Token *token) : TerminalNodeImpl(token) {
 }
 
+ErrorNodeImpl::~ErrorNodeImpl() {
+}
+
 antlrcpp::Any ErrorNodeImpl::accept(ParseTreeVisitor *visitor) {
   return visitor->visitErrorNode(this);
 }

--- a/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.h
+++ b/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.h
@@ -24,6 +24,7 @@ namespace tree {
   class ANTLR4CPP_PUBLIC ErrorNodeImpl : public virtual TerminalNodeImpl, public virtual ErrorNode {
   public:
     ErrorNodeImpl(Token *token);
+    ~ErrorNodeImpl() override;
 
     virtual antlrcpp::Any accept(ParseTreeVisitor *visitor) override;
   };

--- a/runtime/Cpp/runtime/src/tree/ParseTree.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTree.h
@@ -20,7 +20,10 @@ namespace tree {
   class ANTLR4CPP_PUBLIC ParseTree {
   public:
     ParseTree();
+    ParseTree(ParseTree const&) = delete;
     virtual ~ParseTree() {}
+
+    ParseTree& operator=(ParseTree const&) = delete;
 
     /// The parent of this node. If the return value is null, then this
     /// node is the root of the tree.

--- a/runtime/Cpp/runtime/src/tree/ParseTreeListener.cpp
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeListener.cpp
@@ -1,5 +1,4 @@
 #include "ParseTreeListener.h"
 
-antlr4::tree::ParseTreeListener::~ParseTreeListener()
-{
+antlr4::tree::ParseTreeListener::~ParseTreeListener() {
 }

--- a/runtime/Cpp/runtime/src/tree/ParseTreeListener.cpp
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeListener.cpp
@@ -1,0 +1,5 @@
+#include "ParseTreeListener.h"
+
+antlr4::tree::ParseTreeListener::~ParseTreeListener()
+{
+}

--- a/runtime/Cpp/runtime/src/tree/ParseTreeListener.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeListener.h
@@ -23,7 +23,7 @@ namespace tree {
    */
   class ANTLR4CPP_PUBLIC ParseTreeListener {
   public:
-    virtual ~ParseTreeListener() {};
+    virtual ~ParseTreeListener();
 
     virtual void visitTerminal(TerminalNode *node) = 0;
     virtual void visitErrorNode(ErrorNode *node) = 0;

--- a/runtime/Cpp/runtime/src/tree/ParseTreeVisitor.cpp
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeVisitor.cpp
@@ -1,5 +1,4 @@
 #include "ParseTreeVisitor.h"
 
-antlr4::tree::ParseTreeVisitor::~ParseTreeVisitor()
-{
+antlr4::tree::ParseTreeVisitor::~ParseTreeVisitor() {
 }

--- a/runtime/Cpp/runtime/src/tree/ParseTreeVisitor.cpp
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeVisitor.cpp
@@ -1,0 +1,5 @@
+#include "ParseTreeVisitor.h"
+
+antlr4::tree::ParseTreeVisitor::~ParseTreeVisitor()
+{
+}

--- a/runtime/Cpp/runtime/src/tree/ParseTreeVisitor.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeVisitor.h
@@ -20,7 +20,7 @@ namespace tree {
   // ml: no template parameter here, to avoid the need for virtual template functions. Instead we have our Any class.
   class ANTLR4CPP_PUBLIC ParseTreeVisitor {
   public:
-    virtual ~ParseTreeVisitor() {}
+    virtual ~ParseTreeVisitor();
 
     /// <summary>
     /// Visit a parse tree, and return a user-defined result of the operation.

--- a/runtime/Cpp/runtime/src/tree/ParseTreeWalker.cpp
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeWalker.cpp
@@ -17,8 +17,7 @@ using namespace antlrcpp;
 static IterativeParseTreeWalker defaultWalker;
 ParseTreeWalker &ParseTreeWalker::DEFAULT = defaultWalker;
 
-ParseTreeWalker::~ParseTreeWalker()
-{
+ParseTreeWalker::~ParseTreeWalker() {
 }
 
 void ParseTreeWalker::walk(ParseTreeListener *listener, ParseTree *t) const {

--- a/runtime/Cpp/runtime/src/tree/ParseTreeWalker.cpp
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeWalker.cpp
@@ -17,6 +17,10 @@ using namespace antlrcpp;
 static IterativeParseTreeWalker defaultWalker;
 ParseTreeWalker &ParseTreeWalker::DEFAULT = defaultWalker;
 
+ParseTreeWalker::~ParseTreeWalker()
+{
+}
+
 void ParseTreeWalker::walk(ParseTreeListener *listener, ParseTree *t) const {
   if (is<ErrorNode *>(t)) {
     listener->visitErrorNode(dynamic_cast<ErrorNode *>(t));

--- a/runtime/Cpp/runtime/src/tree/ParseTreeWalker.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeWalker.h
@@ -14,7 +14,7 @@ namespace tree {
   public:
     static ParseTreeWalker &DEFAULT;
 
-    virtual ~ParseTreeWalker() {};
+    virtual ~ParseTreeWalker();
 
     virtual void walk(ParseTreeListener *listener, ParseTree *t) const;
 

--- a/runtime/Cpp/runtime/src/tree/TerminalNode.cpp
+++ b/runtime/Cpp/runtime/src/tree/TerminalNode.cpp
@@ -1,5 +1,4 @@
 #include "tree/TerminalNode.h"
 
-antlr4::tree::TerminalNode::~TerminalNode()
-{
+antlr4::tree::TerminalNode::~TerminalNode() {
 }

--- a/runtime/Cpp/runtime/src/tree/TerminalNode.cpp
+++ b/runtime/Cpp/runtime/src/tree/TerminalNode.cpp
@@ -1,0 +1,5 @@
+#include "tree/TerminalNode.h"
+
+antlr4::tree::TerminalNode::~TerminalNode()
+{
+}

--- a/runtime/Cpp/runtime/src/tree/TerminalNode.h
+++ b/runtime/Cpp/runtime/src/tree/TerminalNode.h
@@ -12,6 +12,8 @@ namespace tree {
 
   class ANTLR4CPP_PUBLIC TerminalNode : public ParseTree {
   public:
+    ~TerminalNode() override;
+
     virtual Token* getSymbol() = 0;
 
     /** Set the parent for this leaf node.

--- a/runtime/Cpp/runtime/src/tree/pattern/Chunk.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/Chunk.cpp
@@ -1,0 +1,5 @@
+#include "tree/pattern/Chunk.h"
+
+antlr4::tree::pattern::Chunk::~Chunk()
+{
+}

--- a/runtime/Cpp/runtime/src/tree/pattern/Chunk.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/Chunk.cpp
@@ -1,5 +1,4 @@
 #include "tree/pattern/Chunk.h"
 
-antlr4::tree::pattern::Chunk::~Chunk()
-{
+antlr4::tree::pattern::Chunk::~Chunk() {
 }

--- a/runtime/Cpp/runtime/src/tree/pattern/Chunk.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/Chunk.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "antlr4-common.h"
+
 namespace antlr4 {
 namespace tree {
 namespace pattern {
@@ -22,7 +24,11 @@ namespace pattern {
   /// </summary>
   class ANTLR4CPP_PUBLIC Chunk {
   public:
-    virtual ~Chunk() {};
+    Chunk() = default;
+    Chunk(Chunk const&) = default;
+    virtual ~Chunk();
+
+    Chunk& operator=(Chunk const&) = default;
 
     /// This method returns a text representation of the tag chunk. Labeled tags
     /// are returned in the form {@code label:tag}, and unlabeled tags are

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreeMatch.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreeMatch.cpp
@@ -19,6 +19,10 @@ ParseTreeMatch::ParseTreeMatch(ParseTree *tree, const ParseTreePattern &pattern,
   }
 }
 
+ParseTreeMatch::~ParseTreeMatch()
+{
+}
+
 ParseTree* ParseTreeMatch::get(const std::string &label) {
   auto iterator = _labels.find(label);
   if (iterator == _labels.end() || iterator->second.empty()) {

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreeMatch.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreeMatch.cpp
@@ -19,8 +19,7 @@ ParseTreeMatch::ParseTreeMatch(ParseTree *tree, const ParseTreePattern &pattern,
   }
 }
 
-ParseTreeMatch::~ParseTreeMatch()
-{
+ParseTreeMatch::~ParseTreeMatch() {
 }
 
 ParseTree* ParseTreeMatch::get(const std::string &label) {

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreeMatch.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreeMatch.h
@@ -43,7 +43,9 @@ namespace pattern {
     /// <exception cref="IllegalArgumentException"> if {@code labels} is {@code null} </exception>
     ParseTreeMatch(ParseTree *tree, ParseTreePattern const& pattern,
                    const std::map<std::string, std::vector<ParseTree *>> &labels, ParseTree *mismatchedNode);
-    virtual ~ParseTreeMatch() {};
+    ParseTreeMatch(ParseTreeMatch const&) = default;
+    virtual ~ParseTreeMatch();
+    ParseTreeMatch& operator=(ParseTreeMatch const&) = default;
 
     /// <summary>
     /// Get the last node associated with a specific {@code label}.

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePattern.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePattern.cpp
@@ -17,9 +17,9 @@ using namespace antlr4::tree::pattern;
 
 using namespace antlrcpp;
 
-ParseTreePattern::ParseTreePattern(ParseTreePatternMatcher *matcher, const std::string &pattern, int patternRuleIndex_in,
+ParseTreePattern::ParseTreePattern(ParseTreePatternMatcher *matcher, const std::string &pattern, int patternRuleIndex_,
                                    ParseTree *patternTree)
-  : patternRuleIndex(patternRuleIndex_in), _pattern(pattern), _patternTree(patternTree), _matcher(matcher) {
+  : patternRuleIndex(patternRuleIndex_), _pattern(pattern), _patternTree(patternTree), _matcher(matcher) {
 }
 
 ParseTreePattern::~ParseTreePattern()

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePattern.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePattern.cpp
@@ -22,8 +22,7 @@ ParseTreePattern::ParseTreePattern(ParseTreePatternMatcher *matcher, const std::
   : patternRuleIndex(patternRuleIndex_), _pattern(pattern), _patternTree(patternTree), _matcher(matcher) {
 }
 
-ParseTreePattern::~ParseTreePattern()
-{
+ParseTreePattern::~ParseTreePattern() {
 }
 
 ParseTreeMatch ParseTreePattern::match(ParseTree *tree) {

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePattern.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePattern.cpp
@@ -17,9 +17,13 @@ using namespace antlr4::tree::pattern;
 
 using namespace antlrcpp;
 
-ParseTreePattern::ParseTreePattern(ParseTreePatternMatcher *matcher, const std::string &pattern, int patternRuleIndex,
+ParseTreePattern::ParseTreePattern(ParseTreePatternMatcher *matcher, const std::string &pattern, int patternRuleIndex_in,
                                    ParseTree *patternTree)
-  : patternRuleIndex(patternRuleIndex), _pattern(pattern), _patternTree(patternTree), _matcher(matcher) {
+  : patternRuleIndex(patternRuleIndex_in), _pattern(pattern), _patternTree(patternTree), _matcher(matcher) {
+}
+
+ParseTreePattern::~ParseTreePattern()
+{
 }
 
 ParseTreeMatch ParseTreePattern::match(ParseTree *tree) {

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePattern.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePattern.h
@@ -28,7 +28,9 @@ namespace pattern {
     /// <param name="patternTree"> The tree pattern in <seealso cref="ParseTree"/> form. </param>
     ParseTreePattern(ParseTreePatternMatcher *matcher, const std::string &pattern, int patternRuleIndex,
                      ParseTree *patternTree);
-    virtual ~ParseTreePattern() {};
+    ParseTreePattern(ParseTreePattern const&) = default;
+    virtual ~ParseTreePattern();
+    ParseTreePattern& operator=(ParseTreePattern const&) = default;
 
     /// <summary>
     /// Match a specific parse tree against this tree pattern.

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
@@ -34,8 +34,20 @@ using namespace antlrcpp;
 ParseTreePatternMatcher::CannotInvokeStartRule::CannotInvokeStartRule(const RuntimeException &e) : RuntimeException(e.what()) {
 }
 
+ParseTreePatternMatcher::CannotInvokeStartRule::~CannotInvokeStartRule()
+{
+}
+
+ParseTreePatternMatcher::StartRuleDoesNotConsumeFullPattern::~StartRuleDoesNotConsumeFullPattern()
+{
+}
+
 ParseTreePatternMatcher::ParseTreePatternMatcher(Lexer *lexer, Parser *parser) : _lexer(lexer), _parser(parser) {
   InitializeInstanceFields();
+}
+
+ParseTreePatternMatcher::~ParseTreePatternMatcher()
+{
 }
 
 void ParseTreePatternMatcher::setDelimiters(const std::string &start, const std::string &stop, const std::string &escapeLeft) {

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
@@ -34,20 +34,17 @@ using namespace antlrcpp;
 ParseTreePatternMatcher::CannotInvokeStartRule::CannotInvokeStartRule(const RuntimeException &e) : RuntimeException(e.what()) {
 }
 
-ParseTreePatternMatcher::CannotInvokeStartRule::~CannotInvokeStartRule()
-{
+ParseTreePatternMatcher::CannotInvokeStartRule::~CannotInvokeStartRule() {
 }
 
-ParseTreePatternMatcher::StartRuleDoesNotConsumeFullPattern::~StartRuleDoesNotConsumeFullPattern()
-{
+ParseTreePatternMatcher::StartRuleDoesNotConsumeFullPattern::~StartRuleDoesNotConsumeFullPattern() {
 }
 
 ParseTreePatternMatcher::ParseTreePatternMatcher(Lexer *lexer, Parser *parser) : _lexer(lexer), _parser(parser) {
   InitializeInstanceFields();
 }
 
-ParseTreePatternMatcher::~ParseTreePatternMatcher()
-{
+ParseTreePatternMatcher::~ParseTreePatternMatcher() {
 }
 
 void ParseTreePatternMatcher::setDelimiters(const std::string &start, const std::string &stop, const std::string &escapeLeft) {

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.h
@@ -73,11 +73,18 @@ namespace pattern {
     class CannotInvokeStartRule : public RuntimeException {
     public:
       CannotInvokeStartRule(const RuntimeException &e);
+      ~CannotInvokeStartRule();
     };
 
     // Fixes https://github.com/antlr/antlr4/issues/413
     // "Tree pattern compilation doesn't check for a complete parse"
     class StartRuleDoesNotConsumeFullPattern : public RuntimeException {
+    public:
+      StartRuleDoesNotConsumeFullPattern() = default;
+      StartRuleDoesNotConsumeFullPattern(StartRuleDoesNotConsumeFullPattern const&) = default;
+      ~StartRuleDoesNotConsumeFullPattern();
+
+      StartRuleDoesNotConsumeFullPattern& operator=(StartRuleDoesNotConsumeFullPattern const&) = default;
     };
 
     /// Constructs a <seealso cref="ParseTreePatternMatcher"/> or from a <seealso cref="Lexer"/> and
@@ -85,7 +92,7 @@ namespace pattern {
     /// the tree patterns. The parser is used as a convenient mechanism to get
     /// the grammar name, plus token, rule names.
     ParseTreePatternMatcher(Lexer *lexer, Parser *parser);
-    virtual ~ParseTreePatternMatcher() {};
+    virtual ~ParseTreePatternMatcher();
 
     /// <summary>
     /// Set the delimiters used for marking rule and token tags within concrete

--- a/runtime/Cpp/runtime/src/tree/pattern/TagChunk.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/TagChunk.cpp
@@ -19,6 +19,10 @@ TagChunk::TagChunk(const std::string &label, const std::string &tag) : _tag(tag)
 
 }
 
+TagChunk::~TagChunk()
+{
+}
+
 std::string TagChunk::getTag() {
   return _tag;
 }

--- a/runtime/Cpp/runtime/src/tree/pattern/TagChunk.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/TagChunk.cpp
@@ -19,8 +19,7 @@ TagChunk::TagChunk(const std::string &label, const std::string &tag) : _tag(tag)
 
 }
 
-TagChunk::~TagChunk()
-{
+TagChunk::~TagChunk() {
 }
 
 std::string TagChunk::getTag() {

--- a/runtime/Cpp/runtime/src/tree/pattern/TagChunk.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/TagChunk.h
@@ -37,7 +37,7 @@ namespace pattern {
     /// <exception cref="IllegalArgumentException"> if {@code tag} is {@code null} or
     /// empty. </exception>
     TagChunk(const std::string &tag);
-    virtual ~TagChunk() {};
+    virtual ~TagChunk();
 
     /// <summary>
     /// Construct a new instance of <seealso cref="TagChunk"/> using the specified label

--- a/runtime/Cpp/runtime/src/tree/pattern/TextChunk.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/TextChunk.cpp
@@ -16,8 +16,7 @@ TextChunk::TextChunk(const std::string &text) : text(text) {
 
 }
 
-TextChunk::~TextChunk()
-{
+TextChunk::~TextChunk() {
 }
 
 std::string TextChunk::getText() {

--- a/runtime/Cpp/runtime/src/tree/pattern/TextChunk.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/TextChunk.cpp
@@ -16,6 +16,10 @@ TextChunk::TextChunk(const std::string &text) : text(text) {
 
 }
 
+TextChunk::~TextChunk()
+{
+}
+
 std::string TextChunk::getText() {
   return text;
 }

--- a/runtime/Cpp/runtime/src/tree/pattern/TextChunk.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/TextChunk.h
@@ -29,7 +29,7 @@ namespace pattern {
     /// <exception cref="IllegalArgumentException"> if {@code text} is {@code null}. </exception>
   public:
     TextChunk(const std::string &text);
-    virtual ~TextChunk() {};
+    virtual ~TextChunk();
 
     /// <summary>
     /// Gets the raw text of this chunk.

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathElement.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathElement.cpp
@@ -14,6 +14,9 @@ XPathElement::XPathElement(const std::string &nodeName) {
   _nodeName = nodeName;
 }
 
+XPathElement::~XPathElement() {
+}
+
 std::vector<ParseTree *> XPathElement::evaluate(ParseTree * /*t*/) {
   return {};
 }

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathElement.h
@@ -18,7 +18,10 @@ namespace xpath {
     /// Construct element like {@code /ID} or {@code ID} or {@code /*} etc...
     ///  op is null if just node
     XPathElement(const std::string &nodeName);
-    virtual ~XPathElement() {}
+    XPathElement(XPathElement const&) = default;
+    virtual ~XPathElement();
+
+    XPathElement& operator=(XPathElement const&) = default;
 
     /// Given tree rooted at {@code t} return all nodes matched by this path
     /// element.

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.cpp
@@ -47,7 +47,7 @@ const atn::ATN& XPathLexer::getATN() const {
 
 void XPathLexer::action(RuleContext *context, size_t ruleIndex, size_t actionIndex) {
   switch (ruleIndex) {
-    case 4: IDAction(dynamic_cast<antlr4::RuleContext *>(context), actionIndex); break;
+    case 4: IDAction(context, actionIndex); break;
 
   default:
     break;

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.cpp
@@ -47,7 +47,7 @@ const atn::ATN& XPathLexer::getATN() const {
 
 void XPathLexer::action(RuleContext *context, size_t ruleIndex, size_t actionIndex) {
   switch (ruleIndex) {
-    case 4: IDAction(context, actionIndex); break;
+    case 4: IDAction(dynamic_cast<antlr4::RuleContext *>(context), actionIndex); break;
 
   default:
     break;


### PR DESCRIPTION
These changes are for compiling the C++ runtime and code using the C++ runtime headers with high warning levels and -Werror. There are no functional changes in this commit. Compiled with gcc 5.4 and clang 3.8.