### PR TITLE
Fix compiler warnings on Swift target

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -183,3 +183,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/02/11, io7m, Mark Raynsford, code@io7m.com
 2018/15/05, johnvanderholt, jan dillingh johnvanderholte@gmail.com
 2018/06/16, EternalPhane, Zongyuan Zuo, eternalphane@gmail.com
+2018/07/01, ReactiveRaven, David Godfrey, reactiveraven@reactiveraven.co.uk

--- a/runtime/Swift/Sources/Antlr4/ParserRuleContext.swift
+++ b/runtime/Swift/Sources/Antlr4/ParserRuleContext.swift
@@ -202,7 +202,7 @@ open class ParserRuleContext: RuleContext {
             return [TerminalNode]()
         }
 
-        return children.flatMap {
+        return children.compactMap {
             if let tnode = $0 as? TerminalNode, let symbol = tnode.getSymbol(), symbol.getType() == ttype {
                 return tnode
             }
@@ -220,7 +220,7 @@ open class ParserRuleContext: RuleContext {
         guard let children = children else {
             return [T]()
         }
-        return children.flatMap { $0 as? T }
+        return children.compactMap { $0 as? T }
     }
 
     override

--- a/runtime/Swift/Sources/Antlr4/atn/SemanticContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/SemanticContext.swift
@@ -427,7 +427,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
     }
 
     private static func filterPrecedencePredicates(_ collection: inout Set<SemanticContext>) -> [PrecedencePredicate] {
-        let result = collection.flatMap {
+        let result = collection.compactMap {
             $0 as? PrecedencePredicate
         }
         collection = Set<SemanticContext>(collection.filter {

--- a/runtime/Swift/Sources/Antlr4/misc/extension/UUIDExtension.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/extension/UUIDExtension.swift
@@ -11,7 +11,7 @@ extension UUID {
     public init(mostSigBits: Int64, leastSigBits: Int64) {
         let bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: 16)
         defer {
-            bytes.deallocate(capacity: 16)
+            bytes.deallocate()
         }
         bytes.withMemoryRebound(to: Int64.self, capacity: 2) {
             $0.pointee = leastSigBits


### PR DESCRIPTION
Fixes two warnings when importing Antlr4's Swift framework into a project:
* 'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
    * for these usages, this is effectively just renaming the method. `flatMap` was previously used for two different tasks. Filtering out nils (i.e. `[1, nil, 2]` -> `[1,2]`) and flattening arrays (ie `[[1],[2,3]]` -> `[1,2,3]`). Swift's team think this is a bad idea, because you can get unexpected results if you return optional arrays, so it was split into two separate functions for clarity.
* 'deallocate(capacity:)' is deprecated: Swift currently only supports freeing entire heap blocks, use deallocate() instead
    * As the warning says; the `capacity` must always be the same in allocate and deallocate, so it was dropped from deallocate to avoid confusion.

