### PR TITLE
Add Travis-side caching of the dotnet package that we download from Microsoft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ sudo: true
 language: java
 
 cache:
+  timeout: 600
   directories:
   - $HOME/.m2
+  - $HOME/Library/Caches/Antlr4
   - $HOME/Library/Caches/Homebrew
 
 stages:

--- a/.travis/before-install-osx-dotnet.sh
+++ b/.travis/before-install-osx-dotnet.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+cache_dir="$HOME/Library/Caches/Antlr4"
+dotnet_url='https://download.microsoft.com/download/B/9/F/B9F1AF57-C14A-4670-9973-CDF47209B5BF/dotnet-dev-osx-x64.1.0.4.pkg'
+dotnet_file=$(basename "$dotnet_url")
+dotnet_shasum='63b5d99028cd8b2454736076106c96ba7d05f0fc'
+
 thisdir=$(dirname "$0")
 
 # OpenSSL setup for dotnet core
@@ -10,10 +15,23 @@ ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
 ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
 
 # download dotnet core
-curl https://download.microsoft.com/download/B/9/F/B9F1AF57-C14A-4670-9973-CDF47209B5BF/dotnet-dev-osx-x64.1.0.4.pkg -o /tmp/dotnet-dev-osx-x64.1.0.4.pkg
+mkdir -p "$cache_dir"
+(cd "$cache_dir"
+ if [ -f "$dotnet_file" ]
+ then
+     if ! shasum -s -c <<<"$dotnet_shasum  $dotnet_file"
+     then
+         rm -f "$dotnet_file"
+     fi
+ fi
+ if ! [ -f "$dotnet_file" ]
+ then
+     curl "$dotnet_url" -o "$dotnet_file"
+ fi
+)
 
 # install dotnet core
-sudo installer -pkg /tmp/dotnet-dev-osx-x64.1.0.4.pkg -target /
+sudo installer -pkg "$cache_dir/$dotnet_file" -target /
 
 # make the link
 ln -s /usr/local/share/dotnet/dotnet /usr/local/bin/


### PR DESCRIPTION
This avoids hitting the Microsoft server every time.  The download isn't
super-reliable, so this should help with build reliability.

This extends the cache timeout, because the package is large and the
upload was timing out.
