### PR TITLE
Fix #1890 Standalone CR should be recognized as line separator

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -230,3 +230,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/10, amorimjuliana, Juliana Amorim, juu.amorim@gmail.com
 2019/09/17, kaz, Kazuki Sawada, kazuki@6715.jp
 2019/09/28, lmy269, Mingyang Liu, lmy040758@gmail.com
+2019/03/24, nixel2007, Nikita Gryzlov, nixel2007@gmail.com

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -70,7 +70,6 @@ public class LexerATNSimulator extends ATNSimulator {
 	/** The index of the character relative to the beginning of the line 0..n-1 */
 	protected int charPositionInLine = 0;
 
-
 	public final DFA[] decisionToDFA;
 	protected int mode = Lexer.DEFAULT_MODE;
 
@@ -735,8 +734,13 @@ public class LexerATNSimulator extends ATNSimulator {
 		if ( curChar=='\n' ) {
 			line++;
 			charPositionInLine=0;
-		}
-		else {
+		} else if ( curChar == '\r' ) {
+			int nextChar = input.LA(2);
+			if ( nextChar != '\n') {
+				line++;
+				charPositionInLine=0;
+			}
+		} else {
 			charPositionInLine++;
 		}
 		input.consume();


### PR DESCRIPTION
Hello!

I've made changes to treat stand-alone CR as line separator.
This changes were tested on millions of LOC with-out any noticable perfomance regress. Also I use my fork to parse files everyday as a part of static analysis process.

If antlr4 authors want I can make the same changes for all other supported languages.