### PR TITLE
[Java] Add a new CharStream that converts the symbols to upper or lower case.

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/runtime/TestCaseChangingCharStream.java
+++ b/runtime-testsuite/test/org/antlr/v4/runtime/TestCaseChangingCharStream.java
@@ -29,10 +29,10 @@ public class TestCaseChangingCharStream {
 	public void testUpper() {
 		List<Integer> expected = Lists.newArrayList((int)'A', (int)'B', (int)'C', (int)'D', IntStream.EOF);
 
-		CharStream stream = CharStreams.forceUpper(fromString("abcd"));
+		CharStream stream = CharStreams.toUpper(fromString("abcd"));
 		assertEquals(expected, readAll(stream));
 
-		stream = CharStreams.forceUpper(fromString("ABCD"));
+		stream = CharStreams.toUpper(fromString("ABCD"));
 		assertEquals(expected,  readAll(stream));
 	}
 
@@ -40,10 +40,10 @@ public class TestCaseChangingCharStream {
 	public void testLower() {
 		List<Integer> expected = Lists.newArrayList((int)'a', (int)'b', (int)'c', (int)'d', IntStream.EOF);
 
-		CharStream stream = CharStreams.forceLower(fromString("abcd"));
+		CharStream stream = CharStreams.toLower(fromString("abcd"));
 		assertEquals(expected, readAll(stream));
 
-		stream = CharStreams.forceLower(fromString("ABCD"));
+		stream = CharStreams.toLower(fromString("ABCD"));
 		assertEquals(expected,  readAll(stream));
 	}
 }

--- a/runtime-testsuite/test/org/antlr/v4/runtime/TestCaseChangingCharStream.java
+++ b/runtime-testsuite/test/org/antlr/v4/runtime/TestCaseChangingCharStream.java
@@ -1,0 +1,49 @@
+package org.antlr.v4.runtime;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.antlr.v4.runtime.CharStreams.fromString;
+import static org.junit.Assert.assertEquals;
+
+public class TestCaseChangingCharStream {
+
+	/**
+	 * Helper function to return a complete list of symbols read from the stream.
+	 * @param stream
+	 * @return
+	 */
+	private static List<Integer> readAll(CharStream stream) {
+		List<Integer> symbols = Lists.newArrayList();
+
+		for (int i = 1; i <= stream.size()+1; i++) {
+			symbols.add( stream.LA(i) );
+		}
+
+		return symbols;
+	}
+
+	@Test
+	public void testUpper() {
+		List<Integer> expected = Lists.newArrayList((int)'A', (int)'B', (int)'C', (int)'D', IntStream.EOF);
+
+		CharStream stream = CharStreams.forceUpper(fromString("abcd"));
+		assertEquals(expected, readAll(stream));
+
+		stream = CharStreams.forceUpper(fromString("ABCD"));
+		assertEquals(expected,  readAll(stream));
+	}
+
+	@Test
+	public void testLower() {
+		List<Integer> expected = Lists.newArrayList((int)'a', (int)'b', (int)'c', (int)'d', IntStream.EOF);
+
+		CharStream stream = CharStreams.forceLower(fromString("abcd"));
+		assertEquals(expected, readAll(stream));
+
+		stream = CharStreams.forceLower(fromString("ABCD"));
+		assertEquals(expected,  readAll(stream));
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/CaseChangingCharStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CaseChangingCharStream.java
@@ -3,9 +3,13 @@ package org.antlr.v4.runtime;
 import org.antlr.v4.runtime.misc.Interval;
 
 /**
- * This class wraps an existing {@link CharStream} and converts all returned
- * symbols to upper or lower case. This is useful for case-insensitive grammars
- * where all input is assumed to be either upper or lower case.
+ * This class supports case-insensitive lexing by wrapping an existing
+ * {@link CharStream} and forcing the lexer to see either upper or
+ * lowercase characters. Grammar literals should then be either upper or
+ * lower case such as 'BEGIN' or 'begin'. The text of the character
+ * stream is unaffected. Example: input 'BeGiN' would match lexer rule
+ * 'BEGIN' if constructor parameter upper=true but getText() would return
+ * 'BeGiN'.
  */
 public class CaseChangingCharStream implements CharStream {
 

--- a/runtime/Java/src/org/antlr/v4/runtime/CaseChangingCharStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CaseChangingCharStream.java
@@ -1,0 +1,77 @@
+package org.antlr.v4.runtime;
+
+import org.antlr.v4.runtime.misc.Interval;
+
+/**
+ * This class wraps an existing {@link CharStream} and converts all returned
+ * symbols to upper or lower case. This is useful for case-insensitive grammars
+ * where all input is assumed to be either upper or lower case.
+ */
+public class CaseChangingCharStream implements CharStream {
+
+	final CharStream stream;
+	final boolean upper;
+
+	/**
+	 * Constructs a new CaseChangingCharStream wrapping the given {@link CharStream} forcing
+	 * all characters to upper case or lower case.
+	 * @param stream The stream to wrap.
+	 * @param upper If true force each symbol to upper case, otherwise force to lower.
+	 */
+	public CaseChangingCharStream(CharStream stream, boolean upper) {
+		this.stream = stream;
+		this.upper = upper;
+	}
+
+	@Override
+	public String getText(Interval interval) {
+		return stream.getText(interval);
+	}
+
+	@Override
+	public void consume() {
+		stream.consume();
+	}
+
+	@Override
+	public int LA(int i) {
+		int c = stream.LA(i);
+		if (c <= 0) {
+			return c;
+		}
+		if (upper) {
+			return Character.toUpperCase(c);
+		}
+		return Character.toLowerCase(c);
+	}
+
+	@Override
+	public int mark() {
+		return stream.mark();
+	}
+
+	@Override
+	public void release(int marker) {
+		stream.release(marker);
+	}
+
+	@Override
+	public int index() {
+		return stream.index();
+	}
+
+	@Override
+	public void seek(int index) {
+		stream.seek(index);
+	}
+
+	@Override
+	public int size() {
+		return stream.size();
+	}
+
+	@Override
+	public String getSourceName() {
+		return stream.getSourceName();
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/CharStreams.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CharStreams.java
@@ -305,22 +305,24 @@ public final class CharStreams {
 	}
 
 	/**
-	 * Takes the stream and forces all symbols to uppercase.
+	 * Takes the stream and forces all symbols to uppercase for lexing purposes
+	 * but leaves the original text as-is.
 	 *
 	 * @param in
 	 * @return
 	 */
-	public static CharStream forceUpper(CharStream in) {
+	public static CharStream toUpper(CharStream in) {
 		return new CaseChangingCharStream(in, true);
 	}
 
 	/**
-	 * Takes the stream and forces all symbols to lowercase.
+	 * Takes the stream and forces all symbols to lowercase for lexing purposes
+	 * but leaves the original text as-is.
 	 *
 	 * @param in
 	 * @return
 	 */
-	public static CharStream forceLower(CharStream in) {
+	public static CharStream toLower(CharStream in) {
 		return new CaseChangingCharStream(in, false);
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/CharStreams.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CharStreams.java
@@ -303,4 +303,24 @@ public final class CharStreams {
 			channel.close();
 		}
 	}
+
+	/**
+	 * Takes the stream and forces all symbols to uppercase.
+	 *
+	 * @param in
+	 * @return
+	 */
+	public static CharStream forceUpper(CharStream in) {
+		return new CaseChangingCharStream(in, true);
+	}
+
+	/**
+	 * Takes the stream and forces all symbols to lowercase.
+	 *
+	 * @param in
+	 * @return
+	 */
+	public static CharStream forceLower(CharStream in) {
+		return new CaseChangingCharStream(in, false);
+	}
 }


### PR DESCRIPTION
This is useful for many of the case insensitive grammars found at https://github.com/antlr/grammars-v4/ which assume the input would be all upper or lower case. Related discussion can be found at antlr/antlr4test-maven-plugin#1

This is similar to the version for Go https://github.com/antlr/antlr4/pull/2046