### PR TITLE
add Interval for python3 and correct type annotation

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -211,3 +211,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/11/15, amykyta3, Alex Mykyta, amykyta3@users.noreply.github.com
 2018/11/29, hannemann-tamas, Ralf Hannemann-Tamas, ralf.ht@gmail.com
 2018/12/20, WalterCouto, Walter Couto, WalterCouto@users.noreply.github.com
+2018/12/23, youkaichao, Kaichao You, youkaichao@gmail.com

--- a/runtime/Python2/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python2/src/antlr4/TokenStreamRewriter.py
@@ -104,7 +104,7 @@ class TokenStreamRewriter(object):
 
     def getText(self, program_name, interval):
         """
-        :type interval: Interval.Interval
+        :type interval: IntervalSet.Interval
         :param program_name:
         :param interval:
         :return:

--- a/runtime/Python3/src/antlr4/IntervalSet.py
+++ b/runtime/Python3/src/antlr4/IntervalSet.py
@@ -8,6 +8,29 @@ from io import StringIO
 import unittest
 from antlr4.Token import Token
 
+class Interval(object):
+
+    def __init__(self, start, stop):
+        self.start = start
+        self.stop = stop
+        self.range = xrange(start, stop)
+
+    def __contains__(self, item):
+        return item in self.range
+
+    def __len__(self):
+        return self.stop - self.start
+
+    def __iter__(self):
+        return iter(self.range)
+
+    def __getitem__(self, idx):
+        if idx == 0:
+            return self.start
+        elif idx == 1:
+            return self.stop
+        raise IndexError('Interval index out or range [{}]'.format(idx))
+
 # need forward declarations
 IntervalSet = None
 

--- a/runtime/Python3/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python3/src/antlr4/TokenStreamRewriter.py
@@ -98,7 +98,7 @@ class TokenStreamRewriter(object):
 
     def getText(self, program_name, interval):
         """
-        :type interval: Interval.Interval
+        :type interval: IntervalSet.Interval
         :param program_name:
         :param interval:
         :return:


### PR DESCRIPTION
I have noticed that in python2-runtime, there's this ``Interval`` class inside ``IntervalSet`` module. However, the ``Interval`` class is missing in python3-runtime.

The only direct reference to ``Interval`` class is in ``TokenStreamRewriter.getText`` with out-of-date annotation(it refers to ``Interval.Interval`` which doesn't exist). So I update the annotation for python2 & python3.