### PR TITLE
Fix expressions that have no effect

### DIFF
--- a/runtime/JavaScript/src/antlr4/atn/ATNDeserializer.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNDeserializer.js
@@ -158,7 +158,7 @@ ATNDeserializer.prototype.checkUUID = function() {
     var uuid = this.readUUID();
     if (SUPPORTED_UUIDS.indexOf(uuid)<0) {
         throw ("Could not deserialize ATN with UUID: " + uuid +
-                        " (expected " + SERIALIZED_UUID + " or a legacy UUID).", uuid, SERIALIZED_UUID);
+                        " (expected " + SERIALIZED_UUID + " or a legacy UUID).");
     }
     this.uuid = uuid;
 };

--- a/runtime/JavaScript/src/antlr4/error/Errors.js
+++ b/runtime/JavaScript/src/antlr4/error/Errors.js
@@ -78,7 +78,7 @@ LexerNoViableAltException.prototype.constructor = LexerNoViableAltException;
 LexerNoViableAltException.prototype.toString = function() {
     var symbol = "";
     if (this.startIndex >= 0 && this.startIndex < this.input.size) {
-        symbol = this.input.getText((this.startIndex,this.startIndex));
+        symbol = this.input.getText(this.startIndex);
     }
     return "LexerNoViableAltException" + symbol;
 };


### PR DESCRIPTION
I spotted a couple of places where the comma operator was being used, but possibly wrongly as there were expressions which had no effect. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator

In the case of `ATNDeserializer.js` it looked like it was something like text substitution in to the log message, but in fact the whole first two parts were discarded and it would just print `SERIALIZED_UUID`. By removing the last two parts and the commas it'll actually print the whole mesage.

In the case of `Errors.js` I'm not sure what was meant to happen but this change in this PR is entirely behaviour preserving so hopefully no problem.

As a bonus, this will fix a few alerts on [lgtm.com](lgtm.com). See [ATNDeserializer.js](https://lgtm.com/projects/g/antlr/antlr4/snapshot/dist-1787830766-1498572200128/files/runtime/JavaScript/src/antlr4/atn/ATNDeserializer.js#V160) and [Errors.js](https://lgtm.com/projects/g/antlr/antlr4/snapshot/dist-1787830766-1498572200128/files/runtime/JavaScript/src/antlr4/error/Errors.js#V81).