### PR TITLE
Remove the useless visibility attribute from this "enum class" declaration

### DIFF
--- a/runtime/Cpp/runtime/src/atn/PredictionMode.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionMode.h
@@ -15,7 +15,7 @@ namespace atn {
    * utility methods for analyzing configuration sets for conflicts and/or
    * ambiguities.
    */
-  enum class ANTLR4CPP_PUBLIC PredictionMode {
+  enum class PredictionMode {
     /**
      * The SLL(*) prediction mode. This prediction mode ignores the current
      * parser context when making predictions. This is the fastest prediction


### PR DESCRIPTION
When compiling under gcc, ANTLR4CPP_PUBLIC macro expands to the following gcc visibility attribute:
```
 __attribute__((visibility ("default")))
```
(when compiling under Windows it expands to the corresponding ```__declspec``` attribute)

This change was introduced in commit 8ff852640a7ec62d46330f71e274c591ada1fc70

Although the attribute makes perfect sense when applied to a ```class``` declaration, it makes no sense (has no effect) when applied to an ```enum class``` declaration. I assume that doing so was unintentional; that when the change was introduced it was it was added mechanically to all ```class XXX``` instances in the source code, a process which accidentally picked up one ```enum class XXX``` instance.

Although it has no effect on the object code, it leads to the following warning when compiling under gcc:
```
/usr/local/include/antlr4-runtime/atn/PredictionMode.h:18:31: error: type attributes ignored after type is already defined [-Werror=attributes]
   enum class ANTLR4CPP_PUBLIC PredictionMode {
```

This is a problem for people who would like their builds to be warning-free.

Happily, this declaration can be safely removed. The ```enum class``` construct (just like with regular enum) does not cause any linker symbols to be emitted. So having a linker attribute on the type does not actually have any effect. It can therefore be safely removed.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->