### PR TITLE
Tidy build doc by removing git clone from Compile section

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -180,3 +180,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/12/03, oranoran, Oran Epelbaum, oran / epelbaum me
 2017/12/20, kbsletten, Kyle Sletten, kbsletten@gmail.com
 2017/12/27, jkmar, Jakub Marciniszyn, marciniszyn.jk@gmail.com
+2018/02/27, jcttrll, Jonathan Cottrill, github / jonathancottrill.net

--- a/doc/building-antlr.md
+++ b/doc/building-antlr.md
@@ -28,15 +28,6 @@ Checking out files: 100% (1427/1427), done.
 # Compile
 
 ```bash
-$ cd /tmp
-$ git clone git@github.com:antlr/antlr4.git
-Cloning into 'antlr4'...
-remote: Counting objects: 59858, done.
-remote: Compressing objects: 100% (57/57), done.
-remote: Total 59858 (delta 28), reused 9 (delta 9), pack-reused 59786
-Receiving objects: 100% (59858/59858), 31.10 MiB | 819.00 KiB/s, done.
-Resolving deltas: 100% (31898/31898), done.
-Checking connectivity... done.
 $ cd antlr4
 $ export MAVEN_OPTS="-Xmx1G"   # don't forget this on linux
 $ mvn clean                    # must be separate, not part of install/compile


### PR DESCRIPTION
The `git clone` instructions in the "Compile" section duplicate instructions already given in the previous section, "Get the source".