### PR TITLE
Very minor fix in error handling path for the -o command line option.

### DIFF
--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -246,7 +246,7 @@ public class Tool {
 			haveOutputDir = true;
 			if (outDir.exists() && !outDir.isDirectory()) {
 				errMgr.toolError(ErrorType.OUTPUT_DIR_IS_FILE, outputDirectory);
-				libDirectory = ".";
+				outputDirectory = ".";
 			}
 		}
 		else {


### PR DESCRIPTION
If the specified output path was a file and not a directory, the error
handling intended to invalidate outputDirectory, but due to an apparent
copy-paste error, it invalidated libDirectory instead.
