### PR TITLE
Allow importing StdinStream from antlr4 package

### DIFF
--- a/runtime/Python3/src/antlr4/__init__.py
+++ b/runtime/Python3/src/antlr4/__init__.py
@@ -1,6 +1,7 @@
 from antlr4.Token import Token
 from antlr4.InputStream import InputStream
 from antlr4.FileStream import FileStream
+from antlr4.StdinStream import StdinStream
 from antlr4.BufferedTokenStream import TokenStream
 from antlr4.CommonTokenStream import CommonTokenStream
 from antlr4.Lexer import Lexer


### PR DESCRIPTION
Forgot to add package import in #2336 to be consistent with python2-runtime behaviour.
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->