### PR TITLE
Fix retain cycles in the Swift runtime

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
@@ -72,7 +72,7 @@ TokenStartColumnEquals(i) ::= <%self._tokenStartCharPositionInLine == <i>%>
 
 ImportListener(X) ::= ""
 
-GetExpectedTokenNames() ::= "try self.getExpectedTokens().toString(self.tokenNames)"
+GetExpectedTokenNames() ::= "try self.getExpectedTokens().toString(self.getVocabulary())"
 
 RuleInvocationStack() ::= "getRuleInvocationStack().description.replacingOccurrences(of: \"\\\"\", with: \"\")"
 

--- a/runtime/Swift/Sources/Antlr4/BailErrorStrategy.swift
+++ b/runtime/Swift/Sources/Antlr4/BailErrorStrategy.swift
@@ -41,13 +41,13 @@ public class BailErrorStrategy: DefaultErrorStrategy {
     /// original _org.antlr.v4.runtime.RecognitionException_.
     /// 
     override public func recover(_ recognizer: Parser, _ e: AnyObject) throws {
-        var context: ParserRuleContext? = recognizer.getContext()
-        while let contextWrap = context{
+        var context = recognizer.getContext()
+        while let contextWrap = context {
             contextWrap.exception = e
             context = (contextWrap.getParent() as? ParserRuleContext)
         }
 
-        throw  ANTLRException.recognition(e: e)
+        throw ANTLRException.recognition(e: e)
     }
 
     /// 
@@ -56,15 +56,14 @@ public class BailErrorStrategy: DefaultErrorStrategy {
     /// 
     override
     public func recoverInline(_ recognizer: Parser) throws -> Token {
-        let e: InputMismatchException = try InputMismatchException(recognizer)
-        var context: ParserRuleContext? = recognizer.getContext()
+        let e = try InputMismatchException(recognizer)
+        var context = recognizer.getContext()
         while let contextWrap = context {
              contextWrap.exception = e
              context = (contextWrap.getParent() as? ParserRuleContext)
         }
 
-        throw  ANTLRException.recognition(e: e)
-
+        throw ANTLRException.recognition(e: e)
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/BufferedTokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/BufferedTokenStream.swift
@@ -176,7 +176,7 @@ public class BufferedTokenStream: TokenStream {
             let  index = tokens.count - 1
             throw ANTLRError.indexOutOfBounds(msg: "token index  \(i) out of range 0..\(index)")
         }
-        return tokens[i] //tokens[i]
+        return tokens[i]
     }
 
     /// 
@@ -202,7 +202,6 @@ public class BufferedTokenStream: TokenStream {
         return subset
     }
 
-    //TODO: LT(i)!.getType();
     public func LA(_ i: Int) throws -> Int {
         return try LT(i)!.getType()
     }
@@ -273,11 +272,11 @@ public class BufferedTokenStream: TokenStream {
         fetchedEOF = false
     }
 
-    public func getTokens() -> Array<Token> {
+    public func getTokens() -> [Token] {
         return tokens
     }
 
-    public func getTokens(_ start: Int, _ stop: Int) throws -> Array<Token>? {
+    public func getTokens(_ start: Int, _ stop: Int) throws -> [Token]? {
         return try getTokens(start, stop, nil)
     }
 
@@ -286,40 +285,36 @@ public class BufferedTokenStream: TokenStream {
     /// the token type BitSet.  Return null if no tokens were found.  This
     /// method looks at both on and off channel tokens.
     /// 
-    public func getTokens(_ start: Int, _ stop: Int, _ types: Set<Int>?) throws -> Array<Token>? {
+    public func getTokens(_ start: Int, _ stop: Int, _ types: Set<Int>?) throws -> [Token]? {
         try lazyInit()
-        if start < 0 || stop >= tokens.count ||
-                stop < 0 || start >= tokens.count {
-            throw ANTLRError.indexOutOfBounds(msg: "start \(start) or stop \(stop) not in 0..\(tokens.count - 1)")
+        if start < 0 || start >= tokens.count ||
+            stop < 0 || stop >= tokens.count {
+            throw ANTLRError.indexOutOfBounds(msg: "start \(start) or stop \(stop) not in 0...\(tokens.count - 1)")
 
         }
         if start > stop {
             return nil
         }
 
-
-        var filteredTokens: Array<Token> = Array<Token>()
+        var filteredTokens = [Token]()
         for i in start...stop {
-            let t: Token = tokens[i]
-            if let types = types , !types.contains(t.getType()) {
-            }else {
+            let t = tokens[i]
+            if let types = types, !types.contains(t.getType()) {
+            }
+            else {
                 filteredTokens.append(t)
             }
-
         }
         if filteredTokens.isEmpty {
             return nil
-            //filteredTokens = nil;
         }
         return filteredTokens
     }
 
-    public func getTokens(_ start: Int, _ stop: Int, _ ttype: Int) throws -> Array<Token>? {
-        //TODO Set<Int> initialCapacity
-        var s: Set<Int> = Set<Int>()
+    public func getTokens(_ start: Int, _ stop: Int, _ ttype: Int) throws -> [Token]? {
+        var s = Set<Int>()
         s.insert(ttype)
-        //s.append(ttype);
-        return try  getTokens(start, stop, s)
+        return try getTokens(start, stop, s)
     }
 
     /// 
@@ -464,7 +459,7 @@ public class BufferedTokenStream: TokenStream {
                 }
             }
         }
-        if hidden.count == 0 {
+        if hidden.isEmpty {
             return nil
         }
         return hidden

--- a/runtime/Swift/Sources/Antlr4/CharStream.swift
+++ b/runtime/Swift/Sources/Antlr4/CharStream.swift
@@ -25,5 +25,5 @@ public protocol CharStream: IntStream {
     /// - throws: _ANTLRError.unsupportedOperation_ if the stream does not support
     /// getting the text of the specified interval
     /// 
-    func getText(_ interval: Interval) -> String
+    func getText(_ interval: Interval) throws -> String
 }

--- a/runtime/Swift/Sources/Antlr4/CommonToken.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonToken.swift
@@ -164,7 +164,12 @@ public class CommonToken: WritableToken {
         if let input = getInputStream() {
             let n = input.size()
             if start < n && stop < n {
-                return input.getText(Interval.of(start, stop))
+                do {
+                    return try input.getText(Interval.of(start, stop))
+                }
+                catch {
+                    return nil
+                }
             } else {
                 return "<EOF>"
             }

--- a/runtime/Swift/Sources/Antlr4/CommonToken.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonToken.swift
@@ -21,20 +21,20 @@ public class CommonToken: WritableToken {
     /// 
     /// This is the backing field for _#getLine_ and _#setLine_.
     /// 
-    internal var line: Int = 0
+    internal var line = 0
 
     /// 
     /// This is the backing field for _#getCharPositionInLine_ and
     /// _#setCharPositionInLine_.
     /// 
-    internal var charPositionInLine: Int = -1
+    internal var charPositionInLine = -1
     // set to invalid position
 
     /// 
     /// This is the backing field for _#getChannel_ and
     /// _#setChannel_.
     /// 
-    internal var channel: Int = DEFAULT_CHANNEL
+    internal var channel = DEFAULT_CHANNEL
 
     /// 
     /// This is the backing field for _#getTokenSource_ and
@@ -61,19 +61,19 @@ public class CommonToken: WritableToken {
     /// This is the backing field for _#getTokenIndex_ and
     /// _#setTokenIndex_.
     /// 
-    internal var index: Int = -1
+    internal var index = -1
 
     /// 
     /// This is the backing field for _#getStartIndex_ and
     /// _#setStartIndex_.
     /// 
-    internal var start: Int = 0
+    internal var start = 0
 
     /// 
     /// This is the backing field for _#getStopIndex_ and
     /// _#setStopIndex_.
     /// 
-    internal var stop: Int = 0
+    internal var stop = 0
 
     /// 
     /// Constructs a new _org.antlr.v4.runtime.CommonToken_ with the specified token type.
@@ -157,12 +157,12 @@ public class CommonToken: WritableToken {
 
 
     public func getText() -> String? {
-        if text != nil {
-            return text!
+        if let text = text {
+            return text
         }
 
         if let input = getInputStream() {
-            let n: Int = input.size()
+            let n = input.size()
             if start < n && stop < n {
                 return input.getText(Interval.of(start, stop))
             } else {
@@ -260,10 +260,8 @@ public class CommonToken: WritableToken {
     }
 
     public func toString(_ r: Recognizer<ATNSimulator>?) -> String {
-        var channelStr: String = ""
-        if channel > 0 {
-            channelStr = ",channel=\(channel)"
-        }
+        let channelStr = (channel > 0 ? ",channel=\(channel)" : "")
+
         var txt: String
         if let tokenText = getText() {
             txt = tokenText.replacingOccurrences(of: "\n", with: "\\n")
@@ -272,12 +270,16 @@ public class CommonToken: WritableToken {
         } else {
             txt = "<no text>"
         }
-        var typeString = "\(type)"
+        let typeString: String
         if let r = r {
-            typeString = r.getVocabulary().getDisplayName(type);
+            typeString = r.getVocabulary().getDisplayName(type)
+        }
+        else {
+            typeString = "\(type)"
         }
        return "[@\(getTokenIndex()),\(start):\(stop)='\(txt)',<\(typeString)>\(channelStr),\(line):\(getCharPositionInLine())]"
     }
+
     public var visited: Bool {
         get {
             return _visited

--- a/runtime/Swift/Sources/Antlr4/CommonToken.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonToken.swift
@@ -8,12 +8,6 @@
 
 public class CommonToken: WritableToken {
     /// 
-    /// An empty _org.antlr.v4.runtime.misc.Pair_ which is used as the default value of
-    /// _#source_ for tokens that do not have a source.
-    /// 
-    internal static let EMPTY_SOURCE: (TokenSource?, CharStream?) = (nil, nil)
-
-    /// 
     /// This is the backing field for _#getType_ and _#setType_.
     /// 
     internal var type: Int
@@ -47,7 +41,7 @@ public class CommonToken: WritableToken {
     /// _org.antlr.v4.runtime.misc.Pair_ containing these values.
     /// 
 
-    internal var source: (TokenSource?, CharStream?)
+    internal let source: TokenSourceAndStream
 
     /// 
     /// This is the backing field for _#getText_ when the token text is
@@ -85,16 +79,16 @@ public class CommonToken: WritableToken {
 
     public init(_ type: Int) {
         self.type = type
-        self.source = CommonToken.EMPTY_SOURCE
+        self.source = TokenSourceAndStream.EMPTY
     }
 
-    public init(_ source: (TokenSource?, CharStream?), _ type: Int, _ channel: Int, _ start: Int, _ stop: Int) {
+    public init(_ source: TokenSourceAndStream, _ type: Int, _ channel: Int, _ start: Int, _ stop: Int) {
         self.source = source
         self.type = type
         self.channel = channel
         self.start = start
         self.stop = stop
-        if let tsource = source.0 {
+        if let tsource = source.tokenSource {
             self.line = tsource.getLine()
             self.charPositionInLine = tsource.getCharPositionInLine()
         }
@@ -111,20 +105,12 @@ public class CommonToken: WritableToken {
         self.type = type
         self.channel = CommonToken.DEFAULT_CHANNEL
         self.text = text
-        self.source = CommonToken.EMPTY_SOURCE
+        self.source = TokenSourceAndStream.EMPTY
     }
 
     /// 
     /// Constructs a new _org.antlr.v4.runtime.CommonToken_ as a copy of another _org.antlr.v4.runtime.Token_.
-    /// 
-    /// 
-    /// If `oldToken` is also a _org.antlr.v4.runtime.CommonToken_ instance, the newly
-    /// constructed token will share a reference to the _#text_ field and
-    /// the _org.antlr.v4.runtime.misc.Pair_ stored in _#source_. Otherwise, _#text_ will
-    /// be assigned the result of calling _#getText_, and _#source_
-    /// will be constructed from the result of _org.antlr.v4.runtime.Token#getTokenSource_ and
-    /// _org.antlr.v4.runtime.Token#getInputStream_.
-    /// 
+    ///
     /// - parameter oldToken: The token to copy.
     /// 
     public init(_ oldToken: Token) {
@@ -135,14 +121,8 @@ public class CommonToken: WritableToken {
         channel = oldToken.getChannel()
         start = oldToken.getStartIndex()
         stop = oldToken.getStopIndex()
-
-        if oldToken is CommonToken {
-            text = (oldToken as! CommonToken).text
-            source = (oldToken as! CommonToken).source
-        } else {
-            text = oldToken.getText()
-            source = (oldToken.getTokenSource(), oldToken.getInputStream())
-        }
+        text = oldToken.getText()
+        source = oldToken.getTokenSourceAndStream()
     }
 
 
@@ -252,12 +232,16 @@ public class CommonToken: WritableToken {
 
 
     public func getTokenSource() -> TokenSource? {
-        return source.0
+        return source.tokenSource
     }
 
 
     public func getInputStream() -> CharStream? {
-        return source.1
+        return source.stream
+    }
+
+    public func getTokenSourceAndStream() -> TokenSourceAndStream {
+        return source
     }
 
     public var description: String {

--- a/runtime/Swift/Sources/Antlr4/CommonTokenFactory.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonTokenFactory.swift
@@ -65,7 +65,7 @@ public class CommonTokenFactory: TokenFactory {
     }
 
 
-    public func create(_ source: (TokenSource?, CharStream?), _ type: Int, _ text: String?,
+    public func create(_ source: TokenSourceAndStream, _ type: Int, _ text: String?,
                        _ channel: Int, _ start: Int, _ stop: Int,
                        _ line: Int, _ charPositionInLine: Int) -> Token {
         let t = CommonToken(source, type, channel, start, stop)
@@ -74,7 +74,7 @@ public class CommonTokenFactory: TokenFactory {
         if let text = text {
             t.setText(text)
         }
-        else if let cStream = source.1, copyText {
+        else if let cStream = source.stream, copyText {
             t.setText(try! cStream.getText(Interval.of(start, stop)))
         }
 

--- a/runtime/Swift/Sources/Antlr4/CommonTokenFactory.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonTokenFactory.swift
@@ -68,15 +68,14 @@ public class CommonTokenFactory: TokenFactory {
     public func create(_ source: (TokenSource?, CharStream?), _ type: Int, _ text: String?,
                        _ channel: Int, _ start: Int, _ stop: Int,
                        _ line: Int, _ charPositionInLine: Int) -> Token {
-        let t: CommonToken = CommonToken(source, type, channel, start, stop)
+        let t = CommonToken(source, type, channel, start, stop)
         t.setLine(line)
         t.setCharPositionInLine(charPositionInLine)
-        if text != nil {
-            t.setText(text!)
-        } else {
-            if let cStream = source.1 , copyText {
-                t.setText(cStream.getText(Interval.of(start, stop)))
-            }
+        if let text = text {
+            t.setText(text)
+        }
+        else if let cStream = source.1, copyText {
+            t.setText(cStream.getText(Interval.of(start, stop)))
         }
 
         return t

--- a/runtime/Swift/Sources/Antlr4/CommonTokenFactory.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonTokenFactory.swift
@@ -75,7 +75,7 @@ public class CommonTokenFactory: TokenFactory {
             t.setText(text)
         }
         else if let cStream = source.1, copyText {
-            t.setText(cStream.getText(Interval.of(start, stop)))
+            t.setText(try! cStream.getText(Interval.of(start, stop)))
         }
 
         return t

--- a/runtime/Swift/Sources/Antlr4/CommonTokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonTokenStream.swift
@@ -39,7 +39,7 @@ public class CommonTokenStream: BufferedTokenStream {
     /// The default value is _org.antlr.v4.runtime.Token#DEFAULT_CHANNEL_, which matches the
     /// default channel assigned to tokens created by the lexer.
     /// 
-    internal var channel: Int = CommonToken.DEFAULT_CHANNEL
+    internal var channel = CommonToken.DEFAULT_CHANNEL
 
     /// 
     /// Constructs a new _org.antlr.v4.runtime.CommonTokenStream_ using the specified token
@@ -77,8 +77,8 @@ public class CommonTokenStream: BufferedTokenStream {
             return nil
         }
 
-        var i: Int = p
-        var n: Int = 1
+        var i = p
+        var n = 1
         // find k good tokens looking backwards
         while n <= k {
             // skip off-channel tokens
@@ -101,8 +101,8 @@ public class CommonTokenStream: BufferedTokenStream {
         if k < 0 {
             return try LB(-k)
         }
-        var i: Int = p
-        var n: Int = 1 // we know tokens[p] is a good one
+        var i = p
+        var n = 1 // we know tokens[p] is a good one
         // find k good tokens
         while n < k {
             // skip off-channel tokens, but make sure to not look past EOF
@@ -119,11 +119,11 @@ public class CommonTokenStream: BufferedTokenStream {
     /// Count EOF just once.
     /// 
     public func getNumberOfOnChannelTokens() throws -> Int {
-        var n: Int = 0
+        var n = 0
         try fill()
         let length = tokens.count
         for i in 0..<length {
-            let t: Token = tokens[i]
+            let t = tokens[i]
             if t.getChannel() == channel {
                 n += 1
             }

--- a/runtime/Swift/Sources/Antlr4/DefaultErrorStrategy.swift
+++ b/runtime/Swift/Sources/Antlr4/DefaultErrorStrategy.swift
@@ -538,10 +538,12 @@ public class DefaultErrorStrategy: ANTLRErrorStrategy {
             current = lookback!
         }
 
-        let token = recognizer.getTokenFactory().create((current.getTokenSource(), current.getTokenSource()!.getInputStream()), expectedTokenType, tokenText,
-                CommonToken.DEFAULT_CHANNEL,
-                -1, -1,
-                current.getLine(), current.getCharPositionInLine())
+        let token = recognizer.getTokenFactory().create(
+            current.getTokenSourceAndStream(),
+            expectedTokenType, tokenText,
+            CommonToken.DEFAULT_CHANNEL,
+            -1, -1,
+            current.getLine(), current.getCharPositionInLine())
 
         return token
     }

--- a/runtime/Swift/Sources/Antlr4/FailedPredicateException.swift
+++ b/runtime/Swift/Sources/Antlr4/FailedPredicateException.swift
@@ -28,13 +28,12 @@ public class FailedPredicateException: RecognitionException<ParserATNSimulator> 
 									_ predicate: String?,
 									_ message: String?) throws
 	{
+		let s = recognizer.getInterpreter().atn.states[recognizer.getState()]!
 
-		let s: ATNState  = recognizer.getInterpreter().atn.states[recognizer.getState()]!
-
-		let trans: AbstractPredicateTransition = s.transition(0) as! AbstractPredicateTransition
-		if trans is PredicateTransition {
-			self.ruleIndex = (trans as! PredicateTransition).ruleIndex
-			self.predicateIndex = (trans as! PredicateTransition).predIndex
+		let trans = s.transition(0) as! AbstractPredicateTransition
+		if let predex = trans as? PredicateTransition {
+			self.ruleIndex = predex.ruleIndex
+			self.predicateIndex = predex.predIndex
 		}
 		else {
 			self.ruleIndex = 0
@@ -55,7 +54,6 @@ public class FailedPredicateException: RecognitionException<ParserATNSimulator> 
 	public func getPredIndex() -> Int {
 		return predicateIndex
 	}
-
 
 	public func getPredicate() -> String? {
 		return predicate

--- a/runtime/Swift/Sources/Antlr4/Lexer.swift
+++ b/runtime/Swift/Sources/Antlr4/Lexer.swift
@@ -26,7 +26,7 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
     public static let MAX_CHAR_VALUE = Character.MAX_VALUE;
 
     public var _input: CharStream?
-    internal var _tokenFactorySourcePair: (TokenSource?, CharStream?)
+    internal var _tokenFactorySourcePair: TokenSourceAndStream
 
     /// 
     /// How to create token objects
@@ -87,13 +87,17 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
     public var _text: String?
 
     public override init() {
+        self._tokenFactorySourcePair = TokenSourceAndStream()
+        super.init()
+        self._tokenFactorySourcePair.tokenSource = self
     }
 
     public init(_ input: CharStream) {
-
-        super.init()
         self._input = input
-        self._tokenFactorySourcePair = (self, input)
+        self._tokenFactorySourcePair = TokenSourceAndStream()
+        super.init()
+        self._tokenFactorySourcePair.tokenSource = self
+        self._tokenFactorySourcePair.stream = input
     }
 
     open func reset() throws {
@@ -234,10 +238,10 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
 
     open override func setInputStream(_ input: IntStream) throws {
         self._input = nil
-        self._tokenFactorySourcePair = (self, _input!)
+        self._tokenFactorySourcePair = makeTokenSourceAndStream()
         try reset()
         self._input = input as? CharStream
-        self._tokenFactorySourcePair = (self, _input!)
+        self._tokenFactorySourcePair = makeTokenSourceAndStream()
     }
 
 
@@ -448,5 +452,9 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
     open func recover(_ re: AnyObject) throws {
         // TODO: Do we lose character or line position information?
         try _input!.consume()
+    }
+
+    internal func makeTokenSourceAndStream() -> TokenSourceAndStream {
+        return TokenSourceAndStream(self, _input)
     }
 }

--- a/runtime/Swift/Sources/Antlr4/Lexer.swift
+++ b/runtime/Swift/Sources/Antlr4/Lexer.swift
@@ -373,16 +373,6 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
     }
 
     /// 
-    /// Used to print out token names like ID during debugging and
-    /// error reporting.  The generated parsers implement a method
-    /// that overrides this to point to their String[] tokenNames.
-    /// 
-    override
-    open func getTokenNames() -> [String?]? {
-        return nil
-    }
-
-    /// 
     /// Return a list of all Token objects in input char stream.
     /// Forces load of all tokens. Does not include EOF token.
     /// 

--- a/runtime/Swift/Sources/Antlr4/Lexer.swift
+++ b/runtime/Swift/Sources/Antlr4/Lexer.swift
@@ -395,7 +395,13 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
 
     open func notifyListeners<T>(_ e: LexerNoViableAltException, recognizer: Recognizer<T>) {
 
-        let text = _input!.getText(Interval.of(_tokenStartCharIndex, _input!.index()))
+        let text: String
+        do {
+            text = try _input!.getText(Interval.of(_tokenStartCharIndex, _input!.index()))
+        }
+        catch {
+            text = "<unknown>"
+        }
         let msg = "token recognition error at: '\(getErrorDisplay(text))'"
 
         let listener = getErrorListenerDispatch()

--- a/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
@@ -9,14 +9,9 @@ public class LexerInterpreter: Lexer {
     internal final var grammarFileName: String
     internal final var atn: ATN
 
-    /// 
-    /// /@Deprecated
-    /// 
-    internal final var tokenNames: [String?]?
     internal final var ruleNames: [String]
     internal final var channelNames: [String]
     internal final var modeNames: [String]
-
 
     private final var vocabulary: Vocabulary?
 
@@ -40,13 +35,6 @@ public class LexerInterpreter: Lexer {
 
         self.grammarFileName = grammarFileName
         self.atn = atn
-        self.tokenNames = [String?]()
-        //new String[atn.maxTokenType];
-        let length = tokenNames!.count
-        for i in 0..<length {
-            tokenNames![i] = vocabulary.getDisplayName(i)
-        }
-
         self.ruleNames = ruleNames
         self.channelNames = channelNames
         self.modeNames = modeNames
@@ -76,14 +64,6 @@ public class LexerInterpreter: Lexer {
     override
     public func getGrammarFileName() -> String {
         return grammarFileName
-    }
-
-    override
-    /// 
-    /// /@Deprecated
-    /// 
-    public func getTokenNames() -> [String?]? {
-        return tokenNames
     }
 
     override

--- a/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
@@ -21,8 +21,8 @@ public class LexerInterpreter: Lexer {
     private final var vocabulary: Vocabulary?
 
     internal final var _decisionToDFA: [DFA]
-    internal final var _sharedContextCache: PredictionContextCache =
-    PredictionContextCache()
+    internal final var _sharedContextCache = PredictionContextCache()
+
 //   public override init() {
 //    super.init()}
 

--- a/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
@@ -45,9 +45,7 @@ public class LexerInterpreter: Lexer {
         for i in 0..<_decisionToDFALength {
             _decisionToDFA[i] = DFA(atn.getDecisionState(i)!, i)
         }
-        super.init()
-        self._input = input
-        self._tokenFactorySourcePair = (self, input)
+        super.init(input)
         self._interp = LexerATNSimulator(self, atn, _decisionToDFA, _sharedContextCache)
 
         if atn.grammarType != ATNType.lexer {

--- a/runtime/Swift/Sources/Antlr4/LexerNoViableAltException.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerNoViableAltException.swift
@@ -39,7 +39,7 @@ public class LexerNoViableAltException: RecognitionException<LexerATNSimulator>,
         var symbol = ""
         if let charStream = getInputStream() as? CharStream, startIndex >= 0 && startIndex < charStream.size() {
             let interval = Interval.of(startIndex, startIndex)
-            symbol = charStream.getText(interval)
+            symbol = try! charStream.getText(interval)
             symbol = Utils.escapeWhitespace(symbol, false)
         }
 

--- a/runtime/Swift/Sources/Antlr4/LexerNoViableAltException.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerNoViableAltException.swift
@@ -31,22 +31,14 @@ public class LexerNoViableAltException: RecognitionException<LexerATNSimulator>,
         return startIndex
     }
 
-
     public func getDeadEndConfigs() -> ATNConfigSet {
         return deadEndConfigs
     }
 
-    //override
-//	public func getInputStream() -> CharStream {
-//		return super.getInputStream() as! CharStream;
-//	}
-
-
     public var description: String {
-        var symbol: String = ""
-        if startIndex >= 0 && startIndex < getInputStream().size() {
-            let charStream: CharStream = getInputStream() as! CharStream
-            let interval: Interval = Interval.of(startIndex, startIndex)
+        var symbol = ""
+        if let charStream = getInputStream() as? CharStream, startIndex >= 0 && startIndex < charStream.size() {
+            let interval = Interval.of(startIndex, startIndex)
             symbol = charStream.getText(interval)
             symbol = Utils.escapeWhitespace(symbol, false)
         }

--- a/runtime/Swift/Sources/Antlr4/ListTokenSource.swift
+++ b/runtime/Swift/Sources/Antlr4/ListTokenSource.swift
@@ -17,7 +17,7 @@ public class ListTokenSource: TokenSource {
     /// 
     /// The wrapped collection of _org.antlr.v4.runtime.Token_ objects to return.
     /// 
-    internal final var tokens: Array<Token>
+    internal final var tokens: [Token]
 
     /// 
     /// The name of the input source. If this value is `null`, a call to
@@ -32,7 +32,7 @@ public class ListTokenSource: TokenSource {
     /// _#nextToken_. The end of the input is indicated by this value
     /// being greater than or equal to the number of items in _#tokens_.
     /// 
-    internal var i: Int = 0
+    internal var i = 0
 
     /// 
     /// This field caches the EOF token for the token source.
@@ -43,7 +43,7 @@ public class ListTokenSource: TokenSource {
     /// This is the backing field for _#getTokenFactory_ and
     /// _setTokenFactory_.
     /// 
-    private var _factory: TokenFactory = CommonTokenFactory.DEFAULT
+    private var _factory = CommonTokenFactory.DEFAULT
 
     /// 
     /// Constructs a new _org.antlr.v4.runtime.ListTokenSource_ instance from the specified
@@ -52,7 +52,7 @@ public class ListTokenSource: TokenSource {
     /// - parameter tokens: The collection of _org.antlr.v4.runtime.Token_ objects to provide as a
     /// _org.antlr.v4.runtime.TokenSource_.
     /// 
-    public convenience init(_ tokens: Array<Token>) {
+    public convenience init(_ tokens: [Token]) {
         self.init(tokens, nil)
     }
 
@@ -67,8 +67,7 @@ public class ListTokenSource: TokenSource {
     /// the next _org.antlr.v4.runtime.Token_ (or the previous token if the end of the input has
     /// been reached).
     /// 
-    public init(_ tokens: Array<Token>, _ sourceName: String?) {
-
+    public init(_ tokens: [Token], _ sourceName: String?) {
         self.tokens = tokens
         self.sourceName = sourceName
     }
@@ -76,28 +75,24 @@ public class ListTokenSource: TokenSource {
     public func getCharPositionInLine() -> Int {
         if i < tokens.count {
             return tokens[i].getCharPositionInLine()
-        } else {
-            if let eofToken = eofToken {
-              return eofToken.getCharPositionInLine()
-            } else {
-                if tokens.count > 0 {
-                    // have to calculate the result from the line/column of the previous
-                    // token, along with the text of the token.
-                    let lastToken: Token = tokens[tokens.count - 1]
+        }
+        else if let eofToken = eofToken {
+            return eofToken.getCharPositionInLine()
+        }
+        else if tokens.count > 0 {
+            // have to calculate the result from the line/column of the previous
+            // token, along with the text of the token.
+            let lastToken = tokens[tokens.count - 1]
 
-                    if let tokenText = lastToken.getText() {
-                        let lastNewLine: Int = tokenText.lastIndexOf("\n")
-                        if lastNewLine >= 0 {
-                            return tokenText.length - lastNewLine - 1
-                        }
-                    }
-                    var position = lastToken.getCharPositionInLine()
-                    position += lastToken.getStopIndex()
-                    position -= lastToken.getStartIndex()
-                    position += 1
-                    return position
+            if let tokenText = lastToken.getText() {
+                let lastNewLine = tokenText.lastIndexOf("\n")
+                if lastNewLine >= 0 {
+                    return tokenText.length - lastNewLine - 1
                 }
             }
+            return (lastToken.getCharPositionInLine() +
+                    lastToken.getStopIndex() -
+                    lastToken.getStartIndex() + 1)
         }
 
         // only reach this if tokens is empty, meaning EOF occurs at the first
@@ -108,22 +103,22 @@ public class ListTokenSource: TokenSource {
     public func nextToken() -> Token {
         if i >= tokens.count {
             if eofToken == nil {
-                var start: Int = -1
+                var start = -1
                 if tokens.count > 0 {
-                    let previousStop: Int = tokens[tokens.count - 1].getStopIndex()
+                    let previousStop = tokens[tokens.count - 1].getStopIndex()
                     if previousStop != -1 {
                         start = previousStop + 1
                     }
                 }
 
-                let stop: Int = max(-1, start - 1)
+                let stop = max(-1, start - 1)
                 eofToken = _factory.create((self, getInputStream()!), CommonToken.EOF, "EOF", CommonToken.DEFAULT_CHANNEL, start, stop, getLine(), getCharPositionInLine())
             }
 
             return eofToken!
         }
 
-        let t: Token = tokens[i]
+        let t = tokens[i]
         if i == tokens.count - 1 && t.getType() == CommonToken.EOF {
             eofToken = t
         }
@@ -142,8 +137,8 @@ public class ListTokenSource: TokenSource {
                 if tokens.count > 0 {
                     // have to calculate the result from the line/column of the previous
                     // token, along with the text of the token.
-                    let lastToken: Token = tokens[tokens.count - 1]
-                    var line: Int = lastToken.getLine()
+                    let lastToken = tokens[tokens.count - 1]
+                    var line = lastToken.getLine()
 
                     if let tokenText = lastToken.getText() {
                         let length = tokenText.length
@@ -168,14 +163,12 @@ public class ListTokenSource: TokenSource {
     public func getInputStream() -> CharStream? {
         if i < tokens.count {
             return tokens[i].getInputStream()
-        } else {
-            if let eofToken = eofToken{
-                return eofToken.getInputStream()
-            } else {
-                if tokens.count > 0 {
-                    return tokens[tokens.count - 1].getInputStream()
-                }
-            }
+        }
+        else if let eofToken = eofToken {
+            return eofToken.getInputStream()
+        }
+        else if tokens.count > 0 {
+            return tokens[tokens.count - 1].getInputStream()
         }
 
         // no input stream information is available
@@ -183,8 +176,8 @@ public class ListTokenSource: TokenSource {
     }
 
     public func getSourceName() -> String {
-        if sourceName != nil {
-            return sourceName!
+        if let sourceName = sourceName {
+            return sourceName
         }
 
         if let inputStream = getInputStream() {

--- a/runtime/Swift/Sources/Antlr4/ListTokenSource.swift
+++ b/runtime/Swift/Sources/Antlr4/ListTokenSource.swift
@@ -112,7 +112,8 @@ public class ListTokenSource: TokenSource {
                 }
 
                 let stop = max(-1, start - 1)
-                eofToken = _factory.create((self, getInputStream()!), CommonToken.EOF, "EOF", CommonToken.DEFAULT_CHANNEL, start, stop, getLine(), getCharPositionInLine())
+                let source = TokenSourceAndStream(self, getInputStream())
+                eofToken = _factory.create(source, CommonToken.EOF, "EOF", CommonToken.DEFAULT_CHANNEL, start, stop, getLine(), getCharPositionInLine())
             }
 
             return eofToken!

--- a/runtime/Swift/Sources/Antlr4/Parser.swift
+++ b/runtime/Swift/Sources/Antlr4/Parser.swift
@@ -12,7 +12,7 @@ import Foundation
 /// This is all the parsing support code essentially; most of it is error recovery stuff.
 /// 
 open class Parser: Recognizer<ParserATNSimulator> {
-    public static let EOF: Int = -1
+    public static let EOF = -1
     public static var ConsoleError = true
 
     public class TraceListener: ParseTreeListener {
@@ -27,15 +27,12 @@ open class Parser: Recognizer<ParserATNSimulator> {
             print("enter   \(ruleName), LT(1)=\(lt1)")
         }
 
-
         public func visitTerminal(_ node: TerminalNode) {
             print("consume \(String(describing: node.getSymbol())) rule \(host.getRuleNames()[host._ctx!.getRuleIndex()])")
         }
 
-
         public func visitErrorNode(_ node: ErrorNode) {
         }
-
 
         public func exitEveryRule(_ ctx: ParserRuleContext) throws {
             let ruleName = host.getRuleNames()[ctx.getRuleIndex()]
@@ -45,22 +42,16 @@ open class Parser: Recognizer<ParserATNSimulator> {
     }
 
     public class TrimToSizeListener: ParseTreeListener {
-
-
-        public static let INSTANCE: TrimToSizeListener = TrimToSizeListener()
-
+        public static let INSTANCE = TrimToSizeListener()
 
         public func enterEveryRule(_ ctx: ParserRuleContext) {
         }
 
-
         public func visitTerminal(_ node: TerminalNode) {
         }
 
-
         public func visitErrorNode(_ node: ErrorNode) {
         }
-
 
         public func exitEveryRule(_ ctx: ParserRuleContext) {
             // TODO: Print exit info.
@@ -193,7 +184,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// 
     @discardableResult
     public func match(_ ttype: Int) throws -> Token {
-        var t: Token = try getCurrentToken()
+        var t = try getCurrentToken()
         if t.getType() == ttype {
             _errHandler.reportMatch(self)
             try consume()
@@ -228,7 +219,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// 
     @discardableResult
     public func matchWildcard() throws -> Token {
-        var t: Token = try getCurrentToken()
+        var t = try getCurrentToken()
         if t.getType() > 0 {
             _errHandler.reportMatch(self)
             try consume()
@@ -297,18 +288,11 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// using the default _org.antlr.v4.runtime.Parser.TrimToSizeListener_ during the parse process.
     /// 
     public func getTrimParseTree() -> Bool {
-
         return !getParseListeners().filter({ $0 === TrimToSizeListener.INSTANCE }).isEmpty
     }
 
-
-    public func getParseListeners() -> Array<ParseTreeListener> {
-        let listeners: Array<ParseTreeListener>? = _parseListeners
-        if listeners == nil {
-            return Array<ParseTreeListener>()
-        }
-
-        return listeners!
+    public func getParseListeners() -> [ParseTreeListener] {
+        return _parseListeners ?? [ParseTreeListener]()
     }
 
     /// 
@@ -338,10 +322,10 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// 
     public func addParseListener(_ listener: ParseTreeListener) {
         if _parseListeners == nil {
-            _parseListeners = Array<ParseTreeListener>()
+            _parseListeners = [ParseTreeListener]()
         }
 
-        self._parseListeners!.append(listener)
+        _parseListeners!.append(listener)
     }
 
     /// 
@@ -399,11 +383,11 @@ open class Parser: Recognizer<ParserATNSimulator> {
     public func triggerExitRuleEvent() throws {
         // reverse order walk of listeners
         if let _parseListeners = _parseListeners, let _ctx = _ctx {
-            var i: Int = _parseListeners.count - 1
+            var i = _parseListeners.count - 1
             while i >= 0 {
-                let listener: ParseTreeListener = _parseListeners[i]
+                let listener = _parseListeners[i]
                 _ctx.exitRule(listener)
-                try  listener.exitEveryRule(_ctx)
+                try listener.exitEveryRule(_ctx)
                 i -= 1
             }
         }
@@ -421,14 +405,12 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
     override
     open func getTokenFactory() -> TokenFactory {
-        //<AnyObject>
         return _input.getTokenSource().getTokenFactory()
     }
 
     /// Tell our token source and error strategy about a new way to create tokens.
     override
     open func setTokenFactory(_ factory: TokenFactory) {
-        //<AnyObject>
         _input.getTokenSource().setTokenFactory(factory)
     }
 
@@ -439,15 +421,13 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// - Throws: _ANTLRError.unsupportedOperation_ if the current parser does not
     /// implement the _#getSerializedATN()_ method.
     /// 
-
     public func getATNWithBypassAlts() -> ATN {
-        let serializedAtn: String = getSerializedATN()
+        let serializedAtn = getSerializedATN()
 
-        var result: ATN? = bypassAltsAtnCache[serializedAtn]
-        bypassAltsAtnCacheMutex.synchronized {
-            [unowned self] in
+        var result = bypassAltsAtnCache[serializedAtn]
+        bypassAltsAtnCacheMutex.synchronized { [unowned self] in
             if result == nil {
-                let deserializationOptions: ATNDeserializationOptions = ATNDeserializationOptions()
+                let deserializationOptions = ATNDeserializationOptions()
                 try! deserializationOptions.setGenerateRuleBypassTransitions(true)
                 result = try! ATNDeserializer(deserializationOptions).deserialize(Array(serializedAtn.characters))
                 self.bypassAltsAtnCache[serializedAtn] = result!
@@ -469,14 +449,12 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// 
     public func compileParseTreePattern(_ pattern: String, _ patternRuleIndex: Int) throws -> ParseTreePattern {
         if let tokenStream = getTokenStream() {
-            let tokenSource: TokenSource = tokenStream.getTokenSource()
-            if tokenSource is Lexer {
-                let lexer: Lexer = tokenSource as! Lexer
+            let tokenSource = tokenStream.getTokenSource()
+            if let lexer = tokenSource as? Lexer {
                 return try compileParseTreePattern(pattern, patternRuleIndex, lexer)
             }
         }
         throw ANTLRError.unsupportedOperation(msg: "Parser can't discover a lexer to use")
-
     }
 
     /// 
@@ -485,7 +463,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// 
     public func compileParseTreePattern(_ pattern: String, _ patternRuleIndex: Int,
                                         _ lexer: Lexer) throws -> ParseTreePattern {
-        let m: ParseTreePatternMatcher = ParseTreePatternMatcher(lexer, self)
+        let m = ParseTreePatternMatcher(lexer, self)
         return try m.compile(pattern, patternRuleIndex)
     }
 
@@ -535,12 +513,9 @@ open class Parser: Recognizer<ParserATNSimulator> {
     public func notifyErrorListeners(_ offendingToken: Token, _ msg: String,
                                      _ e: AnyObject?) {
         _syntaxErrors += 1
-        var line: Int = -1
-        var charPositionInLine: Int = -1
-        line = offendingToken.getLine()
-        charPositionInLine = offendingToken.getCharPositionInLine()
-
-        let listener: ANTLRErrorListener = getErrorListenerDispatch()
+        let line = offendingToken.getLine()
+        let charPositionInLine = offendingToken.getCharPositionInLine()
+        let listener = getErrorListenerDispatch()
         listener.syntaxError(self, offendingToken, line, charPositionInLine, msg, e)
     }
 
@@ -567,27 +542,27 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// 
     @discardableResult
     public func consume() throws -> Token {
-        let o: Token = try getCurrentToken()
+        let o = try getCurrentToken()
         if o.getType() != Parser.EOF {
             try getInputStream()!.consume()
         }
         guard let _ctx = _ctx else {
             return o
         }
-        let hasListener: Bool = _parseListeners != nil && !_parseListeners!.isEmpty
+        let hasListener = _parseListeners != nil && !_parseListeners!.isEmpty
 
         if _buildParseTrees || hasListener {
             if _errHandler.inErrorRecoveryMode(self) {
-                let node: ErrorNode = _ctx.addErrorNode(createErrorNode(parent: _ctx, t: o))
+                let node = _ctx.addErrorNode(createErrorNode(parent: _ctx, t: o))
                 if let _parseListeners = _parseListeners {
-                    for listener: ParseTreeListener in _parseListeners {
+                    for listener in _parseListeners {
                         listener.visitErrorNode(node)
                     }
                 }
             } else {
-                let node: TerminalNode = _ctx.addChild(createTerminalNode(parent: _ctx, t: o))
+                let node = _ctx.addChild(createTerminalNode(parent: _ctx, t: o))
                 if let _parseListeners = _parseListeners {
-                    for listener: ParseTreeListener in _parseListeners {
+                    for listener in _parseListeners {
                         listener.visitTerminal(node)
                     }
                 }
@@ -703,7 +678,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// Make the current context the child of the incoming localctx.
     /// 
     public func pushNewRecursionContext(_ localctx: ParserRuleContext, _ state: Int, _ ruleIndex: Int) throws {
-        let previous: ParserRuleContext = _ctx!
+        let previous = _ctx!
         previous.parent = localctx
         previous.invokingState = state
         previous.stop = try _input.LT(-1)
@@ -722,12 +697,12 @@ open class Parser: Recognizer<ParserATNSimulator> {
     public func unrollRecursionContexts(_ _parentctx: ParserRuleContext?) throws {
         _precedenceStack.pop()
         _ctx!.stop = try _input.LT(-1)
-        let retctx: ParserRuleContext = _ctx! // save current ctx (return value)
+        let retctx = _ctx! // save current ctx (return value)
 
         // unroll so _ctx is as it was before call to recursive method
         if _parseListeners != nil {
-            while let ctxWrap = _ctx , ctxWrap !== _parentctx {
-                try  triggerExitRuleEvent()
+            while let ctxWrap = _ctx, ctxWrap !== _parentctx {
+                try triggerExitRuleEvent()
                 _ctx = ctxWrap.parent as? ParserRuleContext
             }
         } else {
@@ -744,7 +719,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     }
 
     public func getInvokingContext(_ ruleIndex: Int) -> ParserRuleContext? {
-        var p: ParserRuleContext? = _ctx
+        var p = _ctx
         while let pWrap = p {
             if pWrap.getRuleIndex() == ruleIndex {
                 return pWrap
@@ -896,11 +871,10 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// the ATN, otherwise `false`.
     /// 
     public func isExpectedToken(_ symbol: Int) throws -> Bool {
-//   		return getInterpreter().atn.nextTokens(_ctx);
-        let atn: ATN = getInterpreter().atn
-        var ctx: ParserRuleContext? = _ctx
-        let s: ATNState = atn.states[getState()]!
-        var following: IntervalSet = try  atn.nextTokens(s)
+        let atn = getInterpreter().atn
+        var ctx = _ctx
+        let s = atn.states[getState()]!
+        var following = try atn.nextTokens(s)
         if following.contains(symbol) {
             return true
         }
@@ -909,10 +883,10 @@ open class Parser: Recognizer<ParserATNSimulator> {
             return false
         }
 
-        while let ctxWrap = ctx , ctxWrap.invokingState >= 0 && following.contains(CommonToken.EPSILON) {
-            let invokingState: ATNState = atn.states[ctxWrap.invokingState]!
-            let rt: RuleTransition = invokingState.transition(0) as! RuleTransition
-            following = try  atn.nextTokens(rt.followState)
+        while let ctxWrap = ctx, ctxWrap.invokingState >= 0 && following.contains(CommonToken.EPSILON) {
+            let invokingState = atn.states[ctxWrap.invokingState]!
+            let rt = invokingState.transition(0) as! RuleTransition
+            following = try atn.nextTokens(rt.followState)
             if following.contains(symbol) {
                 return true
             }
@@ -940,18 +914,14 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
 
     public func getExpectedTokensWithinCurrentRule() throws -> IntervalSet {
-        let atn: ATN = getInterpreter().atn
-        let s: ATNState = atn.states[getState()]!
-        return try  atn.nextTokens(s)
+        let atn = getInterpreter().atn
+        let s = atn.states[getState()]!
+        return try atn.nextTokens(s)
     }
 
     /// Get a rule's index (i.e., `RULE_ruleName` field) or -1 if not found.
     public func getRuleIndex(_ ruleName: String) -> Int {
-        let ruleIndex: Int? = getRuleIndexMap()[ruleName]
-        if ruleIndex != nil {
-            return ruleIndex!
-        }
-        return -1
+        return getRuleIndexMap()[ruleName] ?? -1
     }
 
     public func getRuleContext() -> ParserRuleContext? {
@@ -965,17 +935,17 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// 
     /// This is very useful for error messages.
     /// 
-    public func getRuleInvocationStack() -> Array<String> {
+    public func getRuleInvocationStack() -> [String] {
         return getRuleInvocationStack(_ctx)
     }
 
-    public func getRuleInvocationStack(_ p: RuleContext?) -> Array<String> {
+    public func getRuleInvocationStack(_ p: RuleContext?) -> [String] {
         var p = p
-        var ruleNames: [String] = getRuleNames()
-        var stack: Array<String> = Array<String>()
+        var ruleNames = getRuleNames()
+        var stack = [String]()
         while let pWrap = p {
             // compute what follows who invoked us
-            let ruleIndex: Int = pWrap.getRuleIndex()
+            let ruleIndex = pWrap.getRuleIndex()
             if ruleIndex < 0 {
                 stack.append("n/a")
             } else {
@@ -987,16 +957,14 @@ open class Parser: Recognizer<ParserATNSimulator> {
     }
 
     /// For debugging and other purposes.
-    public func getDFAStrings() -> Array<String> {
-        var s: Array<String> = Array<String>()
+    public func getDFAStrings() -> [String] {
+        var s = [String]()
         guard let _interp = _interp  else {
             return s
         }
-        decisionToDFAMutex.synchronized {
-            [unowned self] in
-
+        decisionToDFAMutex.synchronized { [unowned self] in
             for d in 0..<_interp.decisionToDFA.count {
-                let dfa: DFA = _interp.decisionToDFA[d]
+                let dfa = _interp.decisionToDFA[d]
                 s.append(dfa.toString(self.getVocabulary()))
             }
 
@@ -1006,15 +974,13 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
     /// For debugging and other purposes.
     public func dumpDFA() {
-        guard let _interp = _interp  else {
+        guard let _interp = _interp else {
             return
         }
-        decisionToDFAMutex.synchronized {
-            [unowned self] in
-            var seenOne: Bool = false
+        decisionToDFAMutex.synchronized { [unowned self] in
+            var seenOne = false
 
-            for d in 0..<_interp.decisionToDFA.count {
-                let dfa: DFA = _interp.decisionToDFA[d]
+            for dfa in _interp.decisionToDFA {
                 if !dfa.states.isEmpty {
                     if seenOne {
                         print("")
@@ -1034,9 +1000,9 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
     override
     open func getParseInfo() -> ParseInfo? {
-        let interp: ParserATNSimulator? = getInterpreter()
-        if interp is ProfilingATNSimulator {
-            return ParseInfo(interp as! ProfilingATNSimulator)
+        let interp = getInterpreter()
+        if let interp = interp as? ProfilingATNSimulator {
+            return ParseInfo(interp)
         }
         return nil
     }
@@ -1045,16 +1011,15 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// - Since: 4.3
     /// 
     public func setProfile(_ profile: Bool) {
-        let interp: ParserATNSimulator = getInterpreter()
-        let saveMode: PredictionMode = interp.getPredictionMode()
+        let interp = getInterpreter()
+        let saveMode = interp.getPredictionMode()
         if profile {
             if !(interp is ProfilingATNSimulator) {
                 setInterpreter(ProfilingATNSimulator(self))
             }
         } else {
             if interp is ProfilingATNSimulator {
-                let sim: ParserATNSimulator =
-                ParserATNSimulator(self, getATN(), interp.decisionToDFA, interp.getSharedContextCache()!)
+                let sim = ParserATNSimulator(self, getATN(), interp.decisionToDFA, interp.getSharedContextCache()!)
                 setInterpreter(sim)
             }
         }

--- a/runtime/Swift/Sources/Antlr4/ParserInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/ParserInterpreter.swift
@@ -32,10 +32,6 @@ public class ParserInterpreter: Parser {
     internal final var sharedContextCache: PredictionContextCache =
     PredictionContextCache()
 
-    /// 
-    /// /@Deprecated
-    /// 
-    internal final var tokenNames: [String]
     internal final var ruleNames: [String]
 
     private final var vocabulary: Vocabulary
@@ -64,7 +60,6 @@ public class ParserInterpreter: Parser {
         self.grammarFileName = old.grammarFileName
         self.statesNeedingLeftRecursionContext = old.statesNeedingLeftRecursionContext
         self.decisionToDFA = old.decisionToDFA
-        self.tokenNames = old.tokenNames
         self.ruleNames = old.ruleNames
         self.vocabulary = old.vocabulary
         try  super.init(old.getTokenStream()!)
@@ -73,26 +68,11 @@ public class ParserInterpreter: Parser {
                 sharedContextCache))
     }
 
-    /// 
-    /// Use _#ParserInterpreter(String, org.antlr.v4.runtime.Vocabulary, java.util.Collection, org.antlr.v4.runtime.atn.ATN, org.antlr.v4.runtime.TokenStream)_ instead.
-    /// 
-    //@Deprecated
-    public convenience init(_ grammarFileName: String, _ tokenNames: Array<String?>?,
-                            _ ruleNames: Array<String>, _ atn: ATN, _ input: TokenStream) throws {
-        try self.init(grammarFileName, Vocabulary.fromTokenNames(tokenNames), ruleNames, atn, input)
-    }
-
     public init(_ grammarFileName: String, _ vocabulary: Vocabulary,
                 _ ruleNames: Array<String>, _ atn: ATN, _ input: TokenStream) throws {
 
         self.grammarFileName = grammarFileName
         self.atn = atn
-        self.tokenNames = [String]()//    new String[atn.maxTokenType];
-        let length = tokenNames.count
-        for i in 0..<length {
-            tokenNames[i] = vocabulary.getDisplayName(i)
-        }
-
         self.ruleNames = ruleNames
         self.vocabulary = vocabulary
         self.decisionToDFA = [DFA]() //new DFA[atn.getNumberOfDecisions()];
@@ -121,14 +101,6 @@ public class ParserInterpreter: Parser {
     override
     public func getATN() -> ATN {
         return atn
-    }
-
-//	override
-    /// 
-    /// /@Deprecated
-    /// 
-    public func getTokenNames() -> [String] {
-        return tokenNames
     }
 
     override

--- a/runtime/Swift/Sources/Antlr4/ParserInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/ParserInterpreter.swift
@@ -148,17 +148,17 @@ public class ParserInterpreter: Parser {
 
     /// Begin parsing at startRuleIndex
     public func parse(_ startRuleIndex: Int) throws -> ParserRuleContext {
-        let startRuleStartState: RuleStartState = atn.ruleToStartState[startRuleIndex]
+        let startRuleStartState = atn.ruleToStartState[startRuleIndex]
 
-        let rootContext: InterpreterRuleContext = InterpreterRuleContext(nil, ATNState.INVALID_STATE_NUMBER, startRuleIndex)
+        let rootContext = InterpreterRuleContext(nil, ATNState.INVALID_STATE_NUMBER, startRuleIndex)
         if startRuleStartState.isPrecedenceRule {
-            try    enterRecursionRule(rootContext, startRuleStartState.stateNumber, startRuleIndex, 0)
+            try enterRecursionRule(rootContext, startRuleStartState.stateNumber, startRuleIndex, 0)
         } else {
             try enterRule(rootContext, startRuleStartState.stateNumber, startRuleIndex)
         }
 
         while true {
-            let p: ATNState = getATNState()!
+            let p = getATNState()!
             switch p.getStateType() {
             case ATNState.RULE_STOP:
                 // pop; return from rule
@@ -208,7 +208,7 @@ public class ParserInterpreter: Parser {
         var altNum: Int
         if p.getNumberOfTransitions() > 1 {
             try getErrorHandler().sync(self)
-            let decision: Int = (p as! DecisionState).decision
+            let decision = (p as! DecisionState).decision
             if decision == overrideDecision && _input.index() == overrideDecisionInputIndex {
                 altNum = overrideDecisionAlt
             } else {
@@ -218,7 +218,7 @@ public class ParserInterpreter: Parser {
             altNum = 1
         }
 
-        let transition: Transition = p.transition(altNum - 1)
+        let transition = p.transition(altNum - 1)
         switch transition.getSerializationType() {
         case Transition.EPSILON:
             if try statesNeedingLeftRecursionContext.get(p.stateNumber) &&
@@ -252,9 +252,9 @@ public class ParserInterpreter: Parser {
             break
 
         case Transition.RULE:
-            let ruleStartState: RuleStartState = transition.target as! RuleStartState
-            let ruleIndex: Int = ruleStartState.ruleIndex!
-            let ctx: InterpreterRuleContext = InterpreterRuleContext(_ctx, p.stateNumber, ruleIndex)
+            let ruleStartState = transition.target as! RuleStartState
+            let ruleIndex = ruleStartState.ruleIndex!
+            let ctx = InterpreterRuleContext(_ctx, p.stateNumber, ruleIndex)
             if ruleStartState.isPrecedenceRule {
                 try enterRecursionRule(ctx, ruleStartState.stateNumber, ruleIndex, (transition as! RuleTransition).precedence)
             } else {
@@ -263,7 +263,7 @@ public class ParserInterpreter: Parser {
             break
 
         case Transition.PREDICATE:
-            let predicateTransition: PredicateTransition = transition as! PredicateTransition
+            let predicateTransition = transition as! PredicateTransition
             if try !sempred(_ctx!, predicateTransition.ruleIndex, predicateTransition.predIndex) {
 
                 throw try ANTLRException.recognition(e: FailedPredicateException(self))
@@ -273,7 +273,7 @@ public class ParserInterpreter: Parser {
             break
 
         case Transition.ACTION:
-            let actionTransition: ActionTransition = transition as! ActionTransition
+            let actionTransition = transition as! ActionTransition
             try action(_ctx, actionTransition.ruleIndex, actionTransition.actionIndex)
             break
 
@@ -294,16 +294,16 @@ public class ParserInterpreter: Parser {
     }
 
     internal func visitRuleStopState(_ p: ATNState) throws {
-        let ruleStartState: RuleStartState = atn.ruleToStartState[p.ruleIndex!]
+        let ruleStartState = atn.ruleToStartState[p.ruleIndex!]
         if ruleStartState.isPrecedenceRule {
-            let parentContext: (ParserRuleContext?, Int) = _parentContextStack.pop()
-            try unrollRecursionContexts(parentContext.0!)
-            setState(parentContext.1)
+            let (parentContext, parentState) = _parentContextStack.pop()
+            try unrollRecursionContexts(parentContext!)
+            setState(parentState)
         } else {
             try exitRule()
         }
 
-        let ruleTransition: RuleTransition = atn.states[getState()]!.transition(0) as! RuleTransition
+        let ruleTransition = atn.states[getState()]!.transition(0) as! RuleTransition
         setState(ruleTransition.followState.stateNumber)
     }
 

--- a/runtime/Swift/Sources/Antlr4/ProxyErrorListener.swift
+++ b/runtime/Swift/Sources/Antlr4/ProxyErrorListener.swift
@@ -13,10 +13,9 @@
 /// 
 
 public class ProxyErrorListener: ANTLRErrorListener {
-    private final var delegates: Array<ANTLRErrorListener>
+    private final var delegates: [ANTLRErrorListener]
 
-    public init(_ delegates: Array<ANTLRErrorListener>) {
-
+    public init(_ delegates: [ANTLRErrorListener]) {
         self.delegates = delegates
     }
 
@@ -27,7 +26,7 @@ public class ProxyErrorListener: ANTLRErrorListener {
                                _ msg: String,
                                _ e: AnyObject?)
     {
-        for listener: ANTLRErrorListener in delegates {
+        for listener in delegates {
             listener.syntaxError(recognizer, offendingSymbol, line, charPositionInLine, msg, e)
         }
     }

--- a/runtime/Swift/Sources/Antlr4/RecognitionException.swift
+++ b/runtime/Swift/Sources/Antlr4/RecognitionException.swift
@@ -18,9 +18,9 @@ public class RecognitionException<T:ATNSimulator>  {
     private final var recognizer: Recognizer<T>?
     //Recognizer<AnyObject,ATNSimulator>? ;
 
-    private final var ctx: RuleContext?
+    private final let ctx: RuleContext?
 
-    private final var input: IntStream
+    private final let input: IntStream
 
     /// 
     /// The current _org.antlr.v4.runtime.Token_ when an error occurred. Since not all streams
@@ -29,7 +29,7 @@ public class RecognitionException<T:ATNSimulator>  {
     /// 
     private var offendingToken: Token!
 
-    private var offendingState: Int = -1
+    private var offendingState = -1
 
     public var message: String?
     public init(_ recognizer: Recognizer<T>?,

--- a/runtime/Swift/Sources/Antlr4/RecognitionException.swift
+++ b/runtime/Swift/Sources/Antlr4/RecognitionException.swift
@@ -18,9 +18,9 @@ public class RecognitionException<T:ATNSimulator>  {
     private final var recognizer: Recognizer<T>?
     //Recognizer<AnyObject,ATNSimulator>? ;
 
-    private final let ctx: RuleContext?
+    private final weak var ctx: RuleContext?
 
-    private final let input: IntStream
+    private final var input: IntStream?
 
     /// 
     /// The current _org.antlr.v4.runtime.Token_ when an error occurred. Since not all streams
@@ -113,10 +113,13 @@ public class RecognitionException<T:ATNSimulator>  {
     /// where this exception was thrown, or `null` if the stream is not
     /// available.
     /// 
-    public func getInputStream() -> IntStream {
+    public func getInputStream() -> IntStream? {
         return input
     }
 
+    public func clearInputStream() {
+        input = nil
+    }
 
     public func getOffendingToken() -> Token {
         return offendingToken
@@ -136,5 +139,9 @@ public class RecognitionException<T:ATNSimulator>  {
     /// 
     public func getRecognizer() -> Recognizer<T>? {
         return recognizer
+    }
+
+    public func clearRecognizer() {
+        self.recognizer = nil
     }
 }

--- a/runtime/Swift/Sources/Antlr4/Recognizer.swift
+++ b/runtime/Swift/Sources/Antlr4/Recognizer.swift
@@ -29,8 +29,7 @@ open class Recognizer<ATNInterpreter:ATNSimulator> {
     private let ruleIndexMapCacheMutex = Mutex()
 
     open func getRuleNames() -> [String] {
-        RuntimeException(#function + " must be overridden")
-        return []
+        fatalError(#function + " must be overridden")
     }
 
     ///
@@ -102,16 +101,14 @@ open class Recognizer<ATNInterpreter:ATNSimulator> {
     /// created the interpreter from it.
     /// 
     open func getSerializedATN() -> String {
-        RuntimeException("there is no serialized ATN")
-        fatalError()
+        fatalError("there is no serialized ATN")
     }
 
     /// For debugging and other purposes, might want the grammar name.
     /// Have ANTLR generate an implementation for this method.
     /// 
     open func getGrammarFileName() -> String {
-        RuntimeException(#function + " must be overridden")
-        return ""
+        fatalError(#function + " must be overridden")
     }
 
     /// 
@@ -120,8 +117,7 @@ open class Recognizer<ATNInterpreter:ATNSimulator> {
     /// - Returns: The _org.antlr.v4.runtime.atn.ATN_ used by the recognizer for prediction.
     /// 
     open func getATN() -> ATN {
-        RuntimeException(#function + " must be overridden")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     /// 
@@ -215,22 +211,18 @@ open class Recognizer<ATNInterpreter:ATNSimulator> {
     }
 
     open func getInputStream() -> IntStream? {
-        RuntimeException(#function + "Must be overridden")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     open func setInputStream(_ input: IntStream) throws {
-        RuntimeException(#function + "Must be overridden")
-
+        fatalError(#function + " must be overridden")
     }
 
     open func getTokenFactory() -> TokenFactory {
-        RuntimeException(#function + "Must be overridden")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     open func setTokenFactory(_ input: TokenFactory) {
-        RuntimeException(#function + "Must be overridden")
-
+        fatalError(#function + " must be overridden")
     }
 }

--- a/runtime/Swift/Sources/Antlr4/Recognizer.swift
+++ b/runtime/Swift/Sources/Antlr4/Recognizer.swift
@@ -28,20 +28,6 @@ open class Recognizer<ATNInterpreter:ATNSimulator> {
     /// 
     private let ruleIndexMapCacheMutex = Mutex()
 
-    /// Used to print out token names like ID during debugging and
-    /// error reporting.  The generated parsers implement a method
-    /// that overrides this to point to their String[] tokenNames.
-    /// 
-    /// Use _#getVocabulary()_ instead.
-    /// 
-    /// 
-    /// /@Deprecated
-    /// 
-    open func getTokenNames() -> [String?]? {
-        RuntimeException(#function + " must be overridden")
-        return []
-    }
-
     open func getRuleNames() -> [String] {
         RuntimeException(#function + " must be overridden")
         return []
@@ -54,7 +40,7 @@ open class Recognizer<ATNInterpreter:ATNSimulator> {
     /// vocabulary used by the grammar.
     /// 
     open func getVocabulary() -> Vocabulary {
-        return Vocabulary.fromTokenNames(getTokenNames())
+        fatalError(#function + " must be overridden")
     }
 
     /// 
@@ -174,43 +160,6 @@ open class Recognizer<ATNInterpreter:ATNSimulator> {
         let line = offending.getLine()
         let charPositionInLine = offending.getCharPositionInLine()
         return "line \(line):\(charPositionInLine)"
-    }
-
-    /// How should a token be displayed in an error message? The default
-    /// is to display just the text, but during development you might
-    /// want to have a lot of information spit out.  Override in that case
-    /// to use t.toString() (which, for CommonToken, dumps everything about
-    /// the token). This is better than forcing you to override a method in
-    /// your token objects because you don't have to go modify your lexer
-    /// so that it creates a new Java type.
-    /// 
-    /// This method is not called by the ANTLR 4 Runtime. Specific
-    /// implementations of _org.antlr.v4.runtime.ANTLRErrorStrategy_ may provide a similar
-    /// feature when necessary. For example, see
-    /// _org.antlr.v4.runtime.DefaultErrorStrategy#getTokenErrorDisplay_.
-    /// 
-    /// 
-    /// /@Deprecated
-    /// 
-    open func getTokenErrorDisplay(_ t: Token?) -> String {
-        guard let t = t else {
-            return "<no token>"
-        }
-        var s: String
-
-        if let text = t.getText() {
-            s = text
-        } else {
-            if t.getType() == CommonToken.EOF {
-                s = "<EOF>"
-            } else {
-                s = "<\(t.getType())>"
-            }
-        }
-        s = s.replacingOccurrences(of: "\n", with: "\\n")
-        s = s.replacingOccurrences(of: "\r", with: "\\r")
-        s = s.replacingOccurrences(of: "\t", with: "\\t")
-        return "\(s)"
     }
 
     open func addErrorListener(_ listener: ANTLRErrorListener) {

--- a/runtime/Swift/Sources/Antlr4/RuleContext.swift
+++ b/runtime/Swift/Sources/Antlr4/RuleContext.swift
@@ -56,7 +56,7 @@
 /// 
 
 open class RuleContext: RuleNode {
-    public static let EMPTY: ParserRuleContext = ParserRuleContext()
+    public static let EMPTY = ParserRuleContext()
 
     /// What context invoked this rule?
     public var parent: RuleContext?
@@ -66,7 +66,8 @@ open class RuleContext: RuleNode {
     /// If parent is null, this should be -1 this context object represents
     /// the start rule.
     /// 
-    public var invokingState: Int = -1
+    public var invokingState = -1
+
     override
     public init() {
         super.init()
@@ -79,7 +80,7 @@ open class RuleContext: RuleNode {
     }
 
     open func depth() -> Int {
-        var n: Int = 0
+        var n = 0
         var p: RuleContext? = self
         while let pWrap = p {
             p = pWrap.parent
@@ -131,7 +132,7 @@ open class RuleContext: RuleNode {
             return ""
         }
 
-        let builder: StringBuilder = StringBuilder()
+        let builder = StringBuilder()
         for i in 0..<length {
             builder.append((getChild(i) as! ParseTree).getText())
         }
@@ -159,54 +160,10 @@ open class RuleContext: RuleNode {
         return visitor.visitChildren(self)
     }
 
-//     /// Call this method to view a parse tree in a dialog box visually.
-//     public func inspect(parser : Parser) -> Future<JDialog> {
-//         var ruleNames : Array<String> = parser != nil ? Arrays.asList(parser.getRuleNames()) : null;
-//         return inspect(ruleNames);
-//     }
-//
-//     public func inspect(ruleNames : Array<String>) -> Future<JDialog> {
-//         var viewer : TreeViewer = TreeViewer(ruleNames, self);
-//         return viewer.open();
-//     }
-//
-//     /// Save this tree in a postscript file
-//     public func save(parser : Parser, _ fileName : String)
-//         throws; IOException, PrintException
-//     {
-//         var ruleNames : Array<String> = parser != nil ? Arrays.asList(parser.getRuleNames()) : null;
-//         save(ruleNames, fileName);
-//     }
-//
-//     /// Save this tree in a postscript file using a particular font name and size
-//     public func save(parser : Parser, _ fileName : String,
-//                      _ fontName : String, _ fontSize : Int)
-//         throws; IOException
-//     {
-//         var ruleNames : Array<String> = parser != nil ? Arrays.asList(parser.getRuleNames()) : null;
-//         save(ruleNames, fileName, fontName, fontSize);
-//     }
-//
-//     /// Save this tree in a postscript file
-//     public func save(ruleNames : Array<String>, _ fileName : String)
-//         throws; IOException, PrintException
-//     {
-//         Trees.writePS(self, ruleNames, fileName);
-//     }
-//
-//     /// Save this tree in a postscript file using a particular font name and size
-//     public func save(ruleNames : Array<String>, _ fileName : String,
-//                      _ fontName : String, _ fontSize : Int)
-//         throws; IOException
-//     {
-//         Trees.writePS(self, ruleNames, fileName, fontName, fontSize);
-//     }
- 
     /// Print out a whole tree, not just a node, in LISP format
     /// (root child1 .. childN). Print just a node if this is a leaf.
     /// We have to know the recognizer so we can get rule names.
-    /// 
-
+    ///
     open override func toStringTree(_ recog: Parser) -> String {
         return Trees.toStringTree(self, recog)
     }
@@ -214,19 +171,16 @@ open class RuleContext: RuleNode {
     /// Print out a whole tree, not just a node, in LISP format
     /// (root child1 .. childN). Print just a node if this is a leaf.
     /// 
-    public func toStringTree(_ ruleNames: Array<String>?) -> String {
+    public func toStringTree(_ ruleNames: [String]?) -> String {
         return Trees.toStringTree(self, ruleNames)
     }
 
-
     open override func toStringTree() -> String {
-        let info: Array<String>? = nil
-        return toStringTree(info)
+        return toStringTree(nil)
     }
+
     open override var description: String {
-        let p1: Array<String>? = nil
-        let p2: RuleContext? = nil
-        return toString(p1, p2)
+        return toString(nil, nil)
     }
 
      open override var debugDescription: String {
@@ -237,31 +191,31 @@ open class RuleContext: RuleNode {
         return toString(recog, ParserRuleContext.EMPTY)
     }
 
-    public final func toString(_ ruleNames: Array<String>) -> String {
+    public final func toString(_ ruleNames: [String]) -> String {
         return toString(ruleNames, nil)
     }
 
     // recog null unless ParserRuleContext, in which case we use subclass toString(...)
     open func toString<T>(_ recog: Recognizer<T>?, _ stop: RuleContext) -> String {
-        let ruleNames: [String]? = recog != nil ? recog!.getRuleNames() : nil
-        let ruleNamesList: Array<String>? = ruleNames ?? nil
-        return toString(ruleNamesList, stop)
+        let ruleNames = recog?.getRuleNames()
+        return toString(ruleNames, stop)
     }
 
-    open func toString(_ ruleNames: Array<String>?, _ stop: RuleContext?) -> String {
-        let buf: StringBuilder = StringBuilder()
+    open func toString(_ ruleNames: [String]?, _ stop: RuleContext?) -> String {
+        let buf = StringBuilder()
         var p: RuleContext? = self
         buf.append("[")
-        while let pWrap = p , pWrap !== stop {
-            if ruleNames == nil {
+        while let pWrap = p, pWrap !== stop {
+            if let ruleNames = ruleNames {
+                let ruleIndex = pWrap.getRuleIndex()
+                let ruleIndexInRange = (ruleIndex >= 0 && ruleIndex < ruleNames.count)
+                let ruleName = (ruleIndexInRange ? ruleNames[ruleIndex] : String(ruleIndex))
+                buf.append(ruleName)
+            }
+            else {
                 if !pWrap.isEmpty() {
                     buf.append(pWrap.invokingState)
                 }
-            } else {
-                let ruleIndex: Int = pWrap.getRuleIndex()
-                let ruleIndexInRange: Bool =  ruleIndex >= 0 && ruleIndex < ruleNames!.count
-                let ruleName: String = ruleIndexInRange ? ruleNames![ruleIndex] : String(ruleIndex)
-                buf.append(ruleName)
             }
 
             if pWrap.parent != nil && (ruleNames != nil || !pWrap.parent!.isEmpty()) {

--- a/runtime/Swift/Sources/Antlr4/RuleContext.swift
+++ b/runtime/Swift/Sources/Antlr4/RuleContext.swift
@@ -59,7 +59,7 @@ open class RuleContext: RuleNode {
     public static let EMPTY = ParserRuleContext()
 
     /// What context invoked this rule?
-    public var parent: RuleContext?
+    public weak var parent: RuleContext?
 
     /// What state invoked the rule associated with this context?
     /// The "return address" is the followState of invokingState

--- a/runtime/Swift/Sources/Antlr4/Token.swift
+++ b/runtime/Swift/Sources/Antlr4/Token.swift
@@ -98,5 +98,7 @@ public protocol Token: class, CustomStringConvertible {
     /// 
     func getInputStream() -> CharStream?
 
+    func getTokenSourceAndStream() -> TokenSourceAndStream
+
     var visited: Bool { get set }
 }

--- a/runtime/Swift/Sources/Antlr4/TokenFactory.swift
+++ b/runtime/Swift/Sources/Antlr4/TokenFactory.swift
@@ -15,10 +15,33 @@ public protocol TokenFactory {
     /// error handling strategy. If text!=null, than the start and stop positions
     /// are wiped to -1 in the text override is set in the CommonToken.
     /// 
-    func create(_ source: (TokenSource?, CharStream?), _ type: Int, _ text: String?,
+    func create(_ source: TokenSourceAndStream, _ type: Int, _ text: String?,
                 _ channel: Int, _ start: Int, _ stop: Int,
                 _ line: Int, _ charPositionInLine: Int) -> Token
     /// Generically useful
     func create(_ type: Int, _ text: String) -> Token
 
+}
+
+
+/**
+ Holds the references to the TokenSource and CharStream used to create a Token.
+ These are together to reduce memory footprint by having one instance of
+ TokenSourceAndStream shared across many tokens.  The references here are weak
+ to avoid retain cycles.
+ */
+public class TokenSourceAndStream {
+    ///
+    /// An empty TokenSourceAndStream which is used as the default value of
+    /// _#source_ for tokens that do not have a source.
+    ///
+    public static let EMPTY = TokenSourceAndStream()
+
+    public weak var tokenSource: TokenSource?
+    public weak var stream: CharStream?
+
+    public init(_ tokenSource: TokenSource? = nil, _ stream: CharStream? = nil) {
+        self.tokenSource = tokenSource
+        self.stream = stream
+    }
 }

--- a/runtime/Swift/Sources/Antlr4/TokenFactory.swift
+++ b/runtime/Swift/Sources/Antlr4/TokenFactory.swift
@@ -8,7 +8,6 @@
 /// the error handling strategy (to create missing tokens).  Notifying the parser
 /// of a new factory means that it notifies it's token source and error strategy.
 /// 
-
 public protocol TokenFactory {
 
     //typealias Symbol

--- a/runtime/Swift/Sources/Antlr4/UnbufferedCharStream.swift
+++ b/runtime/Swift/Sources/Antlr4/UnbufferedCharStream.swift
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+
+import Foundation
+
+
+/** Do not buffer up the entire char stream. It does keep a small buffer
+ *  for efficiency and also buffers while a mark exists (set by the
+ *  lookahead prediction in parser). "Unbuffered" here refers to fact
+ *  that it doesn't buffer all data, not that's it's on demand loading of char.
+ *
+ *  Before 4.7, this class used the default environment encoding to convert
+ *  bytes to UTF-16, and held the UTF-16 bytes in the buffer as chars.
+ *
+ *  As of 4.7, the class uses UTF-8 by default, and the buffer holds Unicode
+ *  code points in the buffer as ints.
+ */
+open class UnbufferedCharStream: CharStream {
+    /**
+     * A moving window buffer of the data being scanned. While there's a marker,
+     * we keep adding to buffer. Otherwise, {@link #consume consume()} resets so
+     * we start filling at index 0 again.
+     */
+    internal var data: [Int]
+
+    /**
+     * The number of characters currently in {@link #data data}.
+     *
+     * <p>This is not the buffer capacity, that's {@code data.length}.</p>
+     */
+    internal var n = 0
+
+    /**
+     * 0..n-1 index into {@link #data data} of next character.
+     *
+     * <p>The {@code LA(1)} character is {@code data[p]}. If {@code p == n}, we are
+     * out of buffered characters.</p>
+     */
+    internal var p = 0
+
+    /**
+     * Count up with {@link #mark mark()} and down with
+     * {@link #release release()}. When we {@code release()} the last mark,
+     * {@code numMarkers} reaches 0 and we reset the buffer. Copy
+     * {@code data[p]..data[n-1]} to {@code data[0]..data[(n-1)-p]}.
+     */
+    internal var numMarkers = 0
+
+    /**
+     * This is the {@code LA(-1)} character for the current position.
+     */
+    internal var lastChar = -1
+
+    /**
+     * When {@code numMarkers > 0}, this is the {@code LA(-1)} character for the
+     * first character in {@link #data data}. Otherwise, this is unspecified.
+     */
+    internal var lastCharBufferStart = 0
+
+    /**
+     * Absolute character index. It's the index of the character about to be
+     * read via {@code LA(1)}. Goes from 0 to the number of characters in the
+     * entire stream, although the stream size is unknown before the end is
+     * reached.
+     */
+    internal var currentCharIndex = 0
+
+    internal let input: InputStream
+    private var unicodeIterator: UnicodeScalarStreamIterator
+
+
+    /** The name or source of this char stream. */
+    public var name: String = ""
+
+    public init(_ input: InputStream, _ bufferSize: Int = 256) {
+        self.input = input
+        self.data = [Int](repeating: 0, count: bufferSize)
+        let si = UInt8StreamIterator(input)
+        self.unicodeIterator = UnicodeScalarStreamIterator(si)
+    }
+
+    public func consume() throws {
+        if try LA(1) == CommonToken.EOF {
+            throw ANTLRError.illegalState(msg: "cannot consume EOF")
+        }
+
+        // buf always has at least data[p==0] in this method due to ctor
+        lastChar = data[p]   // track last char for LA(-1)
+
+        if p == n - 1 && numMarkers == 0 {
+            n = 0
+            p = -1 // p++ will leave this at 0
+            lastCharBufferStart = lastChar
+        }
+
+        p += 1
+        currentCharIndex += 1
+        sync(1)
+    }
+
+    /**
+     * Make sure we have 'need' elements from current position {@link #p p}.
+     * Last valid {@code p} index is {@code data.length-1}. {@code p+need-1} is
+     * the char index 'need' elements ahead. If we need 1 element,
+     * {@code (p+1-1)==p} must be less than {@code data.length}.
+     */
+    internal func sync(_ want: Int) {
+        let need = (p + want - 1) - n + 1 // how many more elements we need?
+        if need > 0 {
+            fill(need)
+        }
+    }
+
+    /**
+     * Add {@code n} characters to the buffer. Returns the number of characters
+     * actually added to the buffer. If the return value is less than {@code n},
+     * then EOF was reached before {@code n} characters could be added.
+     */
+    @discardableResult internal func fill(_ toAdd: Int) -> Int {
+        for i in 0 ..< toAdd {
+            if n > 0 && data[n - 1] == CommonToken.EOF {
+                return i
+            }
+
+            guard let c = nextChar() else {
+                return i
+            }
+            add(c)
+        }
+
+        return n
+    }
+
+    /**
+     * Override to provide different source of characters than
+     * {@link #input input}.
+     */
+    internal func nextChar() -> Int? {
+        if let next = unicodeIterator.next() {
+            return Int(next.value)
+        }
+        else if unicodeIterator.hasErrorOccurred {
+            return nil
+        }
+        else {
+            return nil
+        }
+    }
+
+    internal func add(_ c: Int) {
+        if n >= data.count {
+            data += [Int](repeating: 0, count: data.count)
+        }
+        data[n] = c
+        n += 1
+    }
+
+    public func LA(_ i: Int) throws -> Int {
+        let result = try LA_(i)
+        print("LA(\(i)) -> \(result)")
+        return result
+    }
+
+    private func LA_(_ i: Int) throws -> Int {
+
+        if i == -1 {
+            return lastChar // special case
+        }
+        sync(i)
+        let index = p + i - 1
+        if index < 0 {
+            throw ANTLRError.indexOutOfBounds(msg: "")
+        }
+        if index >= n {
+            return CommonToken.EOF
+        }
+        return data[index]
+    }
+
+    /**
+     * Return a marker that we can release later.
+     *
+     * <p>The specific marker value used for this class allows for some level of
+     * protection against misuse where {@code seek()} is called on a mark or
+     * {@code release()} is called in the wrong order.</p>
+     */
+    public func mark() -> Int {
+        if numMarkers == 0 {
+            lastCharBufferStart = lastChar
+        }
+
+        let mark = -numMarkers - 1
+        numMarkers += 1
+        return mark
+    }
+
+    /** Decrement number of markers, resetting buffer if we hit 0.
+     * @param marker
+     */
+    public func release(_ marker: Int) throws {
+        let expectedMark = -numMarkers
+        if marker != expectedMark {
+            preconditionFailure("release() called with an invalid marker.")
+        }
+
+        numMarkers -= 1
+        if numMarkers == 0 && p > 0 {
+            // release buffer when we can, but don't do unnecessary work
+
+            // Copy data[p]..data[n-1] to data[0]..data[(n-1)-p], reset ptrs
+            // p is last valid char; move nothing if p==n as we have no valid char
+            let dataCapacity = data.capacity
+            data = Array(data[p ..< n])
+            data += [Int](repeating: 0, count: dataCapacity - (n - p))
+            precondition(data.capacity == dataCapacity)
+            n = n - p
+            p = 0
+            lastCharBufferStart = lastChar
+        }
+    }
+
+    public func index() -> Int {
+        return currentCharIndex
+    }
+
+    /** Seek to absolute character index, which might not be in the current
+     *  sliding window.  Move {@code p} to {@code index-bufferStartIndex}.
+     */
+    public func seek(_ index_: Int) throws {
+        var index = index_
+
+        if index == currentCharIndex {
+            return
+        }
+
+        if index > currentCharIndex {
+            sync(index - currentCharIndex)
+            index = min(index, getBufferStartIndex() + n - 1)
+        }
+
+        // index == to bufferStartIndex should set p to 0
+        let i = index - getBufferStartIndex()
+        if i < 0 {
+            throw ANTLRError.illegalArgument(msg: "cannot seek to negative index \(index)")
+        }
+        else if i >= n {
+            let si = getBufferStartIndex()
+            let ei = si + n
+            let msg = "seek to index outside buffer: \(index) not in \(si)..\(ei)"
+            throw ANTLRError.unsupportedOperation(msg: msg)
+        }
+
+        p = i
+        currentCharIndex = index
+        if p == 0 {
+            lastChar = lastCharBufferStart
+        }
+        else {
+            lastChar = data[p - 1]
+        }
+    }
+
+    public func size() -> Int {
+        preconditionFailure("Unbuffered stream cannot know its size")
+    }
+
+    public func getSourceName() -> String {
+        return name
+    }
+
+    public func getText(_ interval: Interval) throws -> String {
+        if interval.a < 0 || interval.b < interval.a - 1 {
+            throw ANTLRError.illegalArgument(msg: "invalid interval")
+        }
+
+        let bufferStartIndex = getBufferStartIndex()
+        if n > 0 &&
+            data[n - 1] == CommonToken.EOF &&
+            interval.a + interval.length() > bufferStartIndex + n {
+            throw ANTLRError.illegalArgument(msg: "the interval extends past the end of the stream")
+        }
+
+        if interval.a < bufferStartIndex || interval.b >= bufferStartIndex + n {
+            let msg = "interval \(interval) outside buffer: \(bufferStartIndex)...\(bufferStartIndex + n - 1)"
+            throw ANTLRError.unsupportedOperation(msg: msg)
+        }
+
+        if interval.b < interval.a {
+            // The EOF token.
+            return ""
+        }
+
+        // convert from absolute to local index
+        let i = interval.a - bufferStartIndex
+        let j = interval.b - bufferStartIndex
+
+        // Convert from Int codepoints to a String.
+        let codepoints = data[i ... j].map { Character(Unicode.Scalar($0)!) }
+        return String(codepoints)
+    }
+
+    internal func getBufferStartIndex() -> Int {
+        return currentCharIndex - p
+    }
+}
+
+
+fileprivate struct UInt8StreamIterator: IteratorProtocol {
+    private static let bufferSize = 1024
+
+    private let stream: InputStream
+    private var buffer = [UInt8](repeating: 0, count: UInt8StreamIterator.bufferSize)
+    private var buffGen: IndexingIterator<ArraySlice<UInt8>>
+
+    var hasErrorOccurred = false
+
+
+    init(_ stream: InputStream) {
+        self.stream = stream
+        self.buffGen = buffer[0..<0].makeIterator()
+    }
+
+    mutating func next() -> UInt8? {
+        if let result = buffGen.next() {
+            return result
+        }
+
+        if hasErrorOccurred {
+            return nil
+        }
+
+        switch stream.streamStatus {
+        case .notOpen, .writing, .closed:
+            preconditionFailure()
+        case .atEnd:
+            return nil
+        case .error:
+            hasErrorOccurred = true
+            return nil
+        case .opening, .open, .reading:
+            break
+        }
+
+        let count = stream.read(&buffer, maxLength: buffer.capacity)
+        if count <= 0 {
+            hasErrorOccurred = true
+            return nil
+        }
+
+        buffGen = buffer.prefix(count).makeIterator()
+        return buffGen.next()
+    }
+}
+
+
+fileprivate struct UnicodeScalarStreamIterator: IteratorProtocol {
+    private var streamIterator: UInt8StreamIterator
+    private var codec = Unicode.UTF8()
+
+    var hasErrorOccurred = false
+
+    init(_ streamIterator: UInt8StreamIterator) {
+        self.streamIterator = streamIterator
+    }
+
+    mutating func next() -> Unicode.Scalar? {
+        if streamIterator.hasErrorOccurred {
+            hasErrorOccurred = true
+            return nil
+        }
+
+        switch codec.decode(&streamIterator) {
+        case .scalarValue(let scalar):
+            return scalar
+        case .emptyInput:
+            return nil
+        case .error:
+            hasErrorOccurred = true
+            return nil
+        }
+    }
+}

--- a/runtime/Swift/Sources/Antlr4/UnbufferedTokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/UnbufferedTokenStream.swift
@@ -4,7 +4,7 @@
  */
 
 
-public class UnbufferedTokenStream<T>: TokenStream {
+public class UnbufferedTokenStream: TokenStream {
     internal var tokenSource: TokenSource
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/UnbufferedTokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/UnbufferedTokenStream.swift
@@ -274,10 +274,7 @@ public class UnbufferedTokenStream: TokenStream {
 
 
     public func size() -> Int {
-
-        RuntimeException("Unbuffered stream cannot know its size")
-        fatalError()
-
+        fatalError("Unbuffered stream cannot know its size")
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/atn/ATNConfigSet.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNConfigSet.swift
@@ -27,7 +27,7 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
     /// fields; in particular, conflictingAlts is set after
     /// we've made this readonly.
     ///
-    internal final var readonly: Bool = false
+    internal final var readonly = false
 
     /// 
     /// All configs but hashed by (s, i, _, pi) not including context. Wiped out
@@ -38,11 +38,11 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
     /// 
     /// Track the elements as they are added to the set; supports get(i)
     /// 
-    public final var configs: Array<ATNConfig> = Array<ATNConfig>()
+    public final var configs = [ATNConfig]()
 
     // TODO: these fields make me pretty uncomfortable but nice to pack up info together, saves recomputation
     // TODO: can we track conflicts as they are added to save scanning configs later?
-    public final var uniqueAlt: Int = 0
+    public final var uniqueAlt = 0
     //TODO no default
     /// 
     /// Currently this is only used when we detect SLL conflict; this does
@@ -54,9 +54,9 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
 
     // Used in parser and lexer. In lexer, it indicates we hit a pred
     // while computing a closure operation.  Don't make a DFA state from this.
-    public final var hasSemanticContext: Bool = false
+    public final var hasSemanticContext = false
     //TODO no default
-    public final var dipsIntoOuterContext: Bool = false
+    public final var dipsIntoOuterContext = false
     //TODO no default
 
     /// 
@@ -66,7 +66,7 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
     /// 
     public final var fullCtx: Bool
 
-    private var cachedHashCode: Int = -1
+    private var cachedHashCode = -1
 
     public init(_ fullCtx: Bool) {
         configLookup = LookupDictionary()
@@ -125,10 +125,9 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
                 return true
             }
             // a previous (s,i,pi,_), merge with it and save result
-            let rootIsWildcard: Bool = !fullCtx
+            let rootIsWildcard = !fullCtx
 
-            let merged: PredictionContext =
-            PredictionContext.merge(existing.context!, config.context!, rootIsWildcard, &mergeCache)
+            let merged = PredictionContext.merge(existing.context!, config.context!, rootIsWildcard, &mergeCache)
 
             // no need to check for existing.context, config.context in cache
             // since only way to create new graphs is "call rule" and here. We
@@ -154,14 +153,14 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
     /// 
     /// Return a List holding list of configs
     /// 
-    public final func elements() -> Array<ATNConfig> {
+    public final func elements() -> [ATNConfig] {
         return configs
     }
 
     public final func getStates() -> Set<ATNState> {
 
         let length = configs.count
-        var states: Set<ATNState> = Set<ATNState>(minimumCapacity: length)
+        var states = Set<ATNState>(minimumCapacity: length)
         for i in 0..<length {
             states.insert(configs[i].state)
         }
@@ -177,7 +176,7 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
     /// - since: 4.3
     /// 
     public final func getAlts() throws -> BitSet {
-        let alts: BitSet = BitSet()
+        let alts = BitSet()
         let length = configs.count
         for i in 0..<length {
             try alts.set(configs[i].alt)
@@ -185,8 +184,8 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
         return alts
     }
 
-    public final func getPredicates() -> Array<SemanticContext> {
-        var preds: Array<SemanticContext> = Array<SemanticContext>()
+    public final func getPredicates() -> [SemanticContext] {
+        var preds = [SemanticContext]()
         let length = configs.count
         for i in 0..<length {
             if configs[i].semanticContext != SemanticContext.NONE {
@@ -217,8 +216,8 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
 
     @discardableResult
     public final func addAll(_ coll: ATNConfigSet) throws -> Bool {
-        for c: ATNConfig in coll.configs {
-            try  add(c)
+        for c in coll.configs {
+            try add(c)
         }
         return false
     }
@@ -284,7 +283,7 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
     }
 
     public var description: String {
-        let buf: StringBuilder = StringBuilder()
+        let buf = StringBuilder()
         buf.append(elements().map({ $0.description }))
         if hasSemanticContext {
             buf.append(",hasSemanticContext=")
@@ -321,7 +320,7 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
 
     public final func getConflictingAltSubsets() throws -> Array<BitSet> {
         let length = configs.count
-        let configToAlts: HashMap<Int, BitSet> = HashMap<Int, BitSet>(count: length)
+        let configToAlts = HashMap<Int, BitSet>(count: length)
 
         for i in 0..<length {
             let hash = configHash(configs[i].state.stateNumber, configs[i].context)
@@ -586,9 +585,8 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
     }
 
     public final var allConfigsInRuleStopStates: Bool {
-        let length = configs.count
-        for i in 0..<length {
-            if !(configs[i].state is RuleStopState) {
+        for config in configs {
+            if !(config.state is RuleStopState) {
                 return false
             }
         }

--- a/runtime/Swift/Sources/Antlr4/atn/ATNDeserializer.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNDeserializer.swift
@@ -117,26 +117,24 @@ public class ATNDeserializer {
         }
 
         var p: Int = 0
-        let version: Int = data[p].unicodeValue    //toInt(data[p++]);
+        let version = data[p].unicodeValue
         p += 1
         if version != ATNDeserializer.SERIALIZED_VERSION {
-
-            let reason: String = "Could not deserialize ATN with version \(version) (expected \(ATNDeserializer.SERIALIZED_VERSION))."
-
+            let reason = "Could not deserialize ATN with version \(version) (expected \(ATNDeserializer.SERIALIZED_VERSION))."
             throw ANTLRError.unsupportedOperation(msg: reason)
         }
 
         let uuid: UUID = toUUID(data, p)
         p += 8
         if !ATNDeserializer.SUPPORTED_UUIDS.contains(uuid) {
-            let reason: String = "Could not deserialize ATN with UUID \(uuid) (expected \(ATNDeserializer.SERIALIZED_UUID) or a legacy UUID)."
+            let reason = "Could not deserialize ATN with UUID \(uuid) (expected \(ATNDeserializer.SERIALIZED_UUID) or a legacy UUID)."
             throw ANTLRError.unsupportedOperation(msg: reason)
         }
 
-        let supportsPrecedencePredicates: Bool = isFeatureSupported(ATNDeserializer.ADDED_PRECEDENCE_TRANSITIONS, uuid)
-        let supportsLexerActions: Bool = isFeatureSupported(ATNDeserializer.ADDED_LEXER_ACTIONS, uuid)
+        let supportsPrecedencePredicates = isFeatureSupported(ATNDeserializer.ADDED_PRECEDENCE_TRANSITIONS, uuid)
+        let supportsLexerActions = isFeatureSupported(ATNDeserializer.ADDED_LEXER_ACTIONS, uuid)
 
-        let grammarType: ATNType = ATNType(rawValue: toInt(data[p]))!
+        let grammarType = ATNType(rawValue: toInt(data[p]))!
         p += 1
         let maxTokenType: Int = toInt(data[p])
         p += 1
@@ -145,12 +143,12 @@ public class ATNDeserializer {
         //
         // STATES
         //
-        var loopBackStateNumbers: Array<(LoopEndState, Int)> = Array<(LoopEndState, Int)>()
-        var endStateNumbers: Array<(BlockStartState, Int)> = Array<(BlockStartState, Int)>()
-        let nstates: Int = toInt(data[p])
+        var loopBackStateNumbers = [(LoopEndState, Int)]()
+        var endStateNumbers = [(BlockStartState, Int)]()
+        let nstates = toInt(data[p])
         p += 1
         for _ in 0..<nstates {
-            let stype: Int = toInt(data[p])
+            let stype = toInt(data[p])
             p += 1
             // ignore bad type of states
             if stype == ATNState.INVALID_TYPE {
@@ -158,25 +156,23 @@ public class ATNDeserializer {
                 continue
             }
 
-            var ruleIndex: Int = toInt(data[p])
+            var ruleIndex = toInt(data[p])
             p += 1
             if ruleIndex == Int.max {
                 // Character.MAX_VALUE
                 ruleIndex = -1
             }
 
-            let s: ATNState = try stateFactory(stype, ruleIndex)!
+            let s = try stateFactory(stype, ruleIndex)!
             if stype == ATNState.LOOP_END {
                 // special case
-                let loopBackStateNumber: Int = toInt(data[p])
+                let loopBackStateNumber = toInt(data[p])
                 p += 1
                 loopBackStateNumbers.append((s as! LoopEndState, loopBackStateNumber))
-            } else {
-                if let s = s as? BlockStartState {
-                    let endStateNumber: Int = toInt(data[p])
-                    p += 1
-                    endStateNumbers.append((s, endStateNumber))
-                }
+            } else if let s = s as? BlockStartState {
+                let endStateNumber = toInt(data[p])
+                p += 1
+                endStateNumbers.append((s, endStateNumber))
             }
             atn.addState(s)
         }
@@ -549,15 +545,15 @@ public class ATNDeserializer {
     }
 
     private func readSets(_ data: [Character], _ p: inout Int, _ sets: inout Array<IntervalSet>, _ readUnicode: ([Character], inout Int) -> Int) throws {
-        let nsets: Int = toInt(data[p])
+        let nsets = toInt(data[p])
         p += 1
         for _ in 0..<nsets {
-            let nintervals: Int = toInt(data[p])
+            let nintervals = toInt(data[p])
             p += 1
-            let set: IntervalSet = try IntervalSet()
+            let set = try IntervalSet()
             sets.append(set)
 
-            let containsEof: Bool = toInt(data[p]) != 0
+            let containsEof = (toInt(data[p]) != 0)
             p += 1
             if containsEof {
                 try set.add(-1)
@@ -724,22 +720,22 @@ public class ATNDeserializer {
         //
         // SETS
         //
-        var sets: Array<IntervalSet> = Array<IntervalSet>()
-        let nsets: Int = dict["nsets"] as! Int
+        var sets = [IntervalSet]()
+        let nsets = dict["nsets"] as! Int
         let intervalSet = dict["IntervalSet"] as! [Dictionary<String, Any>]
 
         for i in 0..<nsets {
             let setBuilder = intervalSet[i]
-            let nintervals: Int = setBuilder["size"] as! Int
+            let nintervals = setBuilder["size"] as! Int
 
-            let set: IntervalSet = try IntervalSet()
+            let set = try IntervalSet()
             sets.append(set)
 
-            let containsEof: Bool = (setBuilder["containsEof"] as! Int) != 0
+            let containsEof = (setBuilder["containsEof"] as! Int) != 0
             if containsEof {
                 try set.add(-1)
             }
-            let intervalsBuilder = setBuilder["Intervals"] as! [Dictionary<String, Any>]
+            let intervalsBuilder = setBuilder["Intervals"] as! [[String : Any]]
 
 
             for j in 0..<nintervals {
@@ -759,15 +755,15 @@ public class ATNDeserializer {
         for transitionsBuilder in allTransitions {
 
             for transition in transitionsBuilder {
-                let src: Int = transition["src"] as! Int
-                let trg: Int = transition["trg"] as! Int
-                let ttype: Int = transition["edgeType"] as! Int
-                let arg1: Int = transition["arg1"] as! Int
-                let arg2: Int = transition["arg2"] as! Int
-                let arg3: Int = transition["arg3"] as! Int
-                let trans: Transition = try edgeFactory(atn, ttype, src, trg, arg1, arg2, arg3, sets)
+                let src = transition["src"] as! Int
+                let trg = transition["trg"] as! Int
+                let ttype = transition["edgeType"] as! Int
+                let arg1 = transition["arg1"] as! Int
+                let arg2 = transition["arg2"] as! Int
+                let arg3 = transition["arg3"] as! Int
+                let trans = try edgeFactory(atn, ttype, src, trg, arg1, arg2, arg3, sets)
 
-                let srcState: ATNState = atn.states[src]!
+                let srcState = atn.states[src]!
                 srcState.addTransition(trans)
             }
 
@@ -775,13 +771,13 @@ public class ATNDeserializer {
 
 
         // edges for rule stop states can be derived, so they aren't serialized
-        for state: ATNState? in atn.states {
-            if let state =  state {
+        for state in atn.states {
+            if let state = state {
                 let length = state.getNumberOfTransitions()
                 for i in 0..<length {
-                    let t: Transition = state.transition(i)
+                    let t = state.transition(i)
                     if let ruleTransition = t as? RuleTransition {
-                        var outermostPrecedenceReturn: Int = -1
+                        var outermostPrecedenceReturn = -1
                         if let targetRuleIndex = ruleTransition.target.ruleIndex {
                             if atn.ruleToStartState[targetRuleIndex].isPrecedenceRule {
                                 if ruleTransition.precedence == 0 {
@@ -789,7 +785,7 @@ public class ATNDeserializer {
                                 }
                             }
 
-                            let returnTransition: EpsilonTransition = EpsilonTransition(ruleTransition.followState, outermostPrecedenceReturn)
+                            let returnTransition = EpsilonTransition(ruleTransition.followState, outermostPrecedenceReturn)
                             atn.ruleToStopState[targetRuleIndex].addTransition(returnTransition)
                         }
                     }
@@ -797,39 +793,36 @@ public class ATNDeserializer {
             }
         }
 
-        for state: ATNState? in atn.states {
+        for state in atn.states {
             if let state = state as? BlockStartState {
                 // we need to know the end state to set its start state
                 if let stateEndState = state.endState {
                     // block end states can only be associated to a single block start state
                     if stateEndState.startState != nil {
                         throw ANTLRError.illegalState(msg: "state.endState.startState != nil")
-
                     }
                     stateEndState.startState = state
                 }
                 else {
                     throw ANTLRError.illegalState(msg: "state.endState == nil")
                 }
-
-
             }
 
             if let loopbackState = state as? PlusLoopbackState {
                 let length = loopbackState.getNumberOfTransitions()
                 for i in 0..<length {
-                    let target: ATNState = loopbackState.transition(i).target
-                    if target is PlusBlockStartState {
-                        (target as! PlusBlockStartState).loopBackState = loopbackState
+                    let target = loopbackState.transition(i).target
+                    if let startState = target as? PlusBlockStartState {
+                        startState.loopBackState = loopbackState
                     }
                 }
             } else {
                 if let loopbackState = state as? StarLoopbackState {
                     let length = loopbackState.getNumberOfTransitions()
                     for i in 0..<length {
-                        let target: ATNState = loopbackState.transition(i).target
-                        if target is StarLoopEntryState {
-                            (target as! StarLoopEntryState).loopBackState = loopbackState
+                        let target = loopbackState.transition(i).target
+                        if let entryState = target as? StarLoopEntryState {
+                            entryState.loopBackState = loopbackState
                         }
                     }
                 }
@@ -840,13 +833,12 @@ public class ATNDeserializer {
         //
         // DECISIONS
         //
-        let ndecisions: [Int] = dict["decisionToState"] as! [Int]
+        let ndecisions = dict["decisionToState"] as! [Int]
         let length = ndecisions.count
         for i in 0..<length {
-            let s: Int = ndecisions[i]
-            let decState: DecisionState = atn.states[s] as! DecisionState
+            let s = ndecisions[i]
+            let decState = atn.states[s] as! DecisionState
             atn.appendDecisionToState(decState)
-            //atn.decisionToState.append(decState)
             decState.decision = i
         }
 
@@ -854,40 +846,34 @@ public class ATNDeserializer {
         // LEXER ACTIONS
         //
         if atn.grammarType == ATNType.lexer {
-            let lexerActionsBuilder = dict["lexerActions"] as! [Dictionary<String, Any>]
+            let lexerActionsBuilder = dict["lexerActions"] as! [[String : Any]]
             if supportsLexerActions {
-                atn.lexerActions = [LexerAction](repeating: LexerAction(), count: lexerActionsBuilder.count)   //[toInt(data[p++])];
+                atn.lexerActions = [LexerAction](repeating: LexerAction(), count: lexerActionsBuilder.count)
                 let length = atn.lexerActions.count
                 for i in 0..<length {
                     let actionTypeValue = lexerActionsBuilder[i]["actionType"] as! Int
-                    let actionType: LexerActionType = LexerActionType(rawValue: actionTypeValue)! //LexerActionType.values()[toInt(data[p++])];
-                    let data1: Int = lexerActionsBuilder[i]["a"] as! Int
-
-
-                    let data2: Int = lexerActionsBuilder[i]["b"] as! Int
-
-
-                    let lexerAction: LexerAction = lexerActionFactory(actionType, data1, data2)
-
+                    let actionType = LexerActionType(rawValue: actionTypeValue)!
+                    let data1 = lexerActionsBuilder[i]["a"] as! Int
+                    let data2 = lexerActionsBuilder[i]["b"] as! Int
+                    let lexerAction = lexerActionFactory(actionType, data1, data2)
                     atn.lexerActions[i] = lexerAction
                 }
             } else {
                 // for compatibility with older serialized ATNs, convert the old
                 // serialized action index for action transitions to the new
                 // form, which is the index of a LexerCustomAction
-                var legacyLexerActions: Array<LexerAction> = Array<LexerAction>()
-                for state: ATNState? in atn.states {
+                var legacyLexerActions = [LexerAction]()
+                for state in atn.states {
                     if let state = state {
                         let length = state.getNumberOfTransitions()
                         for i in 0..<length {
-                            let transition: Transition = state.transition(i)
-                            if !(transition is ActionTransition) {
+                            guard let transition = state.transition(i) as? ActionTransition else {
                                 continue
                             }
 
-                            let ruleIndex: Int = (transition as! ActionTransition).ruleIndex
-                            let actionIndex: Int = (transition as! ActionTransition).actionIndex
-                            let lexerAction: LexerCustomAction = LexerCustomAction(ruleIndex, actionIndex)
+                            let ruleIndex = transition.ruleIndex
+                            let actionIndex = transition.actionIndex
+                            let lexerAction = LexerCustomAction(ruleIndex, actionIndex)
                             state.setTransition(i, ActionTransition(transition.target, ruleIndex, legacyLexerActions.count, false))
                             legacyLexerActions.append(lexerAction)
                         }
@@ -912,11 +898,11 @@ public class ATNDeserializer {
             }
 
             for i in 0..<length {
-                let bypassStart: BasicBlockStartState = BasicBlockStartState()
+                let bypassStart = BasicBlockStartState()
                 bypassStart.ruleIndex = i
                 atn.addState(bypassStart)
 
-                let bypassStop: BlockEndState = BlockEndState()
+                let bypassStop = BlockEndState()
                 bypassStop.ruleIndex = i
                 atn.addState(bypassStop)
 
@@ -930,7 +916,7 @@ public class ATNDeserializer {
                 if atn.ruleToStartState[i].isPrecedenceRule {
                     // wrap from the beginning of the rule to the StarLoopEntryState
                     endState = nil
-                    for state: ATNState? in atn.states {
+                    for state in atn.states {
                         if let state = state {
                             if state.ruleIndex != i {
                                 continue
@@ -940,7 +926,7 @@ public class ATNDeserializer {
                                 continue
                             }
 
-                            let maybeLoopEndState: ATNState = state.transition(state.getNumberOfTransitions() - 1).target
+                            let maybeLoopEndState = state.transition(state.getNumberOfTransitions() - 1).target
                             if !(maybeLoopEndState is LoopEndState) {
                                 continue
                             }
@@ -963,9 +949,9 @@ public class ATNDeserializer {
                 }
 
                 // all non-excluded transitions that currently target end state need to target blockEnd instead
-                for state: ATNState? in atn.states {
+                for state in atn.states {
                     if let state = state {
-                        for transition: Transition in state.transitions {
+                        for transition in state.transitions {
                             if transition === excludeTransition! {
                                 continue
                             }
@@ -979,7 +965,7 @@ public class ATNDeserializer {
 
                 // all transitions leaving the rule start state need to leave blockStart instead
                 while atn.ruleToStartState[i].getNumberOfTransitions() > 0 {
-                    let transition: Transition = atn.ruleToStartState[i].removeTransition(atn.ruleToStartState[i].getNumberOfTransitions() - 1)
+                    let transition = atn.ruleToStartState[i].removeTransition(atn.ruleToStartState[i].getNumberOfTransitions() - 1)
                     bypassStart.addTransition(transition)
                 }
 
@@ -987,7 +973,7 @@ public class ATNDeserializer {
                 atn.ruleToStartState[i].addTransition(EpsilonTransition(bypassStart))
                 bypassStop.addTransition(EpsilonTransition(endState!))
 
-                let matchState: ATNState = BasicState()
+                let matchState = BasicState()
                 atn.addState(matchState)
                 matchState.addTransition(AtomTransition(bypassStop, atn.ruleToTokenType[i]))
                 bypassStart.addTransition(EpsilonTransition(matchState))
@@ -1011,7 +997,7 @@ public class ATNDeserializer {
     /// - parameter atn: The ATN.
     /// 
     internal func markPrecedenceDecisions(_ atn: ATN) {
-        for state: ATNState? in atn.states {
+        for state in atn.states {
             if let state = state as? StarLoopEntryState {
 
                 /// 
@@ -1021,7 +1007,7 @@ public class ATNDeserializer {
                 /// 
                 if let stateRuleIndex = state.ruleIndex {
                     if  atn.ruleToStartState[stateRuleIndex].isPrecedenceRule {
-                        let maybeLoopEndState: ATNState = state.transition(state.getNumberOfTransitions() - 1).target
+                        let maybeLoopEndState = state.transition(state.getNumberOfTransitions() - 1).target
                         if maybeLoopEndState is LoopEndState {
                             if maybeLoopEndState.epsilonOnlyTransitions && maybeLoopEndState.transition(0).target is RuleStopState {
                                 state.precedenceRuleDecision = true
@@ -1035,7 +1021,7 @@ public class ATNDeserializer {
 
     internal func verifyATN(_ atn: ATN) throws {
         // verify assumptions
-        for state: ATNState? in atn.states {
+        for state in atn.states {
             guard let state = state else {
                 continue
             }
@@ -1084,8 +1070,7 @@ public class ATNDeserializer {
                 try checkCondition((state as! BlockEndState).startState != nil)
             }
 
-            if state is DecisionState {
-                let decisionState: DecisionState = state as! DecisionState
+            if let decisionState = state as? DecisionState {
                 try checkCondition(decisionState.getNumberOfTransitions() <= 1 || decisionState.decision >= 0)
             } else {
                 try checkCondition(state.getNumberOfTransitions() <= 1 || state is RuleStopState)
@@ -1109,7 +1094,7 @@ public class ATNDeserializer {
                               _ type: Int, _ src: Int, _ trg: Int,
                               _ arg1: Int, _ arg2: Int, _ arg3: Int,
                               _ sets: Array<IntervalSet>) throws -> Transition {
-        let target: ATNState = atn.states[trg]!
+        let target = atn.states[trg]!
         switch type {
         case Transition.EPSILON: return EpsilonTransition(target)
         case Transition.RANGE:
@@ -1119,10 +1104,10 @@ public class ATNDeserializer {
                 return RangeTransition(target, arg1, arg2)
             }
         case Transition.RULE:
-            let rt: RuleTransition = RuleTransition(atn.states[arg1] as! RuleStartState, arg2, arg3, target)
+            let rt = RuleTransition(atn.states[arg1] as! RuleStartState, arg2, arg3, target)
             return rt
         case Transition.PREDICATE:
-            let pt: PredicateTransition = PredicateTransition(target, arg1, arg2, arg3 != 0)
+            let pt = PredicateTransition(target, arg1, arg2, arg3 != 0)
             return pt
         case Transition.PRECEDENCE:
             return PrecedencePredicateTransition(target, arg1)
@@ -1133,17 +1118,14 @@ public class ATNDeserializer {
                 return AtomTransition(target, arg1)
             }
         case Transition.ACTION:
-            let a: ActionTransition = ActionTransition(target, arg1, arg2, arg3 != 0)
-            return a
+            return ActionTransition(target, arg1, arg2, arg3 != 0)
+
         case Transition.SET: return SetTransition(target, sets[arg1])
         case Transition.NOT_SET: return NotSetTransition(target, sets[arg1])
         case Transition.WILDCARD: return WildcardTransition(target)
         default:
             throw ANTLRError.illegalState(msg: "The specified transition type is not valid.")
-
-
         }
-
     }
 
     internal func stateFactory(_ type: Int, _ ruleIndex: Int) throws -> ATNState? {
@@ -1197,12 +1179,6 @@ public class ATNDeserializer {
 
         case .type:
             return LexerTypeAction(data1)
-
-                //default:
-
         }
-        //  let message : String = "The specified lexer action type \(type) is not valid."
-        // RuntimeException(message)
-
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/ATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNSimulator.swift
@@ -17,7 +17,7 @@ open class ATNSimulator {
         return error
     }()
 
-    public var atn: ATN
+    public let atn: ATN
 
     /// 
     /// The context cache maps all PredictionContext objects that are equals()
@@ -79,8 +79,7 @@ open class ATNSimulator {
 
         //TODO: synced (sharedContextCache!)
         //synced (sharedContextCache!) {
-        let visited: HashMap<PredictionContext, PredictionContext> =
-        HashMap<PredictionContext, PredictionContext>()
+        let visited = HashMap<PredictionContext, PredictionContext>()
 
         return PredictionContext.getCachedContext(context,
                 sharedContextCache!,

--- a/runtime/Swift/Sources/Antlr4/atn/ATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNSimulator.swift
@@ -50,7 +50,7 @@ open class ATNSimulator {
     }
 
     open func reset() {
-        RuntimeException(" must overriden ")
+        fatalError(#function + " must be overridden")
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/atn/ATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNSimulator.swift
@@ -8,24 +8,7 @@
 import Foundation
 
 open class ATNSimulator {
-    /// 
-    /// -  Use _org.antlr.v4.runtime.atn.ATNDeserializer#SERIALIZED_VERSION_ instead.
-    /// 
-    public static let SERIALIZED_VERSION: Int = {
-        return ATNDeserializer.SERIALIZED_VERSION
-    }()
-
-
-    /// 
-    /// This is the current serialized UUID.
-    /// -  Use _org.antlr.v4.runtime.atn.ATNDeserializer#checkCondition(boolean)_ instead.
-    /// 
-    public static let SERIALIZED_UUID: UUID = {
-        return (ATNDeserializer.SERIALIZED_UUID as UUID)
-    }()
-
-
-    /// 
+    ///
     /// Must distinguish between missing edge and edge we know leads nowhere
     /// 
     public static let ERROR: DFAState = {
@@ -102,49 +85,6 @@ open class ATNSimulator {
         return PredictionContext.getCachedContext(context,
                 sharedContextCache!,
                 visited)
-        //}
-    }
-
-    /// 
-    /// - note: Use _org.antlr.v4.runtime.atn.ATNDeserializer#deserialize_ instead.
-    /// 
-    public static func deserialize(_ data: [Character]) throws -> ATN {
-        return try ATNDeserializer().deserialize(data)
-    }
-
-    /// 
-    /// - note: Use _org.antlr.v4.runtime.atn.ATNDeserializer#checkCondition(boolean)_ instead.
-    /// 
-    public static func checkCondition(_ condition: Bool) throws {
-        try ATNDeserializer().checkCondition(condition)
-    }
-
-    /// 
-    /// - note: Use _org.antlr.v4.runtime.atn.ATNDeserializer#checkCondition(boolean, String)_ instead.
-    /// 
-    public static func checkCondition(_ condition: Bool, _ message: String) throws {
-        try ATNDeserializer().checkCondition(condition, message)
-    }
-
-    /// 
-    /// - note: Use _org.antlr.v4.runtime.atn.ATNDeserializer#toInt_ instead.
-    /// 
-    public func toInt(_ c: Character) -> Int {
-        return toInt(c)
-    }
-
-    /// 
-    /// - note: Use _org.antlr.v4.runtime.atn.ATNDeserializer#toInt32_ instead.
-    /// 
-    public func toInt32(_ data: [Character], _ offset: Int) -> Int {
-        return toInt32(data, offset)
-    }
-
-    /// 
-    /// - note: Use _org.antlr.v4.runtime.atn.ATNDeserializer#toLong_ instead.
-    /// 
-    public func toLong(_ data: [Character], _ offset: Int) -> Int64 {
-        return toLong(data, offset)
     }
 
     public static func edgeFactory(_ atn: ATN,
@@ -153,12 +93,4 @@ open class ATNSimulator {
                                   _ sets: Array<IntervalSet>) throws -> Transition {
         return try ATNDeserializer().edgeFactory(atn, type, src, trg, arg1, arg2, arg3, sets)
     }
-
-    /// 
-    /// - note: Use _org.antlr.v4.runtime.atn.ATNDeserializer#stateFactory_ instead.
-    /// 
-    public static func stateFactory(_ type: Int, _ ruleIndex: Int) throws -> ATNState {
-        return try ATNDeserializer().stateFactory(type, ruleIndex)!
-    }
-
 }

--- a/runtime/Swift/Sources/Antlr4/atn/ATNState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNState.swift
@@ -183,8 +183,7 @@ public class ATNState: Hashable, CustomStringConvertible {
     }
 
     public func getStateType() -> Int {
-        RuntimeException(#function + " must be overridden")
-        return 0
+        fatalError(#function + " must be overridden")
     }
 
     public final func onlyHasEpsilonTransitions() -> Bool {

--- a/runtime/Swift/Sources/Antlr4/atn/LL1Analyzer.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LL1Analyzer.swift
@@ -34,11 +34,11 @@ public class LL1Analyzer {
              return nil
         }
         let length = s.getNumberOfTransitions()
-        var look: [IntervalSet?] = [IntervalSet?](repeating: nil, count: length)
+        var look = [IntervalSet?](repeating: nil, count: length)
         for alt in 0..<length {
             look[alt] = try IntervalSet()
-            var lookBusy: Set<ATNConfig> = Set<ATNConfig>()
-            let seeThruPreds: Bool = false // fail to get lookahead upon pred
+            var lookBusy = Set<ATNConfig>()
+            let seeThruPreds = false // fail to get lookahead upon pred
             try _LOOK(s.transition(alt).target, nil, PredictionContext.EMPTY,
                     look[alt]!, &lookBusy, BitSet(), seeThruPreds, false)
             // Wipe out lookahead for this alternative if we found nothing
@@ -90,9 +90,9 @@ public class LL1Analyzer {
     /// 
 
     public func LOOK(_ s: ATNState, _ stopState: ATNState?, _ ctx: RuleContext?) throws -> IntervalSet {
-        let r: IntervalSet = try IntervalSet()
-        let seeThruPreds: Bool = true // ignore preds; get all lookahead
-        let lookContext: PredictionContext? = ctx != nil ? PredictionContext.fromRuleContext(s.atn!, ctx) : nil
+        let r = try IntervalSet()
+        let seeThruPreds = true // ignore preds; get all lookahead
+        let lookContext = ctx != nil ? PredictionContext.fromRuleContext(s.atn!, ctx) : nil
         var config = Set<ATNConfig>()
         try _LOOK(s, stopState, lookContext,
                 r, &config, BitSet(), seeThruPreds, true)
@@ -137,11 +137,10 @@ public class LL1Analyzer {
                         _ calledRuleStack: BitSet,
                         _ seeThruPreds: Bool, _ addEOF: Bool) throws {
         // print ("_LOOK(\(s.stateNumber), ctx=\(ctx)");
-        //TODO  var c : ATNConfig = ATNConfig(s, 0, ctx);
         if s.description == "273" {
             var s = 0
         }
-        var c: ATNConfig = ATNConfig(s, 0, ctx)
+        var c = ATNConfig(s, 0, ctx)
         if lookBusy.contains(c) {
             return
         } else {
@@ -177,10 +176,9 @@ public class LL1Analyzer {
                 // run thru all possible stack tops in ctx
                 let length = ctx.size()
                 for i in 0..<length {
-                    var returnState: ATNState = atn.states[(ctx.getReturnState(i))]!
+                    var returnState = atn.states[(ctx.getReturnState(i))]!
 
-
-                    var removed: Bool = try calledRuleStack.get(returnState.ruleIndex!)
+                    var removed = try calledRuleStack.get(returnState.ruleIndex!)
                     try calledRuleStack.clear(returnState.ruleIndex!)
                     try self._LOOK(returnState, stopState, ctx.getParent(i), look, &lookBusy, calledRuleStack, seeThruPreds, addEOF)
                     defer {
@@ -193,20 +191,19 @@ public class LL1Analyzer {
             }
         }
 
-        var n: Int = s.getNumberOfTransitions()
+        var n = s.getNumberOfTransitions()
         for i in 0..<n {
-            var t: Transition = s.transition(i)
-            if type(of: t) == RuleTransition.self {
-                if try calledRuleStack.get((t as! RuleTransition).target.ruleIndex!) {
+            var t = s.transition(i)
+            if let rt = t as? RuleTransition {
+                if try calledRuleStack.get(rt.target.ruleIndex!) {
                     continue
                 }
 
-                var newContext: PredictionContext =
-                SingletonPredictionContext.create(ctx, (t as! RuleTransition).followState.stateNumber)
-                try calledRuleStack.set((t as! RuleTransition).target.ruleIndex!)
+                var newContext = SingletonPredictionContext.create(ctx, rt.followState.stateNumber)
+                try calledRuleStack.set(rt.target.ruleIndex!)
                 try _LOOK(t.target, stopState, newContext, look, &lookBusy, calledRuleStack, seeThruPreds, addEOF)
                 defer {
-                    try! calledRuleStack.clear((t as! RuleTransition).target.ruleIndex!)
+                    try! calledRuleStack.clear(rt.target.ruleIndex!)
                 }
             } else {
                 if t is AbstractPredicateTransition {
@@ -219,11 +216,11 @@ public class LL1Analyzer {
                     if t.isEpsilon() {
                         try _LOOK(t.target, stopState, ctx, look, &lookBusy, calledRuleStack, seeThruPreds, addEOF)
                     } else {
-                        if type(of: t) == WildcardTransition.self {
+                        if t is WildcardTransition {
                             try look.addAll(IntervalSet.of(CommonToken.MIN_USER_TOKEN_TYPE, atn.maxTokenType))
                         } else {
 
-                            var set: IntervalSet? = try t.labelIntervalSet()
+                            var set = try t.labelIntervalSet()
                             if set != nil {
                                 if t is NotSetTransition {
                                     set = try set!.complement(IntervalSet.of(CommonToken.MIN_USER_TOKEN_TYPE, atn.maxTokenType)) as? IntervalSet

--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
@@ -50,7 +50,7 @@ open class LexerATNSimulator: ATNSimulator {
     }
 
 
-    internal let recog: Lexer?
+    internal weak var recog: Lexer?
 
     /// 
     /// The current token's starting index into the character stream.

--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
@@ -736,7 +736,7 @@ open class LexerATNSimulator: ATNSimulator {
 
     public func getText(_ input: CharStream) -> String {
         // index is first lookahead char, don't include.
-        return input.getText(Interval.of(startIndex, input.index() - 1))
+        return try! input.getText(Interval.of(startIndex, input.index() - 1))
     }
 
     public func getLine() -> Int {

--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
@@ -11,11 +11,11 @@
 /// 
 
 open class LexerATNSimulator: ATNSimulator {
-    public static let debug: Bool = false
-    public let dfa_debug: Bool = false
+    public static let debug = false
+    public let dfa_debug = false
 
-    public static let MIN_DFA_EDGE: Int = 0
-    public static let MAX_DFA_EDGE: Int = 127
+    public static let MIN_DFA_EDGE = 0
+    public static let MAX_DFA_EDGE = 127
     // forces unicode to stay in ATN
 
     /// 
@@ -58,21 +58,21 @@ open class LexerATNSimulator: ATNSimulator {
     /// DFA did not have a previous accept state. In this case, we use the
     /// ATN-generated exception object.
     /// 
-    internal var startIndex: Int = -1
+    internal var startIndex = -1
 
     /// 
     /// line number 1..n within the input
     /// 
-    public var line: Int = 1
+    public var line = 1
 
     /// 
     /// The index of the character relative to the beginning of the line 0..n-1
     /// 
-    public var charPositionInLine: Int = 0
+    public var charPositionInLine = 0
 
     public final var decisionToDFA: [DFA]
     
-    internal var mode: Int = Lexer.DEFAULT_MODE
+    internal var mode = Lexer.DEFAULT_MODE
     
     /// 
     /// mutex for DFAState change
@@ -88,9 +88,9 @@ open class LexerATNSimulator: ATNSimulator {
     /// Used during DFA/ATN exec to record the most recent accept configuration info
     /// 
 
-    internal final var prevAccept: SimState = SimState()
+    internal final var prevAccept = SimState()
 
-    public static var match_calls: Int = 0
+    public static var match_calls = 0
 
     public convenience init(_ atn: ATN, _ decisionToDFA: [DFA],
         _ sharedContextCache: PredictionContextCache) {
@@ -116,11 +116,11 @@ open class LexerATNSimulator: ATNSimulator {
     open func match(_ input: CharStream, _ mode: Int) throws -> Int {
         LexerATNSimulator.match_calls += 1
         self.mode = mode
-        var mark: Int = input.mark()
+        var mark = input.mark()
         do {
             self.startIndex = input.index()
             self.prevAccept.reset()
-            var dfa: DFA = decisionToDFA[mode]
+            var dfa = decisionToDFA[mode]
             defer {
                 try! input.release(mark)
             }
@@ -146,31 +146,30 @@ open class LexerATNSimulator: ATNSimulator {
 
     override
     open func clearDFA() {
-
         for d in 0..<decisionToDFA.count {
             decisionToDFA[d] = DFA(atn.getDecisionState(d)!, d)
         }
     }
 
     internal func matchATN(_ input: CharStream) throws -> Int {
-        let startState: ATNState = atn.modeToStartState[mode]
+        let startState = atn.modeToStartState[mode]
 
         if LexerATNSimulator.debug {
             print("matchATN mode \(mode) start: \(startState)\n")
         }
 
-        let old_mode: Int = mode
+        let old_mode = mode
 
-        let s0_closure: ATNConfigSet = try computeStartState(input, startState)
-        let suppressEdge: Bool = s0_closure.hasSemanticContext
+        let s0_closure = try computeStartState(input, startState)
+        let suppressEdge = s0_closure.hasSemanticContext
         s0_closure.hasSemanticContext = false
 
-        let next: DFAState = addDFAState(s0_closure)
+        let next = addDFAState(s0_closure)
         if !suppressEdge {
             decisionToDFA[mode].s0 = next
         }
 
-        let predict: Int = try execATN(input, next)
+        let predict = try execATN(input, next)
 
         if LexerATNSimulator.debug {
             print("DFA after matchATN: \(decisionToDFA[old_mode].toLexerString())")
@@ -190,14 +189,13 @@ open class LexerATNSimulator: ATNSimulator {
             captureSimState(prevAccept, input, ds0)
         }
 
-        var t: Int = try input.LA(1)
+        var t = try input.LA(1)
 
-        var s: DFAState = ds0 // s is current/from DFA state
+        var s = ds0 // s is current/from DFA state
 
         while true {
             // while more work
             if LexerATNSimulator.debug {
-
                 print("execATN loop starting closure: \(s.configs)\n")
             }
 
@@ -268,7 +266,7 @@ open class LexerATNSimulator: ATNSimulator {
             return nil
         }
 
-        let target: DFAState? = s.edges[t - LexerATNSimulator.MIN_DFA_EDGE]
+        let target = s.edges[t - LexerATNSimulator.MIN_DFA_EDGE]
         if LexerATNSimulator.debug && target != nil {
             print("reuse state \(s.stateNumber) edge to \(target!.stateNumber)")
         }
@@ -290,7 +288,7 @@ open class LexerATNSimulator: ATNSimulator {
     /// 
 
     internal func computeTargetState(_ input: CharStream, _ s: DFAState, _ t: Int) throws -> DFAState {
-        let reach: ATNConfigSet = OrderedATNConfigSet()
+        let reach = OrderedATNConfigSet()
 
         // if we don't find an existing DFA state
         // Fill reach starting from closure, following t transitions
@@ -316,7 +314,7 @@ open class LexerATNSimulator: ATNSimulator {
     internal func failOrAccept(_ prevAccept: SimState, _ input: CharStream,
         _ reach: ATNConfigSet, _ t: Int) throws -> Int {
             if let dfaState = prevAccept.dfaState {
-                let lexerActionExecutor: LexerActionExecutor? = dfaState.lexerActionExecutor
+                let lexerActionExecutor = dfaState.lexerActionExecutor
                 try accept(input, lexerActionExecutor, startIndex,
                     prevAccept.index, prevAccept.line, prevAccept.charPos)
                 return dfaState.prediction
@@ -325,8 +323,7 @@ open class LexerATNSimulator: ATNSimulator {
                 if t == BufferedTokenStream.EOF && input.index() == startIndex {
                     return CommonToken.EOF
                 }
-                throw  ANTLRException.recognition(e: LexerNoViableAltException(recog, input, startIndex, reach))
-
+                throw ANTLRException.recognition(e: LexerNoViableAltException(recog, input, startIndex, reach))
             }
     }
 
@@ -338,12 +335,12 @@ open class LexerATNSimulator: ATNSimulator {
     internal func getReachableConfigSet(_ input: CharStream, _ closureConfig: ATNConfigSet, _ reach: ATNConfigSet, _ t: Int) throws {
         // this is used to skip processing for configs which have a lower priority
         // than a config that already reached an accept state for the same rule
-        var skipAlt: Int = ATN.INVALID_ALT_NUMBER
-        for c: ATNConfig in closureConfig.configs {
+        var skipAlt = ATN.INVALID_ALT_NUMBER
+        for c in closureConfig.configs {
             guard let c = c as? LexerATNConfig else {
                 continue
             }
-            let currentAltReachedAcceptState: Bool = c.alt == skipAlt
+            let currentAltReachedAcceptState = (c.alt == skipAlt)
             if currentAltReachedAcceptState && c.hasPassedThroughNonGreedyDecision() {
                 continue
             }
@@ -353,17 +350,17 @@ open class LexerATNSimulator: ATNSimulator {
 
             }
 
-            let n: Int = c.state.getNumberOfTransitions()
+            let n = c.state.getNumberOfTransitions()
             for ti in 0..<n {
                 // for each transition
-                let trans: Transition = c.state.transition(ti)
+                let trans = c.state.transition(ti)
                 if let target = getReachableTarget(trans, t) {
-                    var lexerActionExecutor: LexerActionExecutor? = c.getLexerActionExecutor()
+                    var lexerActionExecutor = c.getLexerActionExecutor()
                     if lexerActionExecutor != nil {
                         lexerActionExecutor = lexerActionExecutor!.fixOffsetBeforeMatch(input.index() - startIndex)
                     }
 
-                    let treatEofAsEpsilon: Bool = t == BufferedTokenStream.EOF
+                    let treatEofAsEpsilon = (t == BufferedTokenStream.EOF)
                     if try closure(input,
                         LexerATNConfig(c, target, lexerActionExecutor),
                         reach,
@@ -384,7 +381,6 @@ open class LexerATNSimulator: ATNSimulator {
         _ startIndex: Int, _ index: Int, _ line: Int, _ charPos: Int) throws {
             if LexerATNSimulator.debug {
                 print("ACTION \(String(describing: lexerActionExecutor))\n")
-
             }
 
             // seek to after last char in token
@@ -393,7 +389,7 @@ open class LexerATNSimulator: ATNSimulator {
             self.charPositionInLine = charPos
             //TODO: CHECK
             if let lexerActionExecutor = lexerActionExecutor, let recog = recog {
-                try    lexerActionExecutor.execute(recog, input, startIndex)
+                try lexerActionExecutor.execute(recog, input, startIndex)
             }
     }
 
@@ -409,12 +405,12 @@ open class LexerATNSimulator: ATNSimulator {
 
     final func computeStartState(_ input: CharStream,
         _ p: ATNState) throws -> ATNConfigSet {
-            let initialContext: PredictionContext = PredictionContext.EMPTY
-            let configs: ATNConfigSet = OrderedATNConfigSet()
+            let initialContext = PredictionContext.EMPTY
+            let configs = OrderedATNConfigSet()
             let length = p.getNumberOfTransitions()
             for i in 0..<length {
-                let target: ATNState = p.transition(i).target
-                let c: LexerATNConfig = LexerATNConfig(target, i + 1, initialContext)
+                let target = p.transition(i).target
+                let c = LexerATNConfig(target, i + 1, initialContext)
                 try closure(input, c, configs, false, false, false)
             }
             return configs
@@ -441,10 +437,8 @@ open class LexerATNSimulator: ATNSimulator {
             if LexerATNSimulator.debug {
                 if recog != nil {
                     print("closure at \(recog!.getRuleNames()[config.state.ruleIndex!]) rule stop \(config)\n")
-
                 } else {
                     print("closure at rule stop \(config)\n")
-
                 }
             }
 
@@ -462,9 +456,9 @@ open class LexerATNSimulator: ATNSimulator {
                 let length = configContext.size()
                 for i in 0..<length {
                     if configContext.getReturnState(i) != PredictionContext.EMPTY_RETURN_STATE {
-                        let newContext: PredictionContext = configContext.getParent(i)! // "pop" return state
-                        let returnState: ATNState? = atn.states[configContext.getReturnState(i)]
-                        let c: LexerATNConfig = LexerATNConfig(config, returnState!, newContext)
+                        let newContext = configContext.getParent(i)! // "pop" return state
+                        let returnState = atn.states[configContext.getReturnState(i)]
+                        let c = LexerATNConfig(config, returnState!, newContext)
                         currentAltReachedAcceptState = try closure(input, c, configs, currentAltReachedAcceptState, speculative, treatEofAsEpsilon)
                     }
                 }
@@ -480,13 +474,12 @@ open class LexerATNSimulator: ATNSimulator {
             }
         }
 
-        let p: ATNState = config.state
+        let p = config.state
         let length = p.getNumberOfTransitions()
         for i in 0..<length {
-            let t: Transition = p.transition(i)
-            let c: LexerATNConfig? = try getEpsilonTarget(input, config, t, configs, speculative, treatEofAsEpsilon)
-            if c != nil {
-                currentAltReachedAcceptState = try closure(input, c!, configs, currentAltReachedAcceptState, speculative, treatEofAsEpsilon)
+            let t = p.transition(i)
+            if let c = try getEpsilonTarget(input, config, t, configs, speculative, treatEofAsEpsilon) {
+                currentAltReachedAcceptState = try closure(input, c, configs, currentAltReachedAcceptState, speculative, treatEofAsEpsilon)
             }
         }
 
@@ -504,9 +497,8 @@ open class LexerATNSimulator: ATNSimulator {
             var c: LexerATNConfig? = nil
             switch t.getSerializationType() {
             case Transition.RULE:
-                let ruleTransition: RuleTransition = t as! RuleTransition
-                let newContext: PredictionContext =
-                SingletonPredictionContext.create(config.context, ruleTransition.followState.stateNumber)
+                let ruleTransition = t as! RuleTransition
+                let newContext = SingletonPredictionContext.create(config.context, ruleTransition.followState.stateNumber)
                 c = LexerATNConfig(config, t.target, newContext)
                 break
 
@@ -534,7 +526,7 @@ open class LexerATNSimulator: ATNSimulator {
                 /// states reached by traversing predicates. Since this is when we
                 /// test them, we cannot cash the DFA state target of ID.
                 /// 
-                let pt: PredicateTransition = t as! PredicateTransition
+                let pt = t as! PredicateTransition
                 if LexerATNSimulator.debug {
                     print("EVAL rule \(pt.ruleIndex):\(pt.predIndex)")
                 }
@@ -558,7 +550,7 @@ open class LexerATNSimulator: ATNSimulator {
                     // getEpsilonTarget to return two configurations, so
                     // additional modifications are needed before we can support
                     // the split operation.
-                    let lexerActionExecutor: LexerActionExecutor = LexerActionExecutor.append(config.getLexerActionExecutor(), atn.lexerActions[(t as! ActionTransition).actionIndex])
+                    let lexerActionExecutor = LexerActionExecutor.append(config.getLexerActionExecutor(), atn.lexerActions[(t as! ActionTransition).actionIndex])
                     c = LexerATNConfig(config, t.target, lexerActionExecutor)
                     break
                 } else {
@@ -619,10 +611,10 @@ open class LexerATNSimulator: ATNSimulator {
             return try recog.sempred(nil, ruleIndex, predIndex)
         }
 
-        var savedCharPositionInLine: Int = charPositionInLine
-        var savedLine: Int = line
-        var index: Int = input.index()
-        var marker: Int = input.mark()
+        var savedCharPositionInLine = charPositionInLine
+        var savedLine = line
+        var index = input.index()
+        var marker = input.mark()
         do {
             try consume(input)
             defer
@@ -663,11 +655,9 @@ open class LexerATNSimulator: ATNSimulator {
             /// If that gets us to a previously created (but dangling) DFA
             /// state, we can continue in pure DFA mode from there.
             /// 
-            let suppressEdge: Bool = q.hasSemanticContext
+            let suppressEdge = q.hasSemanticContext
             q.hasSemanticContext = false
-
-
-            let to: DFAState = addDFAState(q)
+            let to = addDFAState(q)
 
             if suppressEdge {
                 return to
@@ -690,8 +680,7 @@ open class LexerATNSimulator: ATNSimulator {
         dfaStateMutex.synchronized {
             if p.edges == nil {
                 //  make room for tokens 1..n and -1 masquerading as index 0
-                //TODO ARRAY COUNT
-                p.edges = [DFAState?](repeating: nil, count: LexerATNSimulator.MAX_DFA_EDGE - LexerATNSimulator.MIN_DFA_EDGE + 1)      //new DFAState[MAX_DFA_EDGE-MIN_DFA_EDGE+1];
+                p.edges = [DFAState?](repeating: nil, count: LexerATNSimulator.MAX_DFA_EDGE - LexerATNSimulator.MIN_DFA_EDGE + 1)
             }
             p.edges[t - LexerATNSimulator.MIN_DFA_EDGE] = q // connect
         }
@@ -711,8 +700,8 @@ open class LexerATNSimulator: ATNSimulator {
         /// 
         assert(!configs.hasSemanticContext, "Expected: !configs.hasSemanticContext")
 
-        let proposed: DFAState = DFAState(configs)
-        let firstConfigWithRuleStopState: ATNConfig? = configs.firstConfigWithRuleStopState
+        let proposed = DFAState(configs)
+        let firstConfigWithRuleStopState = configs.firstConfigWithRuleStopState
 
         if firstConfigWithRuleStopState != nil {
             proposed.isAcceptState = true
@@ -720,14 +709,14 @@ open class LexerATNSimulator: ATNSimulator {
             proposed.prediction = atn.ruleToTokenType[firstConfigWithRuleStopState!.state.ruleIndex!]
         }
 
-        let dfa: DFA = decisionToDFA[mode]
+        let dfa = decisionToDFA[mode]
 
         return dfaStatesMutex.synchronized {
             if let existing = dfa.states[proposed] {
                 return existing!
             }
 
-            let newState: DFAState = proposed
+            let newState = proposed
             newState.stateNumber = dfa.states.count
             configs.setReadonly(true)
             newState.configs = configs
@@ -767,7 +756,7 @@ open class LexerATNSimulator: ATNSimulator {
     }
 
     public func consume(_ input: CharStream) throws {
-        let curChar: Int = try input.LA(1)
+        let curChar = try input.LA(1)
         if String(Character(integerLiteral: curChar)) == "\n" {
             line += 1
             charPositionInLine = 0

--- a/runtime/Swift/Sources/Antlr4/atn/LexerAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerAction.swift
@@ -22,8 +22,7 @@ public class LexerAction: Hashable {
     /// - returns: The serialization type of the lexer action.
     /// 
     public func getActionType() -> LexerActionType {
-        RuntimeException(" must overriden ")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
 
@@ -42,8 +41,7 @@ public class LexerAction: Hashable {
     /// otherwise, `false`.
     /// 
     public func isPositionDependent() -> Bool {
-        RuntimeException(" must overriden ")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     /// 
@@ -55,12 +53,11 @@ public class LexerAction: Hashable {
     /// - parameter lexer: The lexer instance.
     /// 
     public func execute(_ lexer: Lexer) throws {
-        RuntimeException(" must overriden ")
+        fatalError(#function + " must be overridden")
     }
 
     public var hashValue: Int {
-        RuntimeException(" must overriden ")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
@@ -250,7 +250,8 @@ open class ParserATNSimulator: ATNSimulator {
         }
         return false
     }()
-    internal final var parser: Parser
+
+    internal final unowned let parser: Parser
 
     public final var decisionToDFA: [DFA]
 

--- a/runtime/Swift/Sources/Antlr4/atn/PredictionContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PredictionContext.swift
@@ -12,18 +12,19 @@ public class PredictionContext: Hashable, CustomStringConvertible {
     /// Represents `$` in local context prediction, which means wildcard.
     /// `+x = *`.
     /// 
-    public static let EMPTY: EmptyPredictionContext = EmptyPredictionContext()
+    public static let EMPTY = EmptyPredictionContext()
 
     /// 
     /// Represents `$` in an array in full context mode, when `$`
     /// doesn't mean wildcard: `$ + x = [$,x]`. Here,
     /// `$` = _#EMPTY_RETURN_STATE_.
     /// 
-    public static let EMPTY_RETURN_STATE: Int = Int(Int32.max)
+    public static let EMPTY_RETURN_STATE = Int(Int32.max)
 
     private static let INITIAL_HASH = UInt32(1)
 
-    public static var globalNodeCount: Int = 0
+    public static var globalNodeCount = 0
+
     public final let id: Int = {
         let oldGlobalNodeCount = globalNodeCount
         globalNodeCount += 1
@@ -62,12 +63,7 @@ public class PredictionContext: Hashable, CustomStringConvertible {
     /// Return _#EMPTY_ if `outerContext` is empty or null.
     /// 
     public static func fromRuleContext(_ atn: ATN, _ outerContext: RuleContext?) -> PredictionContext {
-        var _outerContext: RuleContext
-        if let outerContext = outerContext {
-            _outerContext = outerContext
-        }else {
-            _outerContext = RuleContext.EMPTY
-        }
+        let _outerContext = outerContext ?? RuleContext.EMPTY
 
         // if we are in RuleContext of start rule, s, then PredictionContext
         // is EMPTY. Nobody called us. (if we are empty, return empty)
@@ -76,11 +72,10 @@ public class PredictionContext: Hashable, CustomStringConvertible {
         }
 
         // If we have a parent, convert it to a PredictionContext graph
-        var parent: PredictionContext = EMPTY
-        parent = PredictionContext.fromRuleContext(atn, _outerContext.parent)
+        let parent = PredictionContext.fromRuleContext(atn, _outerContext.parent)
 
-        let state: ATNState = atn.states[_outerContext.invokingState]!
-        let transition: RuleTransition = state.transition(0) as! RuleTransition
+        let state = atn.states[_outerContext.invokingState]!
+        let transition = state.transition(0) as! RuleTransition
         return SingletonPredictionContext.create(parent, transition.followState.stateNumber)
     }
 
@@ -160,29 +155,27 @@ public class PredictionContext: Hashable, CustomStringConvertible {
                 return a
             }
 
-            if (a is SingletonPredictionContext && b is SingletonPredictionContext) {
-                return mergeSingletons(a as! SingletonPredictionContext,
-                    b as! SingletonPredictionContext,
-                    rootIsWildcard, &mergeCache)
+            if let spc_a = a as? SingletonPredictionContext, let spc_b = b as? SingletonPredictionContext {
+                return mergeSingletons(spc_a, spc_b, rootIsWildcard, &mergeCache)
             }
 
             // At least one of a or b is array
             // If one is $ and rootIsWildcard, return $ as * wildcard
-            if (rootIsWildcard) {
-                if (a is EmptyPredictionContext) {
+            if rootIsWildcard {
+                if a is EmptyPredictionContext {
                     return a
                 }
-                if (b is EmptyPredictionContext) {
+                if b is EmptyPredictionContext {
                     return b
                 }
             }
 
             // convert singleton so both are arrays to normalize
-            if (a is SingletonPredictionContext) {
-                a = ArrayPredictionContext(a as! SingletonPredictionContext)
+            if let spc_a = a as? SingletonPredictionContext {
+                a = ArrayPredictionContext(spc_a)
             }
-            if (b is SingletonPredictionContext) {
-                b = ArrayPredictionContext(b as! SingletonPredictionContext)
+            if let spc_b = b as? SingletonPredictionContext {
+                b = ArrayPredictionContext(spc_b)
             }
             return mergeArrays(a as! ArrayPredictionContext, b as! ArrayPredictionContext,
                 rootIsWildcard, &mergeCache)
@@ -222,7 +215,7 @@ public class PredictionContext: Hashable, CustomStringConvertible {
         _ mergeCache: inout DoubleKeyMap<PredictionContext, PredictionContext, PredictionContext>?) -> PredictionContext {
 
             if let mergeCache = mergeCache {
-                var previous: PredictionContext? = mergeCache.get(a, b)
+                var previous = mergeCache.get(a, b)
                 if previous != nil {
                     return previous!
                 }
@@ -240,45 +233,45 @@ public class PredictionContext: Hashable, CustomStringConvertible {
                 return rootMerge
             }
 
-            if (a.returnState == b.returnState) {
+            if a.returnState == b.returnState {
                 // a == b
-                let parent: PredictionContext = merge(a.parent!, b.parent!, rootIsWildcard, &mergeCache);
+                let parent = merge(a.parent!, b.parent!, rootIsWildcard, &mergeCache)
                 // if parent is same as existing a or b parent or reduced to a parent, return it
-                if (parent === a.parent!) {
+                if parent === a.parent! {
                     return a
                 } // ax + bx = ax, if a=b
-                if (parent === b.parent!) {
+                if parent === b.parent! {
                     return b
                 } // ax + bx = bx, if a=b
                 // else: ax + ay = a'[x,y]
                 // merge parents x and y, giving array node with x,y then remainders
                 // of those graphs.  dup a, a' points at merged array
                 // new joined parent so create new singleton pointing to it, a'
-                let a_: PredictionContext = SingletonPredictionContext.create(parent, a.returnState);
-                if (mergeCache != nil) {
+                let a_ = SingletonPredictionContext.create(parent, a.returnState);
+                if mergeCache != nil {
                     mergeCache!.put(a, b, a_)
                 }
                 return a_
             } else {
                 // a != b payloads differ
                 // see if we can collapse parents due to $+x parents if local ctx
-                var singleParent: PredictionContext? = nil;
+                var singleParent: PredictionContext? = nil
                 //added by janyou
                 if a === b || (a.parent != nil && a.parent! == b.parent) {
                     // ax + bx = [a,b]x
                     singleParent = a.parent
                 }
-                if (singleParent != nil) {
+                if singleParent != nil {
                     // parents are same
                     // sort payloads and use same parent
-                    var payloads: [Int] = [a.returnState, b.returnState];
-                    if (a.returnState > b.returnState) {
+                    var payloads = [a.returnState, b.returnState]
+                    if a.returnState > b.returnState {
                         payloads[0] = b.returnState
                         payloads[1] = a.returnState
                     }
-                    let parents: [PredictionContext?] = [singleParent, singleParent]
-                    let a_: PredictionContext = ArrayPredictionContext(parents, payloads)
-                    if (mergeCache != nil) {
+                    let parents = [singleParent, singleParent]
+                    let a_ = ArrayPredictionContext(parents, payloads)
+                    if mergeCache != nil {
                         mergeCache!.put(a, b, a_)
                     }
                     return a_
@@ -286,19 +279,19 @@ public class PredictionContext: Hashable, CustomStringConvertible {
                 // parents differ and can't merge them. Just pack together
                 // into array; can't merge.
                 // ax + by = [ax,by]
-                var payloads: [Int] = [a.returnState, b.returnState]
-                var parents: [PredictionContext?] = [a.parent, b.parent];
-                if (a.returnState > b.returnState) {
+                var payloads = [a.returnState, b.returnState]
+                var parents = [a.parent, b.parent]
+                if a.returnState > b.returnState {
                     // sort by payload
                     payloads[0] = b.returnState
                     payloads[1] = a.returnState
                     parents = [b.parent, a.parent]
                 }
                 if a is EmptyPredictionContext {
-                    // print("parenet is null")
+                    // print("parent is null")
                 }
-                let a_: PredictionContext = ArrayPredictionContext(parents, payloads);
-                if (mergeCache != nil) {
+                let a_ = ArrayPredictionContext(parents, payloads)
+                if mergeCache != nil {
                     mergeCache!.put(a, b, a_)
                 }
                 return a_
@@ -346,31 +339,29 @@ public class PredictionContext: Hashable, CustomStringConvertible {
     public static func mergeRoot(_ a: SingletonPredictionContext,
         _ b: SingletonPredictionContext,
         _ rootIsWildcard: Bool) -> PredictionContext? {
-            if (rootIsWildcard) {
-                if (a === PredictionContext.EMPTY) {
+            if rootIsWildcard {
+                if a === PredictionContext.EMPTY {
                     return PredictionContext.EMPTY
                 }  // * + b = *
-                if (b === PredictionContext.EMPTY) {
+                if b === PredictionContext.EMPTY {
                     return PredictionContext.EMPTY
                 }  // a + * = *
             } else {
-                if (a === PredictionContext.EMPTY && b === PredictionContext.EMPTY) {
+                if a === PredictionContext.EMPTY && b === PredictionContext.EMPTY {
                     return PredictionContext.EMPTY
                 } // $ + $ = $
-                if (a === PredictionContext.EMPTY) {
+                if a === PredictionContext.EMPTY {
                     // $ + x = [$,x]
-                    let payloads: [Int] = [b.returnState, EMPTY_RETURN_STATE]
-                    let parents: [PredictionContext?] = [b.parent, nil]
-                    let joined: PredictionContext =
-                    ArrayPredictionContext(parents, payloads)
-                    return joined;
+                    let payloads = [b.returnState, EMPTY_RETURN_STATE]
+                    let parents = [b.parent, nil]
+                    let joined = ArrayPredictionContext(parents, payloads)
+                    return joined
                 }
-                if (b === PredictionContext.EMPTY) {
+                if b === PredictionContext.EMPTY {
                     // x + $ = [$,x] ($ is always first if present)
-                    let payloads: [Int] = [a.returnState, EMPTY_RETURN_STATE]
-                    let parents: [PredictionContext?] = [a.parent, nil]
-                    let joined: PredictionContext =
-                    ArrayPredictionContext(parents, payloads)
+                    let payloads = [a.returnState, EMPTY_RETURN_STATE]
+                    let parents = [a.parent, nil]
+                    let joined = ArrayPredictionContext(parents, payloads)
                     return joined
                 }
             }
@@ -402,30 +393,29 @@ public class PredictionContext: Hashable, CustomStringConvertible {
         _ rootIsWildcard: Bool,
         _ mergeCache: inout DoubleKeyMap<PredictionContext, PredictionContext, PredictionContext>?) -> PredictionContext {
 
-            if (mergeCache != nil) {
-                var previous: PredictionContext? = mergeCache!.get(a, b)
-                if (previous != nil) {
+            if mergeCache != nil {
+                var previous = mergeCache!.get(a, b)
+                if previous != nil {
                     return previous!
                 }
                 previous = mergeCache!.get(b, a)
-                if (previous != nil) {
+                if previous != nil {
                     return previous!
                 }
             }
 
             // merge sorted payloads a + b => M
-            var i: Int = 0 // walks a
-            var j: Int = 0 // walks b
-            var k: Int = 0// walks target M array
+            var i = 0 // walks a
+            var j = 0 // walks b
+            var k = 0 // walks target M array
 
             let aReturnStatesLength = a.returnStates.count
             let bReturnStatesLength = b.returnStates.count
 
             let mergedReturnStatesLength = aReturnStatesLength + bReturnStatesLength
-            var mergedReturnStates: [Int] = [Int](repeating: 0, count: mergedReturnStatesLength)
+            var mergedReturnStates = [Int](repeating: 0, count: mergedReturnStatesLength)
 
-            var mergedParents: [PredictionContext?] = [PredictionContext?](repeating: nil, count: mergedReturnStatesLength)
-            //new PredictionContext[a.returnStates.length + b.returnStates.length];
+            var mergedParents = [PredictionContext?](repeating: nil, count: mergedReturnStatesLength)
             // walk and merge to yield mergedParents, mergedReturnStates
             let aReturnStates = a.returnStates
             let bReturnStates = b.returnStates
@@ -433,35 +423,27 @@ public class PredictionContext: Hashable, CustomStringConvertible {
             let bParents = b.parents
 
             while i < aReturnStatesLength && j < bReturnStatesLength {
-                let a_parent: PredictionContext? = aParents[i]
-                let b_parent: PredictionContext? = bParents[j]
-                if (aReturnStates[i] == bReturnStates[j]) {
+                let a_parent = aParents[i]
+                let b_parent = bParents[j]
+                if aReturnStates[i] == bReturnStates[j] {
                     // same payload (stack tops are equal), must yield merged singleton
-                    let payload: Int = aReturnStates[i]
+                    let payload = aReturnStates[i]
                     // $+$ = $
-                    var both$: Bool = (payload == EMPTY_RETURN_STATE)
-                    both$ =  both$ && a_parent == nil
-                    both$ =  both$ && b_parent == nil
-//                    let both$: Bool = ((payload == EMPTY_RETURN_STATE) &&
-//                        a_parent == nil && b_parent == nil)
-                    var ax_ax: Bool = (a_parent != nil && b_parent != nil)
-                    ax_ax = ax_ax  && a_parent! == b_parent!
-//                    let ax_ax: Bool = (a_parent != nil && b_parent != nil) && a_parent! == b_parent!  // ax+ax -> ax
+                    let both$ = ((payload == EMPTY_RETURN_STATE) && a_parent == nil && b_parent == nil)
+                    let ax_ax = (a_parent != nil && b_parent != nil && a_parent! == b_parent!)
 
-
-                    if (both$ || ax_ax) {
+                    if both$ || ax_ax {
                         mergedParents[k] = a_parent // choose left
                         mergedReturnStates[k] = payload
                     } else {
                         // ax+ay -> a'[x,y]
-                        let mergedParent: PredictionContext =
-                        merge(a_parent!, b_parent!, rootIsWildcard, &mergeCache)
+                        let mergedParent = merge(a_parent!, b_parent!, rootIsWildcard, &mergeCache)
                         mergedParents[k] = mergedParent
                         mergedReturnStates[k] = payload
                     }
                     i += 1 // hop over left one as usual
                     j += 1 // but also skip one in right side since we merge
-                } else if (aReturnStates[i] < bReturnStates[j]) {
+                } else if aReturnStates[i] < bReturnStates[j] {
                     // copy a[i] to M
                     mergedParents[k] = a_parent
                     mergedReturnStates[k] = aReturnStates[i]
@@ -476,7 +458,7 @@ public class PredictionContext: Hashable, CustomStringConvertible {
             }
 
             // copy over any payloads remaining in either array
-            if (i < aReturnStatesLength) {
+            if i < aReturnStatesLength {
 
                 for p in i..<aReturnStatesLength {
                     mergedParents[k] = aParents[p]
@@ -492,14 +474,12 @@ public class PredictionContext: Hashable, CustomStringConvertible {
             }
 
             // trim merged if we combined a few that had same stack tops
-            if (k < mergedParents.count) {
+            if k < mergedParents.count {
                 // write index < last position; trim
-                if (k == 1) {
+                if k == 1 {
                     // for just one merged element, return singleton top
-                    let a_: PredictionContext =
-                    SingletonPredictionContext.create(mergedParents[0],
-                        mergedReturnStates[0])
-                    if (mergeCache != nil) {
+                    let a_ = SingletonPredictionContext.create(mergedParents[0], mergedReturnStates[0])
+                    if mergeCache != nil {
                         mergeCache!.put(a, b, a_)
                     }
                     //print("merge array 1 \(a_)")
@@ -509,8 +489,7 @@ public class PredictionContext: Hashable, CustomStringConvertible {
                 mergedReturnStates = Array(mergedReturnStates[0 ..< k])
             }
 
-            let M: ArrayPredictionContext =
-            ArrayPredictionContext(mergedParents, mergedReturnStates)
+            let M = ArrayPredictionContext(mergedParents, mergedReturnStates)
 
             // if we created same array as a or b, return that instead
             // TODO: track whether this is possible above during merge sort for speed
@@ -539,24 +518,24 @@ public class PredictionContext: Hashable, CustomStringConvertible {
     }
 
     public static func toDOTString(_ context: PredictionContext?) -> String {
-        if (context == nil) {
+        if context == nil {
             return ""
         }
-        let buf: StringBuilder = StringBuilder()
+        let buf = StringBuilder()
         buf.append("digraph G {\n")
         buf.append("rankdir=LR;\n")
 
-        var nodes: Array<PredictionContext> = getAllContextNodes(context!)
+        var nodes = getAllContextNodes(context!)
 
-        nodes.sort(by: { $0.id > $1.id })
+        nodes.sort { $0.id > $1.id }
 
 
-        for current: PredictionContext in nodes {
-            if (current is SingletonPredictionContext) {
-                let s: String = String(current.id)
+        for current in nodes {
+            if current is SingletonPredictionContext {
+                let s = String(current.id)
                 buf.append("  s").append(s)
-                var returnState: String = String(current.getReturnState(0))
-                if (current is EmptyPredictionContext) {
+                var returnState = String(current.getReturnState(0))
+                if current is EmptyPredictionContext {
                     returnState = "$"
                 }
                 buf.append(" [label=\"")
@@ -564,17 +543,17 @@ public class PredictionContext: Hashable, CustomStringConvertible {
                 buf.append("\"];\n")
                 continue
             }
-            let arr: ArrayPredictionContext = current as! ArrayPredictionContext
+            let arr = current as! ArrayPredictionContext
             buf.append("  s").append(arr.id)
             buf.append(" [shape=box, label=\"")
             buf.append("[")
-            var first: Bool = true
+            var first = true
             let returnStates = arr.returnStates
-            for inv: Int in returnStates {
-                if (!first) {
+            for inv in returnStates {
+                if !first {
                     buf.append(", ")
                 }
-                if (inv == EMPTY_RETURN_STATE) {
+                if inv == EMPTY_RETURN_STATE {
                     buf.append("$")
                 } else {
                     buf.append(inv)
@@ -585,8 +564,8 @@ public class PredictionContext: Hashable, CustomStringConvertible {
             buf.append("\"];\n")
         }
 
-        for current: PredictionContext in nodes {
-            if (current === EMPTY) {
+        for current in nodes {
+            if current === EMPTY {
                 continue
             }
             let length = current.size()
@@ -594,13 +573,13 @@ public class PredictionContext: Hashable, CustomStringConvertible {
                 guard let currentParent = current.getParent(i) else {
                     continue
                 }
-                let s: String = String(current.id)
+                let s = String(current.id)
                 buf.append("  s").append(s)
                 buf.append("->")
                 buf.append("s")
                 buf.append(currentParent.id)
-                if (current.size() > 1) {
-                    buf.append(" [label=\"parent[\(i)]\"];\n");
+                if current.size() > 1 {
+                    buf.append(" [label=\"parent[\(i)]\"];\n")
                 } else {
                     buf.append(";\n")
                 }
@@ -616,23 +595,23 @@ public class PredictionContext: Hashable, CustomStringConvertible {
         _ context: PredictionContext,
         _ contextCache: PredictionContextCache,
         _ visited: HashMap<PredictionContext, PredictionContext>) -> PredictionContext {
-            if (context.isEmpty()) {
+            if context.isEmpty() {
                 return context
             }
 
-            var existing: PredictionContext? = visited[context]
-            if (existing != nil) {
+            var existing = visited[context]
+            if existing != nil {
                 return existing!
             }
 
             existing = contextCache.get(context)
-            if (existing != nil) {
+            if existing != nil {
                 visited[context] = existing!
                 return existing!
             }
 
-            var changed: Bool = false
-            var parents: [PredictionContext?] = [PredictionContext?](repeating: nil, count: context.size())
+            var changed = false
+            var parents = [PredictionContext?](repeating: nil, count: context.size())
             let length = parents.count
             for i in 0..<length {
                 //added by janyou
@@ -640,10 +619,10 @@ public class PredictionContext: Hashable, CustomStringConvertible {
                     return context
                 }
 
-                let parent: PredictionContext = getCachedContext(context.getParent(i)!, contextCache, visited)
+                let parent = getCachedContext(context.getParent(i)!, contextCache, visited)
                 //modified by janyou != !==
-                if (changed || parent !== context.getParent(i)) {
-                    if (!changed) {
+                if changed || parent !== context.getParent(i) {
+                    if !changed {
                         parents = [PredictionContext?](repeating: nil, count: context.size())
 
                         for j in 0..<context.size() {
@@ -657,22 +636,22 @@ public class PredictionContext: Hashable, CustomStringConvertible {
                 }
             }
 
-            if (!changed) {
+            if !changed {
                 contextCache.add(context)
                 visited[context] = context
                 return context
             }
 
-            var updated: PredictionContext
-            if (parents.count == 0) {
+            let updated: PredictionContext
+            if parents.isEmpty {
                 updated = EMPTY
-            } else {
-                if (parents.count == 1) {
-                    updated = SingletonPredictionContext.create(parents[0], context.getReturnState(0))
-                } else {
-                    let arrayPredictionContext: ArrayPredictionContext = context as! ArrayPredictionContext
-                    updated = ArrayPredictionContext(parents, arrayPredictionContext.returnStates)
-                }
+            }
+            else if parents.count == 1 {
+                updated = SingletonPredictionContext.create(parents[0], context.getReturnState(0))
+            }
+            else {
+                let arrayPredictionContext = context as! ArrayPredictionContext
+                updated = ArrayPredictionContext(parents, arrayPredictionContext.returnStates)
             }
 
             contextCache.add(updated)
@@ -685,20 +664,17 @@ public class PredictionContext: Hashable, CustomStringConvertible {
 
 
     // ter's recursive version of Sam's getAllNodes()
-    public static func getAllContextNodes(_ context: PredictionContext) -> Array<PredictionContext> {
-        var nodes: Array<PredictionContext> = Array<PredictionContext>()
-        let visited: HashMap<PredictionContext, PredictionContext> =
-        HashMap<PredictionContext, PredictionContext>()
+    public static func getAllContextNodes(_ context: PredictionContext) -> [PredictionContext] {
+        var nodes = [PredictionContext]()
+        let visited = HashMap<PredictionContext, PredictionContext>()
         getAllContextNodes_(context, &nodes, visited)
         return nodes
     }
 
     public static func getAllContextNodes_(_ context: PredictionContext?,
-                                           _ nodes: inout Array<PredictionContext>,
+                                           _ nodes: inout [PredictionContext],
                                            _ visited: HashMap<PredictionContext, PredictionContext>) {
-        //if (context == nil || visited.keys.contains(context!)) {
-
-        guard let context = context , visited[context] == nil else {
+        guard let context = context, visited[context] == nil else {
             return
         }
         visited[context] = context
@@ -720,56 +696,55 @@ public class PredictionContext: Hashable, CustomStringConvertible {
 
     // FROM SAM
     public func toStrings<T>(_ recognizer: Recognizer<T>?, _ stop: PredictionContext, _ currentState: Int) -> [String] {
-        var result: Array<String> = Array<String>()
-        var perm: Int = 0
+        var result = [String]()
+        var perm = 0
         outer: while true {
-                var offset: Int = 0
-                var last: Bool = true
-                var p: PredictionContext = self
-                var stateNumber: Int = currentState
-                let localBuffer: StringBuilder = StringBuilder()
+                var offset = 0
+                var last = true
+                var p = self
+                var stateNumber = currentState
+                let localBuffer = StringBuilder()
                 localBuffer.append("[")
                 while !p.isEmpty() && p !== stop {
-                    var index: Int = 0
-                    if (p.size() > 0) {
-                        var bits: Int = 1
+                    var index = 0
+                    if p.size() > 0 {
+                        var bits = 1
                         while (1 << bits) < p.size() {
                             bits += 1
                         }
 
-                        let mask: Int = (1 << bits) - 1
+                        let mask = (1 << bits) - 1
                         index = (perm >> offset) & mask
 
                         //last &= index >= p.size() - 1;
                         //last = Bool(Int(last) & (index >= p.size() - 1));
                         last = last && (index >= p.size() - 1)
 
-                        if (index >= p.size()) {
+                        if index >= p.size() {
                             continue outer
                         }
                         offset += bits
                     }
 
                     if let recognizer = recognizer {
-                        if (localBuffer.length > 1) {
+                        if localBuffer.length > 1 {
                             // first char is '[', if more than that this isn't the first rule
                             localBuffer.append(" ")
                         }
 
-                        let atn: ATN = recognizer.getATN()
-                        let s: ATNState = atn.states[stateNumber]!
-                        let ruleName: String = recognizer.getRuleNames()[s.ruleIndex!]
+                        let atn = recognizer.getATN()
+                        let s = atn.states[stateNumber]!
+                        let ruleName = recognizer.getRuleNames()[s.ruleIndex!]
                         localBuffer.append(ruleName)
-                    } else {
-                        if (p.getReturnState(index) != PredictionContext.EMPTY_RETURN_STATE) {
-                            if (!p.isEmpty()) {
-                                if (localBuffer.length > 1) {
-                                    // first char is '[', if more than that this isn't the first rule
-                                    localBuffer.append(" ")
-                                }
-
-                                localBuffer.append(p.getReturnState(index))
+                    }
+                    else if p.getReturnState(index) != PredictionContext.EMPTY_RETURN_STATE {
+                        if !p.isEmpty() {
+                            if localBuffer.length > 1 {
+                                // first char is '[', if more than that this isn't the first rule
+                                localBuffer.append(" ")
                             }
+
+                            localBuffer.append(p.getReturnState(index))
                         }
                     }
                     stateNumber = p.getReturnState(index)
@@ -778,7 +753,7 @@ public class PredictionContext: Hashable, CustomStringConvertible {
                 localBuffer.append("]")
                 result.append(localBuffer.toString())
 
-                if (last) {
+                if last {
                     break
                 }
 
@@ -789,17 +764,18 @@ public class PredictionContext: Hashable, CustomStringConvertible {
     }
 
     public var description: String {
-
         return String(describing: PredictionContext.self) + "@" + String(Unmanaged.passUnretained(self).toOpaque().hashValue)
     }
 }
 
 
 public func ==(lhs: RuleContext, rhs: ParserRuleContext) -> Bool {
-    if !(lhs is ParserRuleContext) {
+    if let lhs = lhs as? ParserRuleContext {
+        return lhs === rhs
+    }
+    else {
         return false
     }
-    return (lhs as! ParserRuleContext) === rhs
 }
 
 public func ==(lhs: PredictionContext, rhs: PredictionContext) -> Bool {
@@ -807,16 +783,16 @@ public func ==(lhs: PredictionContext, rhs: PredictionContext) -> Bool {
     if lhs === rhs {
         return true
     }
-    if (lhs is EmptyPredictionContext) {
+    if lhs is EmptyPredictionContext {
         return lhs === rhs
     }
 
-    if (lhs is SingletonPredictionContext) && (rhs is SingletonPredictionContext) {
-        return (lhs as! SingletonPredictionContext) == (rhs as! SingletonPredictionContext)
+    if let lhs = lhs as? SingletonPredictionContext, let rhs = rhs as? SingletonPredictionContext {
+        return lhs == rhs
     }
 
-    if (lhs is ArrayPredictionContext) && (rhs is ArrayPredictionContext) {
-        return (lhs as! ArrayPredictionContext) == (rhs as! ArrayPredictionContext)
+    if let lhs = lhs as? ArrayPredictionContext, let rhs = rhs as? ArrayPredictionContext {
+        return lhs == rhs
     }
 
     return false

--- a/runtime/Swift/Sources/Antlr4/atn/PredictionContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PredictionContext.swift
@@ -80,20 +80,17 @@ public class PredictionContext: Hashable, CustomStringConvertible {
     }
 
     public func size() -> Int {
-        RuntimeException(#function + " must be overridden")
-        return 0
+        fatalError(#function + " must be overridden")
     }
 
 
     public func getParent(_ index: Int) -> PredictionContext? {
-        RuntimeException(#function + " must be overridden")
-        return nil
+        fatalError(#function + " must be overridden")
     }
 
 
     public func getReturnState(_ index: Int) -> Int {
-        RuntimeException(#function + " must be overridden")
-        return 0
+        fatalError(#function + " must be overridden")
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/atn/PredictionMode.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PredictionMode.swift
@@ -376,7 +376,7 @@ public enum PredictionMode {
     /// - returns: `true` if every _java.util.BitSet_ in `altsets` has
     /// _java.util.BitSet#cardinality cardinality_ &gt; 1, otherwise `false`
     /// 
-    public static func allSubsetsConflict(_ altsets: Array<BitSet>) -> Bool {
+    public static func allSubsetsConflict(_ altsets: [BitSet]) -> Bool {
         return !hasNonConflictingAltSet(altsets)
     }
 
@@ -388,7 +388,7 @@ public enum PredictionMode {
     /// - returns: `true` if `altsets` contains a _java.util.BitSet_ with
     /// _java.util.BitSet#cardinality cardinality_ 1, otherwise `false`
     /// 
-    public static func hasNonConflictingAltSet(_ altsets: Array<BitSet>) -> Bool {
+    public static func hasNonConflictingAltSet(_ altsets: [BitSet]) -> Bool {
         for alts: BitSet in altsets {
             if alts.cardinality() == 1 {
                 return true
@@ -405,7 +405,7 @@ public enum PredictionMode {
     /// - returns: `true` if `altsets` contains a _java.util.BitSet_ with
     /// _java.util.BitSet#cardinality cardinality_ &gt; 1, otherwise `false`
     /// 
-    public static func hasConflictingAltSet(_ altsets: Array<BitSet>) -> Bool {
+    public static func hasConflictingAltSet(_ altsets: [BitSet]) -> Bool {
         for alts: BitSet in altsets {
             if alts.cardinality() > 1 {
                 return true
@@ -421,7 +421,7 @@ public enum PredictionMode {
     /// - returns: `true` if every member of `altsets` is equal to the
     /// others, otherwise `false`
     /// 
-    public static func allSubsetsEqual(_ altsets: Array<BitSet>) -> Bool {
+    public static func allSubsetsEqual(_ altsets: [BitSet]) -> Bool {
 
         let first: BitSet = altsets[0]
         for it in altsets {

--- a/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
@@ -113,7 +113,7 @@ public class ProfilingATNSimulator: ParserATNSimulator {
 
     override
     internal func computeTargetState(_ dfa: DFA, _ previousD: DFAState, _ t: Int) throws -> DFAState {
-        let state: DFAState = try  super.computeTargetState(dfa, previousD, t)
+        let state = try super.computeTargetState(dfa, previousD, t)
         currentState = state
         return state
     }
@@ -126,7 +126,7 @@ public class ProfilingATNSimulator: ParserATNSimulator {
             _llStopIndex = _input.index()
         }
 
-        let reachConfigs: ATNConfigSet? = try super.computeReachSet(closure, t, fullCtx)
+        let reachConfigs = try super.computeReachSet(closure, t, fullCtx)
         if fullCtx {
             decisions[currentDecision].LL_ATNTransitions += 1 // count computation even if error
             if reachConfigs != nil {
@@ -152,10 +152,10 @@ public class ProfilingATNSimulator: ParserATNSimulator {
 
     override
     internal func evalSemanticContext(_ pred: SemanticContext, _ parserCallStack: ParserRuleContext, _ alt: Int, _ fullCtx: Bool) throws -> Bool {
-        let result: Bool = try super.evalSemanticContext(pred, parserCallStack, alt, fullCtx)
+        let result = try super.evalSemanticContext(pred, parserCallStack, alt, fullCtx)
         if !(pred is SemanticContext.PrecedencePredicate) {
-            let fullContext: Bool = _llStopIndex >= 0
-            let stopIndex: Int = fullContext ? _llStopIndex : _sllStopIndex
+            let fullContext = _llStopIndex >= 0
+            let stopIndex = fullContext ? _llStopIndex : _sllStopIndex
             decisions[currentDecision].predicateEvals.append(
             PredicateEvalInfo(currentDecision, _input, _startIndex, stopIndex, pred, result, alt, fullCtx)
             )

--- a/runtime/Swift/Sources/Antlr4/atn/SemanticContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/SemanticContext.swift
@@ -38,8 +38,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
     /// dependent predicate evaluation.
     /// 
     public func eval<T>(_ parser: Recognizer<T>, _ parserCallStack: RuleContext) throws -> Bool {
-        RuntimeException(#function + " must be overridden")
-        return false
+        fatalError(#function + " must be overridden")
     }
 
     /// 
@@ -63,13 +62,11 @@ public class SemanticContext: Hashable, CustomStringConvertible {
     }
 
     public var hashValue: Int {
-        RuntimeException(#function + " must be overridden")
-        return 0
+        fatalError(#function + " must be overridden")
     }
 
     public var description: String {
-        RuntimeException(#function + " must be overridden")
-        return ""
+        fatalError(#function + " must be overridden")
     }
 
     public class Predicate: SemanticContext {
@@ -173,8 +170,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
         /// 
 
         public func getOperands() -> Array<SemanticContext> {
-            RuntimeException(" must overriden ")
-            return Array<SemanticContext>()
+            fatalError(#function + " must be overridden")
         }
     }
 

--- a/runtime/Swift/Sources/Antlr4/atn/Transition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/Transition.swift
@@ -82,8 +82,7 @@ public class Transition {
     }
 
     public func getSerializationType() -> Int {
-        RuntimeException(#function + " must be overridden")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     /// 
@@ -105,7 +104,6 @@ public class Transition {
     }
 
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        RuntimeException(#function + " must be overridden")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 }

--- a/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
@@ -186,7 +186,7 @@ public class DFA: CustomStringConvertible {
             return ""
         }
 
-        let serializer: DFASerializer = DFASerializer(self, vocabulary)
+        let serializer = DFASerializer(self, vocabulary)
         return serializer.toString()
     }
 
@@ -194,7 +194,7 @@ public class DFA: CustomStringConvertible {
         if s0 == nil {
             return ""
         }
-        let serializer: DFASerializer = LexerDFASerializer(self)
+        let serializer = LexerDFASerializer(self)
         return serializer.toString()
     }
 

--- a/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
@@ -170,17 +170,6 @@ public class DFA: CustomStringConvertible {
         return description
     }
 
-    /// 
-    /// -  Use _#toString(org.antlr.v4.runtime.Vocabulary)_ instead.
-    /// 
-    public func toString(_ tokenNames: [String?]?) -> String {
-        if s0 == nil {
-            return ""
-        }
-        let serializer: DFASerializer = DFASerializer(self, tokenNames)
-        return serializer.toString()
-    }
-
     public func toString(_ vocabulary: Vocabulary) -> String {
         if s0 == nil {
             return ""

--- a/runtime/Swift/Sources/Antlr4/dfa/DFASerializer.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFASerializer.swift
@@ -10,9 +10,7 @@
 /// 
 
 public class DFASerializer: CustomStringConvertible {
-
     private let dfa: DFA
-
     private let vocabulary: Vocabulary
 
     /// 
@@ -32,18 +30,17 @@ public class DFASerializer: CustomStringConvertible {
         if dfa.s0 == nil {
             return ""
         }
-        let buf: StringBuilder = StringBuilder()
-        let states: Array<DFAState> = dfa.getStates()
-        for s: DFAState in states {
-            var n: Int = 0
-            if let sEdges = s.edges {
-                n = sEdges.count
+        let buf = StringBuilder()
+        let states = dfa.getStates()
+        for s in states {
+            guard let edges = s.edges else {
+                continue
             }
+            let n = edges.count
             for i in 0..<n {
-                let t: DFAState? = s.edges![i]
-                if let t = t , t.stateNumber != Int.max {
+                if let t = s.edges![i], t.stateNumber != Int.max {
                     buf.append(getStateString(s))
-                    let label: String = getEdgeLabel(i)
+                    let label = getEdgeLabel(i)
                     buf.append("-")
                     buf.append(label)
                     buf.append("->")
@@ -53,7 +50,7 @@ public class DFASerializer: CustomStringConvertible {
             }
         }
 
-        let output: String = buf.toString()
+        let output = buf.toString()
         if output.length == 0 {
             return ""
         }
@@ -72,16 +69,16 @@ public class DFASerializer: CustomStringConvertible {
 
 
     internal func getStateString(_ s: DFAState) -> String {
-        let n: Int = s.stateNumber
+        let n = s.stateNumber
 
         let s1 = s.isAcceptState ? ":" : ""
         let s2 = s.requiresFullContext ? "^" : ""
-        let baseStateStr: String = s1 + "s" + String(n) + s2
+        let baseStateStr = s1 + "s" + String(n) + s2
         if s.isAcceptState {
             if let predicates = s.predicates {
                 return baseStateStr + "=>\(predicates)"
             } else {
-                return baseStateStr + "=>\(s.prediction!)"
+                return baseStateStr + "=>\(s.prediction)"
             }
         } else {
             return baseStateStr

--- a/runtime/Swift/Sources/Antlr4/dfa/DFASerializer.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFASerializer.swift
@@ -13,14 +13,6 @@ public class DFASerializer: CustomStringConvertible {
     private let dfa: DFA
     private let vocabulary: Vocabulary
 
-    /// 
-    /// -  Use _#DFASerializer(org.antlr.v4.runtime.dfa.DFA, org.antlr.v4.runtime.Vocabulary)_ instead.
-    /// 
-    //@Deprecated
-    public convenience init(_ dfa: DFA, _ tokenNames: [String?]?) {
-        self.init(dfa, Vocabulary.fromTokenNames(tokenNames))
-    }
-
     public init(_ dfa: DFA, _ vocabulary: Vocabulary) {
         self.dfa = dfa
         self.vocabulary = vocabulary

--- a/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
@@ -32,10 +32,9 @@
 /// 
 
 public class DFAState: Hashable, CustomStringConvertible {
-    public var stateNumber: Int = -1
+    public var stateNumber = -1
 
-
-    public var configs: ATNConfigSet = ATNConfigSet()
+    public var configs = ATNConfigSet()
 
     /// 
     /// `edges[symbol]` points to target of symbol. Shift up by 1 so (-1)
@@ -43,14 +42,14 @@ public class DFAState: Hashable, CustomStringConvertible {
     ///
     public var edges: [DFAState?]!
 
-    public var isAcceptState: Bool = false
+    public var isAcceptState = false
 
     /// 
     /// if accept state, what ttype do we match or alt do we predict?
     /// This is set to _org.antlr.v4.runtime.atn.ATN#INVALID_ALT_NUMBER_ when _#predicates_`!=null` or
     /// _#requiresFullContext_.
     /// 
-    public var prediction: Int! = 0
+    public var prediction = 0
 
     public var lexerActionExecutor: LexerActionExecutor!
 
@@ -60,7 +59,7 @@ public class DFAState: Hashable, CustomStringConvertible {
     /// _org.antlr.v4.runtime.atn.ParserATNSimulator#execATN_ invocations immediately jumped doing
     /// full context prediction if this field is true.
     /// 
-    public var requiresFullContext: Bool = false
+    public var requiresFullContext = false
 
     /// 
     /// During SLL parsing, this is a list of predicates associated with the
@@ -83,20 +82,17 @@ public class DFAState: Hashable, CustomStringConvertible {
     /// 
 
     public class PredPrediction: CustomStringConvertible {
-
         public final var pred: SemanticContext
         // never null; at least SemanticContext.NONE
         public final var alt: Int
+
         public init(_ pred: SemanticContext, _ alt: Int) {
             self.alt = alt
             self.pred = pred
         }
 
-
         public var description: String {
-
             return "(\(pred),\(alt))"
-
         }
     }
 
@@ -116,10 +112,7 @@ public class DFAState: Hashable, CustomStringConvertible {
     /// DFA state.
     /// 
     public func getAltSet() -> Set<Int>? {
-
-        let alts = configs.getAltSet()
-
-        return alts
+        return configs.getAltSet()
     }
 
 
@@ -143,7 +136,7 @@ public class DFAState: Hashable, CustomStringConvertible {
     /// _#stateNumber_ is irrelevant.
     ///
     public var description: String {
-        let buf: StringBuilder = StringBuilder()
+        let buf = StringBuilder()
         buf.append(stateNumber).append(":").append(configs)
         if isAcceptState {
             buf.append("=>")
@@ -155,15 +148,11 @@ public class DFAState: Hashable, CustomStringConvertible {
         }
         return buf.toString()
     }
-
-
 }
 
 public func ==(lhs: DFAState, rhs: DFAState) -> Bool {
-
     if lhs === rhs {
         return true
     }
-    let sameSet: Bool = lhs.configs == rhs.configs
-    return sameSet
+    return (lhs.configs == rhs.configs)
 }

--- a/runtime/Swift/Sources/Antlr4/misc/HashMap.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/HashMap.swift
@@ -74,19 +74,19 @@ public final class HashMap<K: Hashable,V>: Sequence
     /// 
     /// The default initial capacity - MUST be a power of two.
     /// 
-    let DEFAULT_INITIAL_CAPACITY: Int = 16
+    private let DEFAULT_INITIAL_CAPACITY: Int = 16
 
     /// 
     /// The maximum capacity, used if a higher value is implicitly specified
     /// by either of the constructors with arguments.
     /// MUST be a power of two <= 1<<30.
     /// 
-    let MAXIMUM_CAPACITY: Int = 1 << 30
+    private let MAXIMUM_CAPACITY: Int = 1 << 30
 
     /// 
     /// The load factor used when none specified in constructor.
     /// 
-    let DEFAULT_LOAD_FACTOR: Float = 0.75
+    private let DEFAULT_LOAD_FACTOR: Float = 0.75
 
     /// 
     /// The table, resized as necessary. Length MUST Always be a power of two.

--- a/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
@@ -595,14 +595,6 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
         return buf.toString()
     }
 
-    /// 
-    /// -  Use _#toString(org.antlr.v4.runtime.Vocabulary)_ instead.
-    /// /@Deprecated
-    /// 
-    public func toString(_ tokenNames: [String?]?) -> String {
-        return toString(Vocabulary.fromTokenNames(tokenNames))
-    }
-
     public func toString(_ vocabulary: Vocabulary) -> String {
         let buf = StringBuilder()
 
@@ -639,15 +631,6 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
         }
         return buf.toString()
     }
-
-    /// 
-    /// -  Use _#elementName(org.antlr.v4.runtime.Vocabulary, int)_ instead.
-    /// /@Deprecated
-    /// 
-    internal func elementName(_ tokenNames: [String?]?, _ a: Int) -> String {
-        return elementName(Vocabulary.fromTokenNames(tokenNames), a)
-    }
-
 
     internal func elementName(_ vocabulary: Vocabulary, _ a: Int) -> String {
         if a == CommonToken.EOF {

--- a/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
@@ -51,11 +51,11 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
     }
 
     public init(_ els: Int...) throws {
-        if els.count == 0 {
-            intervals = Array<Interval>() // most sets are 1 or 2 elements
+        if els.isEmpty {
+            intervals = [Interval]() // most sets are 1 or 2 elements
         } else {
-            intervals = Array<Interval>()
-            for e: Int in els {
+            intervals = [Interval]()
+            for e in els {
                 try add(e)
             }
         }
@@ -604,7 +604,7 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
     }
 
     public func toString(_ vocabulary: Vocabulary) -> String {
-        let buf: StringBuilder = StringBuilder()
+        let buf = StringBuilder()
 
         if self.intervals.isEmpty {
             return "{}"
@@ -614,14 +614,14 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
         }
 
         var first = true
-        for I: Interval in intervals {
+        for interval in intervals {
             if !first {
                 buf.append(", ")
             }
             first = false
-            //var I : Interval = iter.next();
-            let a: Int = I.a
-            let b: Int = I.b
+
+            let a = interval.a
+            let b = interval.b
             if a == b {
                 buf.append(elementName(vocabulary, a))
             } else {
@@ -752,35 +752,32 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
         if readonly {
             throw ANTLRError.illegalState(msg: "can't alter readonly IntervalSet")
         }
-        let n: Int = intervals.count
-        for i in 0..<n {
-            let I: Interval = intervals[i]
-            let a: Int = I.a
-            let b: Int = I.b
+        for interval in intervals {
+            let a = interval.a
+            let b = interval.b
             if el < a {
                 break // list is sorted and el is before this interval; not here
             }
             // if whole interval x..x, rm
             if el == a && el == b {
-                intervals.remove(at: i)
-                //intervals.remove(i);
+                intervals.removeObject(interval)
                 break
             }
             // if on left edge x..b, adjust left
             if el == a {
-                I.a += 1
+                interval.a += 1
                 break
             }
             // if on right edge a..x, adjust right
             if el == b {
-                I.b -= 1
+                interval.b -= 1
                 break
             }
             // if in middle a..x..b, split interval
             if el > a && el < b {
                 // found in this interval
-                let oldb: Int = I.b
-                I.b = el - 1      // [a..x-1]
+                let oldb = interval.b
+                interval.b = el - 1      // [a..x-1]
                 try add(el + 1, oldb) // add [x+1..b]
             }
         }

--- a/runtime/Swift/Sources/Antlr4/misc/Utils.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/Utils.swift
@@ -34,19 +34,6 @@ public class Utils {
     }
 
 
-    public static func writeFile(_ fileName: String, _ content: String, _ encoding: String.Encoding = String.Encoding.utf8) {
-
-        //writing
-        do {
-            try content.write(toFile: fileName, atomically: false, encoding: encoding)
-        } catch {
-            /* error handling here */
-            RuntimeException(" write file fail \(error)")
-        }
-
-    }
-
-
     public static func readFile(_ path: String, _ encoding: String.Encoding = String.Encoding.utf8) -> [Character] {
 
         var fileContents: String
@@ -58,35 +45,6 @@ public class Utils {
         }
 
         return Array(fileContents.characters)
-    }
-
-    public static func readFile2String(_ fileName: String, _ encoding: String.Encoding = String.Encoding.utf8) -> String {
-        let path = Bundle.main.path(forResource: fileName, ofType: nil)
-        if path == nil {
-            return ""
-        }
-
-        var fileContents: String? = nil
-        do {
-            fileContents = try String(contentsOfFile: path!, encoding: encoding)
-        } catch {
-            return ""
-        }
-
-        return fileContents ?? ""
-    }
-
-    public static func readFile2StringByPath(_ path: String, _ encoding: String.Encoding = String.Encoding.utf8) -> String {
-
-        var fileContents: String? = nil
-        
-        do {
-            fileContents = try String(contentsOfFile: path, encoding: String.Encoding.utf8)
-        } catch {
-            return ""
-        }
-
-        return fileContents ?? ""
     }
 
     public static func toMap(_ keys: [String]) -> Dictionary<String, Int> {

--- a/runtime/Swift/Sources/Antlr4/misc/utils/CommonUtil.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/utils/CommonUtil.swift
@@ -70,17 +70,6 @@ func log(_ message: String = "", file: String = #file, function: String = #funct
     //   #endif
 }
 
-func RuntimeException(_ message: String = "", file: String = #file, function: String = #function, lineNum: Int = #line) {
-    // #if DEBUG
-    let info = "FILE: \(URL(fileURLWithPath: file).pathComponents.last!),FUNC: \(function), LINE: \(lineNum) MESSAGE: \(message)"
-    //   #else
-    // let info = "FILE: \(NSURL(fileURLWithPath: file).pathComponents!.last!),FUNC: \(function), LINE: \(lineNum) MESSAGE: \(message)"
-    //   #endif
-
-    fatalError(info)
-
-}
-
 func toInt(_ c: Character) -> Int {
     return c.unicodeValue
 }

--- a/runtime/Swift/Sources/Antlr4/tree/ParseTree.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/ParseTree.swift
@@ -11,15 +11,7 @@
 /// 
 /// The payload is either a _org.antlr.v4.runtime.Token_ or a _org.antlr.v4.runtime.RuleContext_ object.
 /// 
-//public protocol ParseTree : SyntaxTree {
-
-open class ParseTree: SyntaxTree, CustomStringConvertible , CustomDebugStringConvertible  {
-
-    // the following methods narrow the return type; they are not additional methods
-
-    //func getParent() -> ParseTree?
-
-    //func getChild(i : Int) -> ParseTree?
+open class ParseTree: SyntaxTree, CustomStringConvertible, CustomDebugStringConvertible {
 
     /// The _org.antlr.v4.runtime.tree.ParseTreeVisitor_ needs a double dispatch method.
 
@@ -36,21 +28,20 @@ open class ParseTree: SyntaxTree, CustomStringConvertible , CustomDebugStringCon
         RuntimeException(" must overriden !")
         return ""
     }
+
     /// Specialize toStringTree so that it can print out more information
     /// based upon the parser.
-    /// 
+    ///
     open func toStringTree(_ parser: Parser) -> String {
         RuntimeException(" must overriden !")
         return ""
 
     }
 
-
     open func getSourceInterval() -> Interval {
         RuntimeException(" must overriden !")
         fatalError()
     }
-
 
     open func getParent() -> Tree? {
         RuntimeException(" must overriden !")
@@ -67,7 +58,6 @@ open class ParseTree: SyntaxTree, CustomStringConvertible , CustomDebugStringCon
         fatalError()
     }
 
-
     open func getChildCount() -> Int {
         RuntimeException(" must overriden !")
         fatalError()
@@ -77,7 +67,6 @@ open class ParseTree: SyntaxTree, CustomStringConvertible , CustomDebugStringCon
         RuntimeException(" must overriden !")
         fatalError()
     }
-
 
     open var description: String {
         RuntimeException(" must overriden !")

--- a/runtime/Swift/Sources/Antlr4/tree/ParseTree.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/ParseTree.swift
@@ -16,8 +16,7 @@ open class ParseTree: SyntaxTree, CustomStringConvertible, CustomDebugStringConv
     /// The _org.antlr.v4.runtime.tree.ParseTreeVisitor_ needs a double dispatch method.
 
     open func accept<T>(_ visitor: ParseTreeVisitor<T>) -> T? {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     /// Return the combined text of all leaf nodes. Does not get any
@@ -25,56 +24,45 @@ open class ParseTree: SyntaxTree, CustomStringConvertible, CustomDebugStringConv
     /// comments if they are sent to parser on hidden channel.
     /// 
     open func getText() -> String {
-        RuntimeException(" must overriden !")
-        return ""
+        fatalError(#function + " must be overridden")
     }
 
     /// Specialize toStringTree so that it can print out more information
     /// based upon the parser.
     ///
     open func toStringTree(_ parser: Parser) -> String {
-        RuntimeException(" must overriden !")
-        return ""
-
+        fatalError(#function + " must be overridden")
     }
 
     open func getSourceInterval() -> Interval {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     open func getParent() -> Tree? {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     open func getPayload() -> AnyObject {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     open func getChild(_ i: Int) -> Tree? {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     open func getChildCount() -> Int {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     open func toStringTree() -> String {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     open var description: String {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 
     open var debugDescription: String {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 }

--- a/runtime/Swift/Sources/Antlr4/tree/ParseTreeVisitor.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/ParseTreeVisitor.swift
@@ -27,9 +27,7 @@ open class ParseTreeVisitor<T> {
     /// - Returns: The result of visiting the parse tree.
     /// 
     open func visit(_ tree: ParseTree) -> T? {
-        RuntimeException(" must overriden !")
-        return nil
-
+        fatalError(#function + " must be overridden")
     }
 
     /// 
@@ -40,9 +38,7 @@ open class ParseTreeVisitor<T> {
     /// - Returns: The result of visiting the children of the node.
     /// 
     open func visitChildren(_ node: RuleNode) -> T? {
-        RuntimeException(" must overriden !")
-        return nil
-
+        fatalError(#function + " must be overridden")
     }
 
     /// 
@@ -52,9 +48,7 @@ open class ParseTreeVisitor<T> {
     /// - Returns: The result of visiting the node.
     /// 
     open func visitTerminal(_ node: TerminalNode) -> T? {
-        RuntimeException(" must overriden !")
-        return nil
-
+        fatalError(#function + " must be overridden")
     }
 
     /// 
@@ -64,7 +58,6 @@ open class ParseTreeVisitor<T> {
     /// - Returns: The result of visiting the node.
     /// 
     open func visitErrorNode(_ node: ErrorNode) -> T? {
-        RuntimeException(" must overriden !")
-        return nil
+        fatalError(#function + " must be overridden")
     }
 }

--- a/runtime/Swift/Sources/Antlr4/tree/RuleNode.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/RuleNode.swift
@@ -6,7 +6,6 @@
 
 open class RuleNode: ParseTree {
     open func getRuleContext() -> RuleContext {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 }

--- a/runtime/Swift/Sources/Antlr4/tree/TerminalNode.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/TerminalNode.swift
@@ -5,9 +5,7 @@
 
 public class TerminalNode: ParseTree {
     public func getSymbol() -> Token? {
-        RuntimeException(" must overriden !")
-        fatalError()
-
+        fatalError(#function + " must be overridden")
     }
 
     /// Set the parent for this leaf node.
@@ -20,7 +18,6 @@ public class TerminalNode: ParseTree {
     /// - Since: 4.7
     /// 
     public func setParent(_ parent: RuleContext) {
-        RuntimeException(" must overriden !")
-        fatalError()
+        fatalError(#function + " must be overridden")
     }
 }

--- a/runtime/Swift/Sources/Antlr4/tree/TerminalNodeImpl.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/TerminalNodeImpl.swift
@@ -6,7 +6,7 @@
 
 public class TerminalNodeImpl: TerminalNode {
     public var symbol: Token
-    public var parent: ParseTree?
+    public weak var parent: ParseTree?
 
     public init(_ symbol: Token) {
         self.symbol = symbol

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/ParseTreePatternMatcher.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/ParseTreePatternMatcher.swift
@@ -68,12 +68,12 @@ public class ParseTreePatternMatcher {
     /// 
     /// This is the backing field for _#getLexer()_.
     /// 
-    private final var lexer: Lexer
+    private final let lexer: Lexer
 
     /// 
     /// This is the backing field for _#getParser()_.
     /// 
-    private final var parser: Parser
+    private final let parser: Parser
 
     internal var start: String = "<"
     internal var stop: String = ">"
@@ -159,19 +159,18 @@ public class ParseTreePatternMatcher {
     /// _org.antlr.v4.runtime.tree.pattern.ParseTreePattern_ using this method.
     /// 
     public func compile(_ pattern: String, _ patternRuleIndex: Int) throws -> ParseTreePattern {
-        let tokenList: Array<Token> = try tokenize(pattern)
-        let tokenSrc: ListTokenSource = ListTokenSource(tokenList)
-        let tokens: CommonTokenStream = CommonTokenStream(tokenSrc)
+        let tokenList = try tokenize(pattern)
+        let tokenSrc = ListTokenSource(tokenList)
+        let tokens = CommonTokenStream(tokenSrc)
 
-        let parserInterp: ParserInterpreter = try ParserInterpreter(parser.getGrammarFileName(),
+        let parserInterp = try ParserInterpreter(parser.getGrammarFileName(),
                 parser.getVocabulary(),
                 parser.getRuleNames(),
                 parser.getATNWithBypassAlts(),
                 tokens)
 
-        var tree: ParseTree
         parserInterp.setErrorHandler(BailErrorStrategy())
-        tree = try parserInterp.parse(patternRuleIndex)
+        let tree = try parserInterp.parse(patternRuleIndex)
 
         // Make sure tree pattern compilation checks for a complete parse
         if try tokens.LA(1) != CommonToken.EOF {
@@ -214,8 +213,8 @@ public class ParseTreePatternMatcher {
 
         // x and <ID>, x and y, or x and x; or could be mismatched types
         if tree is TerminalNode && patternTree is TerminalNode {
-            let t1: TerminalNode = tree as! TerminalNode
-            let t2: TerminalNode = patternTree as! TerminalNode
+            let t1 = tree as! TerminalNode
+            let t2 = patternTree as! TerminalNode
             var mismatchedNode: ParseTree? = nil
             // both are tokens and they have same type
             if t1.getSymbol()!.getType() == t2.getSymbol()!.getType() {
@@ -252,7 +251,6 @@ public class ParseTreePatternMatcher {
             var mismatchedNode: ParseTree? = nil
             // (expr ...) and <expr>
             if let ruleTagToken = getRuleTagToken(r2) {
-                //var m : ParseTreeMatch? = nil;
                 if r1.getRuleContext().getRuleIndex() == r2.getRuleContext().getRuleIndex() {
                     // track label->list-of-nodes for both rule name and label (if any)
                     labels.map(ruleTagToken.getRuleName(), tree)
@@ -277,11 +275,8 @@ public class ParseTreePatternMatcher {
                 return mismatchedNode
             }
 
-            let n: Int = r1.getChildCount()
-            for i in 0..<n {
-                let childMatch: ParseTree? =
-                try matchImpl(r1.getChild(i) as! ParseTree, patternTree.getChild(i) as! ParseTree, labels)
-                if childMatch != nil {
+            for i in 0 ..< r1.getChildCount() {
+                if let childMatch = try matchImpl(r1.getChild(i) as! ParseTree, patternTree.getChild(i) as! ParseTree, labels) {
                     return childMatch
                 }
             }
@@ -295,10 +290,9 @@ public class ParseTreePatternMatcher {
 
     /// Is `t` `(expr <expr>)` subtree?
     internal func getRuleTagToken(_ t: ParseTree) -> RuleTagToken? {
-        if t is RuleNode {
-            let r: RuleNode = t as! RuleNode
+        if let r = t as? RuleNode {
             if r.getChildCount() == 1 && r.getChild(0) is TerminalNode {
-                let c: TerminalNode = r.getChild(0) as! TerminalNode
+                let c = r.getChild(0) as! TerminalNode
                 if c.getSymbol() is RuleTagToken {
 //					print("rule tag subtree "+t.toStringTree(parser));
                     return c.getSymbol() as? RuleTagToken
@@ -310,21 +304,20 @@ public class ParseTreePatternMatcher {
 
     public func tokenize(_ pattern: String) throws -> Array<Token> {
         // split pattern into chunks: sea (raw input) and islands (<ID>, <expr>)
-        let chunks: Array<Chunk> = try split(pattern)
+        let chunks = try split(pattern)
 
         // create token stream from text and tags
-        var tokens: Array<Token> = Array<Token>()
-        for chunk: Chunk in chunks {
-            if chunk is TagChunk {
-                let tagChunk: TagChunk = chunk as! TagChunk
+        var tokens = [Token]()
+        for chunk in chunks {
+            if let tagChunk = chunk as? TagChunk {
                 // add special rule token or conjure up new token from name
                 let firstStr = String(tagChunk.getTag()[0])
                 if firstStr.lowercased() != firstStr {
-                    let ttype: Int = parser.getTokenType(tagChunk.getTag())
+                    let ttype = parser.getTokenType(tagChunk.getTag())
                     if ttype == CommonToken.INVALID_TYPE {
                         throw ANTLRError.illegalArgument(msg: "Unknown token " + tagChunk.getTag() + " in pattern: " + pattern)
                     }
-                    let t: TokenTagToken = TokenTagToken(tagChunk.getTag(), ttype, tagChunk.getLabel())
+                    let t = TokenTagToken(tagChunk.getTag(), ttype, tagChunk.getLabel())
                     tokens.append(t)
                 } else {
                     if firstStr.uppercased() != firstStr {
@@ -339,10 +332,10 @@ public class ParseTreePatternMatcher {
                     }
                 }
             } else {
-                let textChunk: TextChunk = chunk as! TextChunk
-                let inputStream: ANTLRInputStream = ANTLRInputStream(textChunk.getText())
+                let textChunk = chunk as! TextChunk
+                let inputStream = ANTLRInputStream(textChunk.getText())
                 try lexer.setInputStream(inputStream)
-                var t: Token = try lexer.nextToken()
+                var t = try lexer.nextToken()
                 while t.getType() != CommonToken.EOF {
                     tokens.append(t)
                     t = try lexer.nextToken()
@@ -357,32 +350,30 @@ public class ParseTreePatternMatcher {
     /// 
     /// Split `<ID> = <e:expr> ;` into 4 chunks for tokenizing by _#tokenize_.
     /// 
-    public func split(_ pattern: String) throws -> Array<Chunk> {
-        var p: Int = 0
-        let n: Int = pattern.length
-        var chunks: Array<Chunk> = Array<Chunk>()
+    public func split(_ pattern: String) throws -> [Chunk] {
+        var p = 0
+        let n = pattern.length
+        var chunks = [Chunk]()
         // find all start and stop indexes first, then collect
-        var starts: Array<Int> = Array<Int>()
-        var stops: Array<Int> = Array<Int>()
+        var starts = [Int]()
+        var stops = [Int]()
         while p < n {
             if p == pattern.indexOf(escape + start, startIndex: p) {
                 p += escape.length + start.length
-            } else {
-                if p == pattern.indexOf(escape + stop, startIndex: p) {
-                    p += escape.length + stop.length
-                } else {
-                    if p == pattern.indexOf(start, startIndex: p) {
-                        starts.append(p)
-                        p += start.length
-                    } else {
-                        if p == pattern.indexOf(stop, startIndex: p) {
-                            stops.append(p)
-                            p += stop.length
-                        } else {
-                            p += 1
-                        }
-                    }
-                }
+            }
+            else if p == pattern.indexOf(escape + stop, startIndex: p) {
+                p += escape.length + stop.length
+            }
+            else if p == pattern.indexOf(start, startIndex: p) {
+                starts.append(p)
+                p += start.length
+            }
+            else if p == pattern.indexOf(stop, startIndex: p) {
+                stops.append(p)
+                p += stop.length
+            }
+            else {
+                p += 1
             }
         }
 
@@ -394,58 +385,55 @@ public class ParseTreePatternMatcher {
             throw ANTLRError.illegalArgument(msg: "missing start tag in pattern: " + pattern)
         }
 
-        let ntags: Int = starts.count
+        let ntags = starts.count
         for i in 0..<ntags {
             if starts[i] != stops[i] {
                 throw ANTLRError.illegalArgument(msg: "tag delimiters out of order in pattern: " + pattern)
-
             }
         }
 
         // collect into chunks now
         if ntags == 0 {
-
-            let text: String = pattern[0 ..< n]
+            let text = pattern[0 ..< n]
             chunks.append(TextChunk(text))
         }
 
         if ntags > 0 && starts[0] > 0 {
             // copy text up to first tag into chunks
-            let text: String = pattern[0 ..< starts[0]] //; substring(0, starts.get(0));
+            let text = pattern[0 ..< starts[0]]
             chunks.append(TextChunk(text))
         }
-        for i in 0..<ntags {
+
+        for i in 0 ..< ntags {
             // copy inside of <tag>
-            let tag: String = pattern[starts[i] + start.length ..< stops[i]]  // pattern.substring(starts.get(i) + start.length(), stops.get(i));
-            var ruleOrToken: String = tag
-            var label: String = ""
-            let colon: Int = tag.indexOf(":")
+            let tag = pattern[starts[i] + start.length ..< stops[i]]
+            var ruleOrToken = tag
+            var label = ""
+            let colon = tag.indexOf(":")
             if colon >= 0 {
-                label = tag[0 ..< colon]    //(0,colon);
-                ruleOrToken = tag[colon + 1 ..< tag.length]   //(colon+1, tag.length());
+                label = tag[0 ..< colon]
+                ruleOrToken = tag[colon + 1 ..< tag.length]
             }
             chunks.append(try TagChunk(label, ruleOrToken))
             if i + 1 < ntags {
                 // copy from end of <tag> to start of next
-                let text: String = pattern[stops[i] + stop.length ..< starts[i] + 1] //.substring(stops.get(i) + stop.length(), starts.get(i + 1));
+                let text = pattern[stops[i] + stop.length ..< starts[i] + 1]
                 chunks.append(TextChunk(text))
             }
         }
         if ntags > 0 {
-            let afterLastTag: Int = stops[ntags - 1] + stop.length
+            let afterLastTag = stops[ntags - 1] + stop.length
             if afterLastTag < n {
                 // copy text from end of last tag to end
-                let text: String = pattern[afterLastTag ..< n]   //.substring(afterLastTag, n);
+                let text = pattern[afterLastTag ..< n]
                 chunks.append(TextChunk(text))
             }
         }
 
         // strip out the escape sequences from text chunks but not tags
-        let length = chunks.count
-        for i in 0..<length {
-            let c: Chunk = chunks[i]
-            if c is TextChunk {
-                let tc: TextChunk = c as! TextChunk
+        for i in 0 ..< chunks.count {
+            let c = chunks[i]
+            if let tc = c as? TextChunk {
                 let unescaped = tc.getText().replacingOccurrences(of: escape, with: "")
                 if unescaped.length < tc.getText().length {
                     chunks[i] = TextChunk(unescaped)

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/RuleTagToken.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/RuleTagToken.swift
@@ -149,14 +149,18 @@ public class RuleTagToken: Token, CustomStringConvertible {
         return nil
     }
 
-    /// 
+    ///
     /// The implementation for _org.antlr.v4.runtime.tree.pattern.RuleTagToken_ always returns `null`.
     /// 
     public func getInputStream() -> CharStream? {
         return nil
     }
 
-    /// 
+    public func getTokenSourceAndStream() -> TokenSourceAndStream {
+        return TokenSourceAndStream.EMPTY
+    }
+
+    ///
     /// The implementation for _org.antlr.v4.runtime.tree.pattern.RuleTagToken_ returns a string of the form
     /// `ruleName:bypassTokenType`.
     /// 

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/RuleTagToken.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/RuleTagToken.swift
@@ -26,7 +26,7 @@ public class RuleTagToken: Token, CustomStringConvertible {
     /// 
     private final var label: String?
 
-    public var visited: Bool = false
+    public var visited = false
 
     /// 
     /// Constructs a new instance of _org.antlr.v4.runtime.tree.pattern.RuleTagToken_ with the specified rule
@@ -55,8 +55,6 @@ public class RuleTagToken: Token, CustomStringConvertible {
     /// or empty.
     /// 
     public init(_ ruleName: String, _ bypassTokenType: Int, _ label: String?) {
-
-
         self.ruleName = ruleName
         self.bypassTokenType = bypassTokenType
         self.label = label
@@ -93,11 +91,10 @@ public class RuleTagToken: Token, CustomStringConvertible {
     /// delimiters.
     /// 
     public func getText() -> String? {
-        if label != nil {
-            return "<" + label! + ":" + ruleName + ">"
+        if let label = label {
+            return "<\(label):\(ruleName)>"
         }
-
-        return "<" + ruleName + ">"
+        return "<\(ruleName)>"
     }
 
     /// 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -241,12 +241,14 @@ open class <parser.name>: <superClass; null="Parser"> {
            }
            return decisionToDFA
      }()
-	internal static let _sharedContextCache: PredictionContextCache = PredictionContextCache()
+	internal static let _sharedContextCache = PredictionContextCache()
+
 	<if(parser.tokens)>
 	public enum Tokens: Int {
 		case EOF = -1, <parser.tokens:{k | <k> = <parser.tokens.(k)>}; separator=", ", wrap, anchor>
 	}
         <endif>
+
 	public static let <parser.rules:{r | RULE_<r.name> = <r.index>}; separator=", ", wrap, anchor>
 	public static let ruleNames: [String] = [
 		<parser.ruleNames:{r | "<r>"}; separator=", ", wrap, anchor>
@@ -285,8 +287,8 @@ case  <f.ruleIndex>:
 <endif>
 
 	<atn>
-   public static let _serializedATN : String = <parser.name>ATN().jsonString
-   public static let _ATN: ATN = ATNDeserializer().deserializeFromJson(_serializedATN)
+   public static let _serializedATN = <parser.name>ATN().jsonString
+   public static let _ATN = ATNDeserializer().deserializeFromJson(_serializedATN)
 }
 >>
 
@@ -297,7 +299,7 @@ private static let _LITERAL_NAMES: [String?] = [
 private static let _SYMBOLIC_NAMES: [String?] = [
 	<symbolicNames:{t | <t>}; null="nil", separator=", ", wrap, anchor>
 ]
-public static let VOCABULARY: Vocabulary = Vocabulary(_LITERAL_NAMES, _SYMBOLIC_NAMES)
+public static let VOCABULARY = Vocabulary(_LITERAL_NAMES, _SYMBOLIC_NAMES)
 
 /**
  * @deprecated Use {@link #VOCABULARY} instead.
@@ -361,11 +363,12 @@ open override func getVocabulary() -> Vocabulary {
     return <p.name>.VOCABULARY
 }
 
-public override init(_ input:TokenStream)throws {
+public override init(_ input:TokenStream) throws {
     RuntimeMetaData.checkVersion("4.7", RuntimeMetaData.VERSION)
 	try super.init(input)
 	_interp = ParserATNSimulator(self,<p.name>._ATN,<p.name>._decisionToDFA, <parser.name>._sharedContextCache)
 }
+
 >>
 
 /* This generates a private method since the actionIndex is generated, making an
@@ -796,7 +799,7 @@ open func <t.name>(_ i:Int) -> TerminalNode?{
 >>
 ContextRuleGetterDecl(r)       ::= <<
 open func <r.name>() -> <r.ctxName>? {
-	return getRuleContext(<r.ctxName>.self,0)
+	return getRuleContext(<r.ctxName>.self, 0)
 }
 >>
 ContextRuleListGetterDecl(r)   ::= <<
@@ -806,7 +809,7 @@ open func <r.name>() -> Array\<<r.ctxName>\> {
 >>
 ContextRuleListIndexedGetterDecl(r)   ::= <<
 open func <r.name>(_ i: Int) -> <r.ctxName>? {
-	return getRuleContext(<r.ctxName>.self,i)
+	return getRuleContext(<r.ctxName>.self, i)
 }
 >>
 
@@ -827,7 +830,7 @@ CaptureNextTokenType(d) ::= "<d.varName> = try _input.LA(1)"
 
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,
            superClass={ParserRuleContext}) ::= <<
-open class <struct.name>:<if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
+open class <struct.name>: <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 	<attrs:{a | public var <a>}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
 	<! <if(ctorAttrs)>public init(_ parent: ParserRuleContext,_ invokingState: Int) { super.init(parent, invokingState)  }<endif> !>
@@ -865,8 +868,8 @@ public  final class <struct.name>: <currentRule.name; format="cap">Context {
 ListenerDispatchMethod(method) ::= <<
 override
 open func <if(method.isEnter)>enter<else>exit<endif>Rule(_ listener: ParseTreeListener) {
-	if listener is <parser.grammarName>Listener {
-	 	(listener as! <parser.grammarName>Listener).<if(method.isEnter)>enter<else>exit<endif><struct.derivedFromName; format="cap">(self)
+	if let listener = listener as? <parser.grammarName>Listener {
+		listener.<if(method.isEnter)>enter<else>exit<endif><struct.derivedFromName; format="cap">(self)
 	}
 }
 >>
@@ -874,11 +877,12 @@ open func <if(method.isEnter)>enter<else>exit<endif>Rule(_ listener: ParseTreeLi
 VisitorDispatchMethod(method) ::= <<
 override
 open func accept\<T>(_ visitor: ParseTreeVisitor\<T>) -> T? {
-	if visitor is <parser.grammarName>Visitor {
-	     return (visitor as! <parser.grammarName>Visitor\<T>).visit<struct.derivedFromName; format="cap">(self)
-	}else if visitor is <parser.grammarName>BaseVisitor {
-    	 return (visitor as! <parser.grammarName>BaseVisitor\<T>).visit<struct.derivedFromName; format="cap">(self)
-    }
+	if let visitor = visitor as? <parser.grammarName>Visitor {
+	    return visitor.visit<struct.derivedFromName; format="cap">(self)
+	}
+	else if let visitor = visitor as? <parser.grammarName>BaseVisitor {
+	    return visitor.visit<struct.derivedFromName; format="cap">(self)
+	}
 	else {
 	     return visitor.visitChildren(self)
 	}
@@ -959,7 +963,7 @@ open class <lexer.name>: <superClass; null="Lexer"> {
            return decisionToDFA
      }()
 
-	internal static let _sharedContextCache:PredictionContextCache = PredictionContextCache()
+	internal static let _sharedContextCache = PredictionContextCache()
 	public static let <lexer.tokens:{k | <k>=<lexer.tokens.(k)>}; separator=", ", wrap, anchor>
 	<if(lexer.channels)>
 	public static let <lexer.channels:{k | <k>=<lexer.channels.(k)>}; separator=", ", wrap, anchor>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -300,32 +300,6 @@ private static let _SYMBOLIC_NAMES: [String?] = [
 	<symbolicNames:{t | <t>}; null="nil", separator=", ", wrap, anchor>
 ]
 public static let VOCABULARY = Vocabulary(_LITERAL_NAMES, _SYMBOLIC_NAMES)
-
-/**
- * @deprecated Use {@link #VOCABULARY} instead.
- */
-//@Deprecated
-public let tokenNames: [String?]? = {
-    let length = _SYMBOLIC_NAMES.count
-    var tokenNames = [String?](repeating: nil, count: length)
-	for i in 0..\<length {
-		var name = VOCABULARY.getLiteralName(i)
-		if name == nil {
-			name = VOCABULARY.getSymbolicName(i)
-		}
-		if name == nil {
-			name = "\<INVALID>"
-		}
-		tokenNames[i] = name
-	}
-	return tokenNames
-}()
-
-override
-<!//@Deprecated!>
-open func getTokenNames() -> [String?]? {
-	return tokenNames
-}
 >>
 
 dumpActions(recog, argFuncs, actionFuncs, sempredFuncs) ::= <<


### PR DESCRIPTION
Fix a number of retain cycles in the Swift runtime (see the individual changesets for details).  These were causing the lexer, parser, ATN simulators, and tokens all to be retained after a parse.

Add `RecognitionException.{clearRecognizer,clearInputStream}` so that client code can clear those fields if desired, thus releasing the parser / token stream if it is not needed for error handling.

This depends on PR #2075 (and transitively upon PR #2072) due to merge conflicts.
