### PR TITLE
[JavaScript] enable auto-suggest engines by exposing the lexer ATN as a property, similar to the parser ATN

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -174,3 +174,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/11/02, jasonmoo, Jason Mooberry, jason.mooberry@gmail.com
 2017/11/05, ajaypanyala, Ajay Panyala, ajay.panyala@gmail.com
 2017/11/24, zqlu.cn, Zhiqiang Lu, zqlu.cn@gmail.com
+2017/12/03, oranoran, Oran Epelbaum, oran / epelbaum me

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -821,6 +821,12 @@ function <lexer.name>(input) {
 <lexer.name>.prototype = Object.create(<if(superClass)><superClass><else>antlr4.Lexer<endif>.prototype);
 <lexer.name>.prototype.constructor = <lexer.name>;
 
+Object.defineProperty(<lexer.name>.prototype, "atn", {
+        get : function() {
+                return atn;
+        }
+});
+
 <lexer.name>.EOF = antlr4.Token.EOF;
 <lexer.tokens:{k | <lexer.name>.<k> = <lexer.tokens.(k)>;}; separator="\n", wrap, anchor>
 


### PR DESCRIPTION
In order to allow JavaScript clients to auto-suggest completions, they need access to the lexer's ATN, not just the parser's.

See usage in:
https://github.com/oranoran/antlr4-autosuggest-js
