### PR TITLE
getText performance improvement by making UTF32Converter thread_local instead of local.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -218,3 +218,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/03/13, base698, Justin Thomas, justin.thomas1@gmail.com
 2019/03/18, carlodri, Carlo Dri, carlo.dri@gmail.com
 2019/05/02, askingalot, Andy Collins, askingalot@gmail.com
+2019/07/11, olowo726, Olof Wolgast, olof@baah.se

--- a/runtime/Cpp/runtime/src/support/StringUtils.h
+++ b/runtime/Cpp/runtime/src/support/StringUtils.h
@@ -22,7 +22,7 @@ namespace antlrcpp {
   inline std::string utf32_to_utf8(T const& data)
   {
     // Don't make the converter static or we have to serialize access to it.
-    UTF32Converter converter;
+    thread_local UTF32Converter converter;
 
     #if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
       auto p = reinterpret_cast<const int32_t *>(data.data());
@@ -34,7 +34,7 @@ namespace antlrcpp {
 
   inline UTF32String utf8_to_utf32(const char* first, const char* last)
   {
-    UTF32Converter converter;
+    thread_local UTF32Converter converter;
 
     #if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
       auto r = converter.from_bytes(first, last);


### PR DESCRIPTION
This is the result of https://github.com/antlr/antlr4/issues/2556