### PR TITLE
[Swift-runtime] Make sure mutexes are being freed accordingly

### DIFF
--- a/runtime/Swift/Sources/Antlr4/misc/utils/Mutex.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/utils/Mutex.swift
@@ -35,4 +35,8 @@ class Mutex {
         return try closure()
     }
 
+    deinit {
+        // free the mutex resource
+        pthread_mutex_destroy(&mutex)
+    }
 }


### PR DESCRIPTION
The mutex util used in the swift-runtime is not destroyed when deallocated. The change in this PR attempts to fix that