### PR TITLE
Add StdninStream for python3 runtime. Closes: #2271

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -188,3 +188,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/05/23, srvance, Stephen Vance, steve@vance.com
 2018/06/14, alecont, Alessandro Contenti, alecontenti@hotmail.com
 2018/06/16, EternalPhane, Zongyuan Zuo, eternalphane@gmail.com
+2018/07/27, Maksim Novikov, mnovikov.work@gmail.com

--- a/runtime/Python3/src/antlr4/StdinStream.py
+++ b/runtime/Python3/src/antlr4/StdinStream.py
@@ -1,0 +1,11 @@
+import codecs
+import sys
+
+from antlr4.InputStream import InputStream
+
+
+class StdinStream(InputStream):
+    def __init__(self, encoding:str='ascii', errors:str='strict') -> None:
+        bytes = sys.stdin.buffer.read()
+        data = codecs.decode(bytes, encoding, errors)
+        super().__init__(data)


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->