### PR TITLE
Report InputMismatchException with original context information

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParserErrorsDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParserErrorsDescriptors.java
@@ -618,4 +618,28 @@ public class ParserErrorsDescriptors {
 		public String grammar;
 
 	}
+
+	public static class ExtraneousInput extends BaseParserTestDescriptor {
+		public String input = "baa";
+		public String output = null;
+		public String errors = "line 1:0 mismatched input 'b' expecting {<EOF>, 'a'}\n";
+		public String startRule = "file";
+		public String grammarName = "T";
+
+		/**
+		 grammar T;
+
+		 member : 'a';
+		 body : member*;
+		 file : body EOF;
+		 B : 'b';
+		 */
+		@CommentHasStringValue
+		public String grammar;
+
+		@Override
+		public boolean ignore(String targetName) {
+			return !"Java".equals(targetName);
+		}
+	}
 }

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/SemPredEvalParserDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/SemPredEvalParserDescriptors.java
@@ -283,11 +283,16 @@ public class SemPredEvalParserDescriptors {
 		public String input = "s\n\n\nx\n";
 		public String output = "(file_ (para (paraContent s) \\n \\n) (para (paraContent \\n x \\n)) <EOF>)\n";
 		/**
-		line 5:0 mismatched input '<EOF>' expecting '
-		'
+		line 5:0 mismatched input '<EOF>' expecting {'s', '
+		', 'x'}
 		 */
 		@CommentHasStringValue
 		public String errors;
+
+		@Override
+		public boolean ignore(String targetName) {
+			return !"Java".equals(targetName);
+		}
 	}
 
 	public static class PredFromAltTestedInLoopBack_2 extends PredFromAltTestedInLoopBack {

--- a/runtime/Java/src/org/antlr/v4/runtime/InputMismatchException.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/InputMismatchException.java
@@ -13,4 +13,10 @@ public class InputMismatchException extends RecognitionException {
 		super(recognizer, recognizer.getInputStream(), recognizer._ctx);
 		this.setOffendingToken(recognizer.getCurrentToken());
 	}
+
+	public InputMismatchException(Parser recognizer, int state, ParserRuleContext ctx) {
+		super(recognizer, recognizer.getInputStream(), ctx);
+		this.setOffendingState(state);
+		this.setOffendingToken(recognizer.getCurrentToken());
+	}
 }


### PR DESCRIPTION
Fixes #1922 

:memo: This needs more test cases, particularly for LL(k) failures where k>1. However, my current understanding is these cases have been impacted by this bug for much longer (since 4.2.2) than the issue being addressed for the k=1 case.