### PR TITLE
Feature/fix gcc compiler warnings

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -212,3 +212,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/11/29, hannemann-tamas, Ralf Hannemann-Tamas, ralf.ht@gmail.com
 2018/12/20, WalterCouto, Walter Couto, WalterCouto@users.noreply.github.com
 2018/12/23, youkaichao, Kaichao You, youkaichao@gmail.com
+2019/01/04, majojoe, Johannes Maier, maier_jo@gmx.de

--- a/runtime/Cpp/runtime/src/NoViableAltException.h
+++ b/runtime/Cpp/runtime/src/NoViableAltException.h
@@ -29,15 +29,14 @@ namespace antlr4 {
     /// Which configurations did we try at input.index() that couldn't match input.LT(1)?
     atn::ATNConfigSet* _deadEndConfigs;
 
-    // Flag that indicates if we own the dead end config set and have to delete it on destruction.
-    bool _deleteConfigs;
-
     /// The token object at the start index; the input stream might
     /// not be buffering tokens so get a reference to it. (At the
     /// time the error occurred, of course the stream needs to keep a
     /// buffer all of the tokens but later we might not have access to those.)
     Token *_startToken;
 
+    // Flag that indicates if we own the dead end config set and have to delete it on destruction.
+    bool _deleteConfigs;
   };
 
 } // namespace antlr4

--- a/runtime/Cpp/runtime/src/atn/ATNState.h
+++ b/runtime/Cpp/runtime/src/atn/ATNState.h
@@ -70,7 +70,8 @@ namespace atn {
   ///
   /// <embed src="images/OptionalNonGreedy.svg" type="image/svg+xml"/>
   /// </summary>
-  class ANTLR4CPP_PUBLIC ATN;
+  //ATN forward declaration does not need ANTLR4CPP_PUBLIC declaration
+  class  ATN;
 
   class ANTLR4CPP_PUBLIC ATNState {
   public:

--- a/runtime/Cpp/runtime/src/support/CPPUtils.cpp
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.cpp
@@ -54,8 +54,11 @@ namespace antlrcpp {
 #if __has_cpp_attribute(clang::fallthrough)
           [[clang::fallthrough]];
 #endif
+          // gcc fall through
+#if __has_cpp_attribute(fallthrough)
+        [[fallthrough]];
 #endif
-
+#endif
         default:
           result += c;
       }

--- a/runtime/Cpp/runtime/src/support/CPPUtils.cpp
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.cpp
@@ -51,14 +51,16 @@ namespace antlrcpp {
           }
           // else fall through
 #ifndef _MSC_VER
-#if __has_cpp_attribute(clang::fallthrough)
-          [[clang::fallthrough]];
-#endif
-          // gcc fall through
+#if (__cplusplus >= 201703L) || (__GNUC__)
 #if __has_cpp_attribute(fallthrough)
         [[fallthrough]];
 #endif
+#else //#if (__cplusplus >= 201703L) || (__GNUC__)
+#if __has_cpp_attribute(clang::fallthrough)
+          [[clang::fallthrough]];
 #endif
+#endif //#if (__cplusplus >= 201703L) || (__GNUC__)
+#endif //#ifndef _MSC_VER
         default:
           result += c;
       }


### PR DESCRIPTION
This fixes the compiler warnings with gcc (mingw) and fixes issue #2481 .
I'm sorry, but I couldn't compile the cpp tests since there is a linker error (tests broken or maybe a dependency is missing? - Have not investigated further). The java tests work. 
However the runtime compiles with clang and gcc without warnings and the runtime seems to work flawlessly for me. 
