### PR TITLE
Corrected `.js` file endings to `.cs` in doc/chsharp-target.md

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -148,3 +148,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/05/11, jimallman, Jim Allman, jim@ibang.com
 2017/05/26, waf, Will Fuqua, wafuqua@gmail.com
 2017/05/29, kosak, Corey Kosak, kosak@kosak.com
+2017/06/11, erikbra, Erik A. Brandstadmoen, erik@brandstadmoen.net

--- a/doc/csharp-target.md
+++ b/doc/csharp-target.md
@@ -35,7 +35,7 @@ using Antlr4.Runtime;
      
 public void MyParseMethod() {
       String input = "your text to parse here";
-      ICharStream stream = CharStreams.fromString(input);
+      ICharStream stream = CharStreams.fromstring(input);
       ITokenSource lexer = new MyGrammarLexer(stream);
       ITokenStream tokens = new CommonTokenStream(lexer);
       MyGrammarParser parser = new MyGrammarParser(tokens);

--- a/doc/csharp-target.md
+++ b/doc/csharp-target.md
@@ -24,9 +24,9 @@ Let's suppose that your grammar is named `MyGrammar`. The tool will generate for
 *  MyGrammarLexer.cs
 *   MyGrammarParser.cs
 *   MyGrammarListener.cs (if you have not activated the -no-listener option)
-*   MyGrammarBaseListener.js (if you have not activated the -no-listener option)
-*   MyGrammarVisitor.js (if you have activated the -visitor option)
-*   MyGrammarBaseVisitor.js (if you have activated the -visitor option)
+*   MyGrammarBaseListener.cs (if you have not activated the -no-listener option)
+*   MyGrammarVisitor.cs (if you have activated the -visitor option)
+*   MyGrammarBaseVisitor.cs (if you have activated the -visitor option)
 
 Now a fully functioning code might look like the following for start rule `StartRule`:
 


### PR DESCRIPTION
The file endings for `MyGrammarBaseListener`, `MyGrammarVisitor` and `MyGrammarBaseVisitor` was `.js`. Changed to `.cs`

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->