### PR TITLE
Support for osgi bundles

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -151,3 +151,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/06/11, erikbra, Erik A. Brandstadmoen, erik@brandstadmoen.net
 2017/06/10, jm-mikkelsen, Jan Martin Mikkelsen, janm@transactionware.com
 2017/06/25, alimg, Alim Gökkaya, alim.gokkaya@gmail.com
+2017/06/30, catull, Carlo Dapor, catull@gmail.com

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,18 @@
 	</scm>
 
 	<build>
+		<plugins>
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<version>3.3.0</version>
+				</plugin>
+				<plugin> <!-- create src jar -->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>3.0.1</version>
+				</plugin>
+		</plugins>
 		<resources>
 			<resource>
 				<directory>resources</directory>

--- a/runtime-testsuite/annotations/pom.xml
+++ b/runtime-testsuite/annotations/pom.xml
@@ -14,6 +14,7 @@
   </parent>
   <artifactId>antlr4-runtime-test-annotations</artifactId>
   <name>ANTLR 4 Runtime Test Annotations</name>
+  <packaging>bundle</packaging>
   <description>The ANTLR 4 Runtime</description>
 
   <build>
@@ -22,7 +23,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.4</version>
+				<extensions>true</extensions>
         <executions>
           <execution>
             <id>bundle-manifest</id>

--- a/runtime-testsuite/processors/pom.xml
+++ b/runtime-testsuite/processors/pom.xml
@@ -14,6 +14,7 @@
 	</parent>
 	<artifactId>antlr4-runtime-test-annotation-processors</artifactId>
 	<name>ANTLR 4 Runtime Test Processors</name>
+	<packaging>bundle</packaging>
 	<description>The ANTLR 4 Runtime</description>
 
 	<dependencies>
@@ -50,6 +51,11 @@
 						-proc:none
 					</compilerArgument>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
 			</plugin>
 		</plugins>
 	</build>

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -14,6 +14,7 @@
 	</parent>
 	<artifactId>antlr4-runtime</artifactId>
 	<name>ANTLR 4 Runtime</name>
+	<packaging>bundle</packaging>
 	<description>The ANTLR 4 Runtime</description>
 
 	<properties>
@@ -88,7 +89,8 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.5.4</version>
+				<version>3.3.0</version>
+				<extensions>true</extensions>
 				<executions>
 					<execution>
 						<id>bundle-manifest</id>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -12,6 +12,7 @@
 		<version>4.7.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>antlr4</artifactId>
+	<packaging>bundle</packaging>
 	<name>ANTLR 4 Tool</name>
 	<url>http://www.antlr.org</url>
 	<description>The ANTLR 4 grammar compiler.</description>
@@ -86,6 +87,7 @@
 			<plugin> <!-- include code-generated sources -->
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<extensions>true</extensions>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -188,6 +190,11 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
The distribution form is a still a jar file, which can be used as before.
The main advantage of a bundle is that it can be used way more easier in an OSGi container.

This PR introduces support for OSGi bundle packaging.
