### PR TITLE
fix git checkout to tag usage

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -180,3 +180,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/12/03, oranoran, Oran Epelbaum, oran / epelbaum me
 2017/12/20, kbsletten, Kyle Sletten, kbsletten@gmail.com
 2017/12/27, jkmar, Jakub Marciniszyn, marciniszyn.jk@gmail.com
+2018/02/18, songtianyi, Tianyi.Song, songtianyi630@163.com

--- a/doc/go-target.md
+++ b/doc/go-target.md
@@ -24,7 +24,7 @@ You'll need to use git to set the release. For example, to set the release tag f
 
 ```bash
 cd $GOPATH/src/github.com/antlr/antlr4 # enter the antlr4 source directory
-git checkout tags/4.6.0 # the go runtime was added in release 4.6.0
+git checkout 4.6 # the go runtime was added in release 4.6.0
 ```
 
 A complete list of releases can be found on [the release page](https://github.com/antlr/antlr4/releases).


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->