### PR TITLE
[CPP] Fix Xpath. Derived class of XPathElement are now transmitted by pointers.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -211,3 +211,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/11/15, amykyta3, Alex Mykyta, amykyta3@users.noreply.github.com
 2018/11/29, hannemann-tamas, Ralf Hannemann-Tamas, ralf.ht@gmail.com
 2018/12/20, WalterCouto, Walter Couto, WalterCouto@users.noreply.github.com
+2018/12/28, Malick F.

--- a/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp
@@ -28,8 +28,8 @@ XPath::XPath(Parser *parser, const std::string &path) {
   _elements = split(path);
 }
 
-std::vector<XPathElement> XPath::split(const std::string &path) {
-  ANTLRFileStream in(path);
+std::vector<Ref<XPathElement>> XPath::split(const std::string &path) {
+  ANTLRInputStream in(path);
   XPathLexer lexer(&in);
   lexer.removeErrorListeners();
   XPathLexerErrorListener listener;
@@ -44,7 +44,7 @@ std::vector<XPathElement> XPath::split(const std::string &path) {
   }
 
   std::vector<Token *> tokens = tokenStream.getTokens();
-  std::vector<XPathElement> elements;
+  std::vector<Ref<XPathElement>> elements;
   size_t n = tokens.size();
   size_t i = 0;
   bool done = false;
@@ -62,8 +62,8 @@ std::vector<XPathElement> XPath::split(const std::string &path) {
           i++;
           next = tokens[i];
         }
-        XPathElement pathElement = getXPathElement(next, anywhere);
-        pathElement.setInvert(invert);
+        Ref<XPathElement> pathElement = getXPathElement(next, anywhere);
+        (*pathElement).setInvert(invert);
         elements.push_back(pathElement);
         i++;
         break;
@@ -88,7 +88,7 @@ std::vector<XPathElement> XPath::split(const std::string &path) {
   return elements;
 }
 
-XPathElement XPath::getXPathElement(Token *wordToken, bool anywhere) {
+Ref<XPathElement> XPath::getXPathElement(Token *wordToken, bool anywhere) {
   if (wordToken->getType() == Token::EOF) {
     throw IllegalArgumentException("Missing path element at end of path");
   }
@@ -98,8 +98,8 @@ XPathElement XPath::getXPathElement(Token *wordToken, bool anywhere) {
   switch (wordToken->getType()) {
     case XPathLexer::WILDCARD :
       if (anywhere)
-        return XPathWildcardAnywhereElement();
-      return XPathWildcardElement();
+        return std::make_shared<XPathWildcardAnywhereElement>(XPathWildcardAnywhereElement());
+      return std::make_shared<XPathWildcardElement>(XPathWildcardElement());
 
     case XPathLexer::TOKEN_REF:
     case XPathLexer::STRING :
@@ -107,16 +107,16 @@ XPathElement XPath::getXPathElement(Token *wordToken, bool anywhere) {
         throw IllegalArgumentException(word + " at index " + std::to_string(wordToken->getStartIndex()) + " isn't a valid token name");
       }
       if (anywhere)
-        return XPathTokenAnywhereElement(word, (int)ttype);
-      return XPathTokenElement(word, (int)ttype);
+        return std::make_shared<XPathTokenAnywhereElement>(XPathTokenAnywhereElement(word, (int)ttype));
+      return std::make_shared<XPathTokenElement>(XPathTokenElement(word, (int)ttype));
 
     default :
       if (ruleIndex == -1) {
         throw IllegalArgumentException(word + " at index " + std::to_string(wordToken->getStartIndex()) + " isn't a valid rule name");
       }
       if (anywhere)
-        return XPathRuleAnywhereElement(word, (int)ruleIndex);
-      return XPathRuleElement(word, (int)ruleIndex);
+        return std::make_shared<XPathRuleAnywhereElement>( XPathRuleAnywhereElement(word, (int)ruleIndex));
+      return std::make_shared<XPathRuleElement>(XPathRuleElement(word, (int)ruleIndex));
   }
 }
 
@@ -131,13 +131,19 @@ std::vector<ParseTree *> XPath::evaluate(ParseTree *t) {
   while (i < _elements.size()) {
     std::vector<ParseTree *> next;
     for (auto node : work) {
-      if (!node->children.empty()) {
-        // only try to match next element if it has children
-        // e.g., //func/*/stat might have a token node for which
-        // we can't go looking for stat nodes.
-        auto matching = _elements[i].evaluate(node);
-        next.insert(next.end(), matching.begin(), matching.end());
-      }
+		if (!node->children.empty()) {
+			// only try to match next element if it has children
+			// e.g., //func/*/stat might have a token node for which
+			// we can't go looking for stat nodes.
+			auto matching = (*_elements[i]).evaluate(node);
+
+			for (std::vector<ParseTree*>::iterator it = matching.begin(); it != matching.end(); ++it) {
+				// only add if not present already
+				if (std::find(next.begin(), next.end(), *it) == next.end()) {
+					next.push_back(*it);
+				}
+			}
+		}
     }
     i++;
     work = next;

--- a/runtime/Cpp/runtime/src/tree/xpath/XPath.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPath.h
@@ -62,7 +62,7 @@ namespace xpath {
     virtual ~XPath() {}
 
     // TO_DO: check for invalid token/rule names, bad syntax
-    virtual std::vector<XPathElement> split(const std::string &path);
+    virtual std::vector<Ref<XPathElement>> split(const std::string &path);
 
     /// Return a list of all nodes starting at {@code t} as root that satisfy the
     /// path. The root {@code /} is relative to the node passed to
@@ -71,13 +71,13 @@ namespace xpath {
 
   protected:
     std::string _path;
-    std::vector<XPathElement> _elements;
+    std::vector<Ref<XPathElement>> _elements;
     Parser *_parser;
 
     /// Convert word like {@code *} or {@code ID} or {@code expr} to a path
     /// element. {@code anywhere} is {@code true} if {@code //} precedes the
     /// word.
-    virtual XPathElement getXPathElement(Token *wordToken, bool anywhere);
+    virtual Ref<XPathElement> getXPathElement(Token *wordToken, bool anywhere);
   };
 
 } // namespace xpath

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathElement.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathElement.cpp
@@ -17,9 +17,6 @@ XPathElement::XPathElement(const std::string &nodeName) {
 XPathElement::~XPathElement() {
 }
 
-std::vector<ParseTree *> XPathElement::evaluate(ParseTree * /*t*/) {
-  return {};
-}
 
 std::string XPathElement::toString() const {
   std::string inv = _invert ? "!" : "";

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathElement.h
@@ -25,7 +25,7 @@ namespace xpath {
 
     /// Given tree rooted at {@code t} return all nodes matched by this path
     /// element.
-    virtual std::vector<ParseTree *> evaluate(ParseTree *t);
+	virtual std::vector<ParseTree *> evaluate(ParseTree *t) = 0;
     virtual std::string toString() const;
 
     void setInvert(bool value);


### PR DESCRIPTION
Derived class of XPathElement are now transmitted by pointers and the evaluate() function of XPathElement is now a pure virtual function to prevent future object slicing problems.

This is a cleaner version of an old pull request, recently rejected (see https://github.com/antlr/antlr4/pull/2231 ) 

The main problem was that `XPath::getXPathElement`  (https://github.com/antlr/antlr4/blob/98dc2c0f0249a67b797b151da3adf4ffbc1fd6a1/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp#L91) was returning a derived class of XpathElement without a pointer. As the result some informations was lost and the Xpath framework was broken. 

I also changed the `XPath::split` (https://github.com/antlr/antlr4/blob/98dc2c0f0249a67b797b151da3adf4ffbc1fd6a1/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp#L31) to properly treat the argument as a string and not as a filepath. In this way the runtime behave as other runtime (for instance see https://github.com/antlr/antlr4/blob/98dc2c0f0249a67b797b151da3adf4ffbc1fd6a1/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Tree/Xpath/XPath.cs#L91)

