### PR TITLE
Fix install dependency for 'typing' library in python3.4

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -207,3 +207,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/10/29, chrisaycock, Christopher Aycock, chris[at]chrisaycock[dot]com
 2018/11/12, vinoski, Steve Vinoski, vinoski@ieee.org
 2018/11/14, nxtstep, Adriaan (Arjan) Duz, codewithadriaan[et]gmail[dot]com
+2018/11/15, amykyta3, Alex Mykyta, amykyta3@users.noreply.github.com

--- a/runtime/Python3/setup.py
+++ b/runtime/Python3/setup.py
@@ -5,6 +5,9 @@ setup(
     version='4.7.1',
     packages=['antlr4', 'antlr4.atn', 'antlr4.dfa', 'antlr4.tree', 'antlr4.error', 'antlr4.xpath'],
     package_dir={'': 'src'},
+    install_requires=[
+        "typing ; python_version<'3.5'",
+    ],
     url='http://www.antlr.org',
     license='BSD',
     author='Eric Vergnaud, Terence Parr, Sam Harwell',


### PR DESCRIPTION
Use of the "typing" library introduced in Python 3.5 is the only thing preventing the Antlr4 runtime to be used with the older Python 3.4.

Fortunately there is a backport available that resolves this dependency: https://pypi.org/project/typing/
Added a version-specific dependency so that the "typing" backport will get installed automatically when using versions of python older than 3.5