### PR TITLE
[Go] Placed the CommonSetStuff code inside a scope

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -777,29 +777,31 @@ MatchSet(m, expr, capture) ::= "<CommonSetStuff(m, expr, capture, false)>"
 MatchNotSet(m, expr, capture) ::= "<CommonSetStuff(m, expr, capture, true)>"
 
 CommonSetStuff(m, expr, capture, invert) ::= <<
-p.SetState(<m.stateNumber>)
-<if(m.labels)>
-
-var _lt = p.GetTokenStream().LT(1)<! TODO: Should LT be called always like InvokeRule and MatchToken? !>
-
-<m.labels:{l | <labelref(l)> = _lt}; separator="\n">
-
-<endif>
-<if(capture)>
-<capture>
-
-<endif>
-<if(invert)>if <m.varName> \<= 0 || <expr> <else>if !(<expr>)<endif> {
+{
+	p.SetState(<m.stateNumber>)
 	<if(m.labels)>
-	var _ri = p.GetErrorHandler().RecoverInline(p)
 
-	<m.labels:{l | <labelref(l)> = _ri}; separator="\n">
-	<else>
-	p.GetErrorHandler().RecoverInline(p)
+	var _lt = p.GetTokenStream().LT(1)<! TODO: Should LT be called always like InvokeRule and MatchToken? !>
+
+	<m.labels:{l | <labelref(l)> = _lt}; separator="\n">
+
 	<endif>
-} else {
-    p.GetErrorHandler().ReportMatch(p)
-	p.Consume()
+	<if(capture)>
+	<capture>
+
+	<endif>
+	<if(invert)>if <m.varName> \<= 0 || <expr> <else>if !(<expr>)<endif> {
+		<if(m.labels)>
+		var _ri = p.GetErrorHandler().RecoverInline(p)
+
+		<m.labels:{l | <labelref(l)> = _ri}; separator="\n">
+		<else>
+		p.GetErrorHandler().RecoverInline(p)
+		<endif>
+	} else {
+		p.GetErrorHandler().ReportMatch(p)
+		p.Consume()
+	}
 }
 >>
 


### PR DESCRIPTION
This is to avoid two _lt variables in the same scope. This happens with the [mysql grammar](https://github.com/antlr/grammars-v4/tree/master/mysql): `build: previous declaration at mysql/mysql_parser.go:12215:6`