### PR TITLE
sign contributors, add Richard Neil Pittman

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -193,3 +193,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/07/03, jgoppert, James Goppert, james.goppert@gmail.com
 2018/07/27, Maksim Novikov, mnovikov.work@gmail.com
 2018/08/03, ENDOH takanao, djmchl@gmail.com
+2018/09/24, Pittman, Richard Neil, pittman@microsoft.com


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->