### PR TITLE
Reverted removal of namespace.

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -1024,7 +1024,7 @@ ContextRuleListIndexedGetterDecl(r) ::= <<
 
 >>
 
-LexerRuleContext() ::= "RuleContext"
+LexerRuleContext() ::= "antlr4::RuleContext"
 
 // The rule context name is the rule followed by a suffix; e.g. r becomes rContext.
 RuleContextNameSuffix() ::= "Context"


### PR DESCRIPTION
That removal breaks the tests, so the namespace is obviously needed there (although I don't see any bad effect on my own code which uses this part).