### PR TITLE
update python runtime doc

### DIFF
--- a/runtime/Python2/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python2/src/antlr4/TokenStreamRewriter.py
@@ -101,14 +101,11 @@ class TokenStreamRewriter(object):
         return self.programs.setdefault(program_name, [])
 
     def getDefaultText(self):
-        return self.getText(self.DEFAULT_PROGRAM_NAME, 0, len(self.tokens.tokens))
+        return self.getText(self.DEFAULT_PROGRAM_NAME, 0, len(self.tokens.tokens) - 1)
 
     def getText(self, program_name, start, stop):
         """
-        :type interval: IntervalSet.Interval
-        :param program_name:
-        :param interval:
-        :return:
+        :return: the text in tokens[start, stop](closed interval)
         """
         rewrites = self.programs.get(program_name)
 

--- a/runtime/Python3/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python3/src/antlr4/TokenStreamRewriter.py
@@ -101,11 +101,11 @@ class TokenStreamRewriter(object):
         return self.programs.setdefault(program_name, [])
         
     def getDefaultText(self):
-        return self.getText(self.DEFAULT_PROGRAM_NAME, 0, len(self.tokens.tokens))
+        return self.getText(self.DEFAULT_PROGRAM_NAME, 0, len(self.tokens.tokens) - 1)
 
     def getText(self, program_name, start:int, stop:int):
         """
-        :return:
+        :return: the text in tokens[start, stop](closed interval)
         """
         rewrites = self.programs.get(program_name)
 


### PR DESCRIPTION
@ericvergnaud  I updated the documentation you mentioned at #2452 .
By the way, the interval used here is closed interval while typical python range uses ``[start, stop)``, which is confusing to newbees. So I add this in documentation and update the code for ``getDefaultText`` (which also corresponds with the java version https://github.com/antlr/antlr4/blob/master/runtime/Java/src/org/antlr/v4/runtime/TokenStreamRewriter.java#L360)