### PR TITLE
[Go] Implemented TokenStreamRewriter

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -151,3 +151,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/06/11, erikbra, Erik A. Brandstadmoen, erik@brandstadmoen.net
 2017/06/10, jm-mikkelsen, Jan Martin Mikkelsen, janm@transactionware.com
 2017/06/25, alimg, Alim Gökkaya, alim.gokkaya@gmail.com
+2017/07/09, neatnerd, Mike Arshinskiy, neatnerd@users.noreply.github.com

--- a/runtime/Go/antlr/tokenstream_rewriter.go
+++ b/runtime/Go/antlr/tokenstream_rewriter.go
@@ -9,11 +9,10 @@ import (
 )
 
 
-// Useful for rewriting out a buffered input token stream after doing some
-//
+// 
 // Useful for rewriting out a buffered input token stream after doing some
 // augmentation or other manipulations on it.
-//
+
 // <p>
 // You can insert stuff, replace, and delete chunks. Note that the operations
 // are done lazily--only if you convert the buffer to a {@link String} with
@@ -24,31 +23,31 @@ import (
 // operation is done and then normal {@link String} rendering continues on the
 // buffer. This is like having multiple Turing machine instruction streams
 // (programs) operating on a single input tape. :)</p>
-//
 // <p>
+
 // This rewriter makes no modifications to the token stream. It does not ask the
 // stream to fill itself up nor does it advance the input cursor. The token
 // stream {@link TokenStream#index()} will return the same value before and
 // after any {@link #getText()} call.</p>
-//
+
 // <p>
 // The rewriter only works on tokens that you have in the buffer and ignores the
 // current input cursor. If you are buffering tokens on-demand, calling
 // {@link #getText()} halfway through the input will only do rewrites for those
 // tokens in the first half of the file.</p>
-//
+
 // <p>
 // Since the operations are done lazily at {@link #getText}-time, operations do
 // not screw up the token index values. That is, an insert operation at token
 // index {@code i} does not change the index values for tokens
 // {@code i}+1..n-1.</p>
-//
+
 // <p>
 // Because operations never actually alter the buffer, you may always get the
 // original token stream back without undoing anything. Since the instructions
 // are queued up, you can easily simulate transactions and roll back any changes
 // if there is an error just by removing instructions. For example,</p>
-//
+
 // <pre>
 // CharStream input = new ANTLRFileStream("input");
 // TLexer lex = new TLexer(input);
@@ -57,10 +56,10 @@ import (
 // TokenStreamRewriter rewriter = new TokenStreamRewriter(tokens);
 // parser.startRule();
 // </pre>
-//
+
 // <p>
 // Then in the rules, you can execute (assuming rewriter is visible):</p>
-//
+
 // <pre>
 // Token t,u;
 // ...
@@ -68,97 +67,25 @@ import (
 // rewriter.insertAfter(u, "text after u");}
 // System.out.println(rewriter.getText());
 // </pre>
-//
+
 // <p>
 // You can also have multiple "instruction streams" and get multiple rewrites
 // from a single pass over the input. Just name the instruction streams and use
 // that name again when printing the buffer. This could be useful for generating
 // a C file and also its header file--all from the same buffer:</p>
-//
+
 // <pre>
 // rewriter.insertAfter("pass1", t, "text to put after t");}
 // rewriter.insertAfter("pass2", u, "text after u");}
 // System.out.println(rewriter.getText("pass1"));
 // System.out.println(rewriter.getText("pass2"));
 // </pre>
-//
+
 // <p>
 // If you don't use named rewrite streams, a "default" stream is used as the
 // first example shows.</p>
-// /augmentation or other manipulations on it.
-//
-// <p>
-// You can insert stuff, replace, and delete chunks. Note that the operations
-// are done lazily--only if you convert the buffer to a {@link String} with
-// {@link TokenStream#getText()}. This is very efficient because you are not
-// moving data around all the time. As the buffer of tokens is converted to
-// strings, the {@link #getText()} method(s) scan the input token stream and
-// check to see if there is an operation at the current index. If so, the
-// operation is done and then normal {@link String} rendering continues on the
-// buffer. This is like having multiple Turing machine instruction streams
-// (programs) operating on a single input tape. :)</p>
-//
-// <p>
-// This rewriter makes no modifications to the token stream. It does not ask the
-// stream to fill itself up nor does it advance the input cursor. The token
-// stream {@link TokenStream#index()} will return the same value before and
-// after any {@link #getText()} call.</p>
-//
-// <p>
-// The rewriter only works on tokens that you have in the buffer and ignores the
-// current input cursor. If you are buffering tokens on-demand, calling
-// {@link #getText()} halfway through the input will only do rewrites for those
-// tokens in the first half of the file.</p>
-//
-// <p>
-// Since the operations are done lazily at {@link #getText}-time, operations do
-// not screw up the token index values. That is, an insert operation at token
-// index {@code i} does not change the index values for tokens
-// {@code i}+1..n-1.</p>
-//
-// <p>
-// Because operations never actually alter the buffer, you may always get the
-// original token stream back without undoing anything. Since the instructions
-// are queued up, you can easily simulate transactions and roll back any changes
-// if there is an error just by removing instructions. For example,</p>
-//
-// <pre>
-// CharStream input = new ANTLRFileStream("input");
-// TLexer lex = new TLexer(input);
-// CommonTokenStream tokens = new CommonTokenStream(lex);
-// T parser = new T(tokens);
-// TokenStreamRewriter rewriter = new TokenStreamRewriter(tokens);
-// parser.startRule();
-// </pre>
-//
-// <p>
-// Then in the rules, you can execute (assuming rewriter is visible):</p>
-//
-// <pre>
-// Token t,u;
-// ...
-// rewriter.insertAfter(t, "text to put after t");}
-// rewriter.insertAfter(u, "text after u");}
-// System.out.println(rewriter.getText());
-// </pre>
-//
-// <p>
-// You can also have multiple "instruction streams" and get multiple rewrites
-// from a single pass over the input. Just name the instruction streams and use
-// that name again when printing the buffer. This could be useful for generating
-// a C file and also its header file--all from the same buffer:</p>
-//
-// <pre>
-// rewriter.insertAfter("pass1", t, "text to put after t");}
-// rewriter.insertAfter("pass2", u, "text after u");}
-// System.out.println(rewriter.getText("pass1"));
-// System.out.println(rewriter.getText("pass2"));
-// </pre>
-//
-// <p>
-// If you don't use named rewrite streams, a "default" stream is used as the
-// first example shows.</p>
-//
+
+
 
 const(
 	Default_Program_Name = "default"
@@ -172,12 +99,12 @@ type RewriteOperation interface {
 	// Execute the rewrite operation by possibly adding to the buffer.
 	// Return the index of the next token to operate on.
 	Execute(buffer *bytes.Buffer)	int
-	String()						string
-	GetInstructionIndex()			int
-	GetIndex()						int
-	GetText()						string
-	GetOpName()						string
-	GetTokens()						TokenStream
+	String()			string
+	GetInstructionIndex()		int
+	GetIndex()			int
+	GetText()			string
+	GetOpName()			string
+	GetTokens()			TokenStream
 	SetInstructionIndex(val int)
 	SetIndex(int)
 	SetText(string)
@@ -187,7 +114,7 @@ type RewriteOperation interface {
 
 type BaseRewriteOperation struct {
 	//Current index of rewrites list
-	instruction_index	int
+	instruction_index		int
 	//Token buffer index
 	index				int
 	//Substitution text

--- a/runtime/Go/antlr/tokenstream_rewriter.go
+++ b/runtime/Go/antlr/tokenstream_rewriter.go
@@ -1,0 +1,722 @@
+// Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+// Use of this file is governed by the BSD 3-clause license that
+// can be found in the LICENSE.txt file in the project root.
+package antlr
+
+import (
+"bytes"
+"fmt"
+)
+
+
+// Useful for rewriting out a buffered input token stream after doing some
+//
+// Useful for rewriting out a buffered input token stream after doing some
+// augmentation or other manipulations on it.
+//
+// <p>
+// You can insert stuff, replace, and delete chunks. Note that the operations
+// are done lazily--only if you convert the buffer to a {@link String} with
+// {@link TokenStream#getText()}. This is very efficient because you are not
+// moving data around all the time. As the buffer of tokens is converted to
+// strings, the {@link #getText()} method(s) scan the input token stream and
+// check to see if there is an operation at the current index. If so, the
+// operation is done and then normal {@link String} rendering continues on the
+// buffer. This is like having multiple Turing machine instruction streams
+// (programs) operating on a single input tape. :)</p>
+//
+// <p>
+// This rewriter makes no modifications to the token stream. It does not ask the
+// stream to fill itself up nor does it advance the input cursor. The token
+// stream {@link TokenStream#index()} will return the same value before and
+// after any {@link #getText()} call.</p>
+//
+// <p>
+// The rewriter only works on tokens that you have in the buffer and ignores the
+// current input cursor. If you are buffering tokens on-demand, calling
+// {@link #getText()} halfway through the input will only do rewrites for those
+// tokens in the first half of the file.</p>
+//
+// <p>
+// Since the operations are done lazily at {@link #getText}-time, operations do
+// not screw up the token index values. That is, an insert operation at token
+// index {@code i} does not change the index values for tokens
+// {@code i}+1..n-1.</p>
+//
+// <p>
+// Because operations never actually alter the buffer, you may always get the
+// original token stream back without undoing anything. Since the instructions
+// are queued up, you can easily simulate transactions and roll back any changes
+// if there is an error just by removing instructions. For example,</p>
+//
+// <pre>
+// CharStream input = new ANTLRFileStream("input");
+// TLexer lex = new TLexer(input);
+// CommonTokenStream tokens = new CommonTokenStream(lex);
+// T parser = new T(tokens);
+// TokenStreamRewriter rewriter = new TokenStreamRewriter(tokens);
+// parser.startRule();
+// </pre>
+//
+// <p>
+// Then in the rules, you can execute (assuming rewriter is visible):</p>
+//
+// <pre>
+// Token t,u;
+// ...
+// rewriter.insertAfter(t, "text to put after t");}
+// rewriter.insertAfter(u, "text after u");}
+// System.out.println(rewriter.getText());
+// </pre>
+//
+// <p>
+// You can also have multiple "instruction streams" and get multiple rewrites
+// from a single pass over the input. Just name the instruction streams and use
+// that name again when printing the buffer. This could be useful for generating
+// a C file and also its header file--all from the same buffer:</p>
+//
+// <pre>
+// rewriter.insertAfter("pass1", t, "text to put after t");}
+// rewriter.insertAfter("pass2", u, "text after u");}
+// System.out.println(rewriter.getText("pass1"));
+// System.out.println(rewriter.getText("pass2"));
+// </pre>
+//
+// <p>
+// If you don't use named rewrite streams, a "default" stream is used as the
+// first example shows.</p>
+// /augmentation or other manipulations on it.
+//
+// <p>
+// You can insert stuff, replace, and delete chunks. Note that the operations
+// are done lazily--only if you convert the buffer to a {@link String} with
+// {@link TokenStream#getText()}. This is very efficient because you are not
+// moving data around all the time. As the buffer of tokens is converted to
+// strings, the {@link #getText()} method(s) scan the input token stream and
+// check to see if there is an operation at the current index. If so, the
+// operation is done and then normal {@link String} rendering continues on the
+// buffer. This is like having multiple Turing machine instruction streams
+// (programs) operating on a single input tape. :)</p>
+//
+// <p>
+// This rewriter makes no modifications to the token stream. It does not ask the
+// stream to fill itself up nor does it advance the input cursor. The token
+// stream {@link TokenStream#index()} will return the same value before and
+// after any {@link #getText()} call.</p>
+//
+// <p>
+// The rewriter only works on tokens that you have in the buffer and ignores the
+// current input cursor. If you are buffering tokens on-demand, calling
+// {@link #getText()} halfway through the input will only do rewrites for those
+// tokens in the first half of the file.</p>
+//
+// <p>
+// Since the operations are done lazily at {@link #getText}-time, operations do
+// not screw up the token index values. That is, an insert operation at token
+// index {@code i} does not change the index values for tokens
+// {@code i}+1..n-1.</p>
+//
+// <p>
+// Because operations never actually alter the buffer, you may always get the
+// original token stream back without undoing anything. Since the instructions
+// are queued up, you can easily simulate transactions and roll back any changes
+// if there is an error just by removing instructions. For example,</p>
+//
+// <pre>
+// CharStream input = new ANTLRFileStream("input");
+// TLexer lex = new TLexer(input);
+// CommonTokenStream tokens = new CommonTokenStream(lex);
+// T parser = new T(tokens);
+// TokenStreamRewriter rewriter = new TokenStreamRewriter(tokens);
+// parser.startRule();
+// </pre>
+//
+// <p>
+// Then in the rules, you can execute (assuming rewriter is visible):</p>
+//
+// <pre>
+// Token t,u;
+// ...
+// rewriter.insertAfter(t, "text to put after t");}
+// rewriter.insertAfter(u, "text after u");}
+// System.out.println(rewriter.getText());
+// </pre>
+//
+// <p>
+// You can also have multiple "instruction streams" and get multiple rewrites
+// from a single pass over the input. Just name the instruction streams and use
+// that name again when printing the buffer. This could be useful for generating
+// a C file and also its header file--all from the same buffer:</p>
+//
+// <pre>
+// rewriter.insertAfter("pass1", t, "text to put after t");}
+// rewriter.insertAfter("pass2", u, "text after u");}
+// System.out.println(rewriter.getText("pass1"));
+// System.out.println(rewriter.getText("pass2"));
+// </pre>
+//
+// <p>
+// If you don't use named rewrite streams, a "default" stream is used as the
+// first example shows.</p>
+//
+
+const(
+	Default_Program_Name = "default"
+	Program_Init_Size = 100
+	Min_Token_Index = 0
+)
+
+// Define the rewrite operation hierarchy
+
+type RewriteOperation interface {
+	// Execute the rewrite operation by possibly adding to the buffer.
+	// Return the index of the next token to operate on.
+	Execute(buffer *bytes.Buffer)	int
+	String()						string
+	GetInstructionIndex()			int
+	GetIndex()						int
+	GetText()						string
+	GetOpName()						string
+	GetTokens()						TokenStream
+	SetInstructionIndex(val int)
+	SetIndex(int)
+	SetText(string)
+	SetOpName(string)
+	SetTokens(TokenStream)
+}
+
+type BaseRewriteOperation struct {
+	//Current index of rewrites list
+	instruction_index	int
+	//Token buffer index
+	index				int
+	//Substitution text
+	text				string
+	//Actual operation name
+	op_name				string
+	//Pointer to token steam
+	tokens				TokenStream
+}
+
+func (op *BaseRewriteOperation)GetInstructionIndex() int{
+	return op.instruction_index
+}
+
+func (op *BaseRewriteOperation)GetIndex() int{
+	return op.index
+}
+
+func (op *BaseRewriteOperation)GetText() string{
+	return op.text
+}
+
+func (op *BaseRewriteOperation)GetOpName() string{
+	return op.op_name
+}
+
+func (op *BaseRewriteOperation)GetTokens() TokenStream{
+	return op.tokens
+}
+
+func (op *BaseRewriteOperation)SetInstructionIndex(val int){
+	op.instruction_index = val
+}
+
+func (op *BaseRewriteOperation)SetIndex(val int) {
+	op.index = val
+}
+
+func (op *BaseRewriteOperation)SetText(val string){
+	op.text = val
+}
+
+func (op *BaseRewriteOperation)SetOpName(val string){
+	op.op_name = val
+}
+
+func (op *BaseRewriteOperation)SetTokens(val TokenStream)  {
+	op.tokens = val
+}
+
+
+func (op *BaseRewriteOperation) Execute(buffer *bytes.Buffer) int{
+	return op.index
+}
+
+func (op *BaseRewriteOperation) String() string  {
+	return fmt.Sprintf("<%s@%d:\"%s\">",
+		op.op_name,
+		op.tokens.Get(op.GetIndex()),
+		op.text,
+	)
+
+}
+
+
+type InsertBeforeOp struct {
+	BaseRewriteOperation
+}
+
+func NewInsertBeforeOp(index int, text string, stream TokenStream) *InsertBeforeOp{
+	return &InsertBeforeOp{BaseRewriteOperation:BaseRewriteOperation{
+		index:index,
+		text:text,
+		op_name:"InsertBeforeOp",
+		tokens:stream,
+	}}
+}
+
+func (op *InsertBeforeOp) Execute(buffer *bytes.Buffer) int{
+	buffer.WriteString(op.text)
+	if op.tokens.Get(op.index).GetTokenType() != TokenEOF{
+		buffer.WriteString(op.tokens.Get(op.index).GetText())
+	}
+	return op.index+1
+}
+
+func (op *InsertBeforeOp) String() string {
+	return op.BaseRewriteOperation.String()
+}
+
+// Distinguish between insert after/before to do the "insert afters"
+//  first and then the "insert befores" at same index. Implementation
+//  of "insert after" is "insert before index+1".
+
+type InsertAfterOp struct {
+	BaseRewriteOperation
+}
+
+func NewInsertAfterOp(index int, text string, stream TokenStream) *InsertAfterOp{
+	return &InsertAfterOp{BaseRewriteOperation:BaseRewriteOperation{
+		index:index+1,
+		text:text,
+		tokens:stream,
+	}}
+}
+
+func (op *InsertAfterOp) Execute(buffer *bytes.Buffer) int {
+	buffer.WriteString(op.text)
+	if op.tokens.Get(op.index).GetTokenType() != TokenEOF{
+		buffer.WriteString(op.tokens.Get(op.index).GetText())
+	}
+	return op.index+1
+}
+
+func (op *InsertAfterOp) String() string {
+	return op.BaseRewriteOperation.String()
+}
+
+// I'm going to try replacing range from x..y with (y-x)+1 ReplaceOp
+// instructions.
+type ReplaceOp struct{
+	BaseRewriteOperation
+	LastIndex int
+}
+
+func NewReplaceOp(from, to int, text string, stream TokenStream)*ReplaceOp {
+	return &ReplaceOp{
+		BaseRewriteOperation:BaseRewriteOperation{
+			index:from,
+			text:text,
+			op_name:"ReplaceOp",
+			tokens:stream,
+		},
+		LastIndex:to,
+	}
+}
+
+func (op *ReplaceOp)Execute(buffer *bytes.Buffer) int{
+	if op.text != ""{
+		buffer.WriteString(op.text)
+	}
+	return op.LastIndex +1
+}
+
+func (op *ReplaceOp) String() string {
+	if op.text == "" {
+		return fmt.Sprintf("<DeleteOP@%d..%d>",
+			op.tokens.Get(op.index), op.tokens.Get(op.LastIndex))
+	}
+	return fmt.Sprintf("<ReplaceOp@%d..%d:\"%s\">",
+		op.tokens.Get(op.index), op.tokens.Get(op.LastIndex), op.text)
+}
+
+
+type TokenStreamRewriter struct {
+	//Our source stream
+	tokens						TokenStream
+	// You may have multiple, named streams of rewrite operations.
+	//  I'm calling these things "programs."
+	//  Maps String (name) &rarr; rewrite (List)
+	programs					map[string][]RewriteOperation
+	last_rewrite_token_indexes	map[string]int
+}
+
+func NewTokenStreamRewriter(tokens TokenStream) *TokenStreamRewriter{
+	return &TokenStreamRewriter{
+		tokens:						tokens,
+		programs:					map[string][]RewriteOperation{
+			Default_Program_Name:make([]RewriteOperation,0, Program_Init_Size),
+		},
+		last_rewrite_token_indexes:	map[string]int{},
+	}
+}
+
+func (tsr *TokenStreamRewriter) GetTokenStream() TokenStream{
+	return tsr.tokens
+}
+
+//  Rollback the instruction stream for a program so that
+//  the indicated instruction (via instructionIndex) is no
+//  longer in the stream. UNTESTED!
+func (tsr *TokenStreamRewriter) Rollback(program_name string, instruction_index int){
+	is, ok  := tsr.programs[program_name]
+	if ok{
+		tsr.programs[program_name] = is[Min_Token_Index:instruction_index]
+	}
+}
+
+func (tsr *TokenStreamRewriter) RollbackDefault(instruction_index int){
+	tsr.Rollback(Default_Program_Name, instruction_index)
+}
+//Reset the program so that no instructions exist
+func (tsr *TokenStreamRewriter) DeleteProgram(program_name string){
+	tsr.Rollback(program_name, Min_Token_Index) //TODO: double test on that cause lower bound is not included
+}
+
+func (tsr *TokenStreamRewriter) DeleteProgramDefault(){
+	tsr.DeleteProgram(Default_Program_Name)
+}
+
+func (tsr *TokenStreamRewriter) InsertAfter(program_name string, index int, text string){
+	// to insert after, just insert before next index (even if past end)
+	var op RewriteOperation = NewInsertAfterOp(index, text, tsr.tokens)
+	rewrites := tsr.GetProgram(program_name)
+	op.SetInstructionIndex(len(rewrites))
+	tsr.AddToProgram(program_name, op)
+}
+
+func (tsr *TokenStreamRewriter) InsertAfterDefault(index int, text string){
+	tsr.InsertAfter(Default_Program_Name, index, text)
+}
+
+func (tsr *TokenStreamRewriter) InsertAfterToken(program_name string, token Token, text string){
+	tsr.InsertAfter(program_name, token.GetTokenIndex(), text)
+}
+
+func (tsr* TokenStreamRewriter) InsertBefore(program_name string, index int, text string){
+	var op RewriteOperation = NewInsertBeforeOp(index, text, tsr.tokens)
+	rewrites := tsr.GetProgram(program_name)
+	op.SetInstructionIndex(len(rewrites))
+	tsr.AddToProgram(program_name, op)
+}
+
+func (tsr *TokenStreamRewriter) InsertBeforeDefault(index int, text string){
+	tsr.InsertBefore(Default_Program_Name, index, text)
+}
+
+func (tsr *TokenStreamRewriter) InsertBeforeToken(program_name string,token Token, text string){
+	tsr.InsertBefore(program_name, token.GetTokenIndex(), text)
+}
+
+func (tsr *TokenStreamRewriter) Replace(program_name string, from, to int, text string){
+	if from > to || from < 0 || to < 0 || to >= tsr.tokens.Size(){
+		panic(fmt.Sprintf("replace: range invalid: %d..%d(size=%d)",
+			from, to, tsr.tokens.Size()))
+	}
+	var op RewriteOperation = NewReplaceOp(from, to, text, tsr.tokens)
+	rewrites := tsr.GetProgram(program_name)
+	op.SetInstructionIndex(len(rewrites))
+	tsr.AddToProgram(program_name, op)
+}
+
+func (tsr *TokenStreamRewriter)ReplaceDefault(from, to int, text string)  {
+	tsr.Replace(Default_Program_Name, from, to, text)
+}
+
+func (tsr *TokenStreamRewriter)ReplaceDefaultPos(index int, text string){
+	tsr.ReplaceDefault(index, index, text)
+}
+
+func (tsr *TokenStreamRewriter)ReplaceToken(program_name string, from, to Token, text string){
+	tsr.Replace(program_name, from.GetTokenIndex(), to.GetTokenIndex(), text)
+}
+
+func (tsr *TokenStreamRewriter)ReplaceTokenDefault(from, to Token, text string){
+	tsr.ReplaceToken(Default_Program_Name, from, to, text)
+}
+
+func (tsr *TokenStreamRewriter)ReplaceTokenDefaultPos(index Token, text string){
+	tsr.ReplaceTokenDefault(index, index, text)
+}
+
+func (tsr *TokenStreamRewriter)Delete(program_name string, from, to int){
+	tsr.Replace(program_name, from, to, "" )
+}
+
+func (tsr *TokenStreamRewriter)DeleteDefault(from, to int){
+	tsr.Delete(Default_Program_Name, from, to)
+}
+
+func (tsr *TokenStreamRewriter)DeleteDefaultPos(index int){
+	tsr.DeleteDefault(index,index)
+}
+
+func (tsr *TokenStreamRewriter)DeleteToken(program_name string, from, to Token)  {
+	tsr.ReplaceToken(program_name, from, to, "")
+}
+
+func (tsr *TokenStreamRewriter)DeleteTokenDefault(from,to Token){
+	tsr.DeleteToken(Default_Program_Name, from, to)
+}
+
+func (tsr *TokenStreamRewriter)GetLastRewriteTokenIndex(program_name string)int  {
+	i, ok := tsr.last_rewrite_token_indexes[program_name]
+	if !ok{
+		return -1
+	}
+	return i
+}
+
+func (tsr *TokenStreamRewriter)GetLastRewriteTokenIndexDefault()int{
+	return tsr.GetLastRewriteTokenIndex(Default_Program_Name)
+}
+
+func (tsr *TokenStreamRewriter)SetLastRewriteTokenIndex(program_name string, i int){
+	tsr.last_rewrite_token_indexes[program_name] = i
+}
+
+func (tsr *TokenStreamRewriter)InitializeProgram(name string)[]RewriteOperation{
+	is := make([]RewriteOperation, 0, Program_Init_Size)
+	tsr.programs[name] = is
+	return is
+}
+
+func (tsr *TokenStreamRewriter)AddToProgram(name string, op RewriteOperation){
+	is := tsr.GetProgram(name)
+	is = append(is, op)
+	tsr.programs[name] = is
+}
+
+func (tsr *TokenStreamRewriter)GetProgram(name string) []RewriteOperation  {
+	is, ok := tsr.programs[name]
+	if !ok{
+		is = tsr.InitializeProgram(name)
+	}
+	return is
+}
+//  Return the text from the original tokens altered per the
+//  instructions given to this rewriter.
+func (tsr *TokenStreamRewriter)GetTextDefault() string{
+	return tsr.GetText(
+		Default_Program_Name,
+		NewInterval(0, tsr.tokens.Size()-1))
+}
+//  Return the text from the original tokens altered per the
+//  instructions given to this rewriter.
+func (tsr *TokenStreamRewriter)GetText(program_name string, interval *Interval) string  {
+	rewrites := tsr.programs[program_name]
+	start := interval.start
+	stop  := interval.stop
+	// ensure start/end are in range
+	stop = min(stop, tsr.tokens.Size()-1)
+	start = max(start,0)
+	if rewrites == nil || len(rewrites) == 0{
+		return tsr.tokens.GetTextFromInterval(interval) // no instructions to execute
+	}
+	buf := bytes.Buffer{}
+	// First, optimize instruction stream
+	indexToOp := reduceToSingleOperationPerIndex(rewrites)
+	// Walk buffer, executing instructions and emitting tokens
+	for i:=start; i<=stop && i<tsr.tokens.Size();{
+		op := indexToOp[i]
+		delete(indexToOp, i)// remove so any left have index size-1
+		t := tsr.tokens.Get(i)
+		if op == nil{
+			// no operation at that index, just dump token
+			if t.GetTokenType() != TokenEOF {buf.WriteString(t.GetText())}
+			i++ // move to next token
+		}else {
+			i = op.Execute(&buf)// execute operation and skip
+		}
+	}
+	// include stuff after end if it's last index in buffer
+	// So, if they did an insertAfter(lastValidIndex, "foo"), include
+	// foo if end==lastValidIndex.
+	if stop == tsr.tokens.Size()-1{
+		// Scan any remaining operations after last token
+		// should be included (they will be inserts).
+		for _, op := range indexToOp{
+			if op.GetIndex() >= tsr.tokens.Size()-1 {buf.WriteString(op.GetText())}
+		}
+	}
+	return buf.String()
+}
+
+//  We need to combine operations and report invalid operations (like
+//  overlapping replaces that are not completed nested). Inserts to
+//  same index need to be combined etc...  Here are the cases:
+//
+//  I.i.u I.j.v								leave alone, nonoverlapping
+//  I.i.u I.i.v								combine: Iivu
+//
+//  R.i-j.u R.x-y.v	| i-j in x-y			delete first R
+//  R.i-j.u R.i-j.v							delete first R
+//  R.i-j.u R.x-y.v	| x-y in i-j			ERROR
+//  R.i-j.u R.x-y.v	| boundaries overlap	ERROR
+//
+//  Delete special case of replace (text==null):
+//  D.i-j.u D.x-y.v	| boundaries overlap	combine to max(min)..max(right)
+//
+//  I.i.u R.x-y.v | i in (x+1)-y			delete I (since insert before
+//											we're not deleting i)
+//  I.i.u R.x-y.v | i not in (x+1)-y		leave alone, nonoverlapping
+//  R.x-y.v I.i.u | i in x-y				ERROR
+//  R.x-y.v I.x.u 							R.x-y.uv (combine, delete I)
+//  R.x-y.v I.i.u | i not in x-y			leave alone, nonoverlapping
+//
+//  I.i.u = insert u before op @ index i
+//  R.x-y.u = replace x-y indexed tokens with u
+//
+//  First we need to examine replaces. For any replace op:
+//
+// 		1. wipe out any insertions before op within that range.
+//		2. Drop any replace op before that is contained completely within
+//	 	that range.
+//		3. Throw exception upon boundary overlap with any previous replace.
+//
+//  	Then we can deal with inserts:
+//
+// 		1. for any inserts to same index, combine even if not adjacent.
+// 		2. for any prior replace with same left boundary, combine this
+//	 	insert with replace and delete this replace.
+// 		3. throw exception if index in same range as previous replace
+//
+//  Don't actually delete; make op null in list. Easier to walk list.
+//  Later we can throw as we add to index &rarr; op map.
+//
+//  Note that I.2 R.2-2 will wipe out I.2 even though, technically, the
+//  inserted stuff would be before the replace range. But, if you
+//  add tokens in front of a method body '{' and then delete the method
+//  body, I think the stuff before the '{' you added should disappear too.
+//
+//  Return a map from token index to operation.
+//
+func reduceToSingleOperationPerIndex(rewrites []RewriteOperation) map[int]RewriteOperation{
+	// WALK REPLACES
+	for i:=0; i < len(rewrites); i++{
+		op := rewrites[i]
+		if op == nil{continue}
+		rop, ok := op.(*ReplaceOp)
+		if !ok{continue}
+		// Wipe prior inserts within range
+		for j:=0; j<i && j < len(rewrites); j++{
+			if iop, ok := rewrites[j].(*InsertBeforeOp);ok{
+				if iop.index == rop.index{
+					// E.g., insert before 2, delete 2..2; update replace
+					// text to include insert before, kill insert
+					rewrites[iop.instruction_index] = nil
+					if rop.text != ""{
+						rop.text = iop.text + rop.text
+					}else{
+						rop.text = iop.text
+					}
+				}else if iop.index > rop.index && iop.index <=rop.LastIndex{
+					// delete insert as it's a no-op.
+					rewrites[iop.instruction_index] = nil
+				}
+			}
+		}
+		// Drop any prior replaces contained within
+		for j:=0; j<i && j < len(rewrites); j++{
+			if prevop, ok := rewrites[j].(*ReplaceOp);ok{
+				if prevop.index>=rop.index && prevop.LastIndex <= rop.LastIndex{
+					// delete replace as it's a no-op.
+					rewrites[prevop.instruction_index] = nil
+					continue
+				}
+				// throw exception unless disjoint or identical
+				disjoint := prevop.LastIndex < rop.index || prevop.index > rop.LastIndex
+				// Delete special case of replace (text==null):
+				// D.i-j.u D.x-y.v	| boundaries overlap	combine to max(min)..max(right)
+				if prevop.text == "" && rop.text == "" && !disjoint{
+					rewrites[prevop.instruction_index] = nil
+					rop.index = min(prevop.index, rop.index)
+					rop.LastIndex = max(prevop.LastIndex, rop.LastIndex)
+					println("new rop" + rop.String()) //TODO: remove console write, taken from Java version
+				}else if !disjoint{
+					panic("replace op boundaries of " + rop.String() + " overlap with previous " + prevop.String())
+				}
+			}
+		}
+	}
+	// WALK INSERTS
+	for i:=0; i < len(rewrites); i++ {
+		op := rewrites[i]
+		if op == nil{continue}
+		//hack to replicate inheritance in composition
+		_, iok := rewrites[i].(*InsertBeforeOp)
+		_, aok := rewrites[i].(*InsertAfterOp)
+		if !iok && !aok{continue}
+		iop := rewrites[i]
+		// combine current insert with prior if any at same index
+		// deviating a bit from TokenStreamRewriter.java - hard to incorporate inheritance logic
+		for j:=0; j<i && j < len(rewrites); j++{
+			if nextIop, ok := rewrites[j].(*InsertAfterOp); ok{
+				if nextIop.index == iop.GetIndex(){
+					iop.SetText(nextIop.text + iop.GetText())
+					rewrites[j] = nil
+				}
+			}
+			if prevIop, ok := rewrites[j].(*InsertBeforeOp); ok{
+				if prevIop.index == iop.GetIndex(){
+					iop.SetText(iop.GetText() + prevIop.text)
+					rewrites[prevIop.instruction_index] = nil
+				}
+			}
+		}
+		// look for replaces where iop.index is in range; error
+		for j:=0; j<i && j < len(rewrites); j++{
+			if rop,ok := rewrites[j].(*ReplaceOp); ok{
+				if iop.GetIndex() == rop.index{
+					rop.text = iop.GetText() + rop.text
+					rewrites[i] = nil
+					continue
+				}
+				if iop.GetIndex() >= rop.index && iop.GetIndex() <= rop.LastIndex{
+					panic("insert op "+iop.String()+" within boundaries of previous "+rop.String())
+				}
+			}
+		}
+	}
+	m := map[int]RewriteOperation{}
+	for i:=0; i < len(rewrites); i++{
+		op := rewrites[i]
+		if op == nil {continue}
+		if _, ok := m[op.GetIndex()]; ok{
+			panic("should only be one op per index")
+		}
+		m[op.GetIndex()] = op
+	}
+	return m
+}
+
+
+/*
+	Quick fixing Go lack of overloads
+ */
+
+func max(a,b int)int{
+	if a>b{
+		return a
+	}else {
+		return b
+	}
+}
+func min(a,b int)int{
+	if a<b{
+		return a
+	}else {
+		return b
+	}
+}

--- a/runtime/Go/antlr/tokenstream_rewriter.go
+++ b/runtime/Go/antlr/tokenstream_rewriter.go
@@ -443,8 +443,8 @@ func (tsr *TokenStreamRewriter)GetTextDefault() string{
 //  instructions given to this rewriter.
 func (tsr *TokenStreamRewriter)GetText(program_name string, interval *Interval) string  {
 	rewrites := tsr.programs[program_name]
-	start := interval.start
-	stop  := interval.stop
+	start := interval.Start
+	stop  := interval.Stop
 	// ensure start/end are in range
 	stop = min(stop, tsr.tokens.Size()-1)
 	start = max(start,0)

--- a/runtime/Go/antlr/tokenstream_rewriter_test.go
+++ b/runtime/Go/antlr/tokenstream_rewriter_test.go
@@ -1,0 +1,392 @@
+// Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+// Use of this file is governed by the BSD 3-clause license that
+// can be found in the LICENSE.txt file in the project root.
+package antlr
+
+import (
+	"testing"
+	"fmt"
+	"unicode"
+	"strings"
+)
+
+func TestInsertBeforeIndex0(t *testing.T){
+	input := NewInputStream("abc")
+	lexer := NewLexerA(input)
+	stream := NewCommonTokenStream(lexer, 0)
+	stream.Fill()
+	tokens := NewTokenStreamRewriter(stream)
+	tokens.InsertBeforeDefault(0, "0")
+	result := tokens.GetTextDefault()
+	if result != "0abc"{
+		t.Errorf("test failed, got %s", result)
+	}
+}
+
+func prepare_rewriter(str string) *TokenStreamRewriter{
+	input := NewInputStream(str)
+	lexer := NewLexerA(input)
+	stream := NewCommonTokenStream(lexer, 0)
+	stream.Fill()
+	return NewTokenStreamRewriter(stream)
+}
+
+type LexerTest struct {
+	input string
+	expected string
+	description string
+	expected_exception []string
+	ops func(*TokenStreamRewriter)
+}
+
+func NewLexerTest(input, expected, desc string, ops func(*TokenStreamRewriter)) LexerTest{
+	return LexerTest{input:input, expected:expected, description:desc, ops:ops}
+}
+
+func NewLexerExceptionTest(input string, expected_err []string, desc string, ops func(*TokenStreamRewriter)) LexerTest{
+	return LexerTest{input:input, expected_exception:expected_err, description:desc, ops:ops}
+}
+
+func panic_tester(t *testing.T, expected_msg []string, r *TokenStreamRewriter){
+	defer func() {
+		r :=recover()
+		if r == nil{
+			t.Errorf("Panic is expected, but finished normally")
+		}else
+		{
+			s_e := r.(string)
+			for _, e := range expected_msg{
+				if !strings.Contains(s_e, e){
+					t.Errorf("Element [%s] is not in error message: [%s]", e, s_e )
+				}
+			}
+		}
+	}()
+	r.GetTextDefault()
+}
+
+func TestLexerA(t *testing.T){
+	tests := []LexerTest{
+		NewLexerTest("abc", "0abc", "InsertBeforeIndex0",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(0, "0")
+		}),
+		NewLexerTest("abc", "abcx","InsertAfterLastIndex",
+		func(r *TokenStreamRewriter){
+			r.InsertAfterDefault(2, "x")
+		}),
+		NewLexerTest("abc", "axbxc", "2InsertBeforeAfterMiddleIndex",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(1, "x")
+			r.InsertAfterDefault(1, "x")
+		}),
+		NewLexerTest("abc", "xbc", "ReplaceIndex0",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefaultPos(0, "x")
+		}),
+		NewLexerTest("abc", "abx", "ReplaceLastIndex",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefaultPos(2, "x")
+		}),
+		NewLexerTest("abc", "axc", "ReplaceMiddleIndex",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefaultPos(1, "x")
+		}),
+		NewLexerTest("abc", "ayc", "2ReplaceMiddleIndex",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefaultPos(1, "x")
+			r.ReplaceDefaultPos(1, "y")
+		}),
+		NewLexerTest("abc", "_ayc", "2ReplaceMiddleIndex1InsertBefore",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(0, "_")
+			r.ReplaceDefaultPos(1, "x")
+			r.ReplaceDefaultPos(1, "y")
+		}),
+		NewLexerTest("abc", "ac", "ReplaceThenDeleteMiddleIndex",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefaultPos(1, "x")
+			r.DeleteDefaultPos(1)
+		}),
+		NewLexerExceptionTest("abc", []string{"insert op", "within boundaries of previous"},
+			"InsertInPriorReplace",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(0,2, "x")
+			r.InsertBeforeDefault(1, "0")
+		}),
+		NewLexerTest("abc", "0xbc", "InsertThenReplaceSameIndex",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(0,"0")
+			r.ReplaceDefaultPos(0, "x")
+		}),
+		NewLexerTest("abc", "ayxbc", "2InsertMiddleIndex",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(1, "x")
+			r.InsertBeforeDefault(1, "y")
+		}),
+		NewLexerTest("abc", "yxzbc", "2InsertThenReplaceIndex0",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(0, "x")
+			r.InsertBeforeDefault(0, "y")
+			r.ReplaceDefaultPos(0,"z")
+		}),
+		NewLexerTest("abc", "abyx", "ReplaceThenInsertBeforeLastIndex",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefaultPos(2, "x")
+			r.InsertBeforeDefault(2, "y")
+		}),
+		NewLexerTest("abc", "abyx", "InsertThenReplaceLastIndex",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(2, "y")
+			r.ReplaceDefaultPos(2, "x")
+		}),
+		NewLexerTest("abc", "abxy", "ReplaceThenInsertAfterLastIndex",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefaultPos(2, "x")
+			r.InsertAfterDefault(2, "y")
+		}),
+		NewLexerTest("abcccba", "abyxba", "ReplaceThenInsertAtLeftEdge",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(2, 4, "x")
+			r.InsertBeforeDefault(2, "y")
+		}),
+		NewLexerTest("abcccba", "abyxba", "ReplaceThenInsertAtLeftEdge",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(2, 4, "x")
+			r.InsertBeforeDefault(2, "y")
+		}),
+		NewLexerExceptionTest("abcccba",
+			[]string{"insert op", "InsertBeforeOp", "within boundaries of previous", "ReplaceOp"},
+			"ReplaceRangeThenInsertAtRightEdge",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(2, 4, "x")
+			r.InsertBeforeDefault(4, "y")
+		}),
+		NewLexerTest("abcccba", "abxyba", "ReplaceRangeThenInsertAfterRightEdge",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(2, 4, "x")
+			r.InsertAfterDefault(4, "y")
+		}),
+		NewLexerTest("abcccba", "x", "ReplaceAll",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(0, 6, "x")
+		}),
+		NewLexerTest("abcccba", "abxyzba", "ReplaceSubsetThenFetch",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(2, 4, "xyz")
+		}),
+		NewLexerExceptionTest("abcccba",
+			[]string{"replace op boundaries of", "ReplaceOp", "overlap with previous"},
+			"ReplaceThenReplaceSuperset",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(2, 4, "xyz")
+			r.ReplaceDefault(3, 5, "foo")
+		}),
+		NewLexerExceptionTest("abcccba",
+			[]string{"replace op boundaries of", "ReplaceOp", "overlap with previous"},
+			"ReplaceThenReplaceLowerIndexedSuperset",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(2, 4, "xyz")
+			r.ReplaceDefault(1, 3, "foo")
+		}),
+		NewLexerTest("abcba", "fooa", "ReplaceSingleMiddleThenOverlappingSuperset",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(2, 2, "xyz")
+			r.ReplaceDefault(0, 3, "foo")
+		}),
+		NewLexerTest("abc", "yxabc", "CombineInserts",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(0, "x")
+			r.InsertBeforeDefault(0, "y")
+		}),
+		NewLexerTest("abc", "yazxbc", "Combine3Inserts",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(1, "x")
+			r.InsertBeforeDefault(0, "y")
+			r.InsertBeforeDefault(1, "z")
+		}),
+		NewLexerTest("abc", "zfoo", "CombineInsertOnLeftWithReplace",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(0, 2, "foo")
+			r.InsertBeforeDefault(0, "z")
+		}),
+		NewLexerTest("abc", "z", "CombineInsertOnLeftWithDelete",
+		func(r *TokenStreamRewriter){
+			r.DeleteDefault(0,2)
+			r.InsertBeforeDefault(0, "z")
+		}),
+		NewLexerTest("abc", "zaxbyc", "DisjointInserts",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(1, "x")
+			r.InsertBeforeDefault(2, "y")
+			r.InsertBeforeDefault(0, "z")
+		}),
+		NewLexerTest("abcc", "bar", "OverlappingReplace",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(1,2, "foo")
+			r.ReplaceDefault(0, 3, "bar")
+		}),
+		NewLexerExceptionTest("abcc",
+			[]string{"replace op boundaries of", "ReplaceOp", "overlap with previous"},
+			"OverlappingReplace2",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(0, 3, "bar")
+			r.ReplaceDefault(1, 2, "foo")
+		}),
+		NewLexerTest("abcc", "barc", "OverlappingReplace3",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(1,2, "foo")
+			r.ReplaceDefault(0, 2, "bar")
+		}),
+		NewLexerTest("abcc", "abar", "OverlappingReplace4",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(1,2, "foo")
+			r.ReplaceDefault(1, 3, "bar")
+		}),
+		NewLexerTest("abcc", "afooc", "DropIdenticalReplace",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(1,2, "foo")
+			r.ReplaceDefault(1, 2, "foo")
+		}),
+		NewLexerTest("abc", "afoofoo", "DropPrevCoveredInsert",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(1, "foo")
+			r.ReplaceDefault(1, 2, "foo")
+		}),
+		NewLexerTest("abcc", "axbfoo", "LeaveAloneDisjointInsert",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(1, "x")
+			r.ReplaceDefault(2, 3, "foo")
+		}),
+		NewLexerTest("abcc", "axbfoo", "LeaveAloneDisjointInsert2",
+		func(r *TokenStreamRewriter){
+			r.ReplaceDefault(2, 3, "foo")
+			r.InsertBeforeDefault(1, "x")
+		}),
+		NewLexerTest("abc", "aby", "InsertBeforeTokenThenDeleteThatToken",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(2, "y")
+			r.DeleteDefaultPos(2)
+		}),
+		NewLexerTest("aa", "<b>a</b><b>a</b>", "DistinguishBetweenInsertAfterAndInsertBeforeToPreserverOrder",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(0, "<b>")
+			r.InsertAfterDefault(0, "</b>")
+			r.InsertBeforeDefault(1, "<b>")
+			r.InsertAfterDefault(1,"</b>")
+		}),
+		NewLexerTest("aa", "<b><p>a</p></b><b>a</b>", "DistinguishBetweenInsertAfterAndInsertBeforeToPreserverOrder2",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(0, "<p>")
+			r.InsertBeforeDefault(0, "<b>")
+			r.InsertAfterDefault(0, "</p>")
+			r.InsertAfterDefault(0, "</b>")
+			r.InsertBeforeDefault(1, "<b>")
+			r.InsertAfterDefault(1,"</b>")
+		}),
+		NewLexerTest("ab", "<div><b><p>a</p></b></div>!b", "DistinguishBetweenInsertAfterAndInsertBeforeToPreserverOrder2",
+		func(r *TokenStreamRewriter){
+			r.InsertBeforeDefault(0, "<p>")
+			r.InsertBeforeDefault(0, "<b>")
+			r.InsertBeforeDefault(0, "<div>")
+			r.InsertAfterDefault(0, "</p>")
+			r.InsertAfterDefault(0, "</b>")
+			r.InsertAfterDefault(0, "</div>")
+			r.InsertBeforeDefault(1, "!")
+		}),
+	}
+
+
+	for _,c := range tests{
+		t.Run(c.description,func(t *testing.T) {
+			rewriter := prepare_rewriter(c.input)
+			c.ops(rewriter)
+			if len(c.expected_exception)>0{
+				panic_tester(t, c.expected_exception, rewriter)
+			}else{
+				result := rewriter.GetTextDefault()
+				if result!=c.expected{
+					t.Errorf("Expected:%s | Result: %s", c.expected, result)
+				}
+			}
+		} )
+	}
+}
+
+
+// Suppress unused import error
+var _ = fmt.Printf
+var _ = unicode.IsLetter
+
+var serializedLexerAtn = []uint16{
+	3, 24715, 42794, 33075, 47597, 16764, 15335, 30598, 22884, 2, 5, 15, 8,
+	1, 4, 2, 9, 2, 4, 3, 9, 3, 4, 4, 9, 4, 3, 2, 3, 2, 3, 3, 3, 3, 3, 4, 3,
+	4, 2, 2, 5, 3, 3, 5, 4, 7, 5, 3, 2, 2, 2, 14, 2, 3, 3, 2, 2, 2, 2, 5, 3,
+	2, 2, 2, 2, 7, 3, 2, 2, 2, 3, 9, 3, 2, 2, 2, 5, 11, 3, 2, 2, 2, 7, 13,
+	3, 2, 2, 2, 9, 10, 7, 99, 2, 2, 10, 4, 3, 2, 2, 2, 11, 12, 7, 100, 2, 2,
+	12, 6, 3, 2, 2, 2, 13, 14, 7, 101, 2, 2, 14, 8, 3, 2, 2, 2, 3, 2, 2,
+}
+
+var lexerDeserializer = NewATNDeserializer(nil)
+var lexerAtn = lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
+
+var lexerChannelNames = []string{
+	"DEFAULT_TOKEN_CHANNEL", "HIDDEN",
+}
+
+var lexerModeNames = []string{
+	"DEFAULT_MODE",
+}
+
+var lexerLiteralNames = []string{
+	"", "'a'", "'b'", "'c'",
+}
+
+var lexerSymbolicNames = []string{
+	"", "A", "B", "C",
+}
+
+var lexerRuleNames = []string{
+	"A", "B", "C",
+}
+
+type LexerA struct {
+	*BaseLexer
+	channelNames []string
+	modeNames    []string
+	// TODO: EOF string
+}
+
+var lexerDecisionToDFA = make([]*DFA, len(lexerAtn.DecisionToState))
+
+func init() {
+	for index, ds := range lexerAtn.DecisionToState {
+		lexerDecisionToDFA[index] = NewDFA(ds, index)
+	}
+}
+
+func NewLexerA(input CharStream) *LexerA {
+
+	l := new(LexerA)
+
+	l.BaseLexer = NewBaseLexer(input)
+	l.Interpreter = NewLexerATNSimulator(l, lexerAtn, lexerDecisionToDFA, NewPredictionContextCache())
+
+	l.channelNames = lexerChannelNames
+	l.modeNames = lexerModeNames
+	l.RuleNames = lexerRuleNames
+	l.LiteralNames = lexerLiteralNames
+	l.SymbolicNames = lexerSymbolicNames
+	l.GrammarFileName = "LexerA.g4"
+	// TODO: l.EOF = antlr.TokenEOF
+
+	return l
+}
+
+// LexerA tokens.
+const (
+	LexerAA = 1
+	LexerAB = 2
+	LexerAC = 3
+)
+


### PR DESCRIPTION
TokenStreamRewriter implementation was missing
Ported code from Java version; however, there are couple of deviations due to difference between composition (Go) and inheritance (Java) concepts
Ported tests from Swift for LexerA
