### PR TITLE
[Swift] Replace IntervalSet.setReadonly with makeReadonly.

### DIFF
--- a/runtime/Swift/Sources/Antlr4/atn/ATN.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATN.swift
@@ -85,13 +85,12 @@ public class ATN {
     /// rule.
     /// 
     public func nextTokens(_ s: ATNState) -> IntervalSet {
-        if let nextTokenWithinRule = s.nextTokenWithinRule
-        {
+        if let nextTokenWithinRule = s.nextTokenWithinRule {
             return nextTokenWithinRule
         }
         let intervalSet = nextTokens(s, nil)
         s.nextTokenWithinRule = intervalSet
-        try! intervalSet.setReadonly(true)
+        intervalSet.makeReadonly()
         return intervalSet
     }
 

--- a/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
@@ -22,13 +22,13 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
     public static let COMPLETE_CHAR_SET: IntervalSet =
     {
         let set = IntervalSet.of(Lexer.MIN_CHAR_VALUE, Lexer.MAX_CHAR_VALUE)
-        try! set.setReadonly(true)
+        set.makeReadonly()
         return set
     }()
 
     public static let EMPTY_SET: IntervalSet = {
         let set = IntervalSet()
-        try! set.setReadonly(true)
+        set.makeReadonly()
         return set
     }()
 
@@ -702,12 +702,8 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
         return readonly
     }
 
-    public func setReadonly(_ readonly: Bool) throws {
-        if self.readonly && !readonly {
-            throw ANTLRError.illegalState(msg: "can't alter readonly IntervalSet")
-
-        }
-        self.readonly = readonly
+    public func makeReadonly() {
+        readonly = true
     }
 }
 


### PR DESCRIPTION
Replace IntervalSet.setReadonly(Bool) with makeReadonly().  This
operation only ever works in one direction, and would throw an exception
if a caller attempted to make a read-only IntervalSet read-write again.
By changing the interface we remove the need to check this, and so we
don't need to declare the exception.  Unlike in the Java runtime, we
need to declare the possibility of the exception at the callsite, so this
was pointlessly cluttering.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->