### PR TITLE
[JavaScript] Fix Interval usage in ErrorStrategy.js

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -171,3 +171,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/05/29, rlfnb, Ralf Neeb, rlfnb@rlfnb.de
 2017/10/29, gendalph, Максим Прохоренко, Maxim\dotProhorenko@gm@il.com
 2017/11/02, jasonmoo, Jason Mooberry, jason.mooberry@gmail.com
+2017/11/24, zqlu.cn, Zhiqiang Lu, zqlu.cn@gmail.com

--- a/runtime/JavaScript/src/antlr4/error/ErrorStrategy.js
+++ b/runtime/JavaScript/src/antlr4/error/ErrorStrategy.js
@@ -267,7 +267,7 @@ DefaultErrorStrategy.prototype.reportNoViableAlternative = function(recognizer, 
         if (e.startToken.type===Token.EOF) {
             input = "<EOF>";
         } else {
-            input = tokens.getText(new Interval(e.startToken, e.offendingToken));
+            input = tokens.getText(new Interval(e.startToken.tokenIndex, e.offendingToken.tokenIndex));
         }
     } else {
         input = "<unknown input>";


### PR DESCRIPTION
I was using the Antlr4 JavaScript version in my project, but get an error related to ErrorStrategy.js.
ErrorStrategy::reportNoViableAlternative method try to new a Interval object, but pass two Token as constructor argument, but Interval class assume the arguments to be numbers. So I fixed by this PR.
