### PR TITLE
[CSharp] Add a new CharStream that converts the symbols to upper or lower case.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -174,3 +174,5 @@ YYYY/MM/DD, github id, Full name, email
 2017/11/02, jasonmoo, Jason Mooberry, jason.mooberry@gmail.com
 2017/11/05, ajaypanyala, Ajay Panyala, ajay.panyala@gmail.com
 2017/11/24, zqlu.cn, Zhiqiang Lu, zqlu.cn@gmail.com
+2017/12/01, DavidMoraisFerreira, David Morais Ferreira, david.moraisferreira@gmail.com
+2017/12/01, SebastianLng, Sebastian Lang, sebastian.lang@outlook.com

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.vs2013.csproj
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.vs2013.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Atn\ATNDeserializationOptions.cs" />
     <Compile Include="Atn\ATNDeserializer.cs" />
     <Compile Include="Atn\ConflictInfo.cs" />
+    <Compile Include="CaseChangingCharStream.cs" />
     <Compile Include="CharStreams.cs" />
     <Compile Include="Dfa\AbstractEdgeMap.cs" />
     <Compile Include="Dfa\AcceptStateInfo.cs" />

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CaseChangingCharStream.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CaseChangingCharStream.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Antlr4.Runtime.Misc;
+
+namespace Antlr4.Runtime
+{
+    public class CaseChangingCharStream : ICharStream
+    {
+        private ICharStream stream;
+        private bool upper;
+
+        public CaseChangingCharStream(ICharStream stream, bool upper)
+        {
+            this.stream = stream;
+            this.upper = upper;
+        }
+
+        public int Index => stream.Index;
+
+        public int Size => stream.Size;
+
+        public string SourceName => stream.SourceName;
+
+        public void Consume() => stream.Consume();
+
+        [return: NotNull]
+        public string GetText(Interval interval) => stream.GetText(interval);
+
+        public int LA(int i)
+        {
+            int c = stream.LA(i);
+
+            if (c <= 0) return c;
+
+            var o = Convert.ToChar(c);
+
+            if (upper) return Convert.ToInt32(char.ToUpper(o));
+
+            return Convert.ToInt32(char.ToLower(o));
+        }
+
+        public int Mark() => stream.Mark();
+
+        public void Release(int marker) => stream.Release(marker);
+
+        public void Seek(int index) => stream.Seek(index);
+    }
+}

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CaseChangingCharStream.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CaseChangingCharStream.cs
@@ -72,13 +72,19 @@ namespace Antlr4.Runtime
         {
             int c = stream.LA(i);
 
-            if (c <= 0) return c;
+            if (c <= 0)
+            {
+                return c;
+            }
 
-            var o = Convert.ToChar(c);
+            char o = (char)c;
 
-            if (upper) return Convert.ToInt32(char.ToUpper(o));
+            if (upper)
+            {
+                return (int)char.ToUpperInvariant(o);
+            }
 
-            return Convert.ToInt32(char.ToLower(o));
+            return (int)char.ToLowerInvariant(o);
         }
 
         public int Mark()

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CaseChangingCharStream.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CaseChangingCharStream.cs
@@ -1,29 +1,72 @@
-﻿using System;
+﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
 using Antlr4.Runtime.Misc;
 
 namespace Antlr4.Runtime
 {
+    /// <summary>
+    /// This class supports case-insensitive lexing by wrapping an existing
+    /// <see cref="ICharStream"/> and forcing the lexer to see either upper or
+    /// lowercase characters. Grammar literals should then be either upper or
+    /// lower case such as 'BEGIN' or 'begin'. The text of the character
+    /// stream is unaffected. Example: input 'BeGiN' would match lexer rule
+    /// 'BEGIN' if constructor parameter upper=true but getText() would return
+    /// 'BeGiN'.
+    /// </summary>
     public class CaseChangingCharStream : ICharStream
     {
         private ICharStream stream;
         private bool upper;
 
+        /// <summary>
+        /// Constructs a new CaseChangingCharStream wrapping the given <paramref name="stream"/> forcing
+        /// all characters to upper case or lower case.
+        /// </summary>
+        /// <param name="stream">The stream to wrap.</param>
+        /// <param name="upper">If true force each symbol to upper case, otherwise force to lower.</param>
         public CaseChangingCharStream(ICharStream stream, bool upper)
         {
             this.stream = stream;
             this.upper = upper;
         }
 
-        public int Index => stream.Index;
+        public int Index
+        {
+            get
+            {
+                return stream.Index;
+            }
+        }
 
-        public int Size => stream.Size;
+        public int Size
+        {
+            get
+            {
+                return stream.Size;
+            }
+        }
 
-        public string SourceName => stream.SourceName;
+        public string SourceName
+        {
+            get
+            {
+                return stream.SourceName;
+            }
+        }
 
-        public void Consume() => stream.Consume();
+        public void Consume()
+        {
+            stream.Consume();
+        }
 
         [return: NotNull]
-        public string GetText(Interval interval) => stream.GetText(interval);
+        public string GetText(Interval interval)
+        {
+            return stream.GetText(interval);
+        }
 
         public int LA(int i)
         {
@@ -38,10 +81,19 @@ namespace Antlr4.Runtime
             return Convert.ToInt32(char.ToLower(o));
         }
 
-        public int Mark() => stream.Mark();
+        public int Mark()
+        {
+            return stream.Mark();
+        }
 
-        public void Release(int marker) => stream.Release(marker);
+        public void Release(int marker)
+        {
+            stream.Release(marker);
+        }
 
-        public void Seek(int index) => stream.Seek(index);
+        public void Seek(int index)
+        {
+            stream.Seek(index);
+        }
     }
 }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CharStreams.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CharStreams.cs
@@ -89,5 +89,15 @@ namespace Antlr4.Runtime
         {
             return new CodePointCharStream(s);
         }
+
+        public static ICharStream toUpper(ICharStream inStream)
+        {
+            return new CaseChangingCharStream(inStream, true);
+        }
+
+        public static ICharStream toLower(ICharStream inStream)
+        {
+            return new CaseChangingCharStream(inStream, false);
+        }
     }
 }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CharStreams.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/CharStreams.cs
@@ -90,11 +90,23 @@ namespace Antlr4.Runtime
             return new CodePointCharStream(s);
         }
 
+        /// <summary>
+        /// Takes the stream and forces all symbols to uppercase for lexing purposes 
+        /// but leaves the original text as-is.
+        /// </summary>
+        /// <param name="inStream"></param>
+        /// <returns></returns>
         public static ICharStream toUpper(ICharStream inStream)
         {
             return new CaseChangingCharStream(inStream, true);
         }
 
+        /// <summary>
+        /// Takes the stream and forces all symbols to lowercase for lexing purposes 
+        /// but leaves the original text as-is.
+        /// </summary>
+        /// <param name="inStream"></param>
+        /// <returns></returns>
         public static ICharStream toLower(ICharStream inStream)
         {
             return new CaseChangingCharStream(inStream, false);


### PR DESCRIPTION
Ported @bramp's java implementation (#2048 and #2046) for case insensitive grammars to the CSharp runtime.