### PR TITLE
fix: Fix a wrong hyperlink

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -154,3 +154,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/07/11, dhalperi, Daniel Halperin, daniel@halper.in
 2017/07/27, shirou, WAKAYAMA Shirou, shirou.faw@gmail.com
 2017/07/09, neatnerd, Mike Arshinskiy, neatnerd@users.noreply.github.com
+2017/09/07, objectx, Masashi Fujita, objectxtreme@gmail.com

--- a/runtime/Cpp/README.md
+++ b/runtime/Cpp/README.md
@@ -16,7 +16,7 @@ The C++ target has been the work of the following people:
 
 * Dan McLaughlin, dan.mclaughlin@gmail.com (initial port, got code to compile)
 * David Sisson, dsisson@google.com (initial port, made the runtime C++ tests runnable)
-* [Mike Lischke](www.soft-gems.net), mike@lischke-online.de (brought the initial port to a working library, made most runtime tests passing)
+* [Mike Lischke](http://www.soft-gems.net/), mike@lischke-online.de (brought the initial port to a working library, made most runtime tests passing)
 
 ## Other contributors
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->
Make it as a correct external link.