### PR TITLE
fixed getting started links in FAQ

### DIFF
--- a/doc/faq/getting-started.md
+++ b/doc/faq/getting-started.md
@@ -2,10 +2,10 @@
 
 ## How to I install and run a simple grammar?
 
-See [Getting Started with ANTLR v4](https://raw.githubusercontent.com/antlr/antlr4/master/doc/getting-started.md).
+See [Getting Started with ANTLR v4](../getting-started.md).
 
 ## Why does my parser test program hang?
 
 Your test program is likely not hanging but simply waiting for you to type some input for standard input. Don't forget that you need to type the end of file character, generally on a line by itself, at the end of the input. On a Mac or Linux machine it is ctrl-D, as gawd intended, or ctrl-Z on a Windows machine.
 
-See [Getting Started with ANTLR v4](https://raw.githubusercontent.com/antlr/antlr4/master/doc/getting-started.md).
+See [Getting Started with ANTLR v4](../getting-started.md).


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->