### PR TITLE
[Swift] Check process exit status during tests.

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/BaseSwiftTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/BaseSwiftTest.java
@@ -57,12 +57,23 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 			throw new RuntimeException("Swift runtime file not found at:" + swiftRuntime.getPath());
 		}
 		ANTLR_RUNTIME_PATH = swiftRuntime.getPath();
-		fastFailRunProcess(ANTLR_RUNTIME_PATH, SWIFT_CMD, "build");
+		try {
+			fastFailRunProcess(ANTLR_RUNTIME_PATH, SWIFT_CMD, "build");
+		}
+		catch (IOException | InterruptedException e) {
+			e.printStackTrace();
+			throw new RuntimeException(e);
+		}
 
 		// shutdown logic
 		Runtime.getRuntime().addShutdownHook(new Thread() {
 			public void run() {
-				fastFailRunProcess(ANTLR_RUNTIME_PATH, SWIFT_CMD, "package", "clean");
+				try {
+					fastFailRunProcess(ANTLR_RUNTIME_PATH, SWIFT_CMD, "package", "clean");
+				}
+				catch (IOException | InterruptedException e) {
+					e.printStackTrace();
+				}
 			}
 		});
 	}
@@ -145,8 +156,14 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 
 		String projectName = "testcase-" + System.currentTimeMillis();
 		String projectDir = getTmpDir() + "/" + projectName;
-		buildProject(projectDir, projectName);
-		return execTest(projectDir, projectName);
+		try {
+			buildProject(projectDir, projectName);
+			return execTest(projectDir, projectName);
+		}
+		catch (IOException | InterruptedException e) {
+			e.printStackTrace();
+			return null;
+		}
 	}
 
 	@Override
@@ -183,7 +200,7 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 		Collections.addAll(this.sourceFiles, files);
 	}
 
-	private void buildProject(String projectDir, String projectName) {
+	private void buildProject(String projectDir, String projectName) throws IOException, InterruptedException {
 		mkdir(projectDir);
 		fastFailRunProcess(projectDir, SWIFT_CMD, "package", "init", "--type", "executable");
 		for (String sourceFile: sourceFiles) {
@@ -191,20 +208,16 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 			fastFailRunProcess(getTmpDir(), "mv", "-f", absPath, projectDir + "/Sources/" + projectName);
 		}
 		fastFailRunProcess(getTmpDir(), "mv", "-f", "input", projectDir);
-
-		try {
-			String dylibPath = ANTLR_RUNTIME_PATH + "/.build/debug/";
-			Pair<String, String> buildResult = runProcess(projectDir, SWIFT_CMD, "build",
-					"-Xswiftc", "-I"+dylibPath,
-					"-Xlinker", "-L"+dylibPath,
-					"-Xlinker", "-lAntlr4",
-					"-Xlinker", "-rpath",
-					"-Xlinker", dylibPath);
-			if (buildResult.b.length() > 0) {
-				throw new RuntimeException("unit test build failed: " + buildResult.a + "\n" + buildResult.b);
-			}
-		} catch (IOException | InterruptedException e) {
-			e.printStackTrace();
+		String dylibPath = ANTLR_RUNTIME_PATH + "/.build/debug/";
+//		System.err.println(dylibPath);
+		Pair<String, String> buildResult = runProcess(projectDir, SWIFT_CMD, "build",
+				"-Xswiftc", "-I"+dylibPath,
+				"-Xlinker", "-L"+dylibPath,
+				"-Xlinker", "-lAntlr4",
+				"-Xlinker", "-rpath",
+				"-Xlinker", dylibPath);
+		if (buildResult.b.length() > 0) {
+			throw new IOException("unit test build failed: " + buildResult.a + "\n" + buildResult.b);
 		}
 	}
 
@@ -214,20 +227,22 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 		StreamVacuum stderrVacuum = new StreamVacuum(process.getErrorStream());
 		stdoutVacuum.start();
 		stderrVacuum.start();
-		process.waitFor();
+		int status = process.waitFor();
 		stdoutVacuum.join();
 		stderrVacuum.join();
+		if (status != 0) {
+			throw new IOException("Process exited with status " + status + ":\n" + stdoutVacuum.toString() + "\n" + stderrVacuum.toString());
+		}
 		return new Pair<>(stdoutVacuum.toString(), stderrVacuum.toString());
 	}
 
-	private static void fastFailRunProcess(String workingDir, String... command) {
+	private static void fastFailRunProcess(String workingDir, String... command) throws IOException, InterruptedException {
 		ProcessBuilder builder = new ProcessBuilder(command);
 		builder.directory(new File(workingDir));
-		try {
-			Process p = builder.start();
-			p.waitFor();
-		} catch (Exception e) {
-			e.printStackTrace();
+		Process p = builder.start();
+		int status = p.waitFor();
+		if (status != 0) {
+			throw new IOException("Process exited with status " + status);
 		}
 	}
 
@@ -251,8 +266,14 @@ public class BaseSwiftTest implements RuntimeTestSupport {
 		addSourceFiles("main.swift");
 		String projectName = "testcase-" + System.currentTimeMillis();
 		String projectDir = getTmpDir() + "/" + projectName;
-		buildProject(projectDir, projectName);
-		return execTest(projectDir, projectName);
+		try {
+			buildProject(projectDir, projectName);
+			return execTest(projectDir, projectName);
+		}
+		catch (IOException | InterruptedException e) {
+			e.printStackTrace();
+			return null;
+		}
 	}
 
 	private void writeParserTestFile(String parserName,


### PR DESCRIPTION
Check the exit status of the processes run during the runtime-testsuite
for Swift.  This means that we'll catch low-level issues earlier.

This changeset also changes the exception handling so that exceptions
throw as far up as possible so that we don't proceed with a test when
something has already broken.
