### PR TITLE
Fix the -message-format command line option.

### DIFF
--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -191,8 +191,11 @@ public class Tool {
 	public Tool(String[] args) {
 		this.args = args;
 		errMgr = new ErrorManager(this);
-		errMgr.setFormat(msgFormat);
+		// We have to use the default message format until we have
+		// parsed the -message-format command line option.
+		errMgr.setFormat("antlr");
 		handleArgs();
+		errMgr.setFormat(msgFormat);
 	}
 
 	protected void handleArgs() {


### PR DESCRIPTION
ErrorManager.setFormat was being called before the command line options
were parsed in handleArgs.  This meant that setFormat was always called
with the default, and so the command line option never took effect.

This option apparently only worked for 2.5 hours on Sep 6 2012 ;-)

Closes #992.
