### PR TITLE
Add cache entry for ~/.m2 to .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: true
 
 language: java
 
+cache:
+  directories:
+  - $HOME/.m2
+
 matrix:
   include:
     - os: linux


### PR DESCRIPTION
This is recommended by the Travis docs to speed up the parts of the
tests that use Maven.
