### PR TITLE
added SVG export of parse tree

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -166,3 +166,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/09/11, sachinjain024, Sachin Jain, sachinjain024@gmail.com
 2017/10/06, bramp, Andrew Brampton, brampton@gmail.com
 2017/10/15, simkimsia, Sim Kim Sia, kimcity@gmail.com
+2017/05/29, rlfnb, Ralf Neeb, rlfnb@rlfnb.de


### PR DESCRIPTION
Main driver for exporting to SVG was the ability to search in big parse trees. I wont add new dependencies to the pom.xml, but if its ok, I'll prepare the next commit for the SVG view, too.