### PR TITLE
Update icu4j to resolve CVEs

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -182,3 +182,4 @@ YYYY/MM/DD, github id, Full name, email
 2017/12/27, jkmar, Jakub Marciniszyn, marciniszyn.jk@gmail.com
 2018/02/11, io7m, Mark Raynsford, code@io7m.com
 2018/15/05, johnvanderholt, jan dillingh johnvanderholte@gmail.com
+2018/23/05, srvance, Stephen Vance, steve@vance.com

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
 			<artifactId>icu4j</artifactId>
-			<version>58.2</version>
+			<version>61.1</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
There are 4 CVEs against the current version of icu4j used by ANTLR. This PR updates to the latest version, which resolves all of the CVEs.

These were identified with the [OWASP Dependency Check](https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html).

To the extent my environment is configured, all tests pass. For configurations I don't have (e.g., Python 3.5), the tests fail identically between versions.

Details:
=====
Published Vulnerabilities
CVE-2017-14952  suppress

Severity:High
CVSS Score: 7.5 (AV:N/AC:L/Au:N/C:P/I:P/A:P)
CWE: CWE-415 Double Free

Double free in i18n/zonemeta.cpp in International Components for Unicode (ICU) for C/C++ through 59.1 allows remote attackers to execute arbitrary code via a crafted string, aka a "redundant UVector entry clean up function call" issue.
CONFIRM - http://bugs.icu-project.org/trac/changeset/40324/trunk/icu4c/source/i18n/zonemeta.cpp
MISC - http://www.sourcebrella.com/blog/double-free-vulnerability-international-components-unicode-icu/
Vulnerable Software & Versions:

cpe:/a:icu-project:international_components_for_unicode:59.1::~~~c%2fc%2b%2b~~ and all previous versions
CVE-2017-17484  suppress

Severity:High
CVSS Score: 7.5 (AV:N/AC:L/Au:N/C:P/I:P/A:P)
CWE: CWE-119 Improper Restriction of Operations within the Bounds of a Memory Buffer

The ucnv_UTF8FromUTF8 function in ucnv_u8.cpp in International Components for Unicode (ICU) for C/C++ through 60.1 mishandles ucnv_convertEx calls for UTF-8 to UTF-8 conversion, which allows remote attackers to cause a denial of service (stack-based buffer overflow and application crash) or possibly have unspecified other impact via a crafted string, as demonstrated by ZNC.
MISC - https://github.com/znc/znc/issues/1459
MISC - https://ssl.icu-project.org/trac/attachment/ticket/13490/poc.cpp
MISC - https://ssl.icu-project.org/trac/changeset/40714
MISC - https://ssl.icu-project.org/trac/changeset/40715
MISC - https://ssl.icu-project.org/trac/ticket/13490
MISC - https://ssl.icu-project.org/trac/ticket/13510
Vulnerable Software & Versions:

cpe:/a:icu-project:international_components_for_unicode:60.1::~~~c%2fc%2b%2b~~ and all previous versions
CVE-2017-7867  suppress

Severity:Medium
CVSS Score: 5.0 (AV:N/AC:L/Au:N/C:N/I:N/A:P)
CWE: CWE-787 Out-of-bounds Write

International Components for Unicode (ICU) for C/C++ before 2017-02-13 has an out-of-bounds write caused by a heap-based buffer overflow related to the utf8TextAccess function in common/utext.cpp and the utext_setNativeIndex* function.
BID - 97672
DEBIAN - DSA-3830
GENTOO - GLSA-201710-03
MISC - http://bugs.icu-project.org/trac/changeset/39671
MISC - https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=213
Vulnerable Software & Versions:

cpe:/a:icu-project:international_components_for_unicode:58.2::~~~c%2fc%2b%2b~~ and all previous versions
CVE-2017-7868  suppress

Severity:Medium
CVSS Score: 5.0 (AV:N/AC:L/Au:N/C:N/I:N/A:P)
CWE: CWE-787 Out-of-bounds Write

International Components for Unicode (ICU) for C/C++ before 2017-02-13 has an out-of-bounds write caused by a heap-based buffer overflow related to the utf8TextAccess function in common/utext.cpp and the utext_moveIndex32* function.
BID - 97674
DEBIAN - DSA-3830
GENTOO - GLSA-201710-03
MISC - http://bugs.icu-project.org/trac/changeset/39671
MISC - https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=437
Vulnerable Software & Versions:

cpe:/a:icu-project:international_components_for_unicode:58.2::~~~c%2fc%2b%2b~~ and all previous versions