### PR TITLE
C++: fix bug in PredictionContext::mergeArrays

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -210,3 +210,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/11/14, nxtstep, Adriaan (Arjan) Duz, codewithadriaan[et]gmail[dot]com
 2018/11/15, amykyta3, Alex Mykyta, amykyta3@users.noreply.github.com
 2018/11/29, hannemann-tamas, Ralf Hannemann-Tamas, ralf.ht@gmail.com
+2018/12/20, WalterCouto, Walter Couto, WalterCouto@users.noreply.github.com

--- a/runtime/Cpp/runtime/src/BufferedTokenStream.cpp
+++ b/runtime/Cpp/runtime/src/BufferedTokenStream.cpp
@@ -272,7 +272,7 @@ ssize_t BufferedTokenStream::previousTokenOnChannel(size_t i, size_t channel) {
     }
 
     if (i == 0)
-      break;
+      return -1;
     i--;
   }
   return i;

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
@@ -278,7 +278,7 @@ Ref<PredictionContext> PredictionContext::mergeArrays(const Ref<ArrayPredictionC
       // same payload (stack tops are equal), must yield merged singleton
       size_t payload = a->returnStates[i];
       // $+$ = $
-      bool both$ = payload == EMPTY_RETURN_STATE && a_parent && b_parent;
+      bool both$ = payload == EMPTY_RETURN_STATE && !a_parent && !b_parent;
       bool ax_ax = (a_parent && b_parent) && *a_parent == *b_parent; // ax+ax -> ax
       if (both$ || ax_ax) {
         mergedParents[k] = a_parent; // choose left


### PR DESCRIPTION
In the orignal PredictionContext::mergeArrays there was a bug on Line 281 where the logic differs from java: It currently is:
bool both$ = payload == EMPTY_RETURN_STATE && a_parent && b_parent;
and should instead match java as:
bool both$ = payload == EMPTY_RETURN_STATE && !a_parent && !b_parent;

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->