### PR TITLE
[Swift] Syntax error in antlr4/runtime/Swift/boot.py

### DIFF
--- a/runtime/Swift/boot.py
+++ b/runtime/Swift/boot.py
@@ -11,6 +11,9 @@ USER_M2 constant below.
 
 the java version is used according to environment variable $JAVA_HOME.
 """
+
+from __future__ import print_function
+
 import glob
 import shutil
 import argparse
@@ -178,11 +181,11 @@ def generate_parser():
 
 
 def antlr_says(msg):
-    print GREEN + "[ANTLR] " + msg + RESET
+    print(GREEN + "[ANTLR] " + msg + RESET)
 
 
 def antlr_complains(msg):
-    print RED + "[ANTLR] " + msg + RESET
+    print(RED + "[ANTLR] " + msg + RESET)
 
 
 if __name__ == "__main__":
@@ -198,6 +201,9 @@ if __name__ == "__main__":
         else:
             parser.print_help()
     except subprocess.CalledProcessError as err:
-        print >>sys.stderr, ("Error: command '%s' exited with status %d" %
-                             (' '.join(err.cmd), err.returncode))
+        print("Error: command '%s' exited with status %d" %
+              (' '.join(err.cmd), err.returncode), file=sys.stderr)
         sys.exit(err.returncode)
+    except (IOError, OSError) as err:
+        print(err, file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Make boot.py work under both Python 2 and 3.  This fixes #2369.

Add an extra exception handler, for neater error messages.
