### PR TITLE
Fix errors in JavaScript run-time.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -213,3 +213,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/12/20, WalterCouto, Walter Couto, WalterCouto@users.noreply.github.com
 2018/12/23, youkaichao, Kaichao You, youkaichao@gmail.com
 2019/02/06, ralucado, Cristina Raluca Vijulie, ralucris.v[at]gmail[dot]com
+2019/02/14, hsomi, Hem Vignesh Somi, hsomi@google.com

--- a/runtime/JavaScript/src/antlr4/Parser.js
+++ b/runtime/JavaScript/src/antlr4/Parser.js
@@ -296,22 +296,6 @@ Parser.prototype.getATNWithBypassAlts = function() {
 
 var Lexer = require('./Lexer').Lexer;
 
-Parser.prototype.compileParseTreePattern = function(pattern, patternRuleIndex, lexer) {
-	lexer = lexer || null;
-	if (lexer === null) {
-		if (this.getTokenStream() !== null) {
-			var tokenSource = this.getTokenStream().tokenSource;
-			if (tokenSource instanceof Lexer) {
-				lexer = tokenSource;
-			}
-		}
-	}
-	if (lexer === null) {
-		throw "Parser can't discover a lexer to use";
-	}
-	throw new Error('Unsupported operation compileParseTreePattern.');
-};
-
 Parser.prototype.getInputStream = function() {
 	return this.getTokenStream();
 };

--- a/runtime/JavaScript/src/antlr4/Parser.js
+++ b/runtime/JavaScript/src/antlr4/Parser.js
@@ -309,8 +309,7 @@ Parser.prototype.compileParseTreePattern = function(pattern, patternRuleIndex, l
 	if (lexer === null) {
 		throw "Parser can't discover a lexer to use";
 	}
-	var m = new ParseTreePatternMatcher(lexer, this);
-	return m.compile(pattern, patternRuleIndex);
+	throw new Error('Unsupported operation compileParseTreePattern.');
 };
 
 Parser.prototype.getInputStream = function() {

--- a/runtime/JavaScript/src/antlr4/RuleContext.js
+++ b/runtime/JavaScript/src/antlr4/RuleContext.js
@@ -27,7 +27,7 @@
 
 var RuleNode = require('./tree/Tree').RuleNode;
 var INVALID_INTERVAL = require('./tree/Tree').INVALID_INTERVAL;
-var INVALID_ALT_NUMBER = require('./atn/ATN').INVALID_ALT_NUMBER;
+var INVALID_ALT_NUMBER = require('./atn/ATN').ATN.INVALID_ALT_NUMBER;
 
 function RuleContext(parent, invokingState) {
 	RuleNode.call(this);

--- a/runtime/JavaScript/src/antlr4/RuleContext.js
+++ b/runtime/JavaScript/src/antlr4/RuleContext.js
@@ -27,7 +27,7 @@
 
 var RuleNode = require('./tree/Tree').RuleNode;
 var INVALID_INTERVAL = require('./tree/Tree').INVALID_INTERVAL;
-var INVALID_ALT_NUMBER = require('./atn/ATN').ATN.INVALID_ALT_NUMBER;
+var INVALID_ALT_NUMBER = require('./atn/ATN').INVALID_ALT_NUMBER;
 
 function RuleContext(parent, invokingState) {
 	RuleNode.call(this);

--- a/runtime/JavaScript/src/antlr4/atn/ATN.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATN.js
@@ -140,3 +140,4 @@ ATN.prototype.getExpectedTokens = function( stateNumber, ctx ) {
 ATN.INVALID_ALT_NUMBER = 0;
 
 exports.ATN = ATN;
+exports.INVALID_ALT_NUMBER = ATN.INVALID_ALT_NUMBER;

--- a/runtime/JavaScript/src/antlr4/atn/ATNConfigSet.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNConfigSet.js
@@ -183,7 +183,7 @@ ATNConfigSet.prototype.hashCode = function() {
 ATNConfigSet.prototype.updateHashCode = function(hash) {
 	if (this.readOnly) {
 		if (this.cachedHashCode === -1) {
-            var hash = new Hash();
+            hash = new Hash();
             hash.update(this.configs);
 			this.cachedHashCode = hash.finish();
 		}

--- a/runtime/JavaScript/src/antlr4/atn/ATNDeserializer.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNDeserializer.js
@@ -158,7 +158,7 @@ ATNDeserializer.prototype.checkUUID = function() {
     var uuid = this.readUUID();
     if (SUPPORTED_UUIDS.indexOf(uuid)<0) {
         throw ("Could not deserialize ATN with UUID: " + uuid +
-                        " (expected " + SERIALIZED_UUID + " or a legacy UUID).", uuid, SERIALIZED_UUID);
+                        " (expected " + SERIALIZED_UUID + " or a legacy UUID).");
     }
     this.uuid = uuid;
 };

--- a/runtime/JavaScript/src/antlr4/atn/ParserATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/ParserATNSimulator.js
@@ -255,7 +255,6 @@ var PredictionContext = require('./../PredictionContext').PredictionContext;
 var Interval = require('./../IntervalSet').Interval;
 var Transitions = require('./Transition');
 var Transition = Transitions.Transition;
-var AtomTransition = Transitions.AtomTransition;
 var SetTransition = Transitions.SetTransition;
 var NotSetTransition = Transitions.NotSetTransition;
 var RuleTransition = Transitions.RuleTransition;
@@ -1571,29 +1570,6 @@ ParserATNSimulator.prototype.getTokenName = function( t) {
 
 ParserATNSimulator.prototype.getLookaheadName = function(input) {
     return this.getTokenName(input.LA(1));
-};
-
-// Used for debugging in adaptivePredict around execATN but I cut
-//  it out for clarity now that alg. works well. We can leave this
-//  "dead" code for a bit.
-//
-ParserATNSimulator.prototype.dumpDeadEndConfigs = function(nvae) {
-    console.log("dead end configs: ");
-    var decs = nvae.getDeadEndConfigs();
-    for(var i=0; i<decs.length; i++) {
-    	var c = decs[i];
-        var trans = "no edges";
-        if (c.state.transitions.length>0) {
-            var t = c.state.transitions[0];
-            if (t instanceof AtomTransition) {
-                trans = "Atom "+ this.getTokenName(t.label);
-            } else if (t instanceof SetTransition) {
-                var neg = (t instanceof NotSetTransition);
-                trans = (neg ? "~" : "") + "Set " + t.set;
-            }
-        }
-        console.error(c.toString(this.parser, true) + ":" + trans);
-    }
 };
 
 ParserATNSimulator.prototype.noViableAlt = function(input, outerContext, configs, startIndex) {

--- a/runtime/JavaScript/src/antlr4/atn/ParserATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/ParserATNSimulator.js
@@ -255,6 +255,7 @@ var PredictionContext = require('./../PredictionContext').PredictionContext;
 var Interval = require('./../IntervalSet').Interval;
 var Transitions = require('./Transition');
 var Transition = Transitions.Transition;
+var AtomTransition = Transitions.AtomTransition;
 var SetTransition = Transitions.SetTransition;
 var NotSetTransition = Transitions.NotSetTransition;
 var RuleTransition = Transitions.RuleTransition;

--- a/runtime/JavaScript/src/antlr4/dfa/DFA.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFA.js
@@ -104,7 +104,7 @@ DFA.prototype.setPrecedenceStartState = function(precedence, startState) {
 
 DFA.prototype.setPrecedenceDfa = function(precedenceDfa) {
 	if (this.precedenceDfa!==precedenceDfa) {
-		this._states = new DFAStatesSet();
+		this._states = new Set();
 		if (precedenceDfa) {
 			var precedenceState = new DFAState(null, new ATNConfigSet());
 			precedenceState.edges = [];

--- a/runtime/JavaScript/src/antlr4/dfa/DFA.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFA.js
@@ -85,39 +85,6 @@ DFA.prototype.setPrecedenceStartState = function(precedence, startState) {
 	this.s0.edges[precedence] = startState;
 };
 
-//
-// Sets whether this is a precedence DFA. If the specified value differs
-// from the current DFA configuration, the following actions are taken;
-// otherwise no changes are made to the current DFA.
-//
-// <ul>
-// <li>The {@link //states} map is cleared</li>
-// <li>If {@code precedenceDfa} is {@code false}, the initial state
-// {@link //s0} is set to {@code null}; otherwise, it is initialized to a new
-// {@link DFAState} with an empty outgoing {@link DFAState//edges} array to
-// store the start states for individual precedence values.</li>
-// <li>The {@link //precedenceDfa} field is updated</li>
-// </ul>
-//
-// @param precedenceDfa {@code true} if this is a precedence DFA; otherwise,
-// {@code false}
-
-DFA.prototype.setPrecedenceDfa = function(precedenceDfa) {
-	if (this.precedenceDfa!==precedenceDfa) {
-		this._states = new Set();
-		if (precedenceDfa) {
-			var precedenceState = new DFAState(null, new ATNConfigSet());
-			precedenceState.edges = [];
-			precedenceState.isAcceptState = false;
-			precedenceState.requiresFullContext = false;
-			this.s0 = precedenceState;
-		} else {
-			this.s0 = null;
-		}
-		this.precedenceDfa = precedenceDfa;
-	}
-};
-
 Object.defineProperty(DFA.prototype, "states", {
 	get : function() {
 		return this._states;

--- a/runtime/JavaScript/src/antlr4/error/Errors.js
+++ b/runtime/JavaScript/src/antlr4/error/Errors.js
@@ -78,7 +78,7 @@ LexerNoViableAltException.prototype.constructor = LexerNoViableAltException;
 LexerNoViableAltException.prototype.toString = function() {
     var symbol = "";
     if (this.startIndex >= 0 && this.startIndex < this.input.size) {
-        symbol = this.input.getText(this.startIndex);
+        symbol = this.input.getText(this.startIndex, this.startIndex);
     }
     return "LexerNoViableAltException" + symbol;
 };

--- a/runtime/JavaScript/src/antlr4/error/Errors.js
+++ b/runtime/JavaScript/src/antlr4/error/Errors.js
@@ -78,7 +78,7 @@ LexerNoViableAltException.prototype.constructor = LexerNoViableAltException;
 LexerNoViableAltException.prototype.toString = function() {
     var symbol = "";
     if (this.startIndex >= 0 && this.startIndex < this.input.size) {
-        symbol = this.input.getText((this.startIndex,this.startIndex));
+        symbol = this.input.getText(this.startIndex);
     }
     return "LexerNoViableAltException" + symbol;
 };

--- a/runtime/JavaScript/src/antlr4/tree/Trees.js
+++ b/runtime/JavaScript/src/antlr4/tree/Trees.js
@@ -10,7 +10,7 @@ var ErrorNode = require('./Tree').ErrorNode;
 var TerminalNode = require('./Tree').TerminalNode;
 var ParserRuleContext = require('./../ParserRuleContext').ParserRuleContext;
 var RuleContext = require('./../RuleContext').RuleContext;
-var INVALID_ALT_NUMBER = require('./../atn/ATN').INVALID_ALT_NUMBER;
+var INVALID_ALT_NUMBER = require('./../atn/ATN').ATN.INVALID_ALT_NUMBER;
 
 
 /** A set of utility routines useful for all kinds of ANTLR trees. */

--- a/runtime/JavaScript/src/antlr4/tree/Trees.js
+++ b/runtime/JavaScript/src/antlr4/tree/Trees.js
@@ -10,7 +10,7 @@ var ErrorNode = require('./Tree').ErrorNode;
 var TerminalNode = require('./Tree').TerminalNode;
 var ParserRuleContext = require('./../ParserRuleContext').ParserRuleContext;
 var RuleContext = require('./../RuleContext').RuleContext;
-var INVALID_ALT_NUMBER = require('./../atn/ATN').ATN.INVALID_ALT_NUMBER;
+var INVALID_ALT_NUMBER = require('./../atn/ATN').INVALID_ALT_NUMBER;
 
 
 /** A set of utility routines useful for all kinds of ANTLR trees. */


### PR DESCRIPTION
Mostly they are references to bogus properties / forgotten imports / forgotten exports.

Found them while I was attempting to bundle ANTLR4's JavaScript with [Closure Compiler](https://developers.google.com/closure/compiler/) which does some static analysis.