### PR TITLE
[Python] Add missing lexer super class imports.

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -749,6 +749,10 @@ import sys
 >>
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
+<if(superClass)>
+from .<superClass> import <superClass>
+
+<endif>
 
 <atn>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -756,7 +756,13 @@ import sys
 >>
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
+<if(superClass)>
+if __name__ is not None and "." in __name__:
+    from .<superClass> import <superClass>
+else:
+    from <superClass> import <superClass>
 
+<endif>
 <atn>
 
 class <lexer.name>(<if(superClass)><superClass><else>Lexer<endif>):


### PR DESCRIPTION
Until now, the generated Python3 code imported the custom parser
superclasses relatively. However, this only worked in Python3 if
the module was inside a package, since relative imports rely on
__name__ to determine the current module's position in the package
hierarchy. In case of a standalone script, this was always __main__
and hence these relative imports failed.
The patch handles this issue them same way as it is handled by
listener imports.
