### PR TITLE
Move the Swift runtime to Swift 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,67 +71,67 @@ matrix:
             - clang-3.7
     - os: osx
       compiler: clang
-      osx_image: xcode9
+      osx_image: xcode10.1
       env:
         - TARGET=cpp
         - GROUP=LEXER
       stage: extended-test
     - os: osx
       compiler: clang
-      osx_image: xcode9
+      osx_image: xcode10.1
       env:
         - TARGET=cpp
         - GROUP=PARSER
       stage: extended-test
     - os: osx
       compiler: clang
-      osx_image: xcode9
+      osx_image: xcode10.1
       env:
         - TARGET=cpp
         - GROUP=RECURSION
       stage: extended-test
     - os: osx
       compiler: clang
-      osx_image: xcode9
+      osx_image: xcode10.1
       env:
         - TARGET=swift
         - GROUP=LEXER
       stage: main-test
     - os: osx
       compiler: clang
-      osx_image: xcode9
+      osx_image: xcode10.1
       env:
         - TARGET=swift
         - GROUP=PARSER
       stage: main-test
     - os: osx
       compiler: clang
-      osx_image: xcode9
+      osx_image: xcode10.1
       env:
         - TARGET=swift
         - GROUP=RECURSION
       stage: main-test
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: clang
       env:
        - TARGET=swift
        - GROUP=ALL
       stage: extended-test
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode10.1
       env:
         - TARGET=dotnet
         - GROUP=LEXER
       stage: extended-test
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode10.1
       env:
         - TARGET=dotnet
         - GROUP=PARSER
       stage: extended-test
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode10.1
       env:
         - TARGET=dotnet
         - GROUP=RECURSION

--- a/.travis/run-tests-swift.sh
+++ b/.travis/run-tests-swift.sh
@@ -6,19 +6,20 @@ set -euo pipefail
 # here since environment variables doesn't pass
 # across scripts
 if [ $TRAVIS_OS_NAME == "linux" ]; then
-  export SWIFT_VERSION=swift-4.0.2
-  export SWIFT_HOME=$(pwd)/swift/$SWIFT_VERSION-RELEASE-ubuntu14.04/usr/bin/
+  export SWIFT_VERSION=swift-4.2.1
+  export SWIFT_HOME=$(pwd)/swift/$SWIFT_VERSION-RELEASE-ubuntu16.04/usr/bin/
   export PATH=$SWIFT_HOME:$PATH
 
   # download swift
   mkdir swift
-  curl https://swift.org/builds/$SWIFT_VERSION-release/ubuntu1404/$SWIFT_VERSION-RELEASE/$SWIFT_VERSION-RELEASE-ubuntu14.04.tar.gz -s | tar xz -C swift &> /dev/null
+  curl https://swift.org/builds/$SWIFT_VERSION-release/ubuntu1604/$SWIFT_VERSION-RELEASE/$SWIFT_VERSION-RELEASE-ubuntu16.04.tar.gz -s | tar xz -C swift &> /dev/null
 fi
 
 if [ -z "${JAVA_HOME-}" ]
 then
-  export JAVA_HOME="$(dirname $(java -XshowSettings:properties -version 2>&1 |
-                                    grep 'java\.home' | awk '{ print $3 }'))"
+  export JAVA_HOME="$(java -XshowSettings:properties -version 2>&1 |
+                          grep 'java\.home' | awk '{ print $3 }')"
+  echo "export JAVA_HOME=$JAVA_HOME"
 fi
 
 # check swift

--- a/doc/swift-target.md
+++ b/doc/swift-target.md
@@ -1,5 +1,12 @@
 # ANTLR4 Language Target, Runtime for Swift
 
+## Requirements
+
+ANTLR 4.7.2 requires Swift 4.2.  It works on Swift 4.2.1 also.
+
+ANTLR 4.7.1 requires Swift 4.0, and does not work on Swift 4.2.  (The status of
+Swift 4.1 support is unknown.)
+
 ## Performance Note
 
 To use ANTLR4 Swift target in production environment, make sure to turn on compiler optimizations by following [these instructions](https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#build-configurations) if you use SwiftPM to build your project. If you are using Xcode to build your project, it's unlikely you will not use `release` build for production build.

--- a/runtime-testsuite/processors/pom.xml
+++ b/runtime-testsuite/processors/pom.xml
@@ -18,11 +18,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.sun</groupId>
-			<artifactId>tools</artifactId>
-			<version>1.4.2</version>
-			<scope>system</scope>
-			<systemPath>${java.home}/../lib/tools.jar</systemPath>
+			<groupId>com.github.olivergondza</groupId>
+			<artifactId>maven-jdk-tools-wrapper</artifactId>
+			<version>0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
@@ -1,6 +1,6 @@
-writeln(s) ::= <<print(<s>)>>
+writeln(s) ::= <<print((<s>) ?? "nil")>>
 
-write(s) ::= <<print(<s>, terminator: "")>>
+write(s) ::= <<print((<s>) ?? "nil", terminator: "")>>
 
 False() ::= "false"
 

--- a/runtime/Swift/Sources/Antlr4/ParserRuleContext.swift
+++ b/runtime/Swift/Sources/Antlr4/ParserRuleContext.swift
@@ -202,7 +202,7 @@ open class ParserRuleContext: RuleContext {
             return [TerminalNode]()
         }
 
-        return children.flatMap {
+        return children.compactMap {
             if let tnode = $0 as? TerminalNode, let symbol = tnode.getSymbol(), symbol.getType() == ttype {
                 return tnode
             }
@@ -220,7 +220,7 @@ open class ParserRuleContext: RuleContext {
         guard let children = children else {
             return [T]()
         }
-        return children.flatMap { $0 as? T }
+        return children.compactMap { $0 as? T }
     }
 
     override

--- a/runtime/Swift/Sources/Antlr4/atn/ATNConfigSet.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNConfigSet.swift
@@ -321,17 +321,17 @@ public class ATNConfigSet: Hashable, CustomStringConvertible {
         return Array(configToAlts.values)
     }
 
-    public final func getStateToAltMap() -> [ATNState: BitSet] {
+    public func getStateToAltMap() -> [Int: BitSet] {
         let length = configs.count
-        var m = [ATNState: BitSet]()
+        var m = [Int: BitSet]()
 
         for i in 0..<length {
             var alts: BitSet
-            if let mAlts =  m[configs[i].state] {
+            if let mAlts =  m[configs[i].state.stateNumber] {
                 alts = mAlts
             } else {
                 alts = BitSet()
-                m[configs[i].state] = alts
+                m[configs[i].state.stateNumber] = alts
             }
 
             try! alts.set(configs[i].alt)

--- a/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
@@ -1754,7 +1754,7 @@ open class ParserATNSimulator: ATNSimulator {
         }
 
         if debug {
-            print("config from pred transition=\(String(describing: c))")
+            print("config from pred transition=\(c?.description ?? "nil")")
         }
         return c!
     }
@@ -1796,7 +1796,7 @@ open class ParserATNSimulator: ATNSimulator {
         }
 
         if debug {
-            print("config from pred transition=\(String(describing: c))")
+            print("config from pred transition=\(c?.description ?? "nil")")
         }
         return c
     }
@@ -1804,7 +1804,7 @@ open class ParserATNSimulator: ATNSimulator {
 
     final func ruleTransition(_ config: ATNConfig, _ t: RuleTransition) -> ATNConfig {
         if debug {
-            print("CALL rule \(getRuleName(t.target.ruleIndex!)), ctx=\(String(describing: config.context))")
+            print("CALL rule \(getRuleName(t.target.ruleIndex!)), ctx=\(config.context?.description ?? "nil")")
         }
 
         let returnState = t.followState
@@ -1961,7 +1961,7 @@ open class ParserATNSimulator: ATNSimulator {
                           _ to: DFAState?) -> DFAState? {
         var to = to
         if debug {
-            print("EDGE \(String(describing: from)) -> \(String(describing: to)) upon \(getTokenName(t))")
+            print("EDGE \(from?.description ?? "nil")) -> \(to?.description ?? "nil") upon \(getTokenName(t))")
         }
 
         if to == nil {

--- a/runtime/Swift/Sources/Antlr4/atn/PredictionMode.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PredictionMode.swift
@@ -485,20 +485,8 @@ public enum PredictionMode {
         return configs.getConflictingAltSubsets()
     }
 
-    /// 
-    /// Get a map from state to alt subset from a configuration set. For each
-    /// configuration `c` in `configs`:
-    /// 
-    /// 
-    /// map[c._org.antlr.v4.runtime.atn.ATNConfig#state state_] U= c._org.antlr.v4.runtime.atn.ATNConfig#alt alt_
-    /// 
-    /// 
-    public static func getStateToAltMap(_ configs: ATNConfigSet) -> [ATNState: BitSet] {
-        return configs.getStateToAltMap()
-    }
-
     public static func hasStateAssociatedWithOneAlt(_ configs: ATNConfigSet) -> Bool {
-        let x = getStateToAltMap(configs)
+        let x = configs.getStateToAltMap()
         for alts in x.values {
             if alts.cardinality() == 1 {
                 return true

--- a/runtime/Swift/Sources/Antlr4/atn/SemanticContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/SemanticContext.swift
@@ -427,7 +427,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
     }
 
     private static func filterPrecedencePredicates(_ collection: inout Set<SemanticContext>) -> [PrecedencePredicate] {
-        let result = collection.flatMap {
+        let result = collection.compactMap {
             $0 as? PrecedencePredicate
         }
         collection = Set<SemanticContext>(collection.filter {

--- a/runtime/Swift/Sources/Antlr4/misc/MurmurHash.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/MurmurHash.swift
@@ -57,7 +57,12 @@ public final class MurmurHash {
     /// - Returns: the updated intermediate hash value
     /// 
     public static func update2(_ hashIn: UInt32, _ value: Int) -> UInt32 {
-        let k = calcK(UInt32(truncatingIfNeeded: value))
+        return updateInternal(hashIn, UInt32(truncatingIfNeeded: value))
+    }
+
+
+    private static func updateInternal(_ hashIn: UInt32, _ value: UInt32) -> UInt32 {
+        let k = calcK(value)
         var hash = hashIn
         hash = hash ^ k
         hash = (hash << r2) | (hash >> (32 - r2))
@@ -147,7 +152,7 @@ public final class MurmurHash {
             word |= UInt32(bytes[i + 2]) << 16
             word |= UInt32(bytes[i + 3]) << 24
 
-            hash = update(hash, word)
+            hash = updateInternal(hash, word)
         }
         let remaining = byteCount & 3
         if remaining != 0 {

--- a/runtime/Swift/Sources/Antlr4/misc/extension/UUIDExtension.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/extension/UUIDExtension.swift
@@ -11,7 +11,7 @@ extension UUID {
     public init(mostSigBits: Int64, leastSigBits: Int64) {
         let bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: 16)
         defer {
-            bytes.deallocate(capacity: 16)
+            bytes.deallocate()
         }
         bytes.withMemoryRebound(to: Int64.self, capacity: 2) {
             $0.pointee = leastSigBits


### PR DESCRIPTION
Move the Swift runtime to Swift 4.2.  There are a number of deprecations and changed semantics here (behavior of implicitly-unwrapped optionals and Hashable most notably).

This also upgrades all the Travis tests to use Xcode 10.1 (including the C++ and .NET macOS tests).