### PR TITLE
lexer declarations and constructor extension

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -1564,6 +1564,10 @@ func New<lexer.name>(input antlr.CharStream) *<lexer.name> {
 	l.LiteralNames = staticData.LiteralNames
 	l.SymbolicNames = staticData.SymbolicNames
 	l.GrammarFileName = "<lexer.grammarFileName>"
+	<if(namedActions.structconstruction)>
+	// Grammar author supplied struct members construction code.
+	<namedActions.structconstruction>
+	<endif>
 	// TODO: l.EOF = antlr.TokenEOF
 
 	return l


### PR DESCRIPTION
Having `@lexer::members` support for Go target is not enough. Just like C++, Go needs `@lexer::declarations` to add needed fields into a lexer and I also added `@lexer::construction` block (I don't know how you call it in ANTLR4) to extend `New<Gramman Name>Lexer` constructor code.

This is how I used this:

```
...

@lexer::declarations {
    comments map[int]map[int]string // This adds a new field "comments"
}

@lexer::construction {
    l.comments = map[int]map[int]string{} // This inits "comments" field in the constructor
}

...
```