### PR TITLE
Universal Windows Support (UWP/UAP)

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -1,4 +1,4 @@
-ANTLR Project Contributors Certification of Origin and Rights
+﻿ANTLR Project Contributors Certification of Origin and Rights
 
 All contributors to ANTLR v4 must formally agree to abide by this
 certificate of origin by signing on the bottom with their github
@@ -181,3 +181,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/12/20, kbsletten, Kyle Sletten, kbsletten@gmail.com
 2017/12/27, jkmar, Jakub Marciniszyn, marciniszyn.jk@gmail.com
 2018/02/11, io7m, Mark Raynsford, code@io7m.com
+2018/03/29, thegoldenmule, Benjamin Jordan, bmj465@gmail.com

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.dotnet.csproj
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.dotnet.csproj
@@ -3,7 +3,7 @@
     <Company>The ANTLR Organization</Company>
     <Version>4.7.1.1</Version>
 	<NeutralLanguage>en-US</NeutralLanguage>
-    <TargetFrameworks>netstandard1.3;net35</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net35;uap10.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1580</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Antlr4.Runtime.Standard</AssemblyName>
@@ -44,10 +44,25 @@
     <Optimize>true</Optimize>
     <OutputPath>lib\Release</OutputPath>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform " Version="5.2.2" />
+  </ItemGroup>
 	<PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
 		<DefineConstants>DOTNETCORE;NET35PLUS;NET40PLUS;NET45PLUS</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)'=='net35'">
 		<DefineConstants>NET35PLUS</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(TargetFramework)'=='uap10.0'">
+		<DefineConstants>DOTNETCORE;NET35PLUS;NET40PLUS;NET45PLUS;WINDOWS_UWP</DefineConstants>
+		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+		<NugetTargetMoniker>UAP,Version=v10.0</NugetTargetMoniker>
+		<TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+		<TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
+		<TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+		<TargetFrameworkIdentifier>.NETCore</TargetFrameworkIdentifier>
+		<TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+		<LanguageTargets>$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets</LanguageTargets>
+		<ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
 	</PropertyGroup>
 </Project>

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.vs2013.csproj
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Antlr4.Runtime.vs2013.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Atn\ATNDeserializer.cs" />
     <Compile Include="Atn\ConflictInfo.cs" />
     <Compile Include="CharStreams.cs" />
+    <Compile Include="Consoles.cs" />
     <Compile Include="Dfa\AbstractEdgeMap.cs" />
     <Compile Include="Dfa\AcceptStateInfo.cs" />
     <Compile Include="Dfa\ArrayEdgeMap.cs" />
@@ -76,6 +77,7 @@
     <Compile Include="Tree\IParseTreeVisitor.cs" />
     <Compile Include="Tree\ParseTreeProperty.cs" />
     <Compile Include="Tree\Xpath\XPathLexer.cs" />
+    <Compile Include="UwpConsole.cs" />
     <Compile Include="Vocabulary.cs" />
     <Compile Include="Atn\ATNSimulator.cs" />
     <Compile Include="Atn\ATNState.cs" />

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ATNSimulator.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ATNSimulator.cs
@@ -77,7 +77,7 @@ namespace Antlr4.Runtime.Atn
 
         protected void ConsoleWriteLine(string format, params object[] arg)
         {
-#if !PORTABLE
+#if !PORTABLE && !WINDOWS_UWP
             System.Console.WriteLine(format, arg);
 #endif
         }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ATNState.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ATNState.cs
@@ -95,7 +95,7 @@ namespace Antlr4.Runtime.Atn
             {
                 if (epsilonOnlyTransitions != e.IsEpsilon)
                 {
-#if !PORTABLE
+#if !PORTABLE && !WINDOWS_UWP
                     System.Console.Error.WriteLine("ATN state {0} has both epsilon and non-epsilon transitions.", stateNumber);
 #endif
                     epsilonOnlyTransitions = false;

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ParserATNSimulator.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ParserATNSimulator.cs
@@ -2109,7 +2109,7 @@ namespace Antlr4.Runtime.Atn
 		 */
 		public void DumpDeadEndConfigs(NoViableAltException nvae)
 		{
-#if !PORTABLE
+#if !PORTABLE && !WINDOWS_UWP
             System.Console.Error.WriteLine("dead end configs: ");
 #endif
             foreach (ATNConfig c in nvae.DeadEndConfigs.configs)
@@ -2130,7 +2130,7 @@ namespace Antlr4.Runtime.Atn
 						trans = (not ? "~" : "") + "Set " + st.set.ToString();
 					}
 				}
-#if !PORTABLE
+#if !PORTABLE && !WINDOWS_UWP
                 System.Console.Error.WriteLine(c.ToString(parser, true) + ":" + trans);
 #endif
 			}

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Consoles.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Consoles.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+
+namespace Antlr4.Runtime
+{
+    /// <summary>
+    /// Mimics needed Windows.Console API.
+    /// </summary>
+    public static class Consoles
+    {
+        /// <summary>
+        /// Retrieves a writer for std output.
+        /// </summary>
+        public static TextWriter Out
+        {
+            get
+            {
+#if WINDOWS_UWP
+                return UwpConsole.Out;
+#else
+                return Console.Out;
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Retrieves a writer for error logging.
+        /// </summary>
+        public static TextWriter Error
+        {
+            get
+            {
+#if WINDOWS_UWP
+                return UwpConsole.Error;
+#else
+                return Console.Error;
+#endif
+            }
+        }
+    }
+}

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/DefaultErrorStrategy.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/DefaultErrorStrategy.cs
@@ -160,7 +160,7 @@ namespace Antlr4.Runtime
                     }
                     else
                     {
-#if !PORTABLE
+#if !PORTABLE && !WINDOWS_UWP
                         System.Console.Error.WriteLine("unknown recognition error type: " + e.GetType().FullName);
 #endif
                         NotifyErrorListeners(recognizer, e.Message, e);

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Lexer.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Lexer.cs
@@ -99,7 +99,7 @@ namespace Antlr4.Runtime
         /// </remarks>
 		private string _text;
 
-        public Lexer(ICharStream input) : this(input, Console.Out, Console.Error) { }
+        public Lexer(ICharStream input) : this(input, Consoles.Out, Consoles.Error) { }
 
         public Lexer(ICharStream input, TextWriter output, TextWriter errorOutput)
         {

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
@@ -171,7 +171,7 @@ namespace Antlr4.Runtime
         protected readonly TextWriter Output;
         protected readonly TextWriter ErrorOutput;
 
-        public Parser(ITokenStream input) : this(input, Console.Out, Console.Error) { }
+        public Parser(ITokenStream input) : this(input, Consoles.Out, Consoles.Error) { }
 
         public Parser(ITokenStream input, TextWriter output, TextWriter errorOutput)
         {

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/TokenStreamRewriter.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/TokenStreamRewriter.cs
@@ -622,7 +622,7 @@ namespace Antlr4.Runtime
                         // kill first delete
                         rop.index = Math.Min(prevRop.index, rop.index);
                         rop.lastIndex = Math.Max(prevRop.lastIndex, rop.lastIndex);
-#if !PORTABLE
+#if !PORTABLE && !WINDOWS_UWP
                         System.Console.Out.WriteLine("new rop " + rop);
 #endif
                     }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/UwpConsole.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/UwpConsole.cs
@@ -1,0 +1,74 @@
+﻿#if WINDOWS_UWP
+
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Antlr4.Runtime
+{
+    /// <summary>
+    /// Mimics Console.Out and Console.Err for UWP apps.
+    /// </summary>
+    public static class UwpConsole
+    {
+        /// <summary>
+        /// TextWriter that forwards to diagnostics, which is the preferred way
+        /// of writing to stdout on UWP.
+        /// </summary>
+        public class UwpOutWriter: TextWriter
+        {
+            /// <inheritdoc />
+            public override Encoding Encoding { get; }
+
+            /// <summary>
+            /// Creates a new writer.
+            /// </summary>
+            public UwpOutWriter()
+            {
+                Encoding = Encoding.UTF8;
+            }
+
+            /// <inheritdoc />
+            public override void Write(char value)
+            {
+                Debug.Write(value);
+            }
+        }
+
+        /// <summary>
+        /// TextWriter that forwards to diagnostics, which is the preferred way
+        /// of writing to stderr UWP.
+        /// </summary>
+        public class UwpErrWriter: TextWriter
+        {
+            /// <inheritdoc />
+            public override Encoding Encoding { get; }
+
+            /// <summary>
+            /// Creates a new writer.
+            /// </summary>
+            public UwpErrWriter()
+            {
+                Encoding = Encoding.UTF8;
+            }
+
+            /// <inheritdoc />
+            public override void Write(char value)
+            {
+                Debug.Fail(value.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Writes to StdOut.
+        /// </summary>
+        public readonly static TextWriter Out = new UwpOutWriter();
+
+        /// <summary>
+        /// Writes to StdErr.
+        /// </summary>
+        public readonly static TextWriter Error = new UwpErrWriter();
+    }
+}
+
+#endif

--- a/runtime/CSharp/runtime/CSharp/Antlr4.dotnet.sln
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.dotnet.sln
@@ -1,34 +1,36 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26114.2
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Antlr4.Runtime.dotnet", "Antlr4.Runtime\Antlr4.Runtime.dotnet.csproj", "{0F9F8436-A767-4407-8E81-F9C6270E2B5A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Antlr4.Runtime.dotnet", "Antlr4.Runtime\Antlr4.Runtime.dotnet.csproj", "{0F9F8436-A767-4407-8E81-F9C6270E2B5A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Debug|x64.ActiveCfg = Debug|x64
-		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Debug|x64.Build.0 = Debug|x64
-		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Debug|x86.ActiveCfg = Debug|x86
-		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Debug|x86.Build.0 = Debug|x86
+		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Debug|x64.Build.0 = Debug|Any CPU
+		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Debug|x86.Build.0 = Debug|Any CPU
 		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Release|x64.ActiveCfg = Release|x64
-		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Release|x64.Build.0 = Release|x64
-		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Release|x86.ActiveCfg = Release|x86
-		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Release|x86.Build.0 = Release|x86
+		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Release|x64.ActiveCfg = Release|Any CPU
+		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Release|x64.Build.0 = Release|Any CPU
+		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Release|x86.ActiveCfg = Release|Any CPU
+		{0F9F8436-A767-4407-8E81-F9C6270E2B5A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {39D6AF85-6E90-4091-BCF9-C7E454D45387}
 	EndGlobalSection
 EndGlobal

--- a/runtime/CSharp/runtime/CSharp/Antlr4.vs2013.sln
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.vs2013.sln
@@ -1,6 +1,7 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2002
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{47C0086D-577C-43DA-ADC7-544F27656E45}"
 EndProject
@@ -19,5 +20,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {56273A79-DA2C-479E-8062-232F0D80AE1E}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
We are using ANTLR4 on HoloLens, which runs on UWP. This platform is very close to `netstandard`, but we needed to make a handful of changes. The only real difference here is that we needed to abstract out `Windows.Console.Out` and `Err` and replace them with `TextWriter` implementations that simply forward to `Diagnostics.Debug`. This is the MS recommended way of writing to stdout and stderr.