### PR TITLE
Make channelNames and modeNames final

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -218,3 +218,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/03/13, base698, Justin Thomas, justin.thomas1@gmail.com
 2019/03/18, carlodri, Carlo Dri, carlo.dri@gmail.com
 2019/05/02, askingalot, Andy Collins, askingalot@gmail.com
+2019/07/07, Fokko, Fokko Driesprong, fokko@apache.org

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -915,11 +915,11 @@ public class <lexer.name> extends <superClass; null="Lexer"> {
 	public static final int
 		<rest(lexer.modes):{m | <m>=<i>}; separator=", ", wrap, anchor>;
 	<endif>
-	public static String[] channelNames = {
+	public static final String[] channelNames = {
 		"DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels:{c| "<c>"}; separator=", ", wrap, anchor><endif>
 	};
 
-	public static String[] modeNames = {
+	public static final String[] modeNames = {
 		<lexer.modes:{m| "<m>"}; separator=", ", wrap, anchor>
 	};
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

Spotbugs is complaining that the `channelNames` and `modeNames` should be final.