### PR TITLE
Add const accessors to antlrcpp::Any C++ class

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -204,3 +204,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/07/31 Lucas Henrqiue, lucashenrique580@gmail.com
 2018/08/03, ENDOH takanao, djmchl@gmail.com
 2018/10/29, chrisaycock, Christopher Aycock, chris[at]chrisaycock[dot]com
+2018/11/12, vinoski, Steve Vinoski, vinoski@ieee.org

--- a/runtime/Cpp/runtime/src/support/Any.h
+++ b/runtime/Cpp/runtime/src/support/Any.h
@@ -46,21 +46,21 @@ struct ANTLR4CPP_PUBLIC Any
 
   template<class U>
   bool is() const {
-    typedef StorageType<U> T;
-
-    auto derived = dynamic_cast<Derived<T> *>(_ptr);
+    auto derived = getDerived<U>();
 
     return derived != nullptr;
   }
 
   template<class U>
   StorageType<U>& as() {
-    typedef StorageType<U> T;
+    auto derived = getDerived<U>();
 
-    auto derived = dynamic_cast<Derived<T>*>(_ptr);
+    return derived->value;
+  }
 
-    if (!derived)
-      throw std::bad_cast();
+  template<class U>
+  const StorageType<U>& as() const {
+    auto derived = getDerived<U>();
 
     return derived->value;
   }
@@ -68,6 +68,11 @@ struct ANTLR4CPP_PUBLIC Any
   template<class U>
   operator U() {
     return as<StorageType<U>>();
+  }
+
+  template<class U>
+  operator const U() const {
+    return as<const StorageType<U>>();
   }
 
   Any& operator = (const Any& a) {
@@ -135,6 +140,18 @@ private:
       return _ptr->clone();
     else
       return nullptr;
+  }
+
+  template<class U>
+  Derived<StorageType<U>>* getDerived() const {
+    typedef StorageType<U> T;
+
+    auto derived = dynamic_cast<Derived<T>*>(_ptr);
+
+    if (!derived)
+      throw std::bad_cast();
+
+    return derived;
   }
 
   Base *_ptr;


### PR DESCRIPTION
To make it easier to work with the const antlrcpp::Any arguments to
the AbstractParseTreeVisitor class aggregateResult and
shouldVisitNextChild functions, add a public const overload for the
antlrcpp::Any::as member function to return a const StorageType&, and
add a public const overloaded conversion operator returning a const
instance of the type contained within the Any.

Add the private antlrcpp::Any::getDerived function to avoid
duplicating the dynamic_cast of the internal pointer, and call it from
the overloaded Any::as functions and also the Any::is function.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->