### PR TITLE
Enable some performance tests on Swift.

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/PerformanceDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/PerformanceDescriptors.java
@@ -113,7 +113,7 @@ public class PerformanceDescriptors {
 
 		@Override
 		public boolean ignore(String targetName) {
-			return !Arrays.asList("Java", "CSharp", "Python2", "Python3", "Node", "Cpp").contains(targetName);
+			return !Arrays.asList("Java", "CSharp", "Python2", "Python3", "Node", "Cpp", "Swift").contains(targetName);
 		}
 	}
 
@@ -199,7 +199,7 @@ public class PerformanceDescriptors {
 		@Override
 		public boolean ignore(String targetName) {
 			// passes, but still too slow in Python and JavaScript
-			return !Arrays.asList("Java", "CSharp", "Cpp").contains(targetName);
+			return !Arrays.asList("Java", "CSharp", "Cpp", "Swift").contains(targetName);
 		}
 	}
 


### PR DESCRIPTION
Port 0803c74 from the Java runtime to Swift.  This was issue #1922.
Enable the corresponding tests for Swift.
