### PR TITLE
[Swift] Make all the mutexes "let" rather than "var".

### DIFF
--- a/runtime/Swift/Sources/Antlr4/Parser.swift
+++ b/runtime/Swift/Sources/Antlr4/Parser.swift
@@ -61,12 +61,12 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// 
     /// mutex for bypassAltsAtnCache updates
     /// 
-    private var bypassAltsAtnCacheMutex = Mutex()
+    private let bypassAltsAtnCacheMutex = Mutex()
     
     /// 
     /// mutex for decisionToDFA updates
     /// 
-    private var decisionToDFAMutex = Mutex()
+    private let decisionToDFAMutex = Mutex()
 
     /// 
     /// This field maps from the serialized ATN string to the deserialized _org.antlr.v4.runtime.atn.ATN_ with

--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
@@ -77,12 +77,12 @@ open class LexerATNSimulator: ATNSimulator {
     /// 
     /// mutex for DFAState change
     /// 
-    private var dfaStateMutex = Mutex()
+    private let dfaStateMutex = Mutex()
     
     /// 
     /// mutex for changes to all DFAStates map
     /// 
-    private var dfaStatesMutex = Mutex()
+    private let dfaStatesMutex = Mutex()
 
     /// 
     /// Used during DFA/ATN exec to record the most recent accept configuration info

--- a/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
@@ -281,12 +281,12 @@ open class ParserATNSimulator: ATNSimulator {
     /// 
     /// mutex for DFAState change
     /// 
-    private var dfaStateMutex = Mutex()
+    private let dfaStateMutex = Mutex()
     
     /// 
     /// mutex for changes in a DFAStates map
     /// 
-    private var dfaStatesMutex = Mutex()
+    private let dfaStatesMutex = Mutex()
 
 //    /// Testing only!
 //    public convenience init(_ atn : ATN, _ decisionToDFA : [DFA],

--- a/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
@@ -32,7 +32,7 @@ public class DFA: CustomStringConvertible {
     /// 
     /// mutex for DFAState changes.
     /// 
-    private var dfaStateMutex = Mutex()
+    private let dfaStateMutex = Mutex()
 
     public convenience init(_ atnStartState: DecisionState) {
         self.init(atnStartState, 0)


### PR DESCRIPTION
Make all the mutexes in the Swift runtime use "let" rather than "var".

They are never changed, and they wouldn't make good mutexes if they were.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->