### PR TITLE
correct the version of the antlr jar package

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -39,7 +39,7 @@ $ alias grun='java org.antlr.v4.gui.TestRig'
 0. Install Java (version 1.6 or higher)
 1. Download antlr-4.5.3-complete.jar (or whatever version) from [http://www.antlr.org/download/](http://www.antlr.org/download/)
 Save to your directory for 3rd party Java libraries, say `C:\Javalib`
-2. Add `antlr-4.5-complete.jar` to CLASSPATH, either:
+2. Add `antlr-4.5.3-complete.jar` to CLASSPATH, either:
   * Permanently: Using System Properties dialog > Environment variables > Create or append to `CLASSPATH` variable
   * Temporarily, at command line:
 ```


### PR DESCRIPTION
version of the antlr jar package is different from other place of this doc，and it make mistake.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->