### PR TITLE
use shared_ptr to avoid multi delete

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -216,3 +216,5 @@ YYYY/MM/DD, github id, Full name, email
 2019/03/13, base698, Justin Thomas, justin.thomas1@gmail.com
 2019/03/18, carlodri, Carlo Dri, carlo.dri@gmail.com
 2019/05/02, askingalot, Andy Collins, askingalot@gmail.com
+2019/05/09, pnck, hio131@gmail.com
+

--- a/runtime/Cpp/runtime/src/NoViableAltException.cpp
+++ b/runtime/Cpp/runtime/src/NoViableAltException.cpp
@@ -22,7 +22,7 @@ NoViableAltException::NoViableAltException(Parser *recognizer, TokenStream *inpu
 
 NoViableAltException::~NoViableAltException() {
   if (_deleteConfigs)
-    delete _deadEndConfigs;
+    _deadEndConfigs = nullptr;
 }
 
 Token* NoViableAltException::getStartToken() const {
@@ -30,5 +30,5 @@ Token* NoViableAltException::getStartToken() const {
 }
 
 atn::ATNConfigSet* NoViableAltException::getDeadEndConfigs() const {
-  return _deadEndConfigs;
+  return _deadEndConfigs.get();
 }

--- a/runtime/Cpp/runtime/src/NoViableAltException.h
+++ b/runtime/Cpp/runtime/src/NoViableAltException.h
@@ -27,7 +27,7 @@ namespace antlr4 {
 
   private:
     /// Which configurations did we try at input.index() that couldn't match input.LT(1)?
-    atn::ATNConfigSet* _deadEndConfigs;
+    std::shared_ptr<atn::ATNConfigSet> _deadEndConfigs;
 
     // Flag that indicates if we own the dead end config set and have to delete it on destruction.
     bool _deleteConfigs;


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->
fix  #2550 : use shared_ptr instead of raw pointer to avoid multiple delete