### PR TITLE
JavaScript parse tree visitor: check if ctx.children is non-null in visitChildren

### DIFF
--- a/runtime/JavaScript/src/antlr4/tree/Tree.js
+++ b/runtime/JavaScript/src/antlr4/tree/Tree.js
@@ -73,7 +73,9 @@ ParseTreeVisitor.prototype.visit = function(ctx) {
 };
 
 ParseTreeVisitor.prototype.visitChildren = function(ctx) {
-  return this.visit(ctx.children);
+	if (ctx.children) {
+		return this.visit(ctx.children);
+	}
 }
 
 ParseTreeVisitor.prototype.visitTerminal = function(node) {

--- a/runtime/JavaScript/src/antlr4/tree/Tree.js
+++ b/runtime/JavaScript/src/antlr4/tree/Tree.js
@@ -75,6 +75,8 @@ ParseTreeVisitor.prototype.visit = function(ctx) {
 ParseTreeVisitor.prototype.visitChildren = function(ctx) {
 	if (ctx.children) {
 		return this.visit(ctx.children);
+	} else {
+		return null;
 	}
 }
 


### PR DESCRIPTION
I've been encountering a problem where the default generated visitor in javascript. It will crash because in the `visit` method it tries to call `accept` on null because it has been passed a null object by `visitChildren`.

This seems like a bug to me as the `children` field is expected to sometimes be null as it is initialised to null and only made non-null when a child is added. Other places handle this case explicitly but here it's assumed to be non-null.

Making the change in this PR makes my visitor work correctly. Do you think it is the right change to make, or if not what should I be doing instead?

---

To explain my reasoning on why this change and not any other:
- The check could easily be `ctx.getChildCount() > 0` and behave the same. I went for this as it's shorter and we're already accessing `ctx.children` directly instead of using `getChild` so it seems in keeping with the current code.
- The check could also have been done in `visit` by changing the `else` to `else if (ctx)` but this seemed a more intrusive way of fixing it and it's entirely reasonable for `visit` to expect a non-null argument.