### PR TITLE
Force usage of 'previousContext'.

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -510,6 +510,7 @@ LeftRecursiveRuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs
   size_t parentState = getState();
   <parser.name>::<currentRule.ctxType> *_localctx = _tracker.createInstance\<<currentRule.ctxType>\>(_ctx, parentState<currentRule.args: {a | , <a.name>}>);
   <parser.name>::<currentRule.ctxType> *previousContext = _localctx;
+  (void)previousContext;
   size_t startState = <currentRule.startState>;
   enterRecursionRule(_localctx, <currentRule.startState>, <parser.name>::Rule<currentRule.name; format = "cap">, precedence);
 


### PR DESCRIPTION
Some generated grammars define but don't use the variable 'previousContext'.

This is a problem for customers who are compiling with warnings, e.g.
-Wall -Werror.

Those customers get this message from gcc:
  error: variable ‘previousContext’ set but not used [-Werror=unused-but-set-variable]

An easy fix is to just force the compiler to consider this variable always
used.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->