### PR TITLE
[dotnet] for linux target, bring up to jdk8 since jdk7 no longer available for Trusty; for linux and osx targets, bring up dotnet from 1.0.3 to 1.0.4; Trusty image now has mvn 3.3.9 builtin, removed install code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
       jdk: oraclejdk7
       env: TARGET=csharp
     - os: linux
-      jdk: oraclejdk7
+      jdk: oraclejdk8
       dist: trusty
       env: TARGET=dotnet
     - os: linux

--- a/.travis/before-install-linux-dotnet.sh
+++ b/.travis/before-install-linux-dotnet.sh
@@ -6,16 +6,5 @@ set -euo pipefail
 sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
 sudo apt-get update
-sudo apt-get install dotnet-dev-1.0.3
-
-# install mvn
-wget http://apache.mirrors.lucidnetworks.net/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz && \
-    wget https://www.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz.md5 && \
-    echo "$(cat apache-maven-3.3.9-bin.tar.gz.md5)  apache-maven-3.3.9-bin.tar.gz" > apache-maven-3.3.9-bin.tar.gz.md5 && \
-    md5sum -c *.md5
-
-sudo rm -rf /usr/local/maven/ && sudo mkdir -p /usr/local/maven && \
-    sudo tar xzvf apache-maven-3.3.9-bin.tar.gz -C /usr/local/maven --strip-components=1
-
-mvn -v
+sudo apt-get install dotnet-dev-1.0.4
 

--- a/.travis/before-install-osx-dotnet.sh
+++ b/.travis/before-install-osx-dotnet.sh
@@ -12,10 +12,10 @@ ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
 ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
 
 # download dotnet core
-curl https://download.microsoft.com/download/1/1/4/114223DE-0AD6-4B8A-A8FB-164E5862AF6E/dotnet-dev-osx-x64.1.0.3.pkg -o /tmp/dotnet-dev-osx-x64.1.0.3.pkg
+curl https://download.microsoft.com/download/B/9/F/B9F1AF57-C14A-4670-9973-CDF47209B5BF/dotnet-dev-osx-x64.1.0.4.pkg -o /tmp/dotnet-dev-osx-x64.1.0.4.pkg
 
 # install dotnet core
-sudo installer -pkg /tmp/dotnet-dev-osx-x64.1.0.3.pkg -target /
+sudo installer -pkg /tmp/dotnet-dev-osx-x64.1.0.4.pkg -target /
 
 # make the link
 ln -s /usr/local/share/dotnet/dotnet /usr/local/bin/


### PR DESCRIPTION
@ericvergnaud @parrt 