### PR TITLE
[Swift] Remove unused ATN.modeNameToStartState.

### DIFF
--- a/runtime/Swift/Sources/Antlr4/atn/ATN.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATN.swift
@@ -28,10 +28,6 @@ public class ATN {
     /// 
     public final var ruleToStopState: [RuleStopState]!
 
-
-    public final let modeNameToStartState: Dictionary<String, TokensStartState> =  Dictionary<String, TokensStartState>()
-    //LinkedHashMap<String, TokensStartState>();
-
     /// 
     /// The type of the ATN.
     /// 


### PR DESCRIPTION
Remove unused ATN.modeNameToStartState.  In the Java runtime this is
only used by LexerATNFactory (i.e. during lexer generation) and we don't
have the equivalent in the Swift runtime at all.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->