### PR TITLE
virtual dtor for ParseTreeProperty

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -208,3 +208,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/11/12, vinoski, Steve Vinoski, vinoski@ieee.org
 2018/11/14, nxtstep, Adriaan (Arjan) Duz, codewithadriaan[et]gmail[dot]com
 2018/11/15, amykyta3, Alex Mykyta, amykyta3@users.noreply.github.com
+2018/11/29, hannemann-tamas, Ralf Hannemann-Tamas, ralf.ht@gmail.com

--- a/runtime/Cpp/runtime/src/tree/ParseTreeProperty.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeProperty.h
@@ -29,6 +29,7 @@ namespace tree {
   template<typename V>
   class ANTLR4CPP_PUBLIC ParseTreeProperty {
   public:
+    virtual ~ParseTreeProperty() {}
     virtual V get(ParseTree *node) {
       return _annotations[node];
     }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->