### PR TITLE
don't unnecessary fetch all tokens when grabbing an interval of text …

### DIFF
--- a/runtime/Cpp/runtime/src/BufferedTokenStream.cpp
+++ b/runtime/Cpp/runtime/src/BufferedTokenStream.cpp
@@ -272,7 +272,7 @@ ssize_t BufferedTokenStream::previousTokenOnChannel(size_t i, size_t channel) {
     }
 
     if (i == 0)
-      break;
+      return -1;
     i--;
   }
   return i;
@@ -358,17 +358,18 @@ std::string BufferedTokenStream::getSourceName() const
 }
 
 std::string BufferedTokenStream::getText() {
+  fill();
   return getText(misc::Interval(0U, size() - 1));
 }
 
 std::string BufferedTokenStream::getText(const misc::Interval &interval) {
   lazyInit();
-  fill();
   size_t start = interval.a;
   size_t stop = interval.b;
   if (start == INVALID_INDEX || stop == INVALID_INDEX) {
     return "";
   }
+  sync(stop);
   if (stop >= _tokens.size()) {
     stop = _tokens.size() - 1;
   }

--- a/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
@@ -441,15 +441,17 @@ public class BufferedTokenStream implements TokenStream {
 
 	@Override
 	public String getText() {
+		fill();
 		return getText(Interval.of(0,size()-1));
 	}
 
 	@Override
 	public String getText(Interval interval) {
+		lazyInit();
 		int start = interval.a;
 		int stop = interval.b;
 		if ( start<0 || stop<0 ) return "";
-		fill();
+		sync(stop);
         if ( stop>=tokens.size() ) stop = tokens.size()-1;
 
 		StringBuilder buf = new StringBuilder();

--- a/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
@@ -441,17 +441,15 @@ public class BufferedTokenStream implements TokenStream {
 
 	@Override
 	public String getText() {
-		fill();
 		return getText(Interval.of(0,size()-1));
 	}
 
 	@Override
 	public String getText(Interval interval) {
-		lazyInit();
 		int start = interval.a;
 		int stop = interval.b;
 		if ( start<0 || stop<0 ) return "";
-		sync(stop);
+		fill();
         if ( stop>=tokens.size() ) stop = tokens.size()-1;
 
 		StringBuilder buf = new StringBuilder();


### PR DESCRIPTION
…(match C# logic)

When an exception is thrown, it calls getText to get the text of the tokens invloved but the current C++ and Java implemention first fetches the rest of the tokens instead of  just using the tokens it already has.  C#'s version is correct (fill() is called only when asking for the entire stream's text).

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->