### PR TITLE
[Java] Check for thread interrupt status in potentially exponential codepaths

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -221,3 +221,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/07/11, olowo726, Olof Wolgast, olof@baah.se
 2019/07/16, abhijithneilabraham, Abhijith Neil Abraham, abhijithneilabrahampk@gmail.com
 2019/07/26, Braavos96, Eric Hettiaratchi, erichettiaratchi@gmail.com
+2019/07/26, ryanpbrewster, Ryan Brewster, ryanpbrewster@google.com

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ArrayPredictionContext.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ArrayPredictionContext.java
@@ -7,6 +7,7 @@
 package org.antlr.v4.runtime.atn;
 
 import java.util.Arrays;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 
 public class ArrayPredictionContext extends PredictionContext {
 	/** Parent can be null only if full ctx mode and we make an array
@@ -62,6 +63,9 @@ public class ArrayPredictionContext extends PredictionContext {
 
 	@Override
 	public boolean equals(Object o) {
+		if (Thread.interrupted()) {
+			throw new ParseCancellationException(new InterruptedException());
+		}
 		if (this == o) {
 			return true;
 		}


### PR DESCRIPTION
## Interrupting runaway parsers
Some grammars take an exponential amount of time to parse (relative to the input size).

One way to safeguard a program from these kinds of inputs is to run the parser in a separate thread and interrupt it if it's not finished after a reasonable amount of time. In Java, computations are expected to occasionally check if the thread they're running on has been interrupted. This PR adds such a check in one particularly important codepath.

Here is an example grammar that can trigger exponential runtime on inputs like `((()))`:
```
grammar Foo;
foo
    : '()'
    | '(' foo ')'
    | '(' foo ')' { notifyErrorListeners("Extra closing ')'"); } ')'
    ;
```

Here is an example of a program that defensively runs the parser in a separate thread and interrupts it after 5 seconds. I have checked that the current behavior does not terminate, and with the changes in this PR it does.

```
  public static void main(String[] args) throws InterruptedException {
    String input = args[0];
    Thread t = new Thread(() -> {
      FooLexer lexer = new FooLexer(CharStreams.fromString(input));
      FooParser parser = new FooParser(new CommonTokenStream(lexer));
      System.out.println(parser.foo());
    });
    t.start();
    Thread.sleep(5000);
    t.interrupt();
    Thread.sleep(60000);
  }
```

## What is the parser doing that takes so long
```
	at org.antlr.v4.runtime.atn.ArrayPredictionContext.equals(ArrayPredictionContext.java:82)
	at java.base/java.util.Objects.equals(Objects.java:77)
	at java.base/java.util.Arrays.equals(Arrays.java:3186)
	at org.antlr.v4.runtime.atn.ArrayPredictionContext.equals(ArrayPredictionContext.java:82)
	at java.base/java.util.Objects.equals(Objects.java:77)
	at java.base/java.util.Arrays.equals(Arrays.java:3186)
	at org.antlr.v4.runtime.atn.ArrayPredictionContext.equals(ArrayPredictionContext.java:82)
	at java.base/java.util.Objects.equals(Objects.java:77)
	at java.base/java.util.Arrays.equals(Arrays.java:3186)
	at org.antlr.v4.runtime.atn.ArrayPredictionContext.equals(ArrayPredictionContext.java:82)
	at java.base/java.util.HashMap.getNode(HashMap.java:572)
	at java.base/java.util.HashMap.get(HashMap.java:557)
	at org.antlr.v4.runtime.atn.PredictionContextCache.get(PredictionContextCache.java:36)
	at org.antlr.v4.runtime.atn.PredictionContext.getCachedContext(PredictionContext.java:556)
	at org.antlr.v4.runtime.atn.ATNSimulator.getCachedContext(ATNSimulator.java:103)
	at org.antlr.v4.runtime.atn.ATNConfigSet.optimizeConfigs(ATNConfigSet.java:217)
	at org.antlr.v4.runtime.atn.ParserATNSimulator.addDFAState(ParserATNSimulator.java:2124)
	at org.antlr.v4.runtime.atn.ParserATNSimulator.addDFAEdge(ParserATNSimulator.java:2078)
	at org.antlr.v4.runtime.atn.ParserATNSimulator.computeTargetState(ParserATNSimulator.java:619)
	at org.antlr.v4.runtime.atn.ParserATNSimulator.execATN(ParserATNSimulator.java:454)
	at org.antlr.v4.runtime.atn.ParserATNSimulator.adaptivePredict(ParserATNSimulator.java:393)
```