### PR TITLE
Clean up namespace of generated Python3 listeners

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -82,6 +82,7 @@ def exit<lname; format="cap">(self, ctx:<file.parserName>.<lname; format="cap">C
 
 }; separator="\n">
 
+del <file.parserName>
 >>
 
 


### PR DESCRIPTION
Added `del <file.parserName>` to the end of the `ListenerFile`
template the same way it is used in `VisitorFile`.
