### PR TITLE
Fixed TextIO compatibility with 3.6+

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -221,3 +221,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/07/11, olowo726, Olof Wolgast, olof@baah.se
 2019/07/16, abhijithneilabraham, Abhijith Neil Abraham, abhijithneilabrahampk@gmail.com
 2019/07/26, Braavos96, Eric Hettiaratchi, erichettiaratchi@gmail.com
+2019/09/10, ImanHosseini, Iman Hosseini, hosseini.iman@yahoo.com

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -51,8 +51,11 @@ ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
 # encoding: utf-8
 from antlr4 import *
 from io import StringIO
-from typing.io import TextIO
 import sys
+if sys.version_info[1] > 5:
+	from typing import TextIO
+else:
+	from typing.io import TextIO
 
 <namedActions.header>
 <parser>


### PR DESCRIPTION
Fixing this issue: https://github.com/antlr/antlr4/issues/2611 (and probably https://github.com/antlr/antlr4/issues/2193)
TextIO has moved since Python 3.6 so it should be imported considering the change for new versions.

[I have signed contributor's file: https://github.com/antlr/antlr4/pull/2612]