### PR TITLE
Fix imports in the Python2 sources.

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -110,7 +110,10 @@ Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
 
 Parser_(parser, funcs, atn, sempredFuncs, ctor, superClass) ::= <<
 <if(superClass)>
-from .<superClass> import <superClass>
+if __name__ is not None and "." in __name__:
+    from .<superClass> import <superClass>
+else:
+    from <superClass> import <superClass>
 
 <endif>
 <atn>
@@ -750,7 +753,10 @@ import sys
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 <if(superClass)>
-from .<superClass> import <superClass>
+if __name__ is not None and "." in __name__:
+    from .<superClass> import <superClass>
+else:
+    from <superClass> import <superClass>
 
 <endif>
 


### PR DESCRIPTION
Contrary to Python3, the lexers and parser generated for Python2 target
support only relative imports which causes a failure in case of
standalone scripts. The patch adapts these imports to work in both
cases.
