### PR TITLE
Report errors in ANTLRFileStream.

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/BaseSwiftTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/BaseSwiftTest.java
@@ -281,7 +281,7 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 						"\n" +
 						"do {\n" +
 						"let args = CommandLine.arguments\n" +
-						"let input = ANTLRFileStream(args[1])\n" +
+						"let input = try ANTLRFileStream(args[1])\n" +
 						"let lex = <lexerName>(input)\n" +
 						"let tokens = CommonTokenStream(lex)\n" +
 						"<createParser>\n" +
@@ -327,7 +327,7 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 
 						"setbuf(stdout, nil)\n" +
 						"let args = CommandLine.arguments\n" +
-						"let input = ANTLRFileStream(args[1])\n" +
+						"let input = try ANTLRFileStream(args[1])\n" +
 						"let lex = <lexerName>(input)\n" +
 						"let tokens = CommonTokenStream(lex)\n" +
 

--- a/runtime/Swift/Sources/Antlr4/ANTLRFileStream.swift
+++ b/runtime/Swift/Sources/Antlr4/ANTLRFileStream.swift
@@ -9,30 +9,18 @@
 import Foundation
 
 public class ANTLRFileStream: ANTLRInputStream {
-    internal var fileName: String
+    private let fileName: String
 
-    public convenience override init(_ fileName: String) {
-        self.init(fileName, nil)
-    }
-
-    public init(_ fileName: String, _ encoding: String.Encoding?) {
+    public init(_ fileName: String, _ encoding: String.Encoding? = nil) throws {
         self.fileName = fileName
         super.init()
-        load(fileName, encoding)
-    }
-
-    public func load(_ fileName: String, _ encoding: String.Encoding?) {
-        if encoding != nil {
-            data = Utils.readFile(fileName, encoding!)
-        } else {
-            data = Utils.readFile(fileName)
-        }
-        self.n = data.count
+        let fileContents = try String(contentsOfFile: fileName, encoding: encoding ?? .utf8)
+        data = Array(fileContents)
+        n = data.count
     }
 
     override
     public func getSourceName() -> String {
         return fileName
     }
-
 }

--- a/runtime/Swift/Sources/Antlr4/misc/Utils.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/Utils.swift
@@ -34,19 +34,6 @@ public class Utils {
     }
 
 
-    public static func readFile(_ path: String, _ encoding: String.Encoding = String.Encoding.utf8) -> [Character] {
-
-        var fileContents: String
-
-        do {
-            fileContents = try String(contentsOfFile: path, encoding: encoding)
-        } catch {
-            return [Character]()
-        }
-
-        return Array(fileContents.characters)
-    }
-
     public static func toMap(_ keys: [String]) -> Dictionary<String, Int> {
         var m = Dictionary<String, Int>()
         for (index,v) in keys.enumerated() {


### PR DESCRIPTION
Change the initializer to ANTLRFileStream so that it throws any errors that
occur while reading the file.  Previously, it was just dropping any errors on
the floor (inside Utils.readFile).

Remove Utils.readFile, it's not used anywhere else.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->