### PR TITLE
[Python3] return result instead of None in visitor

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -178,3 +178,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/12/01, DavidMoraisFerreira, David Morais Ferreira, david.moraisferreira@gmail.com
 2017/12/01, SebastianLng, Sebastian Lang, sebastian.lang@outlook.com
 2017/12/03, oranoran, Oran Epelbaum, oran / epelbaum me
+2017/12/27, jkmar, Jakub Marciniszyn, marciniszyn.jk@gmail.com

--- a/runtime/Python2/src/antlr4/tree/Tree.py
+++ b/runtime/Python2/src/antlr4/tree/Tree.py
@@ -40,7 +40,7 @@ class ParseTreeVisitor(object):
         n = node.getChildCount()
         for i in range(n):
             if not self.shouldVisitNextChild(node, result):
-                return
+                return result
 
             c = node.getChild(i)
             childResult = c.accept(self)

--- a/runtime/Python3/src/antlr4/tree/Tree.py
+++ b/runtime/Python3/src/antlr4/tree/Tree.py
@@ -38,7 +38,7 @@ class ParseTreeVisitor(object):
         n = node.getChildCount()
         for i in range(n):
             if not self.shouldVisitNextChild(node, result):
-                return
+                return result
 
             c = node.getChild(i)
             childResult = c.accept(self)


### PR DESCRIPTION
Previously ParseTreeVisitor in the visitChildren method returned None when it shouldn't visit the next child, so if you overrode the shouldVisitNextChild you would also have to override the visitChildren method only to change that return statement.