### PR TITLE
Add an Automatic-Module-Name

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -180,3 +180,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/12/03, oranoran, Oran Epelbaum, oran / epelbaum me
 2017/12/20, kbsletten, Kyle Sletten, kbsletten@gmail.com
 2017/12/27, jkmar, Jakub Marciniszyn, marciniszyn.jk@gmail.com
+2018/02/11, io7m, Mark Raynsford, code@io7m.com

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -96,6 +96,7 @@
 						<phase>process-classes</phase>
 						<configuration>
 							<instructions>
+								<Automatic-Module-Name>org.antlr.antlr4.runtime</Automatic-Module-Name>
 								<Bundle-SymbolicName>org.antlr.antlr4-runtime</Bundle-SymbolicName>
 							</instructions>
 						</configuration>


### PR DESCRIPTION
This adds an Automatic-Module-Name entry to the runtime jar in order to
provide a stable name upon which other modules can depend. The module
name chosen was "org.antlr.antlr4.runtime". This closely matches the
Maven artifact name with the obvious change that the module name
doesn't contain a hyphen (hyphens can't be used in module names at
the language level in Java).

I have signed the contributor agreement in a separate commit below.

Fix #2163