### PR TITLE
Remove ANTLRError.nullPointer from the Swift runtime.

### DIFF
--- a/runtime/Swift/Sources/Antlr4/CharStream.swift
+++ b/runtime/Swift/Sources/Antlr4/CharStream.swift
@@ -19,7 +19,6 @@ public protocol CharStream: IntStream {
     /// - parameter interval: an interval within the stream
     /// - returns: the text of the specified interval
     /// 
-    /// - throws: _ANTLRError.nullPointer_ if `interval` is `null`
     /// - throws: _ANTLRError.illegalArgument_ if `interval.a < 0`, or if
     /// `interval.b < interval.a - 1`, or if `interval.b` lies at or
     /// past the end of the stream

--- a/runtime/Swift/Sources/Antlr4/Parser.swift
+++ b/runtime/Swift/Sources/Antlr4/Parser.swift
@@ -336,8 +336,6 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// 
     /// - Parameter listener: the listener to add
     /// 
-    /// - Throws: _ANTLRError.nullPointer_ if listener is `null`
-    /// 
     public func addParseListener(_ listener: ParseTreeListener) {
         if _parseListeners == nil {
             _parseListeners = Array<ParseTreeListener>()

--- a/runtime/Swift/Sources/Antlr4/Recognizer.swift
+++ b/runtime/Swift/Sources/Antlr4/Recognizer.swift
@@ -228,9 +228,6 @@ open class Recognizer<ATNInterpreter:ATNSimulator> {
         return "\(s)"
     }
 
-    /// 
-    /// - Throws: ANTLRError.nullPointer if `listener` is `null`.
-    /// 
     open func addErrorListener(_ listener: ANTLRErrorListener) {
 
         _listeners.append(listener)

--- a/runtime/Swift/Sources/Antlr4/TokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/TokenStream.swift
@@ -63,7 +63,6 @@ public protocol TokenStream: IntStream {
     /// 
     /// - Parameter interval: The interval of tokens within this stream to get text
     /// for.
-    /// - Throws: ANTLRError.nullPointer if `interval` is `null`
     /// - Returns: The text of all tokens within the specified interval in this
     /// stream.
     /// 

--- a/runtime/Swift/Sources/Antlr4/misc/BitSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/BitSet.swift
@@ -32,10 +32,6 @@ import Foundation
 /// implementation. The length of a bit set relates to logical length
 /// of a bit set and is defined independently of implementation.
 /// 
-/// Unless otherwise noted, passing a null parameter to any of the
-/// methods in a `BitSet` will result in a
-/// `ANTLRError.nullPointer`.
-/// 
 /// A `BitSet` is not safe for multithreaded use without
 /// external synchronization.
 /// 

--- a/runtime/Swift/Sources/Antlr4/misc/exception/ANTLRError.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/exception/ANTLRError.swift
@@ -14,7 +14,6 @@
 import Foundation
 
 public enum ANTLRError: Error {
-    case nullPointer(msg:String)
     case unsupportedOperation(msg:String)
     case indexOutOfBounds(msg:String)
     case illegalState(msg:String)


### PR DESCRIPTION
This was copied from the API of the equivalent code in Java when
the runtime was ported to Swift.  It is meaningless in Swift, and
was unused.
