### PR TITLE
Python: add public getter to parsers to access syntax error count.

### DIFF
--- a/runtime/Python2/src/antlr4/Parser.py
+++ b/runtime/Python2/src/antlr4/Parser.py
@@ -218,6 +218,13 @@ class Parser (Recognizer):
                 self._ctx.exitRule(listener)
                 listener.exitEveryRule(self._ctx)
 
+    # Gets the number of syntax errors reported during parsing. This value is
+    # incremented each time {@link #notifyErrorListeners} is called.
+    #
+    # @see #notifyErrorListeners
+    #
+    def getNumberOfSyntaxErrors(self):
+        return self._syntaxErrors
 
     def getTokenFactory(self):
         return self._input.tokenSource._factory

--- a/runtime/Python3/src/antlr4/Parser.py
+++ b/runtime/Python3/src/antlr4/Parser.py
@@ -227,6 +227,14 @@ class Parser (Recognizer):
                 listener.exitEveryRule(self._ctx)
 
 
+    # Gets the number of syntax errors reported during parsing. This value is
+    # incremented each time {@link #notifyErrorListeners} is called.
+    #
+    # @see #notifyErrorListeners
+    #
+    def getNumberOfSyntaxErrors(self):
+        return self._syntaxErrors
+
     def getTokenFactory(self):
         return self._input.tokenSource._factory
 


### PR DESCRIPTION
ANTLR parsers in Java are allowed to access the number of encountered
syntax errors via the getNumberOfSyntaxErrors method. However, the
Python variants must use the protected _syntaxErrors member to get this
value. The patch defines the same getter for Python targets too.