### PR TITLE
Fix #2550 

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -216,3 +216,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/03/13, base698, Justin Thomas, justin.thomas1@gmail.com
 2019/03/18, carlodri, Carlo Dri, carlo.dri@gmail.com
 2019/05/02, askingalot, Andy Collins, askingalot@gmail.com
+2019/05/30, pnck, hio131@gmail.com

--- a/runtime/Cpp/runtime/src/NoViableAltException.cpp
+++ b/runtime/Cpp/runtime/src/NoViableAltException.cpp
@@ -11,20 +11,13 @@ using namespace antlr4;
 
 NoViableAltException::NoViableAltException(Parser *recognizer)
   : NoViableAltException(recognizer, recognizer->getTokenStream(), recognizer->getCurrentToken(),
-                         recognizer->getCurrentToken(), nullptr, recognizer->getContext(), false) {
+                         recognizer->getCurrentToken(), nullptr, recognizer->getContext()) {
 }
 
 NoViableAltException::NoViableAltException(Parser *recognizer, TokenStream *input,Token *startToken,
-  Token *offendingToken, atn::ATNConfigSet *deadEndConfigs, ParserRuleContext *ctx, bool deleteConfigs)
+  Token *offendingToken, std::unique_ptr<atn::ATNConfigSet> deadEndConfigs, ParserRuleContext *ctx)
   : RecognitionException("No viable alternative", recognizer, input, ctx, offendingToken),
-    _deadEndConfigs(deadEndConfigs), _startToken(startToken), _deleteConfigs(deleteConfigs) {
-}
-
-NoViableAltException::~NoViableAltException() {
-  if (_deleteConfigs) {
-      _deadEndConfigs = nullptr;
-      _deleteConfigs = false;
-  }
+    _deadEndConfigs(std::move(deadEndConfigs)),_startToken(startToken) {
 }
 
 Token* NoViableAltException::getStartToken() const {

--- a/runtime/Cpp/runtime/src/NoViableAltException.cpp
+++ b/runtime/Cpp/runtime/src/NoViableAltException.cpp
@@ -21,8 +21,10 @@ NoViableAltException::NoViableAltException(Parser *recognizer, TokenStream *inpu
 }
 
 NoViableAltException::~NoViableAltException() {
-  if (_deleteConfigs)
-    delete _deadEndConfigs;
+  if (_deleteConfigs) {
+      _deadEndConfigs = nullptr;
+      _deleteConfigs = false;
+  }
 }
 
 Token* NoViableAltException::getStartToken() const {
@@ -30,5 +32,5 @@ Token* NoViableAltException::getStartToken() const {
 }
 
 atn::ATNConfigSet* NoViableAltException::getDeadEndConfigs() const {
-  return _deadEndConfigs;
+  return _deadEndConfigs.get();
 }

--- a/runtime/Cpp/runtime/src/NoViableAltException.h
+++ b/runtime/Cpp/runtime/src/NoViableAltException.h
@@ -20,14 +20,14 @@ namespace antlr4 {
     NoViableAltException(Parser *recognizer); // LL(1) error
     NoViableAltException(Parser *recognizer, TokenStream *input,Token *startToken,
       Token *offendingToken, atn::ATNConfigSet *deadEndConfigs, ParserRuleContext *ctx, bool deleteConfigs);
-    ~NoViableAltException();
+    ~NoViableAltException() override ;
     
     virtual Token* getStartToken() const;
     virtual atn::ATNConfigSet* getDeadEndConfigs() const;
 
   private:
     /// Which configurations did we try at input.index() that couldn't match input.LT(1)?
-    atn::ATNConfigSet* _deadEndConfigs;
+    std::shared_ptr<atn::ATNConfigSet> _deadEndConfigs;
 
     // Flag that indicates if we own the dead end config set and have to delete it on destruction.
     bool _deleteConfigs;

--- a/runtime/Cpp/runtime/src/NoViableAltException.h
+++ b/runtime/Cpp/runtime/src/NoViableAltException.h
@@ -19,18 +19,14 @@ namespace antlr4 {
   public:
     NoViableAltException(Parser *recognizer); // LL(1) error
     NoViableAltException(Parser *recognizer, TokenStream *input,Token *startToken,
-      Token *offendingToken, atn::ATNConfigSet *deadEndConfigs, ParserRuleContext *ctx, bool deleteConfigs);
-    ~NoViableAltException() override ;
-    
+      Token *offendingToken, std::unique_ptr<atn::ATNConfigSet> deadEndConfigs, ParserRuleContext *ctx);
     virtual Token* getStartToken() const;
     virtual atn::ATNConfigSet* getDeadEndConfigs() const;
 
   private:
     /// Which configurations did we try at input.index() that couldn't match input.LT(1)?
+    /* use shared_ptr instead of unique_ptr because std::make_exception_ptr requires exception copy-constructible */
     std::shared_ptr<atn::ATNConfigSet> _deadEndConfigs;
-
-    // Flag that indicates if we own the dead end config set and have to delete it on destruction.
-    bool _deleteConfigs;
 
     /// The token object at the start index; the input stream might
     /// not be buffering tokens so get a reference to it. (At the

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -46,14 +46,14 @@ using namespace antlrcpp;
 
 const bool ParserATNSimulator::TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT = ParserATNSimulator::getLrLoopSetting();
 
-ParserATNSimulator::ParserATNSimulator(const ATN &atn, std::vector<dfa::DFA> &decisionToDFA,
+ParserATNSimulator::ParserATNSimulator(const ATN &atn, std::vector <dfa::DFA> &decisionToDFA,
                                        PredictionContextCache &sharedContextCache)
-: ParserATNSimulator(nullptr, atn, decisionToDFA, sharedContextCache) {
+        : ParserATNSimulator(nullptr, atn, decisionToDFA, sharedContextCache) {
 }
 
-ParserATNSimulator::ParserATNSimulator(Parser *parser, const ATN &atn, std::vector<dfa::DFA> &decisionToDFA,
+ParserATNSimulator::ParserATNSimulator(Parser *parser, const ATN &atn, std::vector <dfa::DFA> &decisionToDFA,
                                        PredictionContextCache &sharedContextCache)
-: ATNSimulator(atn, sharedContextCache), decisionToDFA(decisionToDFA), parser(parser) {
+        : ATNSimulator(atn, sharedContextCache), decisionToDFA(decisionToDFA), parser(parser) {
   InitializeInstanceFields();
 }
 
@@ -61,7 +61,7 @@ void ParserATNSimulator::reset() {
 }
 
 void ParserATNSimulator::clearDFA() {
-  int size = (int)decisionToDFA.size();
+  int size = (int) decisionToDFA.size();
   decisionToDFA.clear();
   for (int d = 0; d < size; ++d) {
     decisionToDFA.push_back(dfa::DFA(atn.getDecisionState(d), d));
@@ -71,8 +71,8 @@ void ParserATNSimulator::clearDFA() {
 size_t ParserATNSimulator::adaptivePredict(TokenStream *input, size_t decision, ParserRuleContext *outerContext) {
 
 #if DEBUG_ATN == 1 || DEBUG_LIST_ATN_DECISIONS == 1
-    std::cout << "adaptivePredict decision " << decision << " exec LA(1)==" << getLookaheadName(input) << " line "
-      << input->LT(1)->getLine() << ":" << input->LT(1)->getCharPositionInLine() << std::endl;
+  std::cout << "adaptivePredict decision " << decision << " exec LA(1)==" << getLookaheadName(input) << " line "
+    << input->LT(1)->getLine() << ":" << input->LT(1)->getCharPositionInLine() << std::endl;
 #endif
 
   _input = input;
@@ -87,10 +87,10 @@ size_t ParserATNSimulator::adaptivePredict(TokenStream *input, size_t decision, 
   // Now we are certain to have a specific decision's DFA
   // But, do we still need an initial state?
   auto onExit = finally([this, input, index, m] {
-    mergeCache.clear(); // wack cache after each prediction
-    _dfa = nullptr;
-    input->seek(index);
-    input->release(m);
+      mergeCache.clear(); // wack cache after each prediction
+      _dfa = nullptr;
+      input->seek(index);
+      input->release(m);
   });
 
   dfa::DFAState *s0;
@@ -105,8 +105,8 @@ size_t ParserATNSimulator::adaptivePredict(TokenStream *input, size_t decision, 
 
   if (s0 == nullptr) {
     bool fullCtx = false;
-    std::unique_ptr<ATNConfigSet> s0_closure = computeStartState(dynamic_cast<ATNState *>(dfa.atnStartState),
-                                                                 &ParserRuleContext::EMPTY, fullCtx);
+    std::unique_ptr <ATNConfigSet> s0_closure = computeStartState(dynamic_cast<ATNState *>(dfa.atnStartState),
+                                                                  &ParserRuleContext::EMPTY, fullCtx);
 
     _stateLock.writeLock();
     if (dfa.isPrecedenceDfa()) {
@@ -148,14 +148,14 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
                                    ParserRuleContext *outerContext) {
 
 #if DEBUG_ATN == 1 || DEBUG_LIST_ATN_DECISIONS == 1
-    std::cout << "execATN decision " << dfa.decision << " exec LA(1)==" << getLookaheadName(input) <<
-      " line " << input->LT(1)->getLine() << ":" << input->LT(1)->getCharPositionInLine() << std::endl;
+  std::cout << "execATN decision " << dfa.decision << " exec LA(1)==" << getLookaheadName(input) <<
+    " line " << input->LT(1)->getLine() << ":" << input->LT(1)->getCharPositionInLine() << std::endl;
 #endif
 
   dfa::DFAState *previousD = s0;
 
 #if DEBUG_ATN == 1
-    std::cout << "s0 = " << s0 << std::endl;
+  std::cout << "s0 = " << s0 << std::endl;
 #endif
 
   size_t t = input->LA(1);
@@ -181,7 +181,7 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
       if (alt != ATN::INVALID_ALT_NUMBER) {
         return alt;
       }
-      throw noViableAlt(input, outerContext, previousD->configs.get(), startIndex, false);
+      throw noViableAlt(input, outerContext, std::move(previousD->configs), startIndex);
     }
 
     if (D->requiresFullContext && _mode != PredictionMode::SLL) {
@@ -189,7 +189,7 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
       BitSet conflictingAlts;
       if (D->predicates.size() != 0) {
 #if DEBUG_ATN == 1
-          std::cout << "DFA state has preds in DFA sim LL failover" << std::endl;
+        std::cout << "DFA state has preds in DFA sim LL failover" << std::endl;
 #endif
 
         size_t conflictIndex = input->index();
@@ -200,7 +200,7 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
         conflictingAlts = evalSemanticContext(D->predicates, outerContext, true);
         if (conflictingAlts.count() == 1) {
 #if DEBUG_ATN == 1
-            std::cout << "Full LL avoided" << std::endl;
+          std::cout << "Full LL avoided" << std::endl;
 #endif
 
           return conflictingAlts.nextSetBit(0);
@@ -214,11 +214,11 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
       }
 
 #if DEBUG_DFA == 1
-        std::cout << "ctx sensitive state " << outerContext << " in " << D << std::endl;
+      std::cout << "ctx sensitive state " << outerContext << " in " << D << std::endl;
 #endif
 
       bool fullCtx = true;
-      Ref<ATNConfigSet> s0_closure = computeStartState(dfa.atnStartState, outerContext, fullCtx);
+      Ref <ATNConfigSet> s0_closure = computeStartState(dfa.atnStartState, outerContext, fullCtx);
       reportAttemptingFullContext(dfa, conflictingAlts, D->configs.get(), startIndex, input->index());
       size_t alt = execATNWithFullContext(dfa, D, s0_closure.get(), input, startIndex, outerContext);
       return alt;
@@ -234,7 +234,7 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
       BitSet alts = evalSemanticContext(D->predicates, outerContext, true);
       switch (alts.count()) {
         case 0:
-          throw noViableAlt(input, outerContext, D->configs.get(), startIndex, false);
+          throw noViableAlt(input, outerContext, std::move(D->configs), startIndex);
 
         case 1:
           return alts.nextSetBit(0);
@@ -257,7 +257,7 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
 }
 
 dfa::DFAState *ParserATNSimulator::getExistingTargetState(dfa::DFAState *previousD, size_t t) {
-  dfa::DFAState* retval;
+  dfa::DFAState *retval;
   _edgeLock.readLock();
   auto iterator = previousD->edges.find(t);
   retval = (iterator == previousD->edges.end()) ? nullptr : iterator->second;
@@ -266,7 +266,7 @@ dfa::DFAState *ParserATNSimulator::getExistingTargetState(dfa::DFAState *previou
 }
 
 dfa::DFAState *ParserATNSimulator::computeTargetState(dfa::DFA &dfa, dfa::DFAState *previousD, size_t t) {
-  std::unique_ptr<ATNConfigSet> reach = computeReachSet(previousD->configs.get(), t, false);
+  std::unique_ptr <ATNConfigSet> reach = computeReachSet(previousD->configs.get(), t, false);
   if (reach == nullptr) {
     addDFAEdge(dfa, previousD, t, ERROR.get());
     return ERROR.get();
@@ -313,7 +313,7 @@ void ParserATNSimulator::predicateDFAState(dfa::DFAState *dfaState, DecisionStat
   // Update DFA so reach becomes accept state with (predicate,alt)
   // pairs if preds found for conflicting alts
   BitSet altsToCollectPredsFrom = getConflictingAltsOrUniqueAlt(dfaState->configs.get());
-  std::vector<Ref<SemanticContext>> altToPred = getPredsForAmbigAlts(altsToCollectPredsFrom, dfaState->configs.get(), nalts);
+  std::vector <Ref<SemanticContext>> altToPred = getPredsForAmbigAlts(altsToCollectPredsFrom, dfaState->configs.get(), nalts);
   if (!altToPred.empty()) {
     dfaState->predicates = getPredicatePredictions(altsToCollectPredsFrom, altToPred);
     dfaState->prediction = ATN::INVALID_ALT_NUMBER; // make sure we use preds
@@ -326,12 +326,12 @@ void ParserATNSimulator::predicateDFAState(dfa::DFAState *dfaState, DecisionStat
 }
 
 size_t ParserATNSimulator::execATNWithFullContext(dfa::DFA &dfa, dfa::DFAState *D, ATNConfigSet *s0,
-  TokenStream *input, size_t startIndex, ParserRuleContext *outerContext) {
+                                                  TokenStream *input, size_t startIndex, ParserRuleContext *outerContext) {
 
   bool fullCtx = true;
   bool foundExactAmbig = false;
 
-  std::unique_ptr<ATNConfigSet> reach;
+  std::unique_ptr <ATNConfigSet> reach;
   ATNConfigSet *previous = s0;
   input->seek(startIndex);
   size_t t = input->LA(1);
@@ -349,19 +349,24 @@ size_t ParserATNSimulator::execATNWithFullContext(dfa::DFA &dfa, dfa::DFAState *
       // ATN states in SLL implies LL will also get nowhere.
       // If conflict in states that dip out, choose min since we
       // will get error no matter what.
-      NoViableAltException e = noViableAlt(input, outerContext, previous, startIndex, previous != s0);
+
       input->seek(startIndex);
       size_t alt = getSynValidOrSemInvalidAltThatFinishedDecisionEntryRule(previous, outerContext);
       if (alt != ATN::INVALID_ALT_NUMBER) {
         return alt;
       }
-      throw e;
+      if (previous == s0) {
+        previous = nullptr;
+      }
+      throw noViableAlt(input, outerContext, std::unique_ptr<ATNConfigSet>(previous), startIndex);;
     }
     if (previous != s0) // Don't delete the start set.
-        delete previous;
-    previous = nullptr;
+    {
+      delete previous;
+      previous = nullptr;
+    }
 
-    std::vector<BitSet> altSubSets = PredictionModeClass::getConflictingAltSubsets(reach.get());
+    std::vector <BitSet> altSubSets = PredictionModeClass::getConflictingAltSubsets(reach.get());
     reach->uniqueAlt = getUniqueAlt(reach.get());
     // unique prediction?
     if (reach->uniqueAlt != ATN::INVALID_ALT_NUMBER) {
@@ -433,9 +438,9 @@ size_t ParserATNSimulator::execATNWithFullContext(dfa::DFA &dfa, dfa::DFAState *
   return predictedAlt;
 }
 
-std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *closure_, size_t t, bool fullCtx) {
+std::unique_ptr <ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *closure_, size_t t, bool fullCtx) {
 
-  std::unique_ptr<ATNConfigSet> intermediate(new ATNConfigSet(fullCtx));
+  std::unique_ptr <ATNConfigSet> intermediate(new ATNConfigSet(fullCtx));
 
   /* Configurations already in a rule stop state indicate reaching the end
    * of the decision rule (local context) or end of the start rule (full
@@ -447,7 +452,7 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *
    * ensure that the alternative matching the longest overall sequence is
    * chosen when multiple such configurations can match the input.
    */
-  std::vector<Ref<ATNConfig>> skippedStopStates;
+  std::vector <Ref<ATNConfig>> skippedStopStates;
 
   // First figure out where we can reach on input t
   for (auto &c : closure_->configs) {
@@ -464,7 +469,7 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *
     size_t n = c->state->transitions.size();
     for (size_t ti = 0; ti < n; ti++) { // for each transition
       Transition *trans = c->state->transitions[ti];
-      ATNState *target = getReachableTarget(trans, (int)t);
+      ATNState *target = getReachableTarget(trans, (int) t);
       if (target != nullptr) {
         intermediate->add(std::make_shared<ATNConfig>(c, target), &mergeCache);
       }
@@ -472,7 +477,7 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *
   }
 
   // Now figure out where the reach operation can take us...
-  std::unique_ptr<ATNConfigSet> reach;
+  std::unique_ptr <ATNConfigSet> reach;
 
   /* This block optimizes the reach operation for intermediate sets which
    * trivially indicate a termination state for the overall
@@ -529,8 +534,9 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *
      * required.
      */
     ATNConfigSet *temp = removeAllConfigsNotInRuleStopState(reach.get(), *reach == *intermediate);
-    if (temp != reach.get())
-      reach.reset(temp); // We got a new set, so use that.
+    if (temp != reach.get()) {
+      reach.reset(temp);
+    } // We got a new set, so use that.
   }
 
   /* If skippedStopStates is not null, then it contains at least one
@@ -555,8 +561,8 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *
   return reach;
 }
 
-ATNConfigSet* ParserATNSimulator::removeAllConfigsNotInRuleStopState(ATNConfigSet *configs,
-  bool lookToEndOfRule) {
+ATNConfigSet *ParserATNSimulator::removeAllConfigsNotInRuleStopState(ATNConfigSet *configs,
+                                                                     bool lookToEndOfRule) {
   if (PredictionModeClass::allConfigsInRuleStopStates(configs)) {
     return configs;
   }
@@ -564,7 +570,7 @@ ATNConfigSet* ParserATNSimulator::removeAllConfigsNotInRuleStopState(ATNConfigSe
   ATNConfigSet *result = new ATNConfigSet(configs->fullCtx); /* mem-check: released by caller */
 
   for (auto &config : configs->configs) {
-    if (is<RuleStopState*>(config->state)) {
+    if (is<RuleStopState *>(config->state)) {
       result->add(config, &mergeCache);
       continue;
     }
@@ -581,14 +587,14 @@ ATNConfigSet* ParserATNSimulator::removeAllConfigsNotInRuleStopState(ATNConfigSe
   return result;
 }
 
-std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeStartState(ATNState *p, RuleContext *ctx, bool fullCtx) {
+std::unique_ptr <ATNConfigSet> ParserATNSimulator::computeStartState(ATNState *p, RuleContext *ctx, bool fullCtx) {
   // always at least the implicit call to start rule
-  Ref<PredictionContext> initialContext = PredictionContext::fromRuleContext(atn, ctx);
-  std::unique_ptr<ATNConfigSet> configs(new ATNConfigSet(fullCtx));
+  Ref <PredictionContext> initialContext = PredictionContext::fromRuleContext(atn, ctx);
+  std::unique_ptr <ATNConfigSet> configs(new ATNConfigSet(fullCtx));
 
   for (size_t i = 0; i < p->transitions.size(); i++) {
     ATNState *target = p->transitions[i]->target;
-    Ref<ATNConfig> c = std::make_shared<ATNConfig>(target, (int)i + 1, initialContext);
+    Ref <ATNConfig> c = std::make_shared<ATNConfig>(target, (int) i + 1, initialContext);
     ATNConfig::Set closureBusy;
     closure(c, configs.get(), closureBusy, true, fullCtx, false);
   }
@@ -596,16 +602,16 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeStartState(ATNState *p,
   return configs;
 }
 
-std::unique_ptr<ATNConfigSet> ParserATNSimulator::applyPrecedenceFilter(ATNConfigSet *configs) {
-  std::map<size_t, Ref<PredictionContext>> statesFromAlt1;
-  std::unique_ptr<ATNConfigSet> configSet(new ATNConfigSet(configs->fullCtx));
-  for (Ref<ATNConfig> &config : configs->configs) {
+std::unique_ptr <ATNConfigSet> ParserATNSimulator::applyPrecedenceFilter(ATNConfigSet *configs) {
+  std::map <size_t, Ref<PredictionContext>> statesFromAlt1;
+  std::unique_ptr <ATNConfigSet> configSet(new ATNConfigSet(configs->fullCtx));
+  for (Ref <ATNConfig> &config : configs->configs) {
     // handle alt 1 first
     if (config->alt != 1) {
       continue;
     }
 
-    Ref<SemanticContext> updatedContext = config->semanticContext->evalPrecedence(parser, _outerContext);
+    Ref <SemanticContext> updatedContext = config->semanticContext->evalPrecedence(parser, _outerContext);
     if (updatedContext == nullptr) {
       // the configuration was eliminated
       continue;
@@ -614,13 +620,12 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::applyPrecedenceFilter(ATNConfi
     statesFromAlt1[config->state->stateNumber] = config->context;
     if (updatedContext != config->semanticContext) {
       configSet->add(std::make_shared<ATNConfig>(config, updatedContext), &mergeCache);
-    }
-    else {
+    } else {
       configSet->add(config, &mergeCache);
     }
   }
 
-  for (Ref<ATNConfig> &config : configs->configs) {
+  for (Ref <ATNConfig> &config : configs->configs) {
     if (config->alt == 1) {
       // already handled
       continue;
@@ -644,7 +649,7 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::applyPrecedenceFilter(ATNConfi
   return configSet;
 }
 
-atn::ATNState* ParserATNSimulator::getReachableTarget(Transition *trans, size_t ttype) {
+atn::ATNState *ParserATNSimulator::getReachableTarget(Transition *trans, size_t ttype) {
   if (trans->matches(ttype, 0, atn.maxTokenType)) {
     return trans->target;
   }
@@ -653,8 +658,8 @@ atn::ATNState* ParserATNSimulator::getReachableTarget(Transition *trans, size_t 
 }
 
 // Note that caller must memory manage the returned value from this function
-std::vector<Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const BitSet &ambigAlts,
-  ATNConfigSet *configs, size_t nalts) {
+std::vector <Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const BitSet &ambigAlts,
+                                                                            ATNConfigSet *configs, size_t nalts) {
   // REACH=[1|1|[]|0:0, 1|2|[]|0:1]
   /* altToPred starts as an array of all null contexts. The entry at index i
    * corresponds to alternative i. altToPred[i] may have one of three values:
@@ -667,7 +672,7 @@ std::vector<Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const
    *
    * From this, it is clear that NONE||anything==NONE.
    */
-  std::vector<Ref<SemanticContext>> altToPred(nalts + 1);
+  std::vector <Ref<SemanticContext>> altToPred(nalts + 1);
 
   for (auto &c : configs->configs) {
     if (ambigAlts.test(c->alt)) {
@@ -689,38 +694,38 @@ std::vector<Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const
     altToPred.clear();
   }
 #if DEBUG_ATN == 1
-    std::cout << "getPredsForAmbigAlts result " << Arrays::toString(altToPred) << std::endl;
+  std::cout << "getPredsForAmbigAlts result " << Arrays::toString(altToPred) << std::endl;
 #endif
 
   return altToPred;
 }
 
 std::vector<dfa::DFAState::PredPrediction *> ParserATNSimulator::getPredicatePredictions(const antlrcpp::BitSet &ambigAlts,
-  std::vector<Ref<SemanticContext>> const& altToPred) {
-  bool containsPredicate = std::find_if(altToPred.begin(), altToPred.end(), [](Ref<SemanticContext> const context) {
-    return context != SemanticContext::NONE;
+                                                                                         std::vector <Ref<SemanticContext>> const &altToPred) {
+  bool containsPredicate = std::find_if(altToPred.begin(), altToPred.end(), [](Ref <SemanticContext> const context) {
+      return context != SemanticContext::NONE;
   }) != altToPred.end();
-  if (!containsPredicate)
+  if (!containsPredicate) {
     return {};
+  }
 
-  std::vector<dfa::DFAState::PredPrediction*> pairs;
+  std::vector < dfa::DFAState::PredPrediction * > pairs;
   for (size_t i = 1; i < altToPred.size(); ++i) {
-    Ref<SemanticContext> const& pred = altToPred[i];
+    Ref <SemanticContext> const &pred = altToPred[i];
     assert(pred != nullptr); // unpredicted is indicated by SemanticContext.NONE
 
     if (ambigAlts.test(i)) {
-      pairs.push_back(new dfa::DFAState::PredPrediction(pred, (int)i)); /* mem-check: managed by the DFAState it will be assigned to after return */
+      pairs.push_back(new dfa::DFAState::PredPrediction(pred, (int) i)); /* mem-check: managed by the DFAState it will be assigned to after return */
     }
   }
   return pairs;
 }
 
 size_t ParserATNSimulator::getSynValidOrSemInvalidAltThatFinishedDecisionEntryRule(ATNConfigSet *configs,
-  ParserRuleContext *outerContext)
-{
-  std::pair<ATNConfigSet *, ATNConfigSet *> sets = splitAccordingToSemanticValidity(configs, outerContext);
-  std::unique_ptr<ATNConfigSet> semValidConfigs(sets.first);
-  std::unique_ptr<ATNConfigSet> semInvalidConfigs(sets.second);
+                                                                                   ParserRuleContext *outerContext) {
+  std::pair < ATNConfigSet * , ATNConfigSet * > sets = splitAccordingToSemanticValidity(configs, outerContext);
+  std::unique_ptr <ATNConfigSet> semValidConfigs(sets.first);
+  std::unique_ptr <ATNConfigSet> semInvalidConfigs(sets.second);
   size_t alt = getAltThatFinishedDecisionEntryRule(semValidConfigs.get());
   if (alt != ATN::INVALID_ALT_NUMBER) { // semantically/syntactically viable path exists
     return alt;
@@ -749,12 +754,12 @@ size_t ParserATNSimulator::getAltThatFinishedDecisionEntryRule(ATNConfigSet *con
 }
 
 std::pair<ATNConfigSet *, ATNConfigSet *> ParserATNSimulator::splitAccordingToSemanticValidity(ATNConfigSet *configs,
-  ParserRuleContext *outerContext) {
+                                                                                               ParserRuleContext *outerContext) {
 
   // mem-check: both pointers must be freed by the caller.
   ATNConfigSet *succeeded(new ATNConfigSet(configs->fullCtx));
   ATNConfigSet *failed(new ATNConfigSet(configs->fullCtx));
-  for (Ref<ATNConfig> &c : configs->configs) {
+  for (Ref <ATNConfig> &c : configs->configs) {
     if (c->semanticContext != SemanticContext::NONE) {
       bool predicateEvaluationResult = evalSemanticContext(c->semanticContext, outerContext, c->alt, configs->fullCtx);
       if (predicateEvaluationResult) {
@@ -766,10 +771,10 @@ std::pair<ATNConfigSet *, ATNConfigSet *> ParserATNSimulator::splitAccordingToSe
       succeeded->add(c);
     }
   }
-  return { succeeded, failed };
+  return {succeeded, failed};
 }
 
-BitSet ParserATNSimulator::evalSemanticContext(std::vector<dfa::DFAState::PredPrediction*> predPredictions,
+BitSet ParserATNSimulator::evalSemanticContext(std::vector<dfa::DFAState::PredPrediction *> predPredictions,
                                                ParserRuleContext *outerContext, bool complete) {
   BitSet predictions;
   for (auto prediction : predPredictions) {
@@ -784,12 +789,12 @@ BitSet ParserATNSimulator::evalSemanticContext(std::vector<dfa::DFAState::PredPr
     bool fullCtx = false; // in dfa
     bool predicateEvaluationResult = evalSemanticContext(prediction->pred, outerContext, prediction->alt, fullCtx);
 #if DEBUG_ATN == 1 || DEBUG_DFA == 1
-      std::cout << "eval pred " << prediction->toString() << " = " << predicateEvaluationResult << std::endl;
+    std::cout << "eval pred " << prediction->toString() << " = " << predicateEvaluationResult << std::endl;
 #endif
 
     if (predicateEvaluationResult) {
 #if DEBUG_ATN == 1 || DEBUG_DFA == 1
-        std::cout << "PREDICT " << prediction->alt << std::endl;
+      std::cout << "PREDICT " << prediction->alt << std::endl;
 #endif
 
       predictions.set(prediction->alt);
@@ -802,12 +807,12 @@ BitSet ParserATNSimulator::evalSemanticContext(std::vector<dfa::DFAState::PredPr
   return predictions;
 }
 
-bool ParserATNSimulator::evalSemanticContext(Ref<SemanticContext> const& pred, ParserRuleContext *parserCallStack,
+bool ParserATNSimulator::evalSemanticContext(Ref <SemanticContext> const &pred, ParserRuleContext *parserCallStack,
                                              size_t /*alt*/, bool /*fullCtx*/) {
   return pred->eval(parser, parserCallStack);
 }
 
-void ParserATNSimulator::closure(Ref<ATNConfig> const& config, ATNConfigSet *configs, ATNConfig::Set &closureBusy,
+void ParserATNSimulator::closure(Ref <ATNConfig> const &config, ATNConfigSet *configs, ATNConfig::Set &closureBusy,
                                  bool collectPredicates, bool fullCtx, bool treatEofAsEpsilon) {
   const int initialDepth = 0;
   closureCheckingStopState(config, configs, closureBusy, collectPredicates, fullCtx, initialDepth, treatEofAsEpsilon);
@@ -815,11 +820,12 @@ void ParserATNSimulator::closure(Ref<ATNConfig> const& config, ATNConfigSet *con
   assert(!fullCtx || !configs->dipsIntoOuterContext);
 }
 
-void ParserATNSimulator::closureCheckingStopState(Ref<ATNConfig> const& config, ATNConfigSet *configs,
-  ATNConfig::Set &closureBusy, bool collectPredicates, bool fullCtx, int depth, bool treatEofAsEpsilon) {
+void ParserATNSimulator::closureCheckingStopState(Ref <ATNConfig> const &config, ATNConfigSet *configs,
+                                                  ATNConfig::Set &closureBusy, bool collectPredicates, bool fullCtx, int depth,
+                                                  bool treatEofAsEpsilon) {
 
 #if DEBUG_ATN == 1
-    std::cout << "closure(" << config->toString(true) << ")" << std::endl;
+  std::cout << "closure(" << config->toString(true) << ")" << std::endl;
 #endif
 
   if (is<RuleStopState *>(config->state)) {
@@ -834,15 +840,15 @@ void ParserATNSimulator::closureCheckingStopState(Ref<ATNConfig> const& config, 
           } else {
             // we have no context info, just chase follow links (if greedy)
 #if DEBUG_ATN == 1
-              std::cout << "FALLING off rule " << getRuleName(config->state->ruleIndex) << std::endl;
+            std::cout << "FALLING off rule " << getRuleName(config->state->ruleIndex) << std::endl;
 #endif
             closure_(config, configs, closureBusy, collectPredicates, fullCtx, depth, treatEofAsEpsilon);
           }
           continue;
         }
         ATNState *returnState = atn.states[config->context->getReturnState(i)];
-        std::weak_ptr<PredictionContext> newContext = config->context->getParent(i); // "pop" return state
-        Ref<ATNConfig> c = std::make_shared<ATNConfig>(returnState, config->alt, newContext.lock(), config->semanticContext);
+        std::weak_ptr <PredictionContext> newContext = config->context->getParent(i); // "pop" return state
+        Ref <ATNConfig> c = std::make_shared<ATNConfig>(returnState, config->alt, newContext.lock(), config->semanticContext);
         // While we have context to pop back from, we may have
         // gotten that context AFTER having falling off a rule.
         // Make sure we track that we are now out of context.
@@ -868,7 +874,7 @@ void ParserATNSimulator::closureCheckingStopState(Ref<ATNConfig> const& config, 
   closure_(config, configs, closureBusy, collectPredicates, fullCtx, depth, treatEofAsEpsilon);
 }
 
-void ParserATNSimulator::closure_(Ref<ATNConfig> const& config, ATNConfigSet *configs, ATNConfig::Set &closureBusy,
+void ParserATNSimulator::closure_(Ref <ATNConfig> const &config, ATNConfigSet *configs, ATNConfig::Set &closureBusy,
                                   bool collectPredicates, bool fullCtx, int depth, bool treatEofAsEpsilon) {
   ATNState *p = config->state;
   // optimization
@@ -879,15 +885,16 @@ void ParserATNSimulator::closure_(Ref<ATNConfig> const& config, ATNConfigSet *co
   }
 
   for (size_t i = 0; i < p->transitions.size(); i++) {
-    if (i == 0 && canDropLoopEntryEdgeInLeftRecursiveRule(config.get()))
+    if (i == 0 && canDropLoopEntryEdgeInLeftRecursiveRule(config.get())) {
       continue;
+    }
 
     Transition *t = p->transitions[i];
-    bool continueCollecting = !is<ActionTransition*>(t) && collectPredicates;
-    Ref<ATNConfig> c = getEpsilonTarget(config, t, continueCollecting, depth == 0, fullCtx, treatEofAsEpsilon);
+    bool continueCollecting = !is<ActionTransition *>(t) && collectPredicates;
+    Ref <ATNConfig> c = getEpsilonTarget(config, t, continueCollecting, depth == 0, fullCtx, treatEofAsEpsilon);
     if (c != nullptr) {
       int newDepth = depth;
-      if (is<RuleStopState*>(config->state)) {
+      if (is<RuleStopState *>(config->state)) {
         assert(!fullCtx);
 
         // target fell off end of rule; mark resulting c as having dipped into outer context
@@ -925,10 +932,10 @@ void ParserATNSimulator::closure_(Ref<ATNConfig> const& config, ATNConfigSet *co
 
         newDepth--;
 #if DEBUG_DFA == 1
-          std::cout << "dips into outer ctx: " << c << std::endl;
+        std::cout << "dips into outer ctx: " << c << std::endl;
 #endif
 
-      } else  if (!t->isEpsilon()) {
+      } else if (!t->isEpsilon()) {
         // avoid infinite recursion for EOF* and EOF+
         if (closureBusy.count(c) == 0) {
           closureBusy.insert(c);
@@ -937,7 +944,7 @@ void ParserATNSimulator::closure_(Ref<ATNConfig> const& config, ATNConfigSet *co
         }
       }
 
-      if (is<RuleTransition*>(t)) {
+      if (is<RuleTransition *>(t)) {
         // latch when newDepth goes negative - once we step out of the entry context we can't return
         if (newDepth >= 0) {
           newDepth++;
@@ -950,8 +957,9 @@ void ParserATNSimulator::closure_(Ref<ATNConfig> const& config, ATNConfigSet *co
 }
 
 bool ParserATNSimulator::canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *config) const {
-  if (TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT)
+  if (TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT) {
     return false;
+  }
 
   ATNState *p = config->state;
 
@@ -960,10 +968,9 @@ bool ParserATNSimulator::canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *conf
   // the context has an empty stack case. If so, it would mean
   // global FOLLOW so we can't perform optimization
   if (p->getStateType() != ATNState::STAR_LOOP_ENTRY ||
-      !((StarLoopEntryState *)p)->isPrecedenceDecision || // Are we the special loop entry/exit state?
+      !((StarLoopEntryState *) p)->isPrecedenceDecision || // Are we the special loop entry/exit state?
       config->context->isEmpty() ||                      // If SLL wildcard
-      config->context->hasEmptyPath())
-  {
+      config->context->hasEmptyPath()) {
     return false;
   }
 
@@ -972,13 +979,14 @@ bool ParserATNSimulator::canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *conf
   size_t numCtxs = config->context->size();
   for (size_t i = 0; i < numCtxs; i++) { // for each stack context
     ATNState *returnState = atn.states[config->context->getReturnState(i)];
-    if (returnState->ruleIndex != p->ruleIndex)
+    if (returnState->ruleIndex != p->ruleIndex) {
       return false;
+    }
   }
 
-  BlockStartState *decisionStartState = (BlockStartState *)p->transitions[0]->target;
+  BlockStartState *decisionStartState = (BlockStartState *) p->transitions[0]->target;
   size_t blockEndStateNum = decisionStartState->endState->stateNumber;
-  BlockEndState *blockEndState = (BlockEndState *)atn.states[blockEndStateNum];
+  BlockEndState *blockEndState = (BlockEndState *) atn.states[blockEndStateNum];
 
   // Verify that the top of each stack context leads to loop entry/exit
   // state through epsilon edges and w/o leaving rule.
@@ -986,8 +994,7 @@ bool ParserATNSimulator::canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *conf
     size_t returnStateNumber = config->context->getReturnState(i);
     ATNState *returnState = atn.states[returnStateNumber];
     // All states must have single outgoing epsilon edge.
-    if (returnState->transitions.size() != 1 || !returnState->transitions[0]->isEpsilon())
-    {
+    if (returnState->transitions.size() != 1 || !returnState->transitions[0]->isEpsilon()) {
       return false;
     }
 
@@ -1015,8 +1022,7 @@ bool ParserATNSimulator::canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *conf
     if (returnStateTarget->getStateType() == ATNState::BLOCK_END &&
         returnStateTarget->transitions.size() == 1 &&
         returnStateTarget->transitions[0]->isEpsilon() &&
-        returnStateTarget->transitions[0]->target == p)
-    {
+        returnStateTarget->transitions[0]->target == p) {
       continue;
     }
 
@@ -1034,20 +1040,20 @@ std::string ParserATNSimulator::getRuleName(size_t index) {
   return "<rule " + std::to_string(index) + ">";
 }
 
-Ref<ATNConfig> ParserATNSimulator::getEpsilonTarget(Ref<ATNConfig> const& config, Transition *t, bool collectPredicates,
-                                                    bool inContext, bool fullCtx, bool treatEofAsEpsilon) {
+Ref <ATNConfig> ParserATNSimulator::getEpsilonTarget(Ref <ATNConfig> const &config, Transition *t, bool collectPredicates,
+                                                     bool inContext, bool fullCtx, bool treatEofAsEpsilon) {
   switch (t->getSerializationType()) {
     case Transition::RULE:
-      return ruleTransition(config, static_cast<RuleTransition*>(t));
+      return ruleTransition(config, static_cast<RuleTransition *>(t));
 
     case Transition::PRECEDENCE:
-      return precedenceTransition(config, static_cast<PrecedencePredicateTransition*>(t), collectPredicates, inContext, fullCtx);
+      return precedenceTransition(config, static_cast<PrecedencePredicateTransition *>(t), collectPredicates, inContext, fullCtx);
 
     case Transition::PREDICATE:
-      return predTransition(config, static_cast<PredicateTransition*>(t), collectPredicates, inContext, fullCtx);
+      return predTransition(config, static_cast<PredicateTransition *>(t), collectPredicates, inContext, fullCtx);
 
     case Transition::ACTION:
-      return actionTransition(config, static_cast<ActionTransition*>(t));
+      return actionTransition(config, static_cast<ActionTransition *>(t));
 
     case Transition::EPSILON:
       return std::make_shared<ATNConfig>(config, t->target);
@@ -1070,26 +1076,26 @@ Ref<ATNConfig> ParserATNSimulator::getEpsilonTarget(Ref<ATNConfig> const& config
   }
 }
 
-Ref<ATNConfig> ParserATNSimulator::actionTransition(Ref<ATNConfig> const& config, ActionTransition *t) {
+Ref <ATNConfig> ParserATNSimulator::actionTransition(Ref <ATNConfig> const &config, ActionTransition *t) {
 #if DEBUG_DFA == 1
-    std::cout << "ACTION edge " << t->ruleIndex << ":" << t->actionIndex << std::endl;
+  std::cout << "ACTION edge " << t->ruleIndex << ":" << t->actionIndex << std::endl;
 #endif
 
   return std::make_shared<ATNConfig>(config, t->target);
 }
 
-Ref<ATNConfig> ParserATNSimulator::precedenceTransition(Ref<ATNConfig> const& config, PrecedencePredicateTransition *pt,
-    bool collectPredicates, bool inContext, bool fullCtx) {
+Ref <ATNConfig> ParserATNSimulator::precedenceTransition(Ref <ATNConfig> const &config, PrecedencePredicateTransition *pt,
+                                                         bool collectPredicates, bool inContext, bool fullCtx) {
 #if DEBUG_DFA == 1
-    std::cout << "PRED (collectPredicates=" << collectPredicates << ") " << pt->precedence << ">=_p" << ", ctx dependent=true" << std::endl;
-    if (parser != nullptr) {
-      std::cout << "context surrounding pred is " << Arrays::listToString(parser->getRuleInvocationStack(), ", ") << std::endl;
-    }
+  std::cout << "PRED (collectPredicates=" << collectPredicates << ") " << pt->precedence << ">=_p" << ", ctx dependent=true" << std::endl;
+  if (parser != nullptr) {
+    std::cout << "context surrounding pred is " << Arrays::listToString(parser->getRuleInvocationStack(), ", ") << std::endl;
+  }
 #endif
 
-  Ref<ATNConfig> c;
+  Ref <ATNConfig> c;
   if (collectPredicates && inContext) {
-    Ref<SemanticContext::PrecedencePredicate> predicate = pt->getPredicate();
+    Ref <SemanticContext::PrecedencePredicate> predicate = pt->getPredicate();
 
     if (fullCtx) {
       // In full context mode, we can evaluate predicates on-the-fly
@@ -1104,7 +1110,7 @@ Ref<ATNConfig> ParserATNSimulator::precedenceTransition(Ref<ATNConfig> const& co
         c = std::make_shared<ATNConfig>(config, pt->target); // no pred context
       }
     } else {
-      Ref<SemanticContext> newSemCtx = SemanticContext::And(config->semanticContext, predicate);
+      Ref <SemanticContext> newSemCtx = SemanticContext::And(config->semanticContext, predicate);
       c = std::make_shared<ATNConfig>(config, pt->target, newSemCtx);
     }
   } else {
@@ -1112,24 +1118,24 @@ Ref<ATNConfig> ParserATNSimulator::precedenceTransition(Ref<ATNConfig> const& co
   }
 
 #if DEBUG_DFA == 1
-    std::cout << "config from pred transition=" << c << std::endl;
+  std::cout << "config from pred transition=" << c << std::endl;
 #endif
 
   return c;
 }
 
-Ref<ATNConfig> ParserATNSimulator::predTransition(Ref<ATNConfig> const& config, PredicateTransition *pt,
-  bool collectPredicates, bool inContext, bool fullCtx) {
+Ref <ATNConfig> ParserATNSimulator::predTransition(Ref <ATNConfig> const &config, PredicateTransition *pt,
+                                                   bool collectPredicates, bool inContext, bool fullCtx) {
 #if DEBUG_DFA == 1
-    std::cout << "PRED (collectPredicates=" << collectPredicates << ") " << pt->ruleIndex << ":" << pt->predIndex << ", ctx dependent=" << pt->isCtxDependent << std::endl;
-    if (parser != nullptr) {
-      std::cout << "context surrounding pred is " << Arrays::listToString(parser->getRuleInvocationStack(), ", ") << std::endl;
-    }
+  std::cout << "PRED (collectPredicates=" << collectPredicates << ") " << pt->ruleIndex << ":" << pt->predIndex << ", ctx dependent=" << pt->isCtxDependent << std::endl;
+  if (parser != nullptr) {
+    std::cout << "context surrounding pred is " << Arrays::listToString(parser->getRuleInvocationStack(), ", ") << std::endl;
+  }
 #endif
 
-  Ref<ATNConfig> c = nullptr;
+  Ref <ATNConfig> c = nullptr;
   if (collectPredicates && (!pt->isCtxDependent || (pt->isCtxDependent && inContext))) {
-    Ref<SemanticContext::Predicate> predicate = pt->getPredicate();
+    Ref <SemanticContext::Predicate> predicate = pt->getPredicate();
     if (fullCtx) {
       // In full context mode, we can evaluate predicates on-the-fly
       // during closure, which dramatically reduces the size of
@@ -1143,7 +1149,7 @@ Ref<ATNConfig> ParserATNSimulator::predTransition(Ref<ATNConfig> const& config, 
         c = std::make_shared<ATNConfig>(config, pt->target); // no pred context
       }
     } else {
-      Ref<SemanticContext> newSemCtx = SemanticContext::And(config->semanticContext, predicate);
+      Ref <SemanticContext> newSemCtx = SemanticContext::And(config->semanticContext, predicate);
       c = std::make_shared<ATNConfig>(config, pt->target, newSemCtx);
     }
   } else {
@@ -1151,24 +1157,24 @@ Ref<ATNConfig> ParserATNSimulator::predTransition(Ref<ATNConfig> const& config, 
   }
 
 #if DEBUG_DFA == 1
-    std::cout << "config from pred transition=" << c << std::endl;
+  std::cout << "config from pred transition=" << c << std::endl;
 #endif
 
   return c;
 }
 
-Ref<ATNConfig> ParserATNSimulator::ruleTransition(Ref<ATNConfig> const& config, RuleTransition *t) {
+Ref <ATNConfig> ParserATNSimulator::ruleTransition(Ref <ATNConfig> const &config, RuleTransition *t) {
 #if DEBUG_DFA == 1
-    std::cout << "CALL rule " << getRuleName(t->target->ruleIndex) << ", ctx=" << config->context << std::endl;
+  std::cout << "CALL rule " << getRuleName(t->target->ruleIndex) << ", ctx=" << config->context << std::endl;
 #endif
 
   atn::ATNState *returnState = t->followState;
-  Ref<PredictionContext> newContext = SingletonPredictionContext::create(config->context, returnState->stateNumber);
+  Ref <PredictionContext> newContext = SingletonPredictionContext::create(config->context, returnState->stateNumber);
   return std::make_shared<ATNConfig>(config, t->target, newContext);
 }
 
 BitSet ParserATNSimulator::getConflictingAlts(ATNConfigSet *configs) {
-  std::vector<BitSet> altsets = PredictionModeClass::getConflictingAltSubsets(configs);
+  std::vector <BitSet> altsets = PredictionModeClass::getConflictingAltSubsets(configs);
   return PredictionModeClass::getAlts(altsets);
 }
 
@@ -1206,12 +1212,12 @@ void ParserATNSimulator::dumpDeadEndConfigs(NoViableAltException &nvae) {
     std::string trans = "no edges";
     if (c->state->transitions.size() > 0) {
       Transition *t = c->state->transitions[0];
-      if (is<AtomTransition*>(t)) {
-        AtomTransition *at = static_cast<AtomTransition*>(t);
+      if (is<AtomTransition *>(t)) {
+        AtomTransition *at = static_cast<AtomTransition *>(t);
         trans = "Atom " + getTokenName(at->_label);
-      } else if (is<SetTransition*>(t)) {
-        SetTransition *st = static_cast<SetTransition*>(t);
-        bool is_not = is<NotSetTransition*>(st);
+      } else if (is<SetTransition *>(t)) {
+        SetTransition *st = static_cast<SetTransition *>(t);
+        bool is_not = is<NotSetTransition *>(st);
         trans = (is_not ? "~" : "");
         trans += "Set ";
         trans += st->set.toString();
@@ -1222,8 +1228,8 @@ void ParserATNSimulator::dumpDeadEndConfigs(NoViableAltException &nvae) {
 }
 
 NoViableAltException ParserATNSimulator::noViableAlt(TokenStream *input, ParserRuleContext *outerContext,
-  ATNConfigSet *configs, size_t startIndex, bool deleteConfigs) {
-  return NoViableAltException(parser, input, input->get(startIndex), input->LT(1), configs, outerContext, deleteConfigs);
+                                                     std::unique_ptr<ATNConfigSet> configs, size_t startIndex) {
+  return NoViableAltException(parser, input, input->get(startIndex), input->LT(1), std::move(configs), outerContext);
 }
 
 size_t ParserATNSimulator::getUniqueAlt(ATNConfigSet *configs) {
@@ -1240,7 +1246,7 @@ size_t ParserATNSimulator::getUniqueAlt(ATNConfigSet *configs) {
 
 dfa::DFAState *ParserATNSimulator::addDFAEdge(dfa::DFA &dfa, dfa::DFAState *from, ssize_t t, dfa::DFAState *to) {
 #if DEBUG_DFA == 1
-    std::cout << "EDGE " << from << " -> " << to << " upon " << getTokenName(t) << std::endl;
+  std::cout << "EDGE " << from << " -> " << to << " upon " << getTokenName(t) << std::endl;
 #endif
 
   if (to == nullptr) {
@@ -1250,7 +1256,7 @@ dfa::DFAState *ParserATNSimulator::addDFAEdge(dfa::DFA &dfa, dfa::DFAState *from
   _stateLock.writeLock();
   to = addDFAState(dfa, to); // used existing if possible not incoming
   _stateLock.writeUnlock();
-  if (from == nullptr || t > (int)atn.maxTokenType) {
+  if (from == nullptr || t > (int) atn.maxTokenType) {
     return to;
   }
 
@@ -1261,13 +1267,13 @@ dfa::DFAState *ParserATNSimulator::addDFAEdge(dfa::DFA &dfa, dfa::DFAState *from
   }
 
 #if DEBUG_DFA == 1
-    std::string dfaText;
-    if (parser != nullptr) {
-      dfaText = dfa.toString(parser->getVocabulary());
-    } else {
-      dfaText = dfa.toString(dfa::Vocabulary::EMPTY_VOCABULARY);
-    }
-    std::cout << "DFA=\n" << dfaText << std::endl;
+  std::string dfaText;
+  if (parser != nullptr) {
+    dfaText = dfa.toString(parser->getVocabulary());
+  } else {
+    dfaText = dfa.toString(dfa::Vocabulary::EMPTY_VOCABULARY);
+  }
+  std::cout << "DFA=\n" << dfaText << std::endl;
 #endif
 
   return to;
@@ -1283,7 +1289,7 @@ dfa::DFAState *ParserATNSimulator::addDFAState(dfa::DFA &dfa, dfa::DFAState *D) 
     return *existing;
   }
 
-  D->stateNumber = (int)dfa.states.size();
+  D->stateNumber = (int) dfa.states.size();
   if (!D->configs->isReadonly()) {
     D->configs->optimizeConfigs(this);
     D->configs->setReadonly(true);
@@ -1299,10 +1305,10 @@ dfa::DFAState *ParserATNSimulator::addDFAState(dfa::DFA &dfa, dfa::DFAState *D) 
 }
 
 void ParserATNSimulator::reportAttemptingFullContext(dfa::DFA &dfa, const antlrcpp::BitSet &conflictingAlts,
-  ATNConfigSet *configs, size_t startIndex, size_t stopIndex) {
+                                                     ATNConfigSet *configs, size_t startIndex, size_t stopIndex) {
 #if DEBUG_DFA == 1 || RETRY_DEBUG == 1
-    misc::Interval interval = misc::Interval((int)startIndex, (int)stopIndex);
-    std::cout << "reportAttemptingFullContext decision=" << dfa.decision << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
+  misc::Interval interval = misc::Interval((int)startIndex, (int)stopIndex);
+  std::cout << "reportAttemptingFullContext decision=" << dfa.decision << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
 #endif
 
   if (parser != nullptr) {
@@ -1311,10 +1317,10 @@ void ParserATNSimulator::reportAttemptingFullContext(dfa::DFA &dfa, const antlrc
 }
 
 void ParserATNSimulator::reportContextSensitivity(dfa::DFA &dfa, size_t prediction, ATNConfigSet *configs,
-  size_t startIndex, size_t stopIndex) {
+                                                  size_t startIndex, size_t stopIndex) {
 #if DEBUG_DFA == 1 || RETRY_DEBUG == 1
-    misc::Interval interval = misc::Interval(startIndex, stopIndex);
-    std::cout << "reportContextSensitivity decision=" << dfa.decision << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
+  misc::Interval interval = misc::Interval(startIndex, stopIndex);
+  std::cout << "reportContextSensitivity decision=" << dfa.decision << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
 #endif
 
   if (parser != nullptr) {
@@ -1325,8 +1331,8 @@ void ParserATNSimulator::reportContextSensitivity(dfa::DFA &dfa, size_t predicti
 void ParserATNSimulator::reportAmbiguity(dfa::DFA &dfa, dfa::DFAState * /*D*/, size_t startIndex, size_t stopIndex,
                                          bool exact, const antlrcpp::BitSet &ambigAlts, ATNConfigSet *configs) {
 #if DEBUG_DFA == 1 || RETRY_DEBUG == 1
-    misc::Interval interval = misc::Interval((int)startIndex, (int)stopIndex);
-    std::cout << "reportAmbiguity " << ambigAlts << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
+  misc::Interval interval = misc::Interval((int)startIndex, (int)stopIndex);
+  std::cout << "reportAmbiguity " << ambigAlts << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
 #endif
 
   if (parser != nullptr) {
@@ -1342,14 +1348,15 @@ atn::PredictionMode ParserATNSimulator::getPredictionMode() {
   return _mode;
 }
 
-Parser* ParserATNSimulator::getParser() {
+Parser *ParserATNSimulator::getParser() {
   return parser;
 }
 
 bool ParserATNSimulator::getLrLoopSetting() {
   char *var = std::getenv("TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT");
-  if (var == nullptr)
+  if (var == nullptr) {
     return false;
+  }
   std::string value(var);
   return value == "true" || value == "1";
 }

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -46,14 +46,14 @@ using namespace antlrcpp;
 
 const bool ParserATNSimulator::TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT = ParserATNSimulator::getLrLoopSetting();
 
-ParserATNSimulator::ParserATNSimulator(const ATN &atn, std::vector <dfa::DFA> &decisionToDFA,
+ParserATNSimulator::ParserATNSimulator(const ATN &atn, std::vector<dfa::DFA> &decisionToDFA,
                                        PredictionContextCache &sharedContextCache)
-        : ParserATNSimulator(nullptr, atn, decisionToDFA, sharedContextCache) {
+: ParserATNSimulator(nullptr, atn, decisionToDFA, sharedContextCache) {
 }
 
-ParserATNSimulator::ParserATNSimulator(Parser *parser, const ATN &atn, std::vector <dfa::DFA> &decisionToDFA,
+ParserATNSimulator::ParserATNSimulator(Parser *parser, const ATN &atn, std::vector<dfa::DFA> &decisionToDFA,
                                        PredictionContextCache &sharedContextCache)
-        : ATNSimulator(atn, sharedContextCache), decisionToDFA(decisionToDFA), parser(parser) {
+: ATNSimulator(atn, sharedContextCache), decisionToDFA(decisionToDFA), parser(parser) {
   InitializeInstanceFields();
 }
 
@@ -61,7 +61,7 @@ void ParserATNSimulator::reset() {
 }
 
 void ParserATNSimulator::clearDFA() {
-  int size = (int) decisionToDFA.size();
+  int size = (int)decisionToDFA.size();
   decisionToDFA.clear();
   for (int d = 0; d < size; ++d) {
     decisionToDFA.push_back(dfa::DFA(atn.getDecisionState(d), d));
@@ -71,8 +71,8 @@ void ParserATNSimulator::clearDFA() {
 size_t ParserATNSimulator::adaptivePredict(TokenStream *input, size_t decision, ParserRuleContext *outerContext) {
 
 #if DEBUG_ATN == 1 || DEBUG_LIST_ATN_DECISIONS == 1
-  std::cout << "adaptivePredict decision " << decision << " exec LA(1)==" << getLookaheadName(input) << " line "
-    << input->LT(1)->getLine() << ":" << input->LT(1)->getCharPositionInLine() << std::endl;
+    std::cout << "adaptivePredict decision " << decision << " exec LA(1)==" << getLookaheadName(input) << " line "
+      << input->LT(1)->getLine() << ":" << input->LT(1)->getCharPositionInLine() << std::endl;
 #endif
 
   _input = input;
@@ -87,10 +87,10 @@ size_t ParserATNSimulator::adaptivePredict(TokenStream *input, size_t decision, 
   // Now we are certain to have a specific decision's DFA
   // But, do we still need an initial state?
   auto onExit = finally([this, input, index, m] {
-      mergeCache.clear(); // wack cache after each prediction
-      _dfa = nullptr;
-      input->seek(index);
-      input->release(m);
+    mergeCache.clear(); // wack cache after each prediction
+    _dfa = nullptr;
+    input->seek(index);
+    input->release(m);
   });
 
   dfa::DFAState *s0;
@@ -105,8 +105,8 @@ size_t ParserATNSimulator::adaptivePredict(TokenStream *input, size_t decision, 
 
   if (s0 == nullptr) {
     bool fullCtx = false;
-    std::unique_ptr <ATNConfigSet> s0_closure = computeStartState(dynamic_cast<ATNState *>(dfa.atnStartState),
-                                                                  &ParserRuleContext::EMPTY, fullCtx);
+    std::unique_ptr<ATNConfigSet> s0_closure = computeStartState(dynamic_cast<ATNState *>(dfa.atnStartState),
+                                                                 &ParserRuleContext::EMPTY, fullCtx);
 
     _stateLock.writeLock();
     if (dfa.isPrecedenceDfa()) {
@@ -148,14 +148,14 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
                                    ParserRuleContext *outerContext) {
 
 #if DEBUG_ATN == 1 || DEBUG_LIST_ATN_DECISIONS == 1
-  std::cout << "execATN decision " << dfa.decision << " exec LA(1)==" << getLookaheadName(input) <<
-    " line " << input->LT(1)->getLine() << ":" << input->LT(1)->getCharPositionInLine() << std::endl;
+    std::cout << "execATN decision " << dfa.decision << " exec LA(1)==" << getLookaheadName(input) <<
+      " line " << input->LT(1)->getLine() << ":" << input->LT(1)->getCharPositionInLine() << std::endl;
 #endif
 
   dfa::DFAState *previousD = s0;
 
 #if DEBUG_ATN == 1
-  std::cout << "s0 = " << s0 << std::endl;
+    std::cout << "s0 = " << s0 << std::endl;
 #endif
 
   size_t t = input->LA(1);
@@ -176,12 +176,14 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
       // ATN states in SLL implies LL will also get nowhere.
       // If conflict in states that dip out, choose min since we
       // will get error no matter what.
+      NoViableAltException e = noViableAlt(input, outerContext, std::move(previousD->configs), startIndex);
       input->seek(startIndex);
       size_t alt = getSynValidOrSemInvalidAltThatFinishedDecisionEntryRule(previousD->configs.get(), outerContext);
       if (alt != ATN::INVALID_ALT_NUMBER) {
         return alt;
       }
-      throw noViableAlt(input, outerContext, std::move(previousD->configs), startIndex);
+
+      throw e;
     }
 
     if (D->requiresFullContext && _mode != PredictionMode::SLL) {
@@ -189,7 +191,7 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
       BitSet conflictingAlts;
       if (D->predicates.size() != 0) {
 #if DEBUG_ATN == 1
-        std::cout << "DFA state has preds in DFA sim LL failover" << std::endl;
+          std::cout << "DFA state has preds in DFA sim LL failover" << std::endl;
 #endif
 
         size_t conflictIndex = input->index();
@@ -200,7 +202,7 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
         conflictingAlts = evalSemanticContext(D->predicates, outerContext, true);
         if (conflictingAlts.count() == 1) {
 #if DEBUG_ATN == 1
-          std::cout << "Full LL avoided" << std::endl;
+            std::cout << "Full LL avoided" << std::endl;
 #endif
 
           return conflictingAlts.nextSetBit(0);
@@ -214,11 +216,11 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
       }
 
 #if DEBUG_DFA == 1
-      std::cout << "ctx sensitive state " << outerContext << " in " << D << std::endl;
+        std::cout << "ctx sensitive state " << outerContext << " in " << D << std::endl;
 #endif
 
       bool fullCtx = true;
-      Ref <ATNConfigSet> s0_closure = computeStartState(dfa.atnStartState, outerContext, fullCtx);
+      Ref<ATNConfigSet> s0_closure = computeStartState(dfa.atnStartState, outerContext, fullCtx);
       reportAttemptingFullContext(dfa, conflictingAlts, D->configs.get(), startIndex, input->index());
       size_t alt = execATNWithFullContext(dfa, D, s0_closure.get(), input, startIndex, outerContext);
       return alt;
@@ -257,7 +259,7 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
 }
 
 dfa::DFAState *ParserATNSimulator::getExistingTargetState(dfa::DFAState *previousD, size_t t) {
-  dfa::DFAState *retval;
+  dfa::DFAState* retval;
   _edgeLock.readLock();
   auto iterator = previousD->edges.find(t);
   retval = (iterator == previousD->edges.end()) ? nullptr : iterator->second;
@@ -266,7 +268,7 @@ dfa::DFAState *ParserATNSimulator::getExistingTargetState(dfa::DFAState *previou
 }
 
 dfa::DFAState *ParserATNSimulator::computeTargetState(dfa::DFA &dfa, dfa::DFAState *previousD, size_t t) {
-  std::unique_ptr <ATNConfigSet> reach = computeReachSet(previousD->configs.get(), t, false);
+  std::unique_ptr<ATNConfigSet> reach = computeReachSet(previousD->configs.get(), t, false);
   if (reach == nullptr) {
     addDFAEdge(dfa, previousD, t, ERROR.get());
     return ERROR.get();
@@ -313,7 +315,7 @@ void ParserATNSimulator::predicateDFAState(dfa::DFAState *dfaState, DecisionStat
   // Update DFA so reach becomes accept state with (predicate,alt)
   // pairs if preds found for conflicting alts
   BitSet altsToCollectPredsFrom = getConflictingAltsOrUniqueAlt(dfaState->configs.get());
-  std::vector <Ref<SemanticContext>> altToPred = getPredsForAmbigAlts(altsToCollectPredsFrom, dfaState->configs.get(), nalts);
+  std::vector<Ref<SemanticContext>> altToPred = getPredsForAmbigAlts(altsToCollectPredsFrom, dfaState->configs.get(), nalts);
   if (!altToPred.empty()) {
     dfaState->predicates = getPredicatePredictions(altsToCollectPredsFrom, altToPred);
     dfaState->prediction = ATN::INVALID_ALT_NUMBER; // make sure we use preds
@@ -326,12 +328,12 @@ void ParserATNSimulator::predicateDFAState(dfa::DFAState *dfaState, DecisionStat
 }
 
 size_t ParserATNSimulator::execATNWithFullContext(dfa::DFA &dfa, dfa::DFAState *D, ATNConfigSet *s0,
-                                                  TokenStream *input, size_t startIndex, ParserRuleContext *outerContext) {
+  TokenStream *input, size_t startIndex, ParserRuleContext *outerContext) {
 
   bool fullCtx = true;
   bool foundExactAmbig = false;
 
-  std::unique_ptr <ATNConfigSet> reach;
+  std::unique_ptr<ATNConfigSet> reach;
   ATNConfigSet *previous = s0;
   input->seek(startIndex);
   size_t t = input->LA(1);
@@ -349,24 +351,20 @@ size_t ParserATNSimulator::execATNWithFullContext(dfa::DFA &dfa, dfa::DFAState *
       // ATN states in SLL implies LL will also get nowhere.
       // If conflict in states that dip out, choose min since we
       // will get error no matter what.
-
+      auto _previous = std::unique_ptr<ATNConfigSet>(previous==s0 ? nullptr : previous);
+      NoViableAltException e = noViableAlt(input, outerContext, std::move(_previous), startIndex);
       input->seek(startIndex);
       size_t alt = getSynValidOrSemInvalidAltThatFinishedDecisionEntryRule(previous, outerContext);
       if (alt != ATN::INVALID_ALT_NUMBER) {
         return alt;
       }
-      if (previous == s0) {
-        previous = nullptr;
-      }
-      throw noViableAlt(input, outerContext, std::unique_ptr<ATNConfigSet>(previous), startIndex);;
+      throw e;
     }
     if (previous != s0) // Don't delete the start set.
-    {
-      delete previous;
-      previous = nullptr;
-    }
+        delete previous;
+    previous = nullptr;
 
-    std::vector <BitSet> altSubSets = PredictionModeClass::getConflictingAltSubsets(reach.get());
+    std::vector<BitSet> altSubSets = PredictionModeClass::getConflictingAltSubsets(reach.get());
     reach->uniqueAlt = getUniqueAlt(reach.get());
     // unique prediction?
     if (reach->uniqueAlt != ATN::INVALID_ALT_NUMBER) {
@@ -438,9 +436,9 @@ size_t ParserATNSimulator::execATNWithFullContext(dfa::DFA &dfa, dfa::DFAState *
   return predictedAlt;
 }
 
-std::unique_ptr <ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *closure_, size_t t, bool fullCtx) {
+std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *closure_, size_t t, bool fullCtx) {
 
-  std::unique_ptr <ATNConfigSet> intermediate(new ATNConfigSet(fullCtx));
+  std::unique_ptr<ATNConfigSet> intermediate(new ATNConfigSet(fullCtx));
 
   /* Configurations already in a rule stop state indicate reaching the end
    * of the decision rule (local context) or end of the start rule (full
@@ -452,7 +450,7 @@ std::unique_ptr <ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet 
    * ensure that the alternative matching the longest overall sequence is
    * chosen when multiple such configurations can match the input.
    */
-  std::vector <Ref<ATNConfig>> skippedStopStates;
+  std::vector<Ref<ATNConfig>> skippedStopStates;
 
   // First figure out where we can reach on input t
   for (auto &c : closure_->configs) {
@@ -469,7 +467,7 @@ std::unique_ptr <ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet 
     size_t n = c->state->transitions.size();
     for (size_t ti = 0; ti < n; ti++) { // for each transition
       Transition *trans = c->state->transitions[ti];
-      ATNState *target = getReachableTarget(trans, (int) t);
+      ATNState *target = getReachableTarget(trans, (int)t);
       if (target != nullptr) {
         intermediate->add(std::make_shared<ATNConfig>(c, target), &mergeCache);
       }
@@ -477,7 +475,7 @@ std::unique_ptr <ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet 
   }
 
   // Now figure out where the reach operation can take us...
-  std::unique_ptr <ATNConfigSet> reach;
+  std::unique_ptr<ATNConfigSet> reach;
 
   /* This block optimizes the reach operation for intermediate sets which
    * trivially indicate a termination state for the overall
@@ -534,9 +532,8 @@ std::unique_ptr <ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet 
      * required.
      */
     ATNConfigSet *temp = removeAllConfigsNotInRuleStopState(reach.get(), *reach == *intermediate);
-    if (temp != reach.get()) {
-      reach.reset(temp);
-    } // We got a new set, so use that.
+    if (temp != reach.get())
+      reach.reset(temp); // We got a new set, so use that.
   }
 
   /* If skippedStopStates is not null, then it contains at least one
@@ -561,8 +558,8 @@ std::unique_ptr <ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet 
   return reach;
 }
 
-ATNConfigSet *ParserATNSimulator::removeAllConfigsNotInRuleStopState(ATNConfigSet *configs,
-                                                                     bool lookToEndOfRule) {
+ATNConfigSet* ParserATNSimulator::removeAllConfigsNotInRuleStopState(ATNConfigSet *configs,
+  bool lookToEndOfRule) {
   if (PredictionModeClass::allConfigsInRuleStopStates(configs)) {
     return configs;
   }
@@ -570,7 +567,7 @@ ATNConfigSet *ParserATNSimulator::removeAllConfigsNotInRuleStopState(ATNConfigSe
   ATNConfigSet *result = new ATNConfigSet(configs->fullCtx); /* mem-check: released by caller */
 
   for (auto &config : configs->configs) {
-    if (is<RuleStopState *>(config->state)) {
+    if (is<RuleStopState*>(config->state)) {
       result->add(config, &mergeCache);
       continue;
     }
@@ -587,14 +584,14 @@ ATNConfigSet *ParserATNSimulator::removeAllConfigsNotInRuleStopState(ATNConfigSe
   return result;
 }
 
-std::unique_ptr <ATNConfigSet> ParserATNSimulator::computeStartState(ATNState *p, RuleContext *ctx, bool fullCtx) {
+std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeStartState(ATNState *p, RuleContext *ctx, bool fullCtx) {
   // always at least the implicit call to start rule
-  Ref <PredictionContext> initialContext = PredictionContext::fromRuleContext(atn, ctx);
-  std::unique_ptr <ATNConfigSet> configs(new ATNConfigSet(fullCtx));
+  Ref<PredictionContext> initialContext = PredictionContext::fromRuleContext(atn, ctx);
+  std::unique_ptr<ATNConfigSet> configs(new ATNConfigSet(fullCtx));
 
   for (size_t i = 0; i < p->transitions.size(); i++) {
     ATNState *target = p->transitions[i]->target;
-    Ref <ATNConfig> c = std::make_shared<ATNConfig>(target, (int) i + 1, initialContext);
+    Ref<ATNConfig> c = std::make_shared<ATNConfig>(target, (int)i + 1, initialContext);
     ATNConfig::Set closureBusy;
     closure(c, configs.get(), closureBusy, true, fullCtx, false);
   }
@@ -602,16 +599,16 @@ std::unique_ptr <ATNConfigSet> ParserATNSimulator::computeStartState(ATNState *p
   return configs;
 }
 
-std::unique_ptr <ATNConfigSet> ParserATNSimulator::applyPrecedenceFilter(ATNConfigSet *configs) {
-  std::map <size_t, Ref<PredictionContext>> statesFromAlt1;
-  std::unique_ptr <ATNConfigSet> configSet(new ATNConfigSet(configs->fullCtx));
-  for (Ref <ATNConfig> &config : configs->configs) {
+std::unique_ptr<ATNConfigSet> ParserATNSimulator::applyPrecedenceFilter(ATNConfigSet *configs) {
+  std::map<size_t, Ref<PredictionContext>> statesFromAlt1;
+  std::unique_ptr<ATNConfigSet> configSet(new ATNConfigSet(configs->fullCtx));
+  for (Ref<ATNConfig> &config : configs->configs) {
     // handle alt 1 first
     if (config->alt != 1) {
       continue;
     }
 
-    Ref <SemanticContext> updatedContext = config->semanticContext->evalPrecedence(parser, _outerContext);
+    Ref<SemanticContext> updatedContext = config->semanticContext->evalPrecedence(parser, _outerContext);
     if (updatedContext == nullptr) {
       // the configuration was eliminated
       continue;
@@ -620,12 +617,13 @@ std::unique_ptr <ATNConfigSet> ParserATNSimulator::applyPrecedenceFilter(ATNConf
     statesFromAlt1[config->state->stateNumber] = config->context;
     if (updatedContext != config->semanticContext) {
       configSet->add(std::make_shared<ATNConfig>(config, updatedContext), &mergeCache);
-    } else {
+    }
+    else {
       configSet->add(config, &mergeCache);
     }
   }
 
-  for (Ref <ATNConfig> &config : configs->configs) {
+  for (Ref<ATNConfig> &config : configs->configs) {
     if (config->alt == 1) {
       // already handled
       continue;
@@ -649,7 +647,7 @@ std::unique_ptr <ATNConfigSet> ParserATNSimulator::applyPrecedenceFilter(ATNConf
   return configSet;
 }
 
-atn::ATNState *ParserATNSimulator::getReachableTarget(Transition *trans, size_t ttype) {
+atn::ATNState* ParserATNSimulator::getReachableTarget(Transition *trans, size_t ttype) {
   if (trans->matches(ttype, 0, atn.maxTokenType)) {
     return trans->target;
   }
@@ -658,8 +656,8 @@ atn::ATNState *ParserATNSimulator::getReachableTarget(Transition *trans, size_t 
 }
 
 // Note that caller must memory manage the returned value from this function
-std::vector <Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const BitSet &ambigAlts,
-                                                                            ATNConfigSet *configs, size_t nalts) {
+std::vector<Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const BitSet &ambigAlts,
+  ATNConfigSet *configs, size_t nalts) {
   // REACH=[1|1|[]|0:0, 1|2|[]|0:1]
   /* altToPred starts as an array of all null contexts. The entry at index i
    * corresponds to alternative i. altToPred[i] may have one of three values:
@@ -672,7 +670,7 @@ std::vector <Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(cons
    *
    * From this, it is clear that NONE||anything==NONE.
    */
-  std::vector <Ref<SemanticContext>> altToPred(nalts + 1);
+  std::vector<Ref<SemanticContext>> altToPred(nalts + 1);
 
   for (auto &c : configs->configs) {
     if (ambigAlts.test(c->alt)) {
@@ -694,38 +692,38 @@ std::vector <Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(cons
     altToPred.clear();
   }
 #if DEBUG_ATN == 1
-  std::cout << "getPredsForAmbigAlts result " << Arrays::toString(altToPred) << std::endl;
+    std::cout << "getPredsForAmbigAlts result " << Arrays::toString(altToPred) << std::endl;
 #endif
 
   return altToPred;
 }
 
 std::vector<dfa::DFAState::PredPrediction *> ParserATNSimulator::getPredicatePredictions(const antlrcpp::BitSet &ambigAlts,
-                                                                                         std::vector <Ref<SemanticContext>> const &altToPred) {
-  bool containsPredicate = std::find_if(altToPred.begin(), altToPred.end(), [](Ref <SemanticContext> const context) {
-      return context != SemanticContext::NONE;
+  std::vector<Ref<SemanticContext>> const& altToPred) {
+  bool containsPredicate = std::find_if(altToPred.begin(), altToPred.end(), [](Ref<SemanticContext> const context) {
+    return context != SemanticContext::NONE;
   }) != altToPred.end();
-  if (!containsPredicate) {
+  if (!containsPredicate)
     return {};
-  }
 
-  std::vector < dfa::DFAState::PredPrediction * > pairs;
+  std::vector<dfa::DFAState::PredPrediction*> pairs;
   for (size_t i = 1; i < altToPred.size(); ++i) {
-    Ref <SemanticContext> const &pred = altToPred[i];
+    Ref<SemanticContext> const& pred = altToPred[i];
     assert(pred != nullptr); // unpredicted is indicated by SemanticContext.NONE
 
     if (ambigAlts.test(i)) {
-      pairs.push_back(new dfa::DFAState::PredPrediction(pred, (int) i)); /* mem-check: managed by the DFAState it will be assigned to after return */
+      pairs.push_back(new dfa::DFAState::PredPrediction(pred, (int)i)); /* mem-check: managed by the DFAState it will be assigned to after return */
     }
   }
   return pairs;
 }
 
 size_t ParserATNSimulator::getSynValidOrSemInvalidAltThatFinishedDecisionEntryRule(ATNConfigSet *configs,
-                                                                                   ParserRuleContext *outerContext) {
-  std::pair < ATNConfigSet * , ATNConfigSet * > sets = splitAccordingToSemanticValidity(configs, outerContext);
-  std::unique_ptr <ATNConfigSet> semValidConfigs(sets.first);
-  std::unique_ptr <ATNConfigSet> semInvalidConfigs(sets.second);
+  ParserRuleContext *outerContext)
+{
+  std::pair<ATNConfigSet *, ATNConfigSet *> sets = splitAccordingToSemanticValidity(configs, outerContext);
+  std::unique_ptr<ATNConfigSet> semValidConfigs(sets.first);
+  std::unique_ptr<ATNConfigSet> semInvalidConfigs(sets.second);
   size_t alt = getAltThatFinishedDecisionEntryRule(semValidConfigs.get());
   if (alt != ATN::INVALID_ALT_NUMBER) { // semantically/syntactically viable path exists
     return alt;
@@ -754,12 +752,12 @@ size_t ParserATNSimulator::getAltThatFinishedDecisionEntryRule(ATNConfigSet *con
 }
 
 std::pair<ATNConfigSet *, ATNConfigSet *> ParserATNSimulator::splitAccordingToSemanticValidity(ATNConfigSet *configs,
-                                                                                               ParserRuleContext *outerContext) {
+  ParserRuleContext *outerContext) {
 
   // mem-check: both pointers must be freed by the caller.
   ATNConfigSet *succeeded(new ATNConfigSet(configs->fullCtx));
   ATNConfigSet *failed(new ATNConfigSet(configs->fullCtx));
-  for (Ref <ATNConfig> &c : configs->configs) {
+  for (Ref<ATNConfig> &c : configs->configs) {
     if (c->semanticContext != SemanticContext::NONE) {
       bool predicateEvaluationResult = evalSemanticContext(c->semanticContext, outerContext, c->alt, configs->fullCtx);
       if (predicateEvaluationResult) {
@@ -771,10 +769,10 @@ std::pair<ATNConfigSet *, ATNConfigSet *> ParserATNSimulator::splitAccordingToSe
       succeeded->add(c);
     }
   }
-  return {succeeded, failed};
+  return { succeeded, failed };
 }
 
-BitSet ParserATNSimulator::evalSemanticContext(std::vector<dfa::DFAState::PredPrediction *> predPredictions,
+BitSet ParserATNSimulator::evalSemanticContext(std::vector<dfa::DFAState::PredPrediction*> predPredictions,
                                                ParserRuleContext *outerContext, bool complete) {
   BitSet predictions;
   for (auto prediction : predPredictions) {
@@ -789,12 +787,12 @@ BitSet ParserATNSimulator::evalSemanticContext(std::vector<dfa::DFAState::PredPr
     bool fullCtx = false; // in dfa
     bool predicateEvaluationResult = evalSemanticContext(prediction->pred, outerContext, prediction->alt, fullCtx);
 #if DEBUG_ATN == 1 || DEBUG_DFA == 1
-    std::cout << "eval pred " << prediction->toString() << " = " << predicateEvaluationResult << std::endl;
+      std::cout << "eval pred " << prediction->toString() << " = " << predicateEvaluationResult << std::endl;
 #endif
 
     if (predicateEvaluationResult) {
 #if DEBUG_ATN == 1 || DEBUG_DFA == 1
-      std::cout << "PREDICT " << prediction->alt << std::endl;
+        std::cout << "PREDICT " << prediction->alt << std::endl;
 #endif
 
       predictions.set(prediction->alt);
@@ -807,12 +805,12 @@ BitSet ParserATNSimulator::evalSemanticContext(std::vector<dfa::DFAState::PredPr
   return predictions;
 }
 
-bool ParserATNSimulator::evalSemanticContext(Ref <SemanticContext> const &pred, ParserRuleContext *parserCallStack,
+bool ParserATNSimulator::evalSemanticContext(Ref<SemanticContext> const& pred, ParserRuleContext *parserCallStack,
                                              size_t /*alt*/, bool /*fullCtx*/) {
   return pred->eval(parser, parserCallStack);
 }
 
-void ParserATNSimulator::closure(Ref <ATNConfig> const &config, ATNConfigSet *configs, ATNConfig::Set &closureBusy,
+void ParserATNSimulator::closure(Ref<ATNConfig> const& config, ATNConfigSet *configs, ATNConfig::Set &closureBusy,
                                  bool collectPredicates, bool fullCtx, bool treatEofAsEpsilon) {
   const int initialDepth = 0;
   closureCheckingStopState(config, configs, closureBusy, collectPredicates, fullCtx, initialDepth, treatEofAsEpsilon);
@@ -820,12 +818,11 @@ void ParserATNSimulator::closure(Ref <ATNConfig> const &config, ATNConfigSet *co
   assert(!fullCtx || !configs->dipsIntoOuterContext);
 }
 
-void ParserATNSimulator::closureCheckingStopState(Ref <ATNConfig> const &config, ATNConfigSet *configs,
-                                                  ATNConfig::Set &closureBusy, bool collectPredicates, bool fullCtx, int depth,
-                                                  bool treatEofAsEpsilon) {
+void ParserATNSimulator::closureCheckingStopState(Ref<ATNConfig> const& config, ATNConfigSet *configs,
+  ATNConfig::Set &closureBusy, bool collectPredicates, bool fullCtx, int depth, bool treatEofAsEpsilon) {
 
 #if DEBUG_ATN == 1
-  std::cout << "closure(" << config->toString(true) << ")" << std::endl;
+    std::cout << "closure(" << config->toString(true) << ")" << std::endl;
 #endif
 
   if (is<RuleStopState *>(config->state)) {
@@ -840,15 +837,15 @@ void ParserATNSimulator::closureCheckingStopState(Ref <ATNConfig> const &config,
           } else {
             // we have no context info, just chase follow links (if greedy)
 #if DEBUG_ATN == 1
-            std::cout << "FALLING off rule " << getRuleName(config->state->ruleIndex) << std::endl;
+              std::cout << "FALLING off rule " << getRuleName(config->state->ruleIndex) << std::endl;
 #endif
             closure_(config, configs, closureBusy, collectPredicates, fullCtx, depth, treatEofAsEpsilon);
           }
           continue;
         }
         ATNState *returnState = atn.states[config->context->getReturnState(i)];
-        std::weak_ptr <PredictionContext> newContext = config->context->getParent(i); // "pop" return state
-        Ref <ATNConfig> c = std::make_shared<ATNConfig>(returnState, config->alt, newContext.lock(), config->semanticContext);
+        std::weak_ptr<PredictionContext> newContext = config->context->getParent(i); // "pop" return state
+        Ref<ATNConfig> c = std::make_shared<ATNConfig>(returnState, config->alt, newContext.lock(), config->semanticContext);
         // While we have context to pop back from, we may have
         // gotten that context AFTER having falling off a rule.
         // Make sure we track that we are now out of context.
@@ -874,7 +871,7 @@ void ParserATNSimulator::closureCheckingStopState(Ref <ATNConfig> const &config,
   closure_(config, configs, closureBusy, collectPredicates, fullCtx, depth, treatEofAsEpsilon);
 }
 
-void ParserATNSimulator::closure_(Ref <ATNConfig> const &config, ATNConfigSet *configs, ATNConfig::Set &closureBusy,
+void ParserATNSimulator::closure_(Ref<ATNConfig> const& config, ATNConfigSet *configs, ATNConfig::Set &closureBusy,
                                   bool collectPredicates, bool fullCtx, int depth, bool treatEofAsEpsilon) {
   ATNState *p = config->state;
   // optimization
@@ -885,16 +882,15 @@ void ParserATNSimulator::closure_(Ref <ATNConfig> const &config, ATNConfigSet *c
   }
 
   for (size_t i = 0; i < p->transitions.size(); i++) {
-    if (i == 0 && canDropLoopEntryEdgeInLeftRecursiveRule(config.get())) {
+    if (i == 0 && canDropLoopEntryEdgeInLeftRecursiveRule(config.get()))
       continue;
-    }
 
     Transition *t = p->transitions[i];
-    bool continueCollecting = !is<ActionTransition *>(t) && collectPredicates;
-    Ref <ATNConfig> c = getEpsilonTarget(config, t, continueCollecting, depth == 0, fullCtx, treatEofAsEpsilon);
+    bool continueCollecting = !is<ActionTransition*>(t) && collectPredicates;
+    Ref<ATNConfig> c = getEpsilonTarget(config, t, continueCollecting, depth == 0, fullCtx, treatEofAsEpsilon);
     if (c != nullptr) {
       int newDepth = depth;
-      if (is<RuleStopState *>(config->state)) {
+      if (is<RuleStopState*>(config->state)) {
         assert(!fullCtx);
 
         // target fell off end of rule; mark resulting c as having dipped into outer context
@@ -932,10 +928,10 @@ void ParserATNSimulator::closure_(Ref <ATNConfig> const &config, ATNConfigSet *c
 
         newDepth--;
 #if DEBUG_DFA == 1
-        std::cout << "dips into outer ctx: " << c << std::endl;
+          std::cout << "dips into outer ctx: " << c << std::endl;
 #endif
 
-      } else if (!t->isEpsilon()) {
+      } else  if (!t->isEpsilon()) {
         // avoid infinite recursion for EOF* and EOF+
         if (closureBusy.count(c) == 0) {
           closureBusy.insert(c);
@@ -944,7 +940,7 @@ void ParserATNSimulator::closure_(Ref <ATNConfig> const &config, ATNConfigSet *c
         }
       }
 
-      if (is<RuleTransition *>(t)) {
+      if (is<RuleTransition*>(t)) {
         // latch when newDepth goes negative - once we step out of the entry context we can't return
         if (newDepth >= 0) {
           newDepth++;
@@ -957,9 +953,8 @@ void ParserATNSimulator::closure_(Ref <ATNConfig> const &config, ATNConfigSet *c
 }
 
 bool ParserATNSimulator::canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *config) const {
-  if (TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT) {
+  if (TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT)
     return false;
-  }
 
   ATNState *p = config->state;
 
@@ -968,9 +963,10 @@ bool ParserATNSimulator::canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *conf
   // the context has an empty stack case. If so, it would mean
   // global FOLLOW so we can't perform optimization
   if (p->getStateType() != ATNState::STAR_LOOP_ENTRY ||
-      !((StarLoopEntryState *) p)->isPrecedenceDecision || // Are we the special loop entry/exit state?
+      !((StarLoopEntryState *)p)->isPrecedenceDecision || // Are we the special loop entry/exit state?
       config->context->isEmpty() ||                      // If SLL wildcard
-      config->context->hasEmptyPath()) {
+      config->context->hasEmptyPath())
+  {
     return false;
   }
 
@@ -979,14 +975,13 @@ bool ParserATNSimulator::canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *conf
   size_t numCtxs = config->context->size();
   for (size_t i = 0; i < numCtxs; i++) { // for each stack context
     ATNState *returnState = atn.states[config->context->getReturnState(i)];
-    if (returnState->ruleIndex != p->ruleIndex) {
+    if (returnState->ruleIndex != p->ruleIndex)
       return false;
-    }
   }
 
-  BlockStartState *decisionStartState = (BlockStartState *) p->transitions[0]->target;
+  BlockStartState *decisionStartState = (BlockStartState *)p->transitions[0]->target;
   size_t blockEndStateNum = decisionStartState->endState->stateNumber;
-  BlockEndState *blockEndState = (BlockEndState *) atn.states[blockEndStateNum];
+  BlockEndState *blockEndState = (BlockEndState *)atn.states[blockEndStateNum];
 
   // Verify that the top of each stack context leads to loop entry/exit
   // state through epsilon edges and w/o leaving rule.
@@ -994,7 +989,8 @@ bool ParserATNSimulator::canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *conf
     size_t returnStateNumber = config->context->getReturnState(i);
     ATNState *returnState = atn.states[returnStateNumber];
     // All states must have single outgoing epsilon edge.
-    if (returnState->transitions.size() != 1 || !returnState->transitions[0]->isEpsilon()) {
+    if (returnState->transitions.size() != 1 || !returnState->transitions[0]->isEpsilon())
+    {
       return false;
     }
 
@@ -1022,7 +1018,8 @@ bool ParserATNSimulator::canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *conf
     if (returnStateTarget->getStateType() == ATNState::BLOCK_END &&
         returnStateTarget->transitions.size() == 1 &&
         returnStateTarget->transitions[0]->isEpsilon() &&
-        returnStateTarget->transitions[0]->target == p) {
+        returnStateTarget->transitions[0]->target == p)
+    {
       continue;
     }
 
@@ -1040,20 +1037,20 @@ std::string ParserATNSimulator::getRuleName(size_t index) {
   return "<rule " + std::to_string(index) + ">";
 }
 
-Ref <ATNConfig> ParserATNSimulator::getEpsilonTarget(Ref <ATNConfig> const &config, Transition *t, bool collectPredicates,
-                                                     bool inContext, bool fullCtx, bool treatEofAsEpsilon) {
+Ref<ATNConfig> ParserATNSimulator::getEpsilonTarget(Ref<ATNConfig> const& config, Transition *t, bool collectPredicates,
+                                                    bool inContext, bool fullCtx, bool treatEofAsEpsilon) {
   switch (t->getSerializationType()) {
     case Transition::RULE:
-      return ruleTransition(config, static_cast<RuleTransition *>(t));
+      return ruleTransition(config, static_cast<RuleTransition*>(t));
 
     case Transition::PRECEDENCE:
-      return precedenceTransition(config, static_cast<PrecedencePredicateTransition *>(t), collectPredicates, inContext, fullCtx);
+      return precedenceTransition(config, static_cast<PrecedencePredicateTransition*>(t), collectPredicates, inContext, fullCtx);
 
     case Transition::PREDICATE:
-      return predTransition(config, static_cast<PredicateTransition *>(t), collectPredicates, inContext, fullCtx);
+      return predTransition(config, static_cast<PredicateTransition*>(t), collectPredicates, inContext, fullCtx);
 
     case Transition::ACTION:
-      return actionTransition(config, static_cast<ActionTransition *>(t));
+      return actionTransition(config, static_cast<ActionTransition*>(t));
 
     case Transition::EPSILON:
       return std::make_shared<ATNConfig>(config, t->target);
@@ -1076,26 +1073,26 @@ Ref <ATNConfig> ParserATNSimulator::getEpsilonTarget(Ref <ATNConfig> const &conf
   }
 }
 
-Ref <ATNConfig> ParserATNSimulator::actionTransition(Ref <ATNConfig> const &config, ActionTransition *t) {
+Ref<ATNConfig> ParserATNSimulator::actionTransition(Ref<ATNConfig> const& config, ActionTransition *t) {
 #if DEBUG_DFA == 1
-  std::cout << "ACTION edge " << t->ruleIndex << ":" << t->actionIndex << std::endl;
+    std::cout << "ACTION edge " << t->ruleIndex << ":" << t->actionIndex << std::endl;
 #endif
 
   return std::make_shared<ATNConfig>(config, t->target);
 }
 
-Ref <ATNConfig> ParserATNSimulator::precedenceTransition(Ref <ATNConfig> const &config, PrecedencePredicateTransition *pt,
-                                                         bool collectPredicates, bool inContext, bool fullCtx) {
+Ref<ATNConfig> ParserATNSimulator::precedenceTransition(Ref<ATNConfig> const& config, PrecedencePredicateTransition *pt,
+    bool collectPredicates, bool inContext, bool fullCtx) {
 #if DEBUG_DFA == 1
-  std::cout << "PRED (collectPredicates=" << collectPredicates << ") " << pt->precedence << ">=_p" << ", ctx dependent=true" << std::endl;
-  if (parser != nullptr) {
-    std::cout << "context surrounding pred is " << Arrays::listToString(parser->getRuleInvocationStack(), ", ") << std::endl;
-  }
+    std::cout << "PRED (collectPredicates=" << collectPredicates << ") " << pt->precedence << ">=_p" << ", ctx dependent=true" << std::endl;
+    if (parser != nullptr) {
+      std::cout << "context surrounding pred is " << Arrays::listToString(parser->getRuleInvocationStack(), ", ") << std::endl;
+    }
 #endif
 
-  Ref <ATNConfig> c;
+  Ref<ATNConfig> c;
   if (collectPredicates && inContext) {
-    Ref <SemanticContext::PrecedencePredicate> predicate = pt->getPredicate();
+    Ref<SemanticContext::PrecedencePredicate> predicate = pt->getPredicate();
 
     if (fullCtx) {
       // In full context mode, we can evaluate predicates on-the-fly
@@ -1110,7 +1107,7 @@ Ref <ATNConfig> ParserATNSimulator::precedenceTransition(Ref <ATNConfig> const &
         c = std::make_shared<ATNConfig>(config, pt->target); // no pred context
       }
     } else {
-      Ref <SemanticContext> newSemCtx = SemanticContext::And(config->semanticContext, predicate);
+      Ref<SemanticContext> newSemCtx = SemanticContext::And(config->semanticContext, predicate);
       c = std::make_shared<ATNConfig>(config, pt->target, newSemCtx);
     }
   } else {
@@ -1118,24 +1115,24 @@ Ref <ATNConfig> ParserATNSimulator::precedenceTransition(Ref <ATNConfig> const &
   }
 
 #if DEBUG_DFA == 1
-  std::cout << "config from pred transition=" << c << std::endl;
+    std::cout << "config from pred transition=" << c << std::endl;
 #endif
 
   return c;
 }
 
-Ref <ATNConfig> ParserATNSimulator::predTransition(Ref <ATNConfig> const &config, PredicateTransition *pt,
-                                                   bool collectPredicates, bool inContext, bool fullCtx) {
+Ref<ATNConfig> ParserATNSimulator::predTransition(Ref<ATNConfig> const& config, PredicateTransition *pt,
+  bool collectPredicates, bool inContext, bool fullCtx) {
 #if DEBUG_DFA == 1
-  std::cout << "PRED (collectPredicates=" << collectPredicates << ") " << pt->ruleIndex << ":" << pt->predIndex << ", ctx dependent=" << pt->isCtxDependent << std::endl;
-  if (parser != nullptr) {
-    std::cout << "context surrounding pred is " << Arrays::listToString(parser->getRuleInvocationStack(), ", ") << std::endl;
-  }
+    std::cout << "PRED (collectPredicates=" << collectPredicates << ") " << pt->ruleIndex << ":" << pt->predIndex << ", ctx dependent=" << pt->isCtxDependent << std::endl;
+    if (parser != nullptr) {
+      std::cout << "context surrounding pred is " << Arrays::listToString(parser->getRuleInvocationStack(), ", ") << std::endl;
+    }
 #endif
 
-  Ref <ATNConfig> c = nullptr;
+  Ref<ATNConfig> c = nullptr;
   if (collectPredicates && (!pt->isCtxDependent || (pt->isCtxDependent && inContext))) {
-    Ref <SemanticContext::Predicate> predicate = pt->getPredicate();
+    Ref<SemanticContext::Predicate> predicate = pt->getPredicate();
     if (fullCtx) {
       // In full context mode, we can evaluate predicates on-the-fly
       // during closure, which dramatically reduces the size of
@@ -1149,7 +1146,7 @@ Ref <ATNConfig> ParserATNSimulator::predTransition(Ref <ATNConfig> const &config
         c = std::make_shared<ATNConfig>(config, pt->target); // no pred context
       }
     } else {
-      Ref <SemanticContext> newSemCtx = SemanticContext::And(config->semanticContext, predicate);
+      Ref<SemanticContext> newSemCtx = SemanticContext::And(config->semanticContext, predicate);
       c = std::make_shared<ATNConfig>(config, pt->target, newSemCtx);
     }
   } else {
@@ -1157,24 +1154,24 @@ Ref <ATNConfig> ParserATNSimulator::predTransition(Ref <ATNConfig> const &config
   }
 
 #if DEBUG_DFA == 1
-  std::cout << "config from pred transition=" << c << std::endl;
+    std::cout << "config from pred transition=" << c << std::endl;
 #endif
 
   return c;
 }
 
-Ref <ATNConfig> ParserATNSimulator::ruleTransition(Ref <ATNConfig> const &config, RuleTransition *t) {
+Ref<ATNConfig> ParserATNSimulator::ruleTransition(Ref<ATNConfig> const& config, RuleTransition *t) {
 #if DEBUG_DFA == 1
-  std::cout << "CALL rule " << getRuleName(t->target->ruleIndex) << ", ctx=" << config->context << std::endl;
+    std::cout << "CALL rule " << getRuleName(t->target->ruleIndex) << ", ctx=" << config->context << std::endl;
 #endif
 
   atn::ATNState *returnState = t->followState;
-  Ref <PredictionContext> newContext = SingletonPredictionContext::create(config->context, returnState->stateNumber);
+  Ref<PredictionContext> newContext = SingletonPredictionContext::create(config->context, returnState->stateNumber);
   return std::make_shared<ATNConfig>(config, t->target, newContext);
 }
 
 BitSet ParserATNSimulator::getConflictingAlts(ATNConfigSet *configs) {
-  std::vector <BitSet> altsets = PredictionModeClass::getConflictingAltSubsets(configs);
+  std::vector<BitSet> altsets = PredictionModeClass::getConflictingAltSubsets(configs);
   return PredictionModeClass::getAlts(altsets);
 }
 
@@ -1212,12 +1209,12 @@ void ParserATNSimulator::dumpDeadEndConfigs(NoViableAltException &nvae) {
     std::string trans = "no edges";
     if (c->state->transitions.size() > 0) {
       Transition *t = c->state->transitions[0];
-      if (is<AtomTransition *>(t)) {
-        AtomTransition *at = static_cast<AtomTransition *>(t);
+      if (is<AtomTransition*>(t)) {
+        AtomTransition *at = static_cast<AtomTransition*>(t);
         trans = "Atom " + getTokenName(at->_label);
-      } else if (is<SetTransition *>(t)) {
-        SetTransition *st = static_cast<SetTransition *>(t);
-        bool is_not = is<NotSetTransition *>(st);
+      } else if (is<SetTransition*>(t)) {
+        SetTransition *st = static_cast<SetTransition*>(t);
+        bool is_not = is<NotSetTransition*>(st);
         trans = (is_not ? "~" : "");
         trans += "Set ";
         trans += st->set.toString();
@@ -1228,7 +1225,7 @@ void ParserATNSimulator::dumpDeadEndConfigs(NoViableAltException &nvae) {
 }
 
 NoViableAltException ParserATNSimulator::noViableAlt(TokenStream *input, ParserRuleContext *outerContext,
-                                                     std::unique_ptr<ATNConfigSet> configs, size_t startIndex) {
+  std::unique_ptr<ATNConfigSet> configs, size_t startIndex) {
   return NoViableAltException(parser, input, input->get(startIndex), input->LT(1), std::move(configs), outerContext);
 }
 
@@ -1246,7 +1243,7 @@ size_t ParserATNSimulator::getUniqueAlt(ATNConfigSet *configs) {
 
 dfa::DFAState *ParserATNSimulator::addDFAEdge(dfa::DFA &dfa, dfa::DFAState *from, ssize_t t, dfa::DFAState *to) {
 #if DEBUG_DFA == 1
-  std::cout << "EDGE " << from << " -> " << to << " upon " << getTokenName(t) << std::endl;
+    std::cout << "EDGE " << from << " -> " << to << " upon " << getTokenName(t) << std::endl;
 #endif
 
   if (to == nullptr) {
@@ -1256,7 +1253,7 @@ dfa::DFAState *ParserATNSimulator::addDFAEdge(dfa::DFA &dfa, dfa::DFAState *from
   _stateLock.writeLock();
   to = addDFAState(dfa, to); // used existing if possible not incoming
   _stateLock.writeUnlock();
-  if (from == nullptr || t > (int) atn.maxTokenType) {
+  if (from == nullptr || t > (int)atn.maxTokenType) {
     return to;
   }
 
@@ -1267,13 +1264,13 @@ dfa::DFAState *ParserATNSimulator::addDFAEdge(dfa::DFA &dfa, dfa::DFAState *from
   }
 
 #if DEBUG_DFA == 1
-  std::string dfaText;
-  if (parser != nullptr) {
-    dfaText = dfa.toString(parser->getVocabulary());
-  } else {
-    dfaText = dfa.toString(dfa::Vocabulary::EMPTY_VOCABULARY);
-  }
-  std::cout << "DFA=\n" << dfaText << std::endl;
+    std::string dfaText;
+    if (parser != nullptr) {
+      dfaText = dfa.toString(parser->getVocabulary());
+    } else {
+      dfaText = dfa.toString(dfa::Vocabulary::EMPTY_VOCABULARY);
+    }
+    std::cout << "DFA=\n" << dfaText << std::endl;
 #endif
 
   return to;
@@ -1289,7 +1286,7 @@ dfa::DFAState *ParserATNSimulator::addDFAState(dfa::DFA &dfa, dfa::DFAState *D) 
     return *existing;
   }
 
-  D->stateNumber = (int) dfa.states.size();
+  D->stateNumber = (int)dfa.states.size();
   if (!D->configs->isReadonly()) {
     D->configs->optimizeConfigs(this);
     D->configs->setReadonly(true);
@@ -1305,10 +1302,10 @@ dfa::DFAState *ParserATNSimulator::addDFAState(dfa::DFA &dfa, dfa::DFAState *D) 
 }
 
 void ParserATNSimulator::reportAttemptingFullContext(dfa::DFA &dfa, const antlrcpp::BitSet &conflictingAlts,
-                                                     ATNConfigSet *configs, size_t startIndex, size_t stopIndex) {
+  ATNConfigSet *configs, size_t startIndex, size_t stopIndex) {
 #if DEBUG_DFA == 1 || RETRY_DEBUG == 1
-  misc::Interval interval = misc::Interval((int)startIndex, (int)stopIndex);
-  std::cout << "reportAttemptingFullContext decision=" << dfa.decision << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
+    misc::Interval interval = misc::Interval((int)startIndex, (int)stopIndex);
+    std::cout << "reportAttemptingFullContext decision=" << dfa.decision << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
 #endif
 
   if (parser != nullptr) {
@@ -1317,10 +1314,10 @@ void ParserATNSimulator::reportAttemptingFullContext(dfa::DFA &dfa, const antlrc
 }
 
 void ParserATNSimulator::reportContextSensitivity(dfa::DFA &dfa, size_t prediction, ATNConfigSet *configs,
-                                                  size_t startIndex, size_t stopIndex) {
+  size_t startIndex, size_t stopIndex) {
 #if DEBUG_DFA == 1 || RETRY_DEBUG == 1
-  misc::Interval interval = misc::Interval(startIndex, stopIndex);
-  std::cout << "reportContextSensitivity decision=" << dfa.decision << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
+    misc::Interval interval = misc::Interval(startIndex, stopIndex);
+    std::cout << "reportContextSensitivity decision=" << dfa.decision << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
 #endif
 
   if (parser != nullptr) {
@@ -1331,8 +1328,8 @@ void ParserATNSimulator::reportContextSensitivity(dfa::DFA &dfa, size_t predicti
 void ParserATNSimulator::reportAmbiguity(dfa::DFA &dfa, dfa::DFAState * /*D*/, size_t startIndex, size_t stopIndex,
                                          bool exact, const antlrcpp::BitSet &ambigAlts, ATNConfigSet *configs) {
 #if DEBUG_DFA == 1 || RETRY_DEBUG == 1
-  misc::Interval interval = misc::Interval((int)startIndex, (int)stopIndex);
-  std::cout << "reportAmbiguity " << ambigAlts << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
+    misc::Interval interval = misc::Interval((int)startIndex, (int)stopIndex);
+    std::cout << "reportAmbiguity " << ambigAlts << ":" << configs << ", input=" << parser->getTokenStream()->getText(interval) << std::endl;
 #endif
 
   if (parser != nullptr) {
@@ -1348,15 +1345,14 @@ atn::PredictionMode ParserATNSimulator::getPredictionMode() {
   return _mode;
 }
 
-Parser *ParserATNSimulator::getParser() {
+Parser* ParserATNSimulator::getParser() {
   return parser;
 }
 
 bool ParserATNSimulator::getLrLoopSetting() {
   char *var = std::getenv("TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT");
-  if (var == nullptr) {
+  if (var == nullptr)
     return false;
-  }
   std::string value(var);
   return value == "true" || value == "1";
 }

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -176,14 +176,12 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
       // ATN states in SLL implies LL will also get nowhere.
       // If conflict in states that dip out, choose min since we
       // will get error no matter what.
-      NoViableAltException e = noViableAlt(input, outerContext, previousD->configs.get(), startIndex, false);
       input->seek(startIndex);
       size_t alt = getSynValidOrSemInvalidAltThatFinishedDecisionEntryRule(previousD->configs.get(), outerContext);
       if (alt != ATN::INVALID_ALT_NUMBER) {
         return alt;
       }
-
-      throw e;
+      throw noViableAlt(input, outerContext, previousD->configs.get(), startIndex, false);
     }
 
     if (D->requiresFullContext && _mode != PredictionMode::SLL) {

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
@@ -836,7 +836,7 @@ namespace atn {
     virtual antlrcpp::BitSet getConflictingAltsOrUniqueAlt(ATNConfigSet *configs);
 
     virtual NoViableAltException noViableAlt(TokenStream *input, ParserRuleContext *outerContext,
-                                              ATNConfigSet *configs, size_t startIndex, bool deleteConfigs);
+                                              std::unique_ptr<ATNConfigSet> configs, size_t startIndex);
 
     static size_t getUniqueAlt(ATNConfigSet *configs);
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

fix #2550

I found that the `deadEndConfigs` is from a `unique_ptr` whose lifetime was handled by the `DFAState`.

when the `NoViableAltException` was thrown, the current dfa state makes no more sense, so i think it's ok to transfer the ownership of `ATNConfigSet` into `NoViableAltException` and let it deleted 