### PR TITLE
fix NPE

### DIFF
--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/PredictionContext.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/PredictionContext.cs
@@ -352,7 +352,7 @@ namespace Antlr4.Runtime.Atn
 			for (int p = 0; p < parents.Length; p++)
 			{
 				PredictionContext parent = parents[p];
-				if (!uniqueParents.ContainsKey(parent))
+				if (parent!=null && !uniqueParents.ContainsKey(parent))
 				{ // don't replace
 					uniqueParents.Put(parent, parent);
 				}
@@ -360,7 +360,9 @@ namespace Antlr4.Runtime.Atn
 
 			for (int p = 0; p < parents.Length; p++)
 			{
-				parents[p] = uniqueParents.Get(parents[p]);
+				PredictionContext parent = parents[p];
+				if (parent!=null)
+					parents[p] = uniqueParents.Get(parent);
 			}
 		}
 


### PR DESCRIPTION
fix NPE encountered with a left-recursive grammar such as:
stuff:
   stuff1       # Stuff1
   | stuff2    # Stuff2
   | (stuff1 | stuff2) stuff3
 ;

Does not happen in Java because null keys are allowed
