### PR TITLE
Change bitset upperbound to another higher arbitrary value to allow f…

### DIFF
--- a/runtime/Cpp/runtime/src/support/BitSet.h
+++ b/runtime/Cpp/runtime/src/support/BitSet.h
@@ -9,7 +9,7 @@
 
 namespace antlrcpp {
 
-  class ANTLR4CPP_PUBLIC BitSet : public std::bitset<1024> {
+  class ANTLR4CPP_PUBLIC BitSet : public std::bitset<2048> {
   public:
     size_t nextSetBit(size_t pos) const {
       for (size_t i = pos; i < size(); i++){


### PR DESCRIPTION
…or larger number of rules

We had a complex grammar file hit past this upperbound.  One solution is to put this up higher, another is to refactor into a container that can grow.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->