### PR TITLE
C++ runtime: Add support for non-copyable objects to the Any and visitor classes

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -154,3 +154,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/07/11, dhalperi, Daniel Halperin, daniel@halper.in
 2017/07/27, shirou, WAKAYAMA Shirou, shirou.faw@gmail.com
 2017/07/09, neatnerd, Mike Arshinskiy, neatnerd@users.noreply.github.com
+2017/06/16, Griffon26, Maurice van der Pot, griffon26@kfk4ever.com

--- a/runtime/Cpp/runtime/src/support/Any.h
+++ b/runtime/Cpp/runtime/src/support/Any.h
@@ -24,21 +24,17 @@ struct ANTLR4CPP_PUBLIC Any
   bool isNull() const { return _ptr == nullptr; }
   bool isNotNull() const { return _ptr != nullptr; }
 
-  Any() : _ptr(nullptr) {
-  }
+  Any() = delete;
 
-  Any(Any& that) : _ptr(that.clone()) {
-  }
+  Any(Any& that) = delete;
 
   Any(Any&& that) : _ptr(that._ptr) {
     that._ptr = nullptr;
   }
 
-  Any(const Any& that) : _ptr(that.clone()) {
-  }
+  Any(const Any& that) = delete;
 
-  Any(const Any&& that) : _ptr(that.clone()) {
-  }
+  Any(const Any&& that) = delete;
 
   template<typename U>
   Any(U&& value) : _ptr(new Derived<StorageType<U>>(std::forward<U>(value))) {
@@ -67,21 +63,10 @@ struct ANTLR4CPP_PUBLIC Any
 
   template<class U>
   operator U() {
-    return as<StorageType<U>>();
+    return std::move(as<StorageType<U>>());
   }
 
-  Any& operator = (const Any& a) {
-    if (_ptr == a._ptr)
-      return *this;
-
-    auto old_ptr = _ptr;
-    _ptr = a.clone();
-
-    if (old_ptr)
-      delete old_ptr;
-
-    return *this;
-  }
+  Any& operator = (const Any& a) = delete;
 
   Any& operator = (Any&& a) {
     if (_ptr == a._ptr)
@@ -101,7 +86,6 @@ struct ANTLR4CPP_PUBLIC Any
 private:
   struct Base {
     virtual ~Base();
-    virtual Base* clone() const = 0;
   };
 
   template<typename T>
@@ -112,19 +96,7 @@ private:
 
     T value;
 
-    Base* clone() const {
-      return new Derived<T>(value);
-    }
-
   };
-
-  Base* clone() const
-  {
-    if (_ptr)
-      return _ptr->clone();
-    else
-      return nullptr;
-  }
 
   Base *_ptr;
 

--- a/runtime/Cpp/runtime/src/tree/AbstractParseTreeVisitor.h
+++ b/runtime/Cpp/runtime/src/tree/AbstractParseTreeVisitor.h
@@ -91,8 +91,8 @@ namespace tree {
     /// a child node.
     /// </param>
     /// <returns> The updated aggregate result. </returns>
-    virtual antlrcpp::Any aggregateResult(antlrcpp::Any /*aggregate*/, const antlrcpp::Any &nextResult) {
-      return nextResult;
+    virtual antlrcpp::Any aggregateResult(antlrcpp::Any &/*aggregate*/, antlrcpp::Any &nextResult) {
+      return std::move(nextResult);
     }
 
     /// <summary>


### PR DESCRIPTION
These changes make it possible to use std::unique_ptr to manage ownership of objects created while parsing. I think it works just as well with copyable types, but I would appreciate anyone trying this with some real-world examples.

I tried to run the runtime tests, but that failed with this message and I don't have the Java knowledge to fix this: "Could not find artifact org.antlr:antlr4-maven-plugin:jar:4.7.1-SNAPSHOT"