### PR TITLE
Better word choice

### DIFF
--- a/doc/cpp-target.md
+++ b/doc/cpp-target.md
@@ -74,7 +74,7 @@ int main(int argc, const char* argv[]) {
  
 This example assumes your grammar contains a parser rule named `key` for which the enterKey function was generated.
 
-## Specialities of this ANTLR target
+## Singularities of this ANTLR target
 
 There are a couple of things that only the C++ ANTLR target has to deal with. They are described here.
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->