### PR TITLE
 Fixed warning from MingGW and error from Clang Windows

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -180,3 +180,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/12/03, oranoran, Oran Epelbaum, oran / epelbaum me
 2017/12/20, kbsletten, Kyle Sletten, kbsletten@gmail.com
 2017/12/27, jkmar, Jakub Marciniszyn, marciniszyn.jk@gmail.com
+2018/02/25, chaseoxide, Marcus Ong, taccs97[at]gmail[dot]com

--- a/runtime/Cpp/runtime/src/antlr4-common.h
+++ b/runtime/Cpp/runtime/src/antlr4-common.h
@@ -78,9 +78,12 @@
     #endif
   #endif
 
-  namespace std {
-  class ANTLR4CPP_PUBLIC exception; // Needed for VS 2015.
-  } // namespace std
+  #if defined(_MSC_VER) && !defined(__clang__)
+    // clang-cl should escape this to prevent [ignored-attributes].
+    namespace std {
+    class ANTLR4CPP_PUBLIC exception; // Prevents warning C4275 from MSVC.
+    } // namespace std
+  #endif
 
 #elif defined(__APPLE__)
   typedef std::u32string UTF32String;

--- a/runtime/Cpp/runtime/src/antlr4-common.h
+++ b/runtime/Cpp/runtime/src/antlr4-common.h
@@ -81,7 +81,7 @@
   #if defined(_MSC_VER) && !defined(__clang__)
     // clang-cl should escape this to prevent [ignored-attributes].
     namespace std {
-    class ANTLR4CPP_PUBLIC exception; // Prevents warning C4275 from MSVC.
+      class ANTLR4CPP_PUBLIC exception; // Prevents warning C4275 from MSVC.
     } // namespace std
   #endif
 

--- a/runtime/Cpp/runtime/src/antlr4-common.h
+++ b/runtime/Cpp/runtime/src/antlr4-common.h
@@ -78,7 +78,9 @@
     #endif
   #endif
 
-  class ANTLR4CPP_PUBLIC std::exception; // Needed for VS 2015.
+  namespace std {
+  class ANTLR4CPP_PUBLIC exception; // Needed for VS 2015.
+  } // namespace std
 
 #elif defined(__APPLE__)
   typedef std::u32string UTF32String;


### PR DESCRIPTION
Reasons for changes are in commit messages.

In general, it fixes:
- In MingGW
   ```
   warning: declaration 'class std::exception' does not declare anything
   class ANTLR4CPP_PUBLIC std::exception; // Needed for VS 2015.
   ```
- In Clang (I tested with clang-tidy on Windows specifically)
   ```
   error: forward declaration of class cannot have a nested name specifier [clang-diagnostic-error]
     class ANTLR4CPP_PUBLIC std::exception; // Needed for VS 2015.
   ```

Side note: This sort of reverts the commit [19f584d](https://github.com/antlr/antlr4/commit/19f584da05bcc277f9804a596765acfc3c8172c5), where the `#ifdef` flag for the forward declaration was removed.
Another note: Seems like there's more than just `std::exception` that requires forward declaration.