### PR TITLE
[Swift] Make ATNSimulator.sharedContextCache non-optional.

### DIFF
--- a/runtime/Swift/Sources/Antlr4/Parser.swift
+++ b/runtime/Swift/Sources/Antlr4/Parser.swift
@@ -1022,11 +1022,10 @@ open class Parser: Recognizer<ParserATNSimulator> {
             if !(interp is ProfilingATNSimulator) {
                 setInterpreter(ProfilingATNSimulator(self))
             }
-        } else {
-            if interp is ProfilingATNSimulator {
-                let sim = ParserATNSimulator(self, getATN(), interp.decisionToDFA, interp.getSharedContextCache()!)
-                setInterpreter(sim)
-            }
+        }
+        else if interp is ProfilingATNSimulator {
+            let sim = ParserATNSimulator(self, getATN(), interp.decisionToDFA, interp.getSharedContextCache())
+            setInterpreter(sim)
         }
         getInterpreter().setPredictionMode(saveMode)
     }

--- a/runtime/Swift/Sources/Antlr4/atn/ATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNSimulator.swift
@@ -40,7 +40,7 @@ open class ATNSimulator {
     /// more time I think and doesn't save on the overall footprint
     /// so it's not worth the complexity.
     /// 
-    internal final var sharedContextCache: PredictionContextCache?
+    internal let sharedContextCache: PredictionContextCache
 
     public init(_ atn: ATN,
                 _ sharedContextCache: PredictionContextCache) {
@@ -68,21 +68,17 @@ open class ATNSimulator {
         throw ANTLRError.unsupportedOperation(msg: "This ATN simulator does not support clearing the DFA. ")
     }
 
-    open func getSharedContextCache() -> PredictionContextCache? {
+    open func getSharedContextCache() -> PredictionContextCache {
         return sharedContextCache
     }
 
     open func getCachedContext(_ context: PredictionContext) -> PredictionContext {
-        if sharedContextCache == nil {
-            return context
-        }
-
         //TODO: synced (sharedContextCache!)
         //synced (sharedContextCache!) {
         let visited = HashMap<PredictionContext, PredictionContext>()
 
         return PredictionContext.getCachedContext(context,
-                sharedContextCache!,
+                sharedContextCache,
                 visited)
     }
 

--- a/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
@@ -41,7 +41,7 @@ public class ProfilingATNSimulator: ParserATNSimulator {
         super.init(parser,
                 parser.getInterpreter().atn,
                 parser.getInterpreter().decisionToDFA,
-                parser.getInterpreter().sharedContextCache!)
+                parser.getInterpreter().sharedContextCache)
 
         numDecisions = atn.decisionToState.count
         for i in 0..<numDecisions {


### PR DESCRIPTION
Make ATNSimulator.sharedContextCache declared as non-optional.  It
was used this way anyway, so it was just being pointlessly forced
at the use-sites.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->