### PR TITLE
Replace oraclejdk7 with openjdk7 in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - os: linux
       compiler: clang
-      jdk: oraclejdk7
+      jdk: openjdk7
       env:
         - TARGET=cpp
         - CXX=g++-5
@@ -104,13 +104,13 @@ matrix:
         - TARGET=dotnet
         - GROUP=RECURSION
     - os: linux
-      jdk: oraclejdk7
+      jdk: openjdk7
       env: TARGET=java
     - os: linux
       jdk: oraclejdk8
       env: TARGET=java
     - os: linux
-      jdk: oraclejdk7
+      jdk: openjdk7
       env: TARGET=csharp
     - os: linux
       jdk: oraclejdk8
@@ -131,10 +131,10 @@ matrix:
         - TARGET=dotnet
         - GROUP=RECURSION
     - os: linux
-      jdk: oraclejdk7
+      jdk: openjdk7
       env: TARGET=python2
     - os: linux
-      jdk: oraclejdk7
+      jdk: openjdk7
       env: TARGET=python3
       addons:
         apt:
@@ -143,10 +143,10 @@ matrix:
           packages:
             - python3.5
     - os: linux
-      jdk: oraclejdk7
+      jdk: openjdk7
       env: TARGET=javascript
     - os: linux
-      jdk: oraclejdk7
+      jdk: openjdk7
       env: TARGET=go
 
 before_install:


### PR DESCRIPTION
Oracle JDK 7 support has been withdrawn.

https://github.com/travis-ci/travis-ci/issues/7964
http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html
