### PR TITLE
Fix the AppVeyor tests.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: '4.7.1-SNAPSHOT+AppVeyor.{build}'
-os: Windows Server 2012
+build: off
 build_script:
-  - mvn -DskipTests install -q --batch-mode 
+  - mvn -DskipTests install --batch-mode
+  - msbuild runtime/CSharp/runtime/CSharp/Antlr4.vs2013.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:detailed
+  - msbuild ./runtime-testsuite/target/classes/CSharp/runtime/CSharp/Antlr4.vs2013.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:detailed
 test_script:
-  - mvn install -q -Dantlr-python2-python="C:\Python27\python.exe" -Dantlr-python3-python="C:\Python35\python.exe" -Dantlr-javascript-nodejs="C:\Program Files (x86)\nodejs\node.exe" --batch-mode
-build:
-  verbosity: minimal
+  - mvn install -Dantlr-python2-python="C:\Python27\python.exe" -Dantlr-python3-python="C:\Python35\python.exe" -Dantlr-javascript-nodejs="C:\Program Files (x86)\nodejs\node.exe" --batch-mode


### PR DESCRIPTION
For some reason, possibly the new images that AppVeyor rolled out on Oct 22,
our AppVeyor tests now fail immediately, with msbuild complaining that there
are multiple solutions in the repository.

Address this by not using the default AppVeyor build section, but calling
msbuild ourselves explicitly in the build_script section.  This way, we can
specify which .slns we want to build.  I have specified the runtime and
runtime-testsuite Antlr4.vs2013.slns; the other ones didn't work for me in
this configuration.

Also, these builds were previously running with low / zero logging.  As
far as I can tell, this gave AppVeyor no way to know whether the build has
succeeded or not.  It certainly gives no way to diagnose any failures that do
occur.  I have dialed the logging up on everything.

Also, remove the os declaration.  That appears to be well out of date, and
isn't on AppVeyor's list of images any more.  I presume that we've been
using their default image for some time.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->