### PR TITLE
[Swift] Report InputMismatchException with original context information

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParserErrorsDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/ParserErrorsDescriptors.java
@@ -639,7 +639,7 @@ public class ParserErrorsDescriptors {
 
 		@Override
 		public boolean ignore(String targetName) {
-			return !"Java".equals(targetName);
+			return !"Java".equals(targetName) && !"Swift".equals(targetName);
 		}
 	}
 }

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/SemPredEvalParserDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/SemPredEvalParserDescriptors.java
@@ -291,7 +291,7 @@ public class SemPredEvalParserDescriptors {
 
 		@Override
 		public boolean ignore(String targetName) {
-			return !"Java".equals(targetName);
+			return !"Java".equals(targetName) && !"Swift".equals(targetName);
 		}
 	}
 

--- a/runtime/Swift/Sources/Antlr4/InputMismatchException.swift
+++ b/runtime/Swift/Sources/Antlr4/InputMismatchException.swift
@@ -11,10 +11,16 @@
 /// 
 
 public class InputMismatchException: RecognitionException {
-    public init(_ recognizer: Parser) {
-        super.init(recognizer, recognizer.getInputStream()!, recognizer._ctx)
+    public init(_ recognizer: Parser, state: Int = ATNState.INVALID_STATE_NUMBER, ctx: ParserRuleContext? = nil) {
+        let bestCtx = ctx ?? recognizer._ctx
+
+        super.init(recognizer, recognizer.getInputStream()!, bestCtx)
+
         if let token = try? recognizer.getCurrentToken() {
             setOffendingToken(token)
+        }
+        if (state != ATNState.INVALID_STATE_NUMBER) {
+            setOffendingState(state)
         }
     }
 }


### PR DESCRIPTION
Port 0803c74 from the Java runtime to Swift.  This was issue #1922.
Enable the corresponding tests for Swift.
