### PR TITLE
Simplify output path generation

### DIFF
--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -761,18 +761,11 @@ public class Tool {
 		File outputDir;
 		String fileDirectory;
 
-		// Some files are given to us without a PATH but should should
-		// still be written to the output directory in the relative path of
-		// the output directory. The file directory is either the set of sub directories
-		// or just or the relative path recorded for the parent grammar. This means
-		// that when we write the tokens files, or the .java files for imported grammars
-		// taht we will write them in the correct place.
 		if (fileNameWithPath.lastIndexOf(File.separatorChar) == -1) {
 			// No path is included in the file name, so make the file
-			// directory the same as the parent grammar (which might sitll be just ""
+			// directory the same as the parent grammar (which might still be just ""
 			// but when it is not, we will write the file in the correct place.
 			fileDirectory = ".";
-
 		}
 		else {
 			fileDirectory = fileNameWithPath.substring(0, fileNameWithPath.lastIndexOf(File.separatorChar));
@@ -781,21 +774,8 @@ public class Tool {
 			// -o /tmp /var/lib/t.g4 => /tmp/T.java
 			// -o subdir/output /usr/lib/t.g4 => subdir/output/T.java
 			// -o . /usr/lib/t.g4 => ./T.java
-			if (fileDirectory != null &&
-				(new File(fileDirectory).isAbsolute() ||
-				 fileDirectory.startsWith("~"))) { // isAbsolute doesn't count this :(
-				// somebody set the dir, it takes precendence; write new file there
-				outputDir = new File(outputDirectory);
-			}
-			else {
-				// -o /tmp subdir/t.g4 => /tmp/subdir/t.g4
-				if (fileDirectory != null) {
-					outputDir = new File(outputDirectory, fileDirectory);
-				}
-				else {
-					outputDir = new File(outputDirectory);
-				}
-			}
+			// -o /tmp subdir/t.g4 => /tmp/t.g4
+			outputDir = new File(outputDirectory);
 		}
 		else {
 			// they didn't specify a -o dir so just write to location

--- a/tool/src/org/antlr/v4/parse/TokenVocabParser.java
+++ b/tool/src/org/antlr/v4/parse/TokenVocabParser.java
@@ -146,6 +146,22 @@ public class TokenVocabParser {
 		// files are generated (in the base, not relative to the input
 		// location.)
 		f = new File(g.tool.outputDirectory, vocabName + CodeGenerator.VOCAB_FILE_EXTENSION);
-		return f;
+		if ( f.exists() ) {
+			return f;
+		}
+		
+		// Still not found? Use the grammar's subfolder then.
+		String fileDirectory;
+
+		if (g.fileName.lastIndexOf(File.separatorChar) == -1) {
+			// No path is included in the file name, so make the file
+			// directory the same as the parent grammar (which might still be just ""
+			// but when it is not, we will write the file in the correct place.
+			fileDirectory = ".";
+		}
+		else {
+			fileDirectory = g.fileName.substring(0, g.fileName.lastIndexOf(File.separatorChar));
+		}
+		return new File(fileDirectory, vocabName + CodeGenerator.VOCAB_FILE_EXTENSION);
 	}
 }


### PR DESCRIPTION
This is a new version of PR #1829 from 19 April and #1905 (which lost all the changes I made during a git merge).

The twisted way to create a javac like output path breaks many use cases, including very simple ones with lexer + parser grammar in a relative subdir (where parser generation doesn't find the lexer tokens). Additionally, not all projects prefer to have their generated files in an output folder which is comprised of the given output path and the subdir given for the grammar files. The check for absolute paths as decision criterion is a weak one anyway - it makes simple usage difficult and doesn't deal with path expansion on all platforms.

If a javac like output path is required it should be easy to construct this upfront and provide it as the output path parameter, instead of implicitely creating it. This patch simplifies things without any WTF moments because generated files end up at unexpected locations. It now can deal with simple cases (no output, no grammar subdir) up to complicated cases (nested and/or absolute output dir, multiple grammar subfolders).

If more than one output folder is wanted run the tool multiple times with different output path settings and add the lib option if you need to reference previously created files.

It might look like a disadvantage that now generation of parser files ends up at a different path when run with relative grammar subfolders, but actually that was broken anyway so I don't expect anyone having used that (but instead either absolute paths or no subfolders at all). 

Fixes #1087, #753,  #638, tunnelvisionlabs/antlr4ts#306, tunnelvisionlabs/antlr4ts#303 