### PR TITLE
Remove unused macros from test templates.

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CSharp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CSharp.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "Object <s> = <v>;"
-
 AssertIsList(v) ::= "System.Collections.IList __ttt__ = <v>;" // just use static type system
 
 AssignLocal(s,v) ::= "<s> = <v>;"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%this.<n>%>
 SetMember(n,v) ::= <%this.<n> = <v>;%>
 
 AddMember(n,v) ::= <%this.<n> += <v>;%>
-
-PlusMember(v,n) ::= <%<v> + this.<n>%>
 
 MemberEquals(n,v) ::= <%this.<n> == <v>%>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Chrome.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Chrome.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "var <s> = <v>;"
-
 AssertIsList(v) ::= <<if ( !(v instanceof Array) ) {throw "value is not an array";}>>
 
 AssignLocal(s,v) ::= "<s> = <v>;"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%this.<n>%>
 SetMember(n,v) ::= <%this.<n> = <v>;%>
 
 AddMember(n,v) ::= <%this.<n> += <v>;%>
-
-PlusMember(v,n) ::= <%<v> + this.<n>%>
 
 MemberEquals(n,v) ::= <%this.<n> === <v>%>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
@@ -10,8 +10,6 @@ Cast(t,v) ::= "dynamic_cast\<<t> *>(<v>)" // Should actually use a more specific
 Append(a,b) ::= "<a> + <b>->toString()"
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "<s> = <v>"
-
 AssertIsList(v) ::= "assert(<v>.size() >= 0);" // Use a method that exists only on a list (vector actually).
 AssignLocal(s,v) ::= "<s> = <v>;"
 
@@ -21,7 +19,6 @@ InitBooleanMember(n,v) ::= "bool <n> = <v>;"
 GetMember(n) ::= "<n>"
 SetMember(n,v) ::= "<n> = <v>;"
 AddMember(n,v) ::= "<n> += <v>;"
-PlusMember(v,n) ::= "<v> + <n>"
 MemberEquals(n,v) ::= "<n> == <v>"
 ModMemberEquals(n,m,v) ::= "<n> % <m> == <v>"
 ModMemberNotEquals(n,m,v) ::= "<n> % <m> != <v>"

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Explorer.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Explorer.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "var <s> = <v>;"
-
 AssertIsList(v) ::= <<if ( !(v instanceof Array) ) {throw "value is not an array";}>>
 
 AssignLocal(s,v) ::= "<s> = <v>;"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%this.<n>%>
 SetMember(n,v) ::= <%this.<n> = <v>;%>
 
 AddMember(n,v) ::= <%this.<n> += <v>;%>
-
-PlusMember(v,n) ::= <%<v> + this.<n>%>
 
 MemberEquals(n,v) ::= <%this.<n> === <v>%>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Firefox.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Firefox.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "var <s> = <v>;"
-
 AssertIsList(v) ::= <<if ( !(v instanceof Array) ) {throw "value is not an array"}>>
 
 AssignLocal(s,v) ::= "<s> = <v>;"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%this.<n>%>
 SetMember(n,v) ::= <%this.<n> = <v>;%>
 
 AddMember(n,v) ::= <%this.<n> += <v>;%>
-
-PlusMember(v,n) ::= <%<v> + this.<n>%>
 
 MemberEquals(n,v) ::= <%this.<n> === <v>%>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + fmt.Sprint(<b>)"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s, v) ::= "var <s> = <v>"
-
 AssertIsList(v) ::= ""
 
 AssignLocal(s, v) ::= "<s> = <v>;"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%<n>%>
 SetMember(n, v) ::= <%<n> = <v>;%>
 
 AddMember(n, v) ::= <%<n> += <v>;%>
-
-PlusMember(v, n) ::= <%<v> + fmt.Sprint(<n>)%>
 
 MemberEquals(n, v) ::= <%<n> == <v>%>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Java.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Java.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "Object <s> = <v>;"
-
 AssertIsList(v) ::= "List\<?> __ttt__ = <v>;" // just use static type system
 
 AssignLocal(s,v) ::= "<s> = <v>;"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%this.<n>%>
 SetMember(n,v) ::= <%this.<n> = <v>;%>
 
 AddMember(n,v) ::= <%this.<n> += <v>;%>
-
-PlusMember(v,n) ::= <%<v> + this.<n>%>
 
 MemberEquals(n,v) ::= <%this.<n> == <v>%>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Node.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Node.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "var <s> = <v>;"
-
 AssertIsList(v) ::= <<if ( !(v instanceof Array) ) {throw "value is not an array";}>>
 
 AssignLocal(s,v) ::= "<s> = <v>;"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%this.<n>%>
 SetMember(n,v) ::= <%this.<n> = <v>;%>
 
 AddMember(n,v) ::= <%this.<n> += <v>;%>
-
-PlusMember(v,n) ::= <%<v> + this.<n>%>
 
 MemberEquals(n,v) ::= <%this.<n> === <v>%>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python2.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python2.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + str(<b>)"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "<s> = <v>"
-
 AssertIsList(v) ::= "assert isinstance(v, (list, tuple))"
 
 AssignLocal(s,v) ::= "<s> = <v>"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%self.<n>%>
 SetMember(n,v) ::= <%self.<n> = <v>%>
 
 AddMember(n,v) ::= <%self.<n> += <v>%>
-
-PlusMember(v,n) ::= <%<v> + str(self.<n>)%>
 
 MemberEquals(n,v) ::= <%self.<n> == <v>%>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python3.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python3.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + str(<b>)"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "<s> = <v>"
-
 AssertIsList(v) ::= "assert isinstance(v, (list, tuple))"
 
 AssignLocal(s,v) ::= "<s> = <v>"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%self.<n>%>
 SetMember(n,v) ::= <%self.<n> = <v>%>
 
 AddMember(n,v) ::= <%self.<n> += <v>%>
-
-PlusMember(v,n) ::= <%<v> + str(self.<n>)%>
 
 MemberEquals(n,v) ::= <%self.<n> == <v>%>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Safari.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Safari.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "var <s> = <v>;"
-
 AssertIsList(v) ::= <<if ( !(v instanceof Array) ) {throw "value is not an array";}>>
 
 AssignLocal(s,v) ::= "<s> = <v>;"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%this.<n>%>
 SetMember(n,v) ::= <%this.<n> = <v>;%>
 
 AddMember(n,v) ::= <%this.<n> += <v>;%>
-
-PlusMember(v,n) ::= <%<v> + this.<n>%>
 
 MemberEquals(n,v) ::= <%this.<n> === <v>%>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
@@ -16,8 +16,6 @@ Append(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-DeclareLocal(s,v) ::= "var <s> = <v>"
-
 AssertIsList(v) ::= "var __ttt__ = <v>;" // just use static type system
 
 AssignLocal(s,v) ::= "<s> = <v>"
@@ -31,8 +29,6 @@ GetMember(n) ::= <%self.<n>%>
 SetMember(n,v) ::= <%self.<n> = <v>%>
 
 AddMember(n,v) ::= <%self.<n> += <v>%>
-
-PlusMember(v,n) ::= <%<v> + self.<n>%>
 
 MemberEquals(n,v) ::= <%self.<n> == <v>%>
 


### PR DESCRIPTION
Remove unused DeclareLocal and PlusMember macros from *.test.stg.
DeclareLocal was last used in 5c5228 (June 2015) and PlusMember was
last used in 7f16fe6 (Nov 2016).
