### PR TITLE
DOCS: do not use python built-in as variable name

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -214,3 +214,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/12/23, youkaichao, Kaichao You, youkaichao@gmail.com
 2019/02/06, ralucado, Cristina Raluca Vijulie, ralucris.v[at]gmail[dot]com
 2019/03/13, base698, Justin Thomas, justin.thomas1@gmail.com
+2019/03/18, carlodri, Carlo Dri, carlo.dri@gmail.com

--- a/doc/python-target.md
+++ b/doc/python-target.md
@@ -50,8 +50,8 @@ from MyGrammarLexer import MyGrammarLexer
 from MyGrammarParser import MyGrammarParser
  
 def main(argv):
-    input = FileStream(argv[1])
-    lexer = MyGrammarLexer(input)
+    input_stream = FileStream(argv[1])
+    lexer = MyGrammarLexer(input_stream)
     stream = CommonTokenStream(lexer)
     parser = MyGrammarParser(stream)
     tree = parser.startRule()


### PR DESCRIPTION
do not use `input` as  a variable name since it is a [Python built-in function](https://docs.python.org/3/library/functions.html#input)

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->