### PR TITLE
Make CharStream.init(CharStream) required (in the Swift runtime).

### DIFF
--- a/runtime/Swift/Sources/Antlr4/Lexer.swift
+++ b/runtime/Swift/Sources/Antlr4/Lexer.swift
@@ -92,7 +92,7 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
         self._tokenFactorySourcePair.tokenSource = self
     }
 
-    public init(_ input: CharStream) {
+    public required init(_ input: CharStream) {
         self._input = input
         self._tokenFactorySourcePair = TokenSourceAndStream()
         super.init()

--- a/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
@@ -18,19 +18,6 @@ public class LexerInterpreter: Lexer {
     internal final var _decisionToDFA: [DFA]
     internal final var _sharedContextCache = PredictionContextCache()
 
-//   public override init() {
-//    super.init()}
-
-//    public  convenience   init(_ input : CharStream) {
-//        self.init()
-//        self._input = input;
-//        self._tokenFactorySourcePair = (self, input);
-//    }
-    //@Deprecated
-    public convenience init(_ grammarFileName: String, _ tokenNames: Array<String?>?, _ ruleNames: Array<String>, _ channelNames: Array<String>, _ modeNames: Array<String>, _ atn: ATN, _ input: CharStream) throws {
-        try self.init(grammarFileName, Vocabulary.fromTokenNames(tokenNames), ruleNames, channelNames, modeNames, atn, input)
-    }
-
     public init(_ grammarFileName: String, _ vocabulary: Vocabulary, _ ruleNames: Array<String>, _ channelNames: Array<String>, _ modeNames: Array<String>, _ atn: ATN, _ input: CharStream) throws {
 
         self.grammarFileName = grammarFileName
@@ -52,6 +39,10 @@ public class LexerInterpreter: Lexer {
             throw ANTLRError.illegalArgument(msg: "The ATN must be a lexer ATN.")
 
         }
+    }
+
+    public required init(_ input: CharStream) {
+        fatalError("Use the other initializer")
     }
 
     override

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -964,7 +964,7 @@ open class <lexer.name>: <superClass; null="Lexer"> {
         return <lexer.name>.VOCABULARY
     }
 
-	public override init(_ input: CharStream) {
+	public required init(_ input: CharStream) {
 	    RuntimeMetaData.checkVersion("<lexerFile.ANTLRVersion>", RuntimeMetaData.VERSION)
 		super.init(input)
 		_interp = LexerATNSimulator(self, <lexer.name>._ATN, <lexer.name>._decisionToDFA, <lexer.name>._sharedContextCache)


### PR DESCRIPTION
This makes it possible for client code to use CharStream as a generic type
constraint and construct Lexer subclasses generically.
