### PR TITLE
Fix input mismatch errors not reported the same way as Java in Python

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -148,3 +148,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/05/11, jimallman, Jim Allman, jim@ibang.com
 2017/05/26, waf, Will Fuqua, wafuqua@gmail.com
 2017/05/29, kosak, Corey Kosak, kosak@kosak.com
+2017/06/25, alimg, Alim Gökkaya, alim.gokkaya@gmail.com

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParserErrorsDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParserErrorsDescriptors.java
@@ -581,4 +581,41 @@ public class ParserErrorsDescriptors {
 		public String grammar;
 
 	}
+
+	public static class TokenMismatch3 extends BaseParserTestDescriptor {
+		public String input = "";
+		public String output = null;
+		public String errors = "line 1:0 mismatched input '<EOF>' expecting {'(', BOOLEAN_LITERAL, ID, '$'}\n";
+		public String startRule = "expression";
+		public String grammarName = "T";
+
+		/**
+		 grammar T;
+
+		 expression
+		 :   value
+		 |   expression op=AND expression
+		 |   expression op=OR expression
+		 ;
+		 value
+		 :   BOOLEAN_LITERAL
+		 |   ID
+		 |   ID1
+		 |   '(' expression ')'
+		 ;
+
+		 AND : '&&';
+		 OR  : '||';
+
+		 BOOLEAN_LITERAL : 'true' | 'false';
+
+		 ID  : [a-z]+;
+		 ID1 : '$';
+
+		 WS  : [ \t\r\n]+ -> skip ;
+		 */
+		@CommentHasStringValue
+		public String grammar;
+
+	}
 }

--- a/runtime/Python2/src/antlr4/IntervalSet.py
+++ b/runtime/Python2/src/antlr4/IntervalSet.py
@@ -193,7 +193,7 @@ class IntervalSet(object):
         elif a==Token.EPSILON:
             return u"<EPSILON>"
         else:
-            if a<len(literalNames):
+            if a<len(literalNames) and literalNames[a] != u"<INVALID>":
                 return literalNames[a]
             if a<len(symbolicNames):
                 return symbolicNames[a]

--- a/runtime/Python3/src/antlr4/IntervalSet.py
+++ b/runtime/Python3/src/antlr4/IntervalSet.py
@@ -173,7 +173,7 @@ class IntervalSet(object):
         elif a==Token.EPSILON:
             return "<EPSILON>"
         else:
-            if a<len(literalNames):
+            if a<len(literalNames) and literalNames[a] != "<INVALID>":
                 return literalNames[a]
             if a<len(symbolicNames):
                 return symbolicNames[a]


### PR DESCRIPTION
I'm getting different error messages from Java and Python runtimes for the same grammar. Figured out a check from the Java version was missing in the Python one so here's it