### PR TITLE
This resolves the recently opened issue 2175 (a memory leak).

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -697,6 +697,7 @@ std::vector<Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const
 
 std::vector<dfa::DFAState::PredPrediction *> ParserATNSimulator::getPredicatePredictions(const antlrcpp::BitSet &ambigAlts,
   std::vector<Ref<SemanticContext>> altToPred) {
+  bool containsPredicate = false;
   for (size_t i = 1; i < altToPred.size(); i++) {
     const Ref<SemanticContext>& pred = altToPred[i];
 
@@ -704,11 +705,14 @@ std::vector<dfa::DFAState::PredPrediction *> ParserATNSimulator::getPredicatePre
     assert(pred != nullptr);
 
     if (pred != SemanticContext::NONE) {
-      return std::vector<dfa::DFAState::PredPrediction*>();
+      containsPredicate = true;
+      break;
     }
   }
 
   std::vector<dfa::DFAState::PredPrediction*> pairs;
+  if (!containsPredicate) return pairs;
+
   for (size_t i = 1; i < altToPred.size(); i++) {
     if (ambigAlts.test(i)) {
       pairs.push_back(new dfa::DFAState::PredPrediction(altToPred[i], (int)i)); /* mem-check: managed by the DFAState it will be assigned to after return */

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -696,31 +696,22 @@ std::vector<Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const
 }
 
 std::vector<dfa::DFAState::PredPrediction *> ParserATNSimulator::getPredicatePredictions(const antlrcpp::BitSet &ambigAlts,
-  std::vector<Ref<SemanticContext>> altToPred) {
-  bool containsPredicate = false;
-  for (size_t i = 1; i < altToPred.size(); i++) {
-    const Ref<SemanticContext>& pred = altToPred[i];
-    // unpredicted is indicated by SemanticContext.NONE
-    assert(pred != nullptr);
-
-    if (pred != SemanticContext::NONE) {
-      containsPredicate = true;
-      break;
-    }
-  }
+  std::vector<Ref<SemanticContext>> const& altToPred) {
+  bool containsPredicate = std::find_if(altToPred.begin(), altToPred.end(), [](Ref<SemanticContext> const context) {
+    return context != SemanticContext::NONE;
+  }) != altToPred.end();
+  if (!containsPredicate)
+    return {};
 
   std::vector<dfa::DFAState::PredPrediction*> pairs;
-  if (!containsPredicate) return pairs;
-
-  for (size_t i = 1; i < altToPred.size(); i++) {
-    // unpredicted is indicated by SemanticContext.NONE
-    assert(altToPred[i] != nullptr);
+  for (size_t i = 1; i < altToPred.size(); ++i) {
+    Ref<SemanticContext> const& pred = altToPred[i];
+    assert(pred != nullptr); // unpredicted is indicated by SemanticContext.NONE
 
     if (ambigAlts.test(i)) {
-      pairs.push_back(new dfa::DFAState::PredPrediction(altToPred[i], (int)i)); /* mem-check: managed by the DFAState it will be assigned to after return */
+      pairs.push_back(new dfa::DFAState::PredPrediction(pred, (int)i)); /* mem-check: managed by the DFAState it will be assigned to after return */
     }
   }
-
   return pairs;
 }
 

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -700,7 +700,6 @@ std::vector<dfa::DFAState::PredPrediction *> ParserATNSimulator::getPredicatePre
   bool containsPredicate = false;
   for (size_t i = 1; i < altToPred.size(); i++) {
     const Ref<SemanticContext>& pred = altToPred[i];
-
     // unpredicted is indicated by SemanticContext.NONE
     assert(pred != nullptr);
 
@@ -714,6 +713,9 @@ std::vector<dfa::DFAState::PredPrediction *> ParserATNSimulator::getPredicatePre
   if (!containsPredicate) return pairs;
 
   for (size_t i = 1; i < altToPred.size(); i++) {
+    // unpredicted is indicated by SemanticContext.NONE
+    assert(altToPred[i] != nullptr);
+
     if (ambigAlts.test(i)) {
       pairs.push_back(new dfa::DFAState::PredPrediction(altToPred[i], (int)i)); /* mem-check: managed by the DFAState it will be assigned to after return */
     }

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -697,7 +697,6 @@ std::vector<Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const
 
 std::vector<dfa::DFAState::PredPrediction *> ParserATNSimulator::getPredicatePredictions(const antlrcpp::BitSet &ambigAlts,
   std::vector<Ref<SemanticContext>> altToPred) {
-  bool containsPredicate = false;
   for (size_t i = 1; i < altToPred.size(); i++) {
     const Ref<SemanticContext>& pred = altToPred[i];
 
@@ -705,16 +704,11 @@ std::vector<dfa::DFAState::PredPrediction *> ParserATNSimulator::getPredicatePre
     assert(pred != nullptr);
 
     if (pred != SemanticContext::NONE) {
-      containsPredicate = true;
-      break;
+      return std::vector<dfa::DFAState::PredPrediction*>();
     }
   }
 
   std::vector<dfa::DFAState::PredPrediction*> pairs;
-  if (!containsPredicate) {
-      return pairs;
-  }
-
   for (size_t i = 1; i < altToPred.size(); i++) {
     if (ambigAlts.test(i)) {
       pairs.push_back(new dfa::DFAState::PredPrediction(altToPred[i], (int)i)); /* mem-check: managed by the DFAState it will be assigned to after return */

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -697,24 +697,28 @@ std::vector<Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const
 
 std::vector<dfa::DFAState::PredPrediction *> ParserATNSimulator::getPredicatePredictions(const antlrcpp::BitSet &ambigAlts,
   std::vector<Ref<SemanticContext>> altToPred) {
-  std::vector<dfa::DFAState::PredPrediction*> pairs;
   bool containsPredicate = false;
   for (size_t i = 1; i < altToPred.size(); i++) {
-    Ref<SemanticContext> pred = altToPred[i];
+    const Ref<SemanticContext>& pred = altToPred[i];
 
     // unpredicted is indicated by SemanticContext.NONE
     assert(pred != nullptr);
 
-    if (ambigAlts.test(i)) {
-      pairs.push_back(new dfa::DFAState::PredPrediction(pred, (int)i)); /* mem-check: managed by the DFAState it will be assigned to after return */
-    }
     if (pred != SemanticContext::NONE) {
       containsPredicate = true;
+      break;
     }
   }
 
+  std::vector<dfa::DFAState::PredPrediction*> pairs;
   if (!containsPredicate) {
-    pairs.clear();
+      return pairs;
+  }
+
+  for (size_t i = 1; i < altToPred.size(); i++) {
+    if (ambigAlts.test(i)) {
+      pairs.push_back(new dfa::DFAState::PredPrediction(altToPred[i], (int)i)); /* mem-check: managed by the DFAState it will be assigned to after return */
+    }
   }
 
   return pairs;

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -652,7 +652,7 @@ namespace atn {
                                                                    ATNConfigSet *configs, size_t nalts);
 
     virtual std::vector<dfa::DFAState::PredPrediction*> getPredicatePredictions(const antlrcpp::BitSet &ambigAlts,
-                                                                                std::vector<Ref<SemanticContext>> altToPred);
+                                                                                std::vector<Ref<SemanticContext>> const& altToPred);
 
     /**
      * This method is used to improve the localization of error messages by


### PR DESCRIPTION
Function should still make the same calculation but without leaking memory in the process.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->