### PR TITLE
Make grun alias as same as antlr4.

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -31,7 +31,7 @@ It's also a good idea to put this in your `.bash_profile` or whatever your start
 3. Create aliases for the ANTLR Tool, and `TestRig`.
 ```
 $ alias antlr4='java -Xmx500M -cp "/usr/local/lib/antlr-4.7.1-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
-$ alias grun='java org.antlr.v4.gui.TestRig'
+$ alias grun='java -Xmx500M -cp "/usr/local/lib/antlr-4.7.1-complete.jar:$CLASSPATH" org.antlr.v4.gui.TestRig'
 ```
 
 ### WINDOWS


### PR DESCRIPTION
I think we should make the alias for antlr4 and grun same. The grun alias command right now depend on step 2, but antlr4 didn't.

Sign of contributors is here: #2315

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->