### PR TITLE
[Swift] Fix initialization of {Lexer,Parser}Interpreter.decisionToDFA.

### DIFF
--- a/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
@@ -27,9 +27,8 @@ public class LexerInterpreter: Lexer {
         self.modeNames = modeNames
         self.vocabulary = vocabulary
 
-        self._decisionToDFA = [DFA]() //new DFA[atn.getNumberOfDecisions()];
-        let _decisionToDFALength = _decisionToDFA.count
-        for i in 0..<_decisionToDFALength {
+        self._decisionToDFA = [DFA]()
+        for i in 0 ..< atn.getNumberOfDecisions() {
             _decisionToDFA[i] = DFA(atn.getDecisionState(i)!, i)
         }
         super.init(input)

--- a/runtime/Swift/Sources/Antlr4/ParserInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/ParserInterpreter.swift
@@ -75,9 +75,8 @@ public class ParserInterpreter: Parser {
         self.atn = atn
         self.ruleNames = ruleNames
         self.vocabulary = vocabulary
-        self.decisionToDFA = [DFA]() //new DFA[atn.getNumberOfDecisions()];
-        let decisionToDFALength = decisionToDFA.count
-        for i in 0..<decisionToDFALength {
+        self.decisionToDFA = [DFA]()
+        for i in 0 ..< atn.getNumberOfDecisions() {
             decisionToDFA[i] = DFA(atn.getDecisionState(i)!, i)
         }
 


### PR DESCRIPTION
Fix initialization of {Lexer,Parser}Interpreter.decisionToDFA.  These
were always being created as empty arrays, which would never work.

I don't know if anyone's using this code; presumably not.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->