### PR TITLE
Remove ~/.m2/repository/org/antlr from the Travis cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: true
 
 language: java
 
+before_cache:
+  - rm -rf $HOME/.m2/repository/org/antlr
 cache:
   directories:
   - $HOME/.m2


### PR DESCRIPTION
Caching ~/.m2 is useful; caching org/antlr inside there is not.  It causes
unnecessary re-submission of the cache every build.
