### PR TITLE
Remove unused  `_loadString` parameter

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -178,3 +178,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/12/01, DavidMoraisFerreira, David Morais Ferreira, david.moraisferreira@gmail.com
 2017/12/01, SebastianLng, Sebastian Lang, sebastian.lang@outlook.com
 2017/12/03, oranoran, Oran Epelbaum, oran / epelbaum me
+2017/12/20, kbsletten, Kyle Sletten, kbsletten@gmail.com

--- a/runtime/JavaScript/src/antlr4/InputStream.js
+++ b/runtime/JavaScript/src/antlr4/InputStream.js
@@ -11,7 +11,7 @@ require('./polyfills/fromcodepoint');
 
 // Vacuum all input from a string and then treat it like a buffer.
 
-function _loadString(stream, decodeToUnicodeCodePoints) {
+function _loadString(stream) {
 	stream._index = 0;
 	stream.data = [];
 	if (stream.decodeToUnicodeCodePoints) {


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->