### PR TITLE
[Swift] Make DFA.precedenceDfa be a "let" rather than a "var".

### DIFF
--- a/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
@@ -27,7 +27,7 @@ public class DFA: CustomStringConvertible {
     /// `true` if this DFA is for a precedence decision; otherwise,
     /// `false`. This is the backing field for _#isPrecedenceDfa_.
     /// 
-    private final var precedenceDfa: Bool
+    private let precedenceDfa: Bool
     
     /// 
     /// mutex for DFAState changes.
@@ -42,19 +42,19 @@ public class DFA: CustomStringConvertible {
         self.atnStartState = atnStartState
         self.decision = decision
 
-        var precedenceDfa: Bool = false
-        if atnStartState is StarLoopEntryState {
-            if (atnStartState as! StarLoopEntryState).precedenceRuleDecision {
-                precedenceDfa = true
-                let precedenceState: DFAState = DFAState(ATNConfigSet())
-                precedenceState.edges = [DFAState]() //new DFAState[0];
-                precedenceState.isAcceptState = false
-                precedenceState.requiresFullContext = false
-                self.s0 = precedenceState
-            }
-        }
+        if let starLoopState = atnStartState as? StarLoopEntryState, starLoopState.precedenceRuleDecision {
+            let precedenceState = DFAState(ATNConfigSet())
+            precedenceState.edges = [DFAState]()
+            precedenceState.isAcceptState = false
+            precedenceState.requiresFullContext = false
 
-        self.precedenceDfa = precedenceDfa
+            precedenceDfa = true
+            s0 = precedenceState
+        }
+        else {
+            precedenceDfa = false
+            s0 = nil
+        }
     }
 
     /// 
@@ -130,25 +130,7 @@ public class DFA: CustomStringConvertible {
         }
     }
 
-    /// 
-    /// Sets whether this is a precedence DFA.
-    /// 
-    /// - parameter precedenceDfa: `true` if this is a precedence DFA; otherwise,
-    /// `false`
-    /// 
-    /// - throws: ANTLRError.unsupportedOperation if `precedenceDfa` does not
-    /// match the value of _#isPrecedenceDfa_ for the current DFA.
-    /// 
-    /// - note: This method no longer performs any action.
-    /// 
-    public final func setPrecedenceDfa(_ precedenceDfa: Bool) throws {
-        if precedenceDfa != isPrecedenceDfa() {
-            throw ANTLRError.unsupportedOperation(msg: "The precedenceDfa field cannot change after a DFA is constructed.")
-
-        }
-    }
-
-    /// 
+    ///
     /// Return a list of all states in this DFA, ordered by state number.
     /// 
     public func getStates() -> Array<DFAState> {


### PR DESCRIPTION
Make DFA.precedenceDfa be a "let" rather than a "var", and remove
setPrecedenceDfa.  This field never varies after construction.  The
code in setPrecedenceDfa was carried over from the Java runtime, but
it only threw an exception, and was deprecated.  There's no need for
that in the Swift runtime.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->