### PR TITLE
BaseTestJava.java: Allow for custom template

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
@@ -452,6 +452,25 @@ public class BaseJavaTest implements RuntimeTestSupport {
 	}
 
 	protected String execLexer(String grammarFileName,
+            String grammarStr,
+            String lexerName,
+            String input,
+            ST template) {
+
+		boolean success = rawGenerateAndBuildRecognizer(grammarFileName,
+                                        grammarStr,
+                                        null,
+                                        lexerName);
+		assertTrue(success);
+		writeFile(tmpdir, "input", input);
+		writeLexerTestFile(lexerName, template);
+		compile("Test.java");
+		String output = execClass("Test");
+		return output;
+		}
+
+	
+	protected String execLexer(String grammarFileName,
 	                           String grammarStr,
 	                           String lexerName,
 	                           String input) {


### PR DESCRIPTION
To support complex test case I needed to use a custom StringText template.

With the proposed change the template can be defined together with the unit test that needs this.