### PR TITLE
Include the Swift runtime in "mvn clean".

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,20 @@
 				<directory>test</directory>
 			</testResource>
 		</testResources>
+		<plugins>
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.0.0</version>
+				<configuration>
+					<filesets>
+						<fileset>
+							<directory>runtime/Swift/.build</directory>
+							<directory>runtime/Swift/Tests/Antlr4Tests/gen</directory>
+						</fileset>
+					</filesets>
+				</configuration>
+			</plugin>
+		</plugins>
 		<pluginManagement>
 			<plugins>
 				<plugin>


### PR DESCRIPTION
Add an entry to pom.xml so that the runtime/Swift subdirectories that contain
build output are removed when "mvn clean" is used.
