### PR TITLE
Add RuleContext interface methods to reserved words

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -170,3 +170,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/10/27, Griffon26, Maurice van der Pot, griffon26@kfk4ever.com
 2017/05/29, rlfnb, Ralf Neeb, rlfnb@rlfnb.de
 2017/10/29, gendalph, Максим Прохоренко, Maxim\dotProhorenko@gm@il.com
+2017/11/02, jasonmoo, Jason Mooberry, jason.mooberry@gmail.com

--- a/tool/src/org/antlr/v4/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/GoTarget.java
@@ -49,8 +49,18 @@ public class GoTarget extends Target {
 			"make", "new", "panic", "print", "println", "real", "recover"
 	};
 
+	// interface definition of RuleContext from runtime/Go/antlr/rule_context.go
+	private static final String[] goRuleContextInterfaceMethods = {
+		"Accept", "GetAltNumber", "GetBaseRuleContext", "GetChild", "GetChildCount",
+		"GetChildren", "GetInvokingState", "GetParent", "GetPayload", "GetRuleContext",
+		"GetRuleIndex", "GetSourceInterval", "GetText", "IsEmpty", "SetAltNumber",
+		"SetInvokingState", "SetParent", "String"
+	};
+
 	/** Avoid grammar symbols in this set to prevent conflicts in gen'd code. */
-	private final Set<String> badWords = new HashSet<String>(goKeywords.length + goPredeclaredIdentifiers.length + 3);
+	private final Set<String> badWords = new HashSet<String>(
+		goKeywords.length + goPredeclaredIdentifiers.length + goRuleContextInterfaceMethods.length + 3
+	);
 
 	private static final boolean DO_GOFMT = !Boolean.parseBoolean(System.getenv("ANTLR_GO_DISABLE_GOFMT"))
 			&& !Boolean.parseBoolean(System.getProperty("antlr.go.disable-gofmt"));
@@ -75,6 +85,7 @@ public class GoTarget extends Target {
 	protected void addBadWords() {
 		badWords.addAll(Arrays.asList(goKeywords));
 		badWords.addAll(Arrays.asList(goPredeclaredIdentifiers));
+		badWords.addAll(Arrays.asList(goRuleContextInterfaceMethods));
 		badWords.add("rule");
 		badWords.add("parserRule");
 		badWords.add("action");


### PR DESCRIPTION
This fixes https://github.com/antlr/antlr4/issues/2080 by adding all method names from the `RuleContext` interface definition to the reserved words list.  Arguably this is a quick fix and not a full solution, but should help avoid some headaches in the mean time.

```go
type Tree interface {
	GetParent() Tree
	SetParent(Tree)
	GetPayload() interface{}
	GetChild(i int) Tree
	GetChildCount() int
	GetChildren() []Tree
}

type SyntaxTree interface {
	Tree

	GetSourceInterval() *Interval
}

type ParseTree interface {
	SyntaxTree

	Accept(Visitor ParseTreeVisitor) interface{}
	GetText() string

	ToStringTree([]string, Recognizer) string
}

type RuleNode interface {
	ParseTree

	GetRuleContext() RuleContext
	GetBaseRuleContext() *BaseRuleContext
}

type RuleContext interface {
	RuleNode

	GetInvokingState() int
	SetInvokingState(int)

	GetRuleIndex() int
	IsEmpty() bool

	GetAltNumber() int
	SetAltNumber(altNumber int)

	String([]string, RuleContext) string
}
```