### PR TITLE
Remove unnecessary Travis files.

### DIFF
--- a/.travis/before-install-linux-cpp.sh
+++ b/.travis/before-install-linux-cpp.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt-get update -qq

--- a/.travis/before-install-linux-go.sh
+++ b/.travis/before-install-linux-go.sh
@@ -2,7 +2,5 @@
 
 set -euo pipefail
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt-get update -qq
 eval "$(sudo gimme 1.7.3)"
 ( go version ; go env ) || true

--- a/.travis/before-install-linux-java.sh
+++ b/.travis/before-install-linux-java.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt-get update -qq

--- a/.travis/before-install-linux-javascript.sh
+++ b/.travis/before-install-linux-javascript.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 sudo apt-get update -qq
 curl -sL https://deb.nodesource.com/setup_0.12 | sudo -E bash -
 sudo apt-get install -qq nodejs

--- a/.travis/before-install-linux-python2.sh
+++ b/.travis/before-install-linux-python2.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-sudo apt-get update -qq
-python --version

--- a/.travis/before-install-linux-python3.sh
+++ b/.travis/before-install-linux-python3.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-python3 --version

--- a/.travis/run-tests-python2.sh
+++ b/.travis/run-tests-python2.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+python --version
+
 mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=python2.* test
 
 cd ../runtime/Python2/tests

--- a/.travis/run-tests-python3.sh
+++ b/.travis/run-tests-python3.sh
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
+python3 --version
+
 mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=python3.* test
 
 cd ../runtime/Python3/test
 
-python3.6 run.py
+python3 run.py


### PR DESCRIPTION
Remove .travis/before-install-linux-{cpp,java,python2,python3}.sh, and
remove some lines from before-install-linux-{javascript,go}.sh.

These contained apt commands for configuring the Mono project's GPG key,
which is not used in any of these builds, and pointless apt-get update
calls.
