### PR TITLE
Split Travis tests into three phases, and add caching and timeout management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ cache:
   - $HOME/.m2
   - $HOME/Library/Caches/Homebrew
 
+stages:
+  - smoke-test
+  - main-test
+  - extended-test
+
 matrix:
   include:
     - os: linux
@@ -16,6 +21,7 @@ matrix:
         - TARGET=cpp
         - CXX=g++-5
         - GROUP=ALL
+      stage: main-test
       addons:
         apt:
           sources:
@@ -31,113 +37,107 @@ matrix:
       env:
         - TARGET=cpp
         - GROUP=LEXER
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - g++-5
-            - uuid-dev
-            - clang-3.7
+      stage: extended-test
     - os: osx
       compiler: clang
       osx_image: xcode8.1
       env:
         - TARGET=cpp
         - GROUP=PARSER
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - g++-5
-            - uuid-dev
-            - clang-3.7
+      stage: extended-test
     - os: osx
       compiler: clang
       osx_image: xcode8.1
       env:
         - TARGET=cpp
         - GROUP=RECURSION
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - g++-5
-            - uuid-dev
-            - clang-3.7
+      stage: extended-test
     - os: osx
       compiler: clang
       osx_image: xcode8.1
       env:
         - TARGET=swift
         - GROUP=LEXER
+      stage: main-test
     - os: osx
       compiler: clang
       osx_image: xcode8.1
       env:
         - TARGET=swift
         - GROUP=PARSER
+      stage: main-test
     - os: osx
       compiler: clang
       osx_image: xcode8.1
       env:
         - TARGET=swift
         - GROUP=RECURSION
+      stage: main-test
     - os: linux
       compiler: clang
       env:
        - TARGET=swift
        - GROUP=ALL
+      stage: extended-test
     - os: osx
       osx_image: xcode8.2
       env:
         - TARGET=dotnet
         - GROUP=LEXER
+      stage: extended-test
     - os: osx
       osx_image: xcode8.2
       env:
         - TARGET=dotnet
         - GROUP=PARSER
+      stage: extended-test
     - os: osx
       osx_image: xcode8.2
       env:
         - TARGET=dotnet
         - GROUP=RECURSION
+      stage: extended-test
     - os: linux
       jdk: openjdk7
       env: TARGET=java
+      stage: extended-test
+    - os: linux
+      jdk: openjdk8
+      env: TARGET=java
+      stage: extended-test
     - os: linux
       jdk: oraclejdk8
       env: TARGET=java
+      stage: smoke-test
     - os: linux
       jdk: openjdk7
       env: TARGET=csharp
+      stage: extended-test
     - os: linux
       jdk: oraclejdk8
       dist: trusty
       env:
         - TARGET=dotnet
         - GROUP=LEXER
+      stage: main-test
     - os: linux
-      jdk: oraclejdk8
+      jdk: openjdk8
       dist: trusty
       env:
         - TARGET=dotnet
         - GROUP=PARSER
+      stage: main-test
     - os: linux
       jdk: oraclejdk8
       dist: trusty
       env:
         - TARGET=dotnet
         - GROUP=RECURSION
+      stage: main-test
     - os: linux
       jdk: openjdk7
       env: TARGET=python2
+      stage: extended-test
     - os: linux
       jdk: openjdk7
       env: TARGET=python3
@@ -147,12 +147,17 @@ matrix:
             - deadsnakes # source required so it finds the package definition below
           packages:
             - python3.5
+      stage: main-test
     - os: linux
-      jdk: openjdk7
+      dist: trusty
+      jdk: openjdk8
       env: TARGET=javascript
+      stage: main-test
     - os: linux
-      jdk: openjdk7
+      dist: trusty
+      jdk: openjdk8
       env: TARGET=go
+      stage: main-test
 
 before_install:
   - ./.travis/before-install-$TRAVIS_OS_NAME-$TARGET.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,41 @@ matrix:
       env:
         - TARGET=cpp
         - CXX=g++-5
-        - GROUP=ALL
+        - GROUP=LEXER
+      stage: main-test
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - g++-5
+            - uuid-dev
+            - clang-3.7
+    - os: linux
+      compiler: clang
+      jdk: openjdk7
+      env:
+        - TARGET=cpp
+        - CXX=g++-5
+        - GROUP=PARSER
+      stage: main-test
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - g++-5
+            - uuid-dev
+            - clang-3.7
+    - os: linux
+      compiler: clang
+      jdk: openjdk7
+      env:
+        - TARGET=cpp
+        - CXX=g++-5
+        - GROUP=RECURSION
       stage: main-test
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ sudo: true
 
 language: java
 
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/Library/Caches/Homebrew
+
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,4 +158,4 @@ before_install:
   - ./.travis/before-install-$TRAVIS_OS_NAME-$TARGET.sh
 
 script:
-  - cd runtime-testsuite; ../.travis/run-tests-$TARGET.sh
+  - cd runtime-testsuite; travis_wait 40 ../.travis/run-tests-$TARGET.sh


### PR DESCRIPTION
Split Travis tests into three phases.  This gives a "smoke-test" phase which just runs the Java tests, to get a quick check that compilation is working.  It is followed by the "main-test" phase that tests each target on their preferred platform (e.g. Swift on macOS, Python on Linux) followed by "test-extended" which runs all the remaining tests (all the other Java variants, and any other platforms supported by each target).

This means that those tests in the later phases won't run unless the earlier phases have passed.  This should vastly improve our Travis turnaround.

This PR also changes the matrix so that we get some coverage across all of openjdk7,8 and oraclejdk7,8 and moves the Go and Javascript tests to Trusty just so that they are more up-to-date.  This adds one additional Java test run, so now we compare oraclejdk8 and openjdk8 in case of problems in that regard.

Note that the test matrix has not been extended to cover oraclejdk9.  This currently fails for us with a build issue, so it is not included here.

The C++ tests have been broken into three groups, for reliability.

Also:
* add some caching to improve turnaround speeds;
* add a travis_wait call when running the tests so that Travis does not time out the long-running-but-silent TestLeftRecursion tests.
* remove the meaningless custom apt configuration in the section for macOS .NET tests.