### PR TITLE
Set the tab width in .editorconfig so GitHub shows source properly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,8 @@
 root = true
 
+[*]
+tab_width = 4
+
 [*.{java,stg}]
 charset = utf-8
 insert_final_newline = true


### PR DESCRIPTION
As an example, compare [before](https://github.com/antlr/antlr4/blob/1203794259adf03e140dfd4698de8e9e91f5c985/runtime/Java/src/org/antlr/v4/runtime/ANTLRFileStream.java) and [after](https://github.com/sharwell/antlr4/blob/set-tab-width/runtime/Java/src/org/antlr/v4/runtime/ANTLRFileStream.java).