### PR TITLE
Initial ParserInterpreter fix for Python3 target

### DIFF
--- a/runtime/Python3/src/antlr4/ParserRuleContext.py
+++ b/runtime/Python3/src/antlr4/ParserRuleContext.py
@@ -184,3 +184,6 @@ class InterpreterRuleContext(ParserRuleContext):
     def __init__(self, parent:ParserRuleContext, invokingStateNumber:int, ruleIndex:int):
         super().__init__(parent, invokingStateNumber)
         self.ruleIndex = ruleIndex
+
+    def getRuleIndex(self):
+        return self.ruleIndex

--- a/runtime/Python3/src/antlr4/Recognizer.py
+++ b/runtime/Python3/src/antlr4/Recognizer.py
@@ -69,10 +69,12 @@ class Recognizer(object):
         if ruleNames is None:
             from antlr4.error.Errors import UnsupportedOperationException
             raise UnsupportedOperationException("The current recognizer does not provide a list of rule names.")
-        result = self.ruleIndexMapCache.get(ruleNames, None)
+
+        rname_hash = str(ruleNames)
+        result = self.ruleIndexMapCache.get(rname_hash, None)
         if result is None:
-            result = zip( ruleNames, range(0, len(ruleNames)))
-            self.ruleIndexMapCache[ruleNames] = result
+            result = dict(zip( ruleNames, range(0, len(ruleNames))))
+            self.ruleIndexMapCache[rname_hash] = result
         return result
 
     def getTokenType(self, tokenName:str):

--- a/runtime/Python3/src/antlr4/atn/ParserATNSimulator.py
+++ b/runtime/Python3/src/antlr4/atn/ParserATNSimulator.py
@@ -924,16 +924,17 @@ class ParserATNSimulator(ATNSimulator):
         #
         # From this, it is clear that NONE||anything==NONE.
         #
-        altToPred = [None] * (nalts + 1)
+
+        altToPred = dict()
         for c in configs:
             if c.alt in ambigAlts:
-                altToPred[c.alt] = orContext(altToPred[c.alt], c.semanticContext)
+                altToPred[c.alt] = orContext(altToPred.get(c.alt, None), c.semanticContext)
 
         nPredAlts = 0
-        for i in range(1, nalts+1):
-            if altToPred[i] is None:
+        for i in range(1, max(altToPred.keys()) + 1):
+            if altToPred.get(i, SemanticContext.NONE) is SemanticContext.NONE:
                 altToPred[i] = SemanticContext.NONE
-            elif altToPred[i] is not SemanticContext.NONE:
+            elif altToPred.get(i, SemanticContext.NONE) is not SemanticContext.NONE:
                 nPredAlts += 1
 
         # nonambig alts are null in altToPred
@@ -941,7 +942,11 @@ class ParserATNSimulator(ATNSimulator):
             altToPred = None
         if ParserATNSimulator.debug:
             print("getPredsForAmbigAlts result " + str_list(altToPred))
-        return altToPred
+
+        if altToPred:
+            return [altToPred.get(x, None) for x in range(0, max(altToPred.keys()) + 1)]
+        else:
+            return None
 
     def getPredicatePredictions(self, ambigAlts:set, altToPred:list):
         pairs = []


### PR DESCRIPTION
This is a set of initial changes in an attempt to update the ParserInterpreter in the Python3 target, however, there are still outstanding issues somewhere that are causing some of the cases in my test suite to fail, namely:

```Python traceback
$ PYTHONPATH="../antlr4/runtime/Python3/src" python3 output/test.py
........................F.F.........
======================================================================
FAIL: testLeftRecursion_interpreter (__main__.InterpreterTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "output/test.py", line 201, in testLeftRecursion_interpreter
    testInterp(self, 'testLeftRecursion', parser_mod, lexer_mod, "s", "a+a", "(s (e (e a) + (e a)))")
  File "output/test.py", line 27, in testInterp
    who.assertEqual(tree.toStringTree(parser_mod.T.ruleNames), expect)
AssertionError: '(s (e a + (e a)))' != '(s (e (e a) + (e a)))'
- (s (e a + (e a)))
+ (s (e (e a) + (e a)))


======================================================================
FAIL: testLeftRecursiveStartRule_interpreter (__main__.InterpreterTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "output/test.py", line 219, in testLeftRecursiveStartRule_interpreter
    testInterp(self, 'testLeftRecursiveStartRule', parser_mod, lexer_mod, "e", "a+a", "(e (e a) + (e a))")
  File "output/test.py", line 27, in testInterp
    who.assertEqual(tree.toStringTree(parser_mod.T.ruleNames), expect)
AssertionError: '(e a + (e a))' != '(e (e a) + (e a))'
- (e a + (e a))
+ (e (e a) + (e a))


----------------------------------------------------------------------
Ran 36 tests in 0.072s

FAILED (failures=2)
```

I am proposing this push request in hope that I can get an initial review and maybe some help on completing the behavior of this module.
[Here's a little test suite](https://github.com/JohnnyonFlame/antlr4/files/3580407/ParserInterpreterTestSuite.zip) automatically generated from "_tool-testsuite/test/org/antlr/v4/test/tool/TestParserInterpreter.java_", don't mind the code there too much, it's only meant to enable me to tdd with a known set of working examples and known possible regressions.
