### PR TITLE
Bugfix/pythonruntime

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -211,3 +211,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/11/15, amykyta3, Alex Mykyta, amykyta3@users.noreply.github.com
 2018/11/29, hannemann-tamas, Ralf Hannemann-Tamas, ralf.ht@gmail.com
 2018/12/20, WalterCouto, Walter Couto, WalterCouto@users.noreply.github.com
+2018/12/23, youkaichao, Kaichao You, youkaichao@gmail.com

--- a/runtime/Python2/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python2/src/antlr4/TokenStreamRewriter.py
@@ -88,7 +88,8 @@ class TokenStreamRewriter(object):
     def delete(self, program_name, from_idx, to_idx):
         if isinstance(from_idx, Token):
             self.replace(program_name, from_idx.tokenIndex, to_idx.tokenIndex, "")
-        self.replace(program_name, from_idx, to_idx, "")
+        else:
+            self.replace(program_name, from_idx, to_idx, "")
 
     def lastRewriteTokenIndex(self, program_name=DEFAULT_PROGRAM_NAME):
         return self.lastRewriteTokenIndexes.get(program_name, -1)

--- a/runtime/Python3/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python3/src/antlr4/TokenStreamRewriter.py
@@ -85,7 +85,8 @@ class TokenStreamRewriter(object):
     def delete(self, program_name, from_idx, to_idx):
         if isinstance(from_idx, Token):
             self.replace(program_name, from_idx.tokenIndex, to_idx.tokenIndex, None)
-        self.replace(program_name, from_idx, to_idx, None)
+        else:
+            self.replace(program_name, from_idx, to_idx, None)
 
     def lastRewriteTokenIndex(self, program_name=DEFAULT_PROGRAM_NAME):
         return self.lastRewriteTokenIndexes.get(program_name, -1)


### PR DESCRIPTION
@ericvergnaud  Here is an obvious bug.

If we call ``TokenStreamRewriter.delete`` with 2 tokens as argument, then ``replace`` will be called twice, and an exception will occur at the second time, cause ``replace`` requires two ``int`` arguments.
 