### PR TITLE
Fix Xpath in Cpp runtime 

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -171,3 +171,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/05/29, rlfnb, Ralf Neeb, rlfnb@rlfnb.de
 2017/10/29, gendalph, Максим Прохоренко, Maxim\dotProhorenko@gm@il.com
 2017/11/02, jasonmoo, Jason Mooberry, jason.mooberry@gmail.com
+2017/11/22  Malick F.

--- a/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp
@@ -29,7 +29,7 @@ XPath::XPath(Parser *parser, const std::string &path) {
 }
 
 std::vector<XPathElement> XPath::split(const std::string &path) {
-  ANTLRFileStream in(path);
+  ANTLRInputStream in(path);
   XPathLexer lexer(&in);
   lexer.removeErrorListeners();
   XPathLexerErrorListener listener;


### PR DESCRIPTION
close #2037

The split function does not behave as in other runtime. It should accept a string instead of a file as argument in order to behave as in other runtime. I just did it.

