### PR TITLE
Do not throw std::bad_cast from antlrcpp::Any::is

### DIFF
--- a/runtime/Cpp/runtime/src/support/Any.h
+++ b/runtime/Cpp/runtime/src/support/Any.h
@@ -46,21 +46,21 @@ struct ANTLR4CPP_PUBLIC Any
 
   template<class U>
   bool is() const {
-    auto derived = getDerived<U>();
+    auto derived = getDerived<U>(false);
 
     return derived != nullptr;
   }
 
   template<class U>
   StorageType<U>& as() {
-    auto derived = getDerived<U>();
+    auto derived = getDerived<U>(true);
 
     return derived->value;
   }
 
   template<class U>
   const StorageType<U>& as() const {
-    auto derived = getDerived<U>();
+    auto derived = getDerived<U>(true);
 
     return derived->value;
   }
@@ -143,12 +143,12 @@ private:
   }
 
   template<class U>
-  Derived<StorageType<U>>* getDerived() const {
+  Derived<StorageType<U>>* getDerived(bool checkCast) const {
     typedef StorageType<U> T;
 
     auto derived = dynamic_cast<Derived<T>*>(_ptr);
 
-    if (!derived)
+    if (checkCast && !derived)
       throw std::bad_cast();
 
     return derived;


### PR DESCRIPTION
The antlrcpp::Any::is function should not throw a std::bad_cast
exception if the contained type can't be cast to the requested type,
but should instead just return a boolean result. Add a boolean
parameter to the private getDerived helper function to allow callers
to specify whether or not they want the cast results checked. In the
is() function, pass false for this parameter; in the as() functions,
pass true.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->