### PR TITLE
Fix issue with tree finding when the underlying slice needs to be resized.

### DIFF
--- a/runtime/Go/antlr/trees.go
+++ b/runtime/Go/antlr/trees.go
@@ -103,11 +103,11 @@ func TreesfindAllRuleNodes(t ParseTree, ruleIndex int) []ParseTree {
 
 func TreesfindAllNodes(t ParseTree, index int, findTokens bool) []ParseTree {
 	nodes := make([]ParseTree, 0)
-	TreesFindAllNodes(t, index, findTokens, nodes)
+	treesFindAllNodes(t, index, findTokens, &nodes)
 	return nodes
 }
 
-func TreesFindAllNodes(t ParseTree, index int, findTokens bool, nodes []ParseTree) {
+func treesFindAllNodes(t ParseTree, index int, findTokens bool, nodes *[]ParseTree) {
 	// check this node (the root) first
 
 	t2, ok := t.(TerminalNode)
@@ -115,16 +115,16 @@ func TreesFindAllNodes(t ParseTree, index int, findTokens bool, nodes []ParseTre
 
 	if findTokens && ok {
 		if t2.GetSymbol().GetTokenType() == index {
-			nodes = append(nodes, t2)
+			*nodes = append(*nodes, t2)
 		}
 	} else if !findTokens && ok2 {
 		if t3.GetRuleIndex() == index {
-			nodes = append(nodes, t3)
+			*nodes = append(*nodes, t3)
 		}
 	}
 	// check children
 	for i := 0; i < t.GetChildCount(); i++ {
-		TreesFindAllNodes(t.GetChild(i).(ParseTree), index, findTokens, nodes)
+		treesFindAllNodes(t.GetChild(i).(ParseTree), index, findTokens, nodes)
 	}
 }
 


### PR DESCRIPTION
Hides a function that is essentially internal and is unused outside of this module.
