### PR TITLE
[Swift] Fix parse-cancellation in BailErrorStrategy.

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/BaseSwiftTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/BaseSwiftTest.java
@@ -290,8 +290,6 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 						"let tree = try parser.<parserStartRuleName>()\n" +
 						"<if(profile)>print(profiler.getDecisionInfo().description)<endif>\n" +
 						"try ParseTreeWalker.DEFAULT.walk(TreeShapeListener(), tree)\n" +
-						"}catch ANTLRException.cannotInvokeStartRule {\n" +
-						"    print(\"error occur: cannotInvokeStartRule\")\n" +
 						"}catch ANTLRException.recognition(let e )   {\n" +
 						"    print(\"error occur\\(e)\")\n" +
 						"}catch {\n" +
@@ -333,8 +331,6 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 
 						"do {\n" +
 						"	try tokens.fill()\n" +
-						"} catch ANTLRException.cannotInvokeStartRule {\n" +
-						"	print(\"error occur: cannotInvokeStartRule\")\n" +
 						"} catch ANTLRException.recognition(let e )   {\n" +
 						"	print(\"error occur\\(e)\")\n" +
 						"} catch {\n" +

--- a/runtime/Swift/Sources/Antlr4/BailErrorStrategy.swift
+++ b/runtime/Swift/Sources/Antlr4/BailErrorStrategy.swift
@@ -47,7 +47,7 @@ public class BailErrorStrategy: DefaultErrorStrategy {
             context = (contextWrap.getParent() as? ParserRuleContext)
         }
 
-        throw ANTLRException.recognition(e: e)
+        throw ANTLRException.parseCancellation(e: e)
     }
 
     /// 
@@ -63,7 +63,7 @@ public class BailErrorStrategy: DefaultErrorStrategy {
              context = (contextWrap.getParent() as? ParserRuleContext)
         }
 
-        throw ANTLRException.recognition(e: e)
+        throw ANTLRException.parseCancellation(e: e)
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/misc/exception/ANTLRError.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/exception/ANTLRError.swift
@@ -19,5 +19,4 @@ public enum ANTLRError: Error {
     case illegalState(msg:String)
     case illegalArgument(msg:String)
     case negativeArraySize(msg:String)
-    case parseCancellation
 }

--- a/runtime/Swift/Sources/Antlr4/misc/exception/ANTLRException.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/exception/ANTLRException.swift
@@ -15,6 +15,6 @@
 import Foundation
 
 public enum ANTLRException: Error {
-    case cannotInvokeStartRule
+    case parseCancellation(e: RecognitionException)
     case recognition(e: RecognitionException)
 }


### PR DESCRIPTION
BailErrorStrategy is supposed to throw an error that's different from
the ordinary recognition error, specifically so that it can be handled
differently by client code.  This was not ported over from Java correctly.

Fix this by moving parseCancellation from ANTLRError to ANTLRException,
adding its RecognitionException argument, and throwing it from the
two handlers in BailErrorStrategy.

Also remove ANTLRException.cannotInvokeStartRule, which is unused.
(The Java runtime uses it when ParseTreePatternMatcher throws a generic
exception, but we don't have that.)

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->