### PR TITLE
Run the Swift runtime unit tests during the Travis run.

### DIFF
--- a/.travis/run-tests-swift.sh
+++ b/.travis/run-tests-swift.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # linux specific setup, those setup have to be
 # here since environment variables doesn't pass
 # across scripts
@@ -13,9 +15,19 @@ if [ $TRAVIS_OS_NAME == "linux" ]; then
   curl https://swift.org/builds/$SWIFT_VERSION-release/ubuntu1404/$SWIFT_VERSION-RELEASE/$SWIFT_VERSION-RELEASE-ubuntu14.04.tar.gz -s | tar xz -C swift &> /dev/null
 fi
 
+if [ -z "${JAVA_HOME-}" ]
+then
+  export JAVA_HOME="$(dirname $(java -XshowSettings:properties -version 2>&1 |
+                                    grep 'java\.home' | awk '{ print $3 }'))"
+fi
+
 # check swift
 swift --version
 swift build --version
+
+pushd ../runtime/Swift
+./boot.py --test
+popd
 
 if [ $GROUP == "LEXER" ]; then
     mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=swift.* test


### PR DESCRIPTION
These are the unit tests that are written in Swift, not the more
in-depth runtime-testsuite tests (we were always running those).

I don't know why JAVA_HOME isn't set during run-tests-swift.sh, but it
isn't.  Set it, since runtime/Swift/boot.py expects it as part of the
parser generation.
