### PR TITLE
C++ avoid warning in visual studio build due to clang specific directive

### DIFF
--- a/runtime/Cpp/runtime/src/support/CPPUtils.cpp
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.cpp
@@ -50,8 +50,10 @@ namespace antlrcpp {
             break;
           }
           // else fall through
+#ifndef _MSC_VER
 #if __has_cpp_attribute(clang::fallthrough)
           [[clang::fallthrough]];
+#endif
 #endif
 
         default:


### PR DESCRIPTION
The recently added clang directive cause a new warning for Visual Studio build. Need to include the new code with a directive checking for visual studio

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->