### PR TITLE
[CSharp] Add extra diagnostics and a retry to the C# runtime tests and upgrade the macOS runtime

### DIFF
--- a/.travis/before-install-osx-dotnet.sh
+++ b/.travis/before-install-osx-dotnet.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 cache_dir="$HOME/Library/Caches/Antlr4"
-dotnet_url='https://download.microsoft.com/download/B/9/F/B9F1AF57-C14A-4670-9973-CDF47209B5BF/dotnet-dev-osx-x64.1.0.4.pkg'
+dotnet_url='https://download.microsoft.com/download/F/4/F/F4FCB6EC-5F05-4DF8-822C-FF013DF1B17F/dotnet-dev-osx-x64.1.1.4.pkg'
 dotnet_file=$(basename "$dotnet_url")
-dotnet_shasum='63b5d99028cd8b2454736076106c96ba7d05f0fc'
+dotnet_shasum='dc46d93716db8bea8cc3c668088cc9e39384b5a4'
 
 thisdir=$(dirname "$0")
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
@@ -337,7 +337,9 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
 	}
 
 	public String execRecognizer() {
-		compile();
+		boolean success = compile();
+		assertTrue(success);
+
 		String output = execTest();
 		if ( output!=null && output.length()==0 ) {
 			output = null;
@@ -507,6 +509,7 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
                 runtimeProjPath
             };
             boolean success = runProcess(args, tmpdir);
+            assertTrue(success);
 
             // restore project
             args = new String[] {
@@ -516,6 +519,7 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
                 "--no-dependencies"
             };
             success = runProcess(args, tmpdir);
+            assertTrue(success);
 
             // build test
             args = new String[] {
@@ -527,6 +531,7 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
                 "--no-dependencies"
             };
             success = runProcess(args, tmpdir);
+            assertTrue(success);
         }
         catch(Exception e) {
             e.printStackTrace(System.err);

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
@@ -354,6 +354,7 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
                     return false;
                 return true;
             } catch(Exception e) {
+                e.printStackTrace(System.err);
                 return false;
             }
         }
@@ -362,6 +363,7 @@ public class BaseCSharpTest implements RuntimeTestSupport /*, SpecialRuntimeTest
             try {
                 return buildDotnetProject();
             } catch(Exception e) {
+                e.printStackTrace(System.err);
                 return false;
             }
         }


### PR DESCRIPTION
Issue #2078 is a crash (SIGILL) inside the .NET runtime when running on macOS on Travis.  This is intermittent, so a retry may help.  Retry this specific exit status inside runProcess.

Log the command / stdout / stderr / exit status at three places during the C# runtime tests.  At these places we are executing subprocesses, but if those fail we weren't logging the info that we needed to diagnose the problem.

Print the stack trace if compilation fails.

Assert that test compilation succeeded.

Switch to .NET Core SDK 1.1.4 for the Travis macOS tests.  This is the LTS release at the moment.  This didn't fix #2078, sadly.  I've already seen one SIGILL on 1.1.4.  We should upgrade anyway.
