### PR TITLE
Various Travis configuration updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   include:
     - os: linux
       compiler: clang
-      jdk: openjdk7
+      jdk: openjdk10
       env:
         - TARGET=cpp
         - CXX=g++-5
@@ -37,7 +37,7 @@ matrix:
             - clang-3.7
     - os: linux
       compiler: clang
-      jdk: openjdk7
+      jdk: openjdk10
       env:
         - TARGET=cpp
         - CXX=g++-5
@@ -54,7 +54,7 @@ matrix:
             - clang-3.7
     - os: linux
       compiler: clang
-      jdk: openjdk7
+      jdk: openjdk10
       env:
         - TARGET=cpp
         - CXX=g++-5
@@ -137,48 +137,48 @@ matrix:
         - GROUP=RECURSION
       stage: extended-test
     - os: linux
-      jdk: openjdk7
+      jdk: openjdk10
       env: TARGET=java
       stage: extended-test
     - os: linux
-      jdk: openjdk8
+      jdk: openjdk11
       env: TARGET=java
       stage: extended-test
     - os: linux
-      jdk: oraclejdk8
+      jdk: oraclejdk11
       env: TARGET=java
       stage: smoke-test
     - os: linux
-      jdk: openjdk7
+      jdk: openjdk10
       env: TARGET=csharp
       stage: main-test
     - os: linux
-      jdk: oraclejdk8
+      jdk: oraclejdk11
       dist: trusty
       env:
         - TARGET=dotnet
         - GROUP=LEXER
       stage: extended-test
     - os: linux
-      jdk: openjdk8
+      jdk: openjdk11
       dist: trusty
       env:
         - TARGET=dotnet
         - GROUP=PARSER
       stage: extended-test
     - os: linux
-      jdk: oraclejdk8
+      jdk: oraclejdk11
       dist: trusty
       env:
         - TARGET=dotnet
         - GROUP=RECURSION
       stage: extended-test
     - os: linux
-      jdk: openjdk7
+      jdk: openjdk10
       env: TARGET=python2
       stage: main-test
     - os: linux
-      jdk: openjdk7
+      jdk: openjdk10
       env: TARGET=python3
       addons:
         apt:
@@ -189,12 +189,12 @@ matrix:
       stage: main-test
     - os: linux
       dist: trusty
-      jdk: openjdk8
+      jdk: openjdk11
       env: TARGET=javascript
       stage: main-test
     - os: linux
       dist: trusty
-      jdk: openjdk8
+      jdk: openjdk11
       env: TARGET=go
       stage: main-test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ stages:
 matrix:
   include:
     - os: linux
+      dist: trusty
       compiler: clang
       jdk: openjdk10
       env:
@@ -36,6 +37,7 @@ matrix:
             - uuid-dev
             - clang-3.7
     - os: linux
+      dist: trusty
       compiler: clang
       jdk: openjdk10
       env:
@@ -53,6 +55,7 @@ matrix:
             - uuid-dev
             - clang-3.7
     - os: linux
+      dist: trusty
       compiler: clang
       jdk: openjdk10
       env:

--- a/.travis/before-install-linux-cpp.sh
+++ b/.travis/before-install-linux-cpp.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt-get update -qq

--- a/.travis/before-install-linux-csharp.sh
+++ b/.travis/before-install-linux-csharp.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb http://download.mono-project.com/repo/debian xenial main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
 sudo apt-get update -qq
-echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.12.1 main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
 sudo apt-get install -qq mono-complete

--- a/.travis/before-install-linux-go.sh
+++ b/.travis/before-install-linux-go.sh
@@ -2,7 +2,5 @@
 
 set -euo pipefail
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt-get update -qq
 eval "$(sudo gimme 1.7.3)"
 ( go version ; go env ) || true

--- a/.travis/before-install-linux-java.sh
+++ b/.travis/before-install-linux-java.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt-get update -qq

--- a/.travis/before-install-linux-javascript.sh
+++ b/.travis/before-install-linux-javascript.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 sudo apt-get update -qq
 curl -sL https://deb.nodesource.com/setup_0.12 | sudo -E bash -
 sudo apt-get install -qq nodejs

--- a/.travis/before-install-linux-python2.sh
+++ b/.travis/before-install-linux-python2.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt-get update -qq
-python --version

--- a/.travis/before-install-linux-python3.sh
+++ b/.travis/before-install-linux-python3.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-python3 --version

--- a/.travis/run-tests-python2.sh
+++ b/.travis/run-tests-python2.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+python --version
+
 mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=python2.* test
 
 cd ../runtime/Python2/tests

--- a/.travis/run-tests-python3.sh
+++ b/.travis/run-tests-python3.sh
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
+python3 --version
+
 mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=python3.* test
 
 cd ../runtime/Python3/test
 
-python3.6 run.py
+python3 run.py


### PR DESCRIPTION
Replace all the JDK versions used on Travis, since Travis and Oracle have EOL'd the previous versions.

    openjdk7 -> openjdk10
    openjdk8 -> openjdk11
    oraclejdk8 -> oraclejdk11

Change the Linux C# tests on Travis to use the current version of Mono (5.20.1.19 at the moment) instead of an ancient snapshot (3.12.1) that no longer exists.  This also means that the Mono build will match the Travis worker (running xenial) instead of being a version built for wheezy.

Change the Linux C++ tests on Travis to use Trusty.  This is what we've been using historically, but Travis switched the default Linux to Xenial in May 2019.  Put it back to Trusty, because the build currently doesn't work on Xenial at the moment :-(

Remove .travis/before-install-linux-{cpp,java,python2,python3}.sh, and remove some lines from before-install-linux-{javascript,go}.sh.  These contained apt commands for configuring the Mono project's GPG key, which is not used in any of these builds, and pointless apt-get update calls.