### PR TITLE
Fix ST4 Snapshot dependency

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -206,3 +206,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/08/03, ENDOH takanao, djmchl@gmail.com
 2018/10/29, chrisaycock, Christopher Aycock, chris[at]chrisaycock[dot]com
 2018/11/12, vinoski, Steve Vinoski, vinoski@ieee.org
+2018/11/14, nxtstep, Adriaan (Arjan) Duz, codewithadriaan[et]gmail[dot]com

--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>org.antlr</groupId>
 			<artifactId>ST4</artifactId>
-			<version>4.1-SNAPSHOT</version>
+			<version>4.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tool-testsuite/pom.xml
+++ b/tool-testsuite/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>ST4</artifactId>
-      <version>4.1-SNAPSHOT</version>
+      <version>4.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Simple removal of `-SNAPSHOT` from the ST4 dependency as it appears to be forgotten