### PR TITLE
[Swift] Make ParserATNSimulator.precedenceTransition return a nullable value.

### DIFF
--- a/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
@@ -1722,7 +1722,7 @@ open class ParserATNSimulator: ATNSimulator {
                                     _ pt: PrecedencePredicateTransition,
                                     _ collectPredicates: Bool,
                                     _ inContext: Bool,
-                                    _ fullCtx: Bool) throws -> ATNConfig {
+                                    _ fullCtx: Bool) throws -> ATNConfig? {
         if debug {
             print("PRED (collectPredicates=\(collectPredicates)) \(pt.precedence)>=_p, ctx dependent=true")
             //if ( parser != nil ) {
@@ -1757,7 +1757,7 @@ open class ParserATNSimulator: ATNSimulator {
         if debug {
             print("config from pred transition=\(c?.description ?? "nil")")
         }
-        return c!
+        return c
     }
 
 


### PR DESCRIPTION
This was always clearly a possibility, looking at the body of the method.
The newly-enabled performance tests expose this bug (and I don't know how
we've gotten away with it otherwise for so long).

The Java runtime also returns null at this point.

This fixes the test failures currently seen in PR #2405 and #2407.