### PR TITLE
Fix javascript parser cache performance issue

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -228,3 +228,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/10, marcospassos, Marcos Passos, marcospassos.com@gmail.com
 2019/09/10, amorimjuliana, Juliana Amorim, juu.amorim@gmail.com
 2019/09/17, kaz, Kazuki Sawada, kazuki@6715.jp
+2019/09/28, lmy269, Mingyang Liu, lmy040758@gmail.com

--- a/runtime/JavaScript/src/antlr4/PredictionContext.js
+++ b/runtime/JavaScript/src/antlr4/PredictionContext.js
@@ -660,13 +660,13 @@ function getCachedPredictionContext(context, contextCache, visited) {
 	if (context.isEmpty()) {
 		return context;
 	}
-	var existing = visited[context.hashCode()] || null;
+	var existing = visited.get(context) || null;
 	if (existing !== null) {
 		return existing;
 	}
 	existing = contextCache.get(context);
 	if (existing !== null) {
-		visited[context.hashCode()] = existing;
+		visited.put(context, existing);
 		return existing;
 	}
 	var changed = false;
@@ -686,7 +686,7 @@ function getCachedPredictionContext(context, contextCache, visited) {
 	}
 	if (!changed) {
 		contextCache.add(context);
-		visited[context.hashCode()] = context;
+		visited.put(context, context);
 		return context;
 	}
 	var updated = null;
@@ -699,8 +699,8 @@ function getCachedPredictionContext(context, contextCache, visited) {
 		updated = new ArrayPredictionContext(parents, context.returnStates);
 	}
 	contextCache.add(updated);
-	visited[updated.hashCode()] = updated;
-	visited[context.hashCode()] = updated;
+	visited.put(updated, updated);
+	visited.put(context, updated);
 
 	return updated;
 }

--- a/runtime/JavaScript/src/antlr4/PredictionContext.js
+++ b/runtime/JavaScript/src/antlr4/PredictionContext.js
@@ -79,7 +79,7 @@ function calculateHashString(parent, returnState) {
 // can be used for both lexers and parsers.
 
 function PredictionContextCache() {
-	this.cache = new Map();
+	this.cache = {};
 	return this;
 }
 
@@ -91,16 +91,16 @@ PredictionContextCache.prototype.add = function(ctx) {
 	if (ctx === PredictionContext.EMPTY) {
 		return PredictionContext.EMPTY;
 	}
-	var existing = this.cache.get(ctx) || null;
+	var existing = this.cache[ctx] || null;
 	if (existing !== null) {
 		return existing;
 	}
-	this.cache.set(ctx, ctx);
+	this.cache[ctx] = ctx;
 	return ctx;
 };
 
 PredictionContextCache.prototype.get = function(ctx) {
-	return this.cache.get(ctx) || null;
+	return this.cache[ctx] || null;
 };
 
 Object.defineProperty(PredictionContextCache.prototype, "length", {
@@ -642,16 +642,16 @@ function mergeArrays(a, b, rootIsWildcard, mergeCache) {
 // ones.
 // /
 function combineCommonParents(parents) {
-	var uniqueParents = new Map();
+	var uniqueParents = {};
 
 	for (var p = 0; p < parents.length; p++) {
 		var parent = parents[p];
-		if (!uniqueParents.get(parent)) {
-			uniqueParents.set(parent, parent);
+		if (!(parent in uniqueParents)) {
+			uniqueParents[parent] = parent;
 		}
 	}
 	for (var q = 0; q < parents.length; q++) {
-		parents[q] = uniqueParents.get(parents[q]);
+		parents[q] = uniqueParents[parents[q]];
 	}
 }
 
@@ -659,13 +659,13 @@ function getCachedPredictionContext(context, contextCache, visited) {
 	if (context.isEmpty()) {
 		return context;
 	}
-	var existing = visited.get(context) || null;
+	var existing = visited[context] || null;
 	if (existing !== null) {
 		return existing;
 	}
 	existing = contextCache.get(context);
 	if (existing !== null) {
-		visited.set(context, existing);
+		visited[context] = existing;
 		return existing;
 	}
 	var changed = false;
@@ -685,7 +685,7 @@ function getCachedPredictionContext(context, contextCache, visited) {
 	}
 	if (!changed) {
 		contextCache.add(context);
-		visited.set(context, context);
+		visited[context] = context;
 		return context;
 	}
 	var updated = null;
@@ -698,8 +698,8 @@ function getCachedPredictionContext(context, contextCache, visited) {
 		updated = new ArrayPredictionContext(parents, context.returnStates);
 	}
 	contextCache.add(updated);
-	visited.set(updated, updated);
-	visited.set(context, updated);
+	visited[updated] = updated;
+	visited[context] = updated;
 
 	return updated;
 }
@@ -710,13 +710,13 @@ function getAllContextNodes(context, nodes, visited) {
 		nodes = [];
 		return getAllContextNodes(context, nodes, visited);
 	} else if (visited === null) {
-		visited = new Map();
+		visited = {};
 		return getAllContextNodes(context, nodes, visited);
 	} else {
-		if (context === null || visited.get(context) !== null) {
+		if (context === null || visited[context] !== null) {
 			return nodes;
 		}
-		visited.set(context, context);
+		visited[context] = context;
 		nodes.push(context);
 		for (var i = 0; i < context.length; i++) {
 			getAllContextNodes(context.getParent(i), nodes, visited);

--- a/runtime/JavaScript/src/antlr4/Utils.js
+++ b/runtime/JavaScript/src/antlr4/Utils.js
@@ -323,7 +323,9 @@ AltDict.prototype.values = function () {
     });
 };
 
-function DoubleDict() {
+function DoubleDict(defaultMapCtor) {
+    this.defaultMapCtor = defaultMapCtor || Map;
+    this.cacheMap = new this.defaultMapCtor();
     return this;
 }
 
@@ -389,17 +391,17 @@ function hashStuff() {
 }
 
 DoubleDict.prototype.get = function (a, b) {
-    var d = this[a.hashCode()] || null;
-    return d === null ? null : (d[b.hashCode()] || null);
+    var d = this.cacheMap.get(a) || null;
+    return d === null ? null : (d.get(b) || null);
 };
 
 DoubleDict.prototype.set = function (a, b, o) {
-    var d = this[a.hashCode()] || null;
+    var d = this.cacheMap.get(a) || null;
     if (d === null) {
-        d = {};
-        this[a.hashCode()] = d;
+        d = new this.defaultMapCtor();
+        this.cacheMap.put(a, d);
     }
-    d[b.hashCode()] = o;
+    d.put(b, o);
 };
 
 

--- a/runtime/JavaScript/src/antlr4/Utils.js
+++ b/runtime/JavaScript/src/antlr4/Utils.js
@@ -197,14 +197,14 @@ BitSet.prototype.toString = function () {
     return "{" + this.values().join(", ") + "}";
 };
 
-function Dictionary(hashFunction, equalsFunction) {
+function Map(hashFunction, equalsFunction) {
     this.data = {};
     this.hashFunction = hashFunction || standardHashCodeFunction;
     this.equalsFunction = equalsFunction || standardEqualsFunction;
     return this;
 }
 
-Object.defineProperty(Dictionary.prototype, "length", {
+Object.defineProperty(Map.prototype, "length", {
     get: function () {
         var l = 0;
         for (var hashKey in this.data) {
@@ -216,7 +216,7 @@ Object.defineProperty(Dictionary.prototype, "length", {
     }
 });
 
-Dictionary.prototype.put = function (key, value) {
+Map.prototype.put = function (key, value) {
     var hashKey = "hash_" + this.hashFunction(key);
     if (hashKey in this.data) {
         var entries = this.data[hashKey];
@@ -236,7 +236,7 @@ Dictionary.prototype.put = function (key, value) {
     }
 };
 
-Dictionary.prototype.containsKey = function (key) {
+Map.prototype.containsKey = function (key) {
     var hashKey = "hash_" + this.hashFunction(key);
     if(hashKey in this.data) {
         var entries = this.data[hashKey];
@@ -249,7 +249,7 @@ Dictionary.prototype.containsKey = function (key) {
     return false;
 };
 
-Dictionary.prototype.get = function (key) {
+Map.prototype.get = function (key) {
     var hashKey = "hash_" + this.hashFunction(key);
     if(hashKey in this.data) {
         var entries = this.data[hashKey];
@@ -262,7 +262,7 @@ Dictionary.prototype.get = function (key) {
     return null;
 };
 
-Dictionary.prototype.entries = function () {
+Map.prototype.entries = function () {
     var l = [];
     for (var key in this.data) {
         if (key.indexOf("hash_") === 0) {
@@ -273,21 +273,21 @@ Dictionary.prototype.entries = function () {
 };
 
 
-Dictionary.prototype.getKeys = function () {
+Map.prototype.getKeys = function () {
     return this.entries().map(function(e) {
         return e.key;
     });
 };
 
 
-Dictionary.prototype.getValues = function () {
+Map.prototype.getValues = function () {
     return this.entries().map(function(e) {
             return e.value;
     });
 };
 
 
-Dictionary.prototype.toString = function () {
+Map.prototype.toString = function () {
     var ss = this.entries().map(function(entry) {
         return '{' + entry.key + ':' + entry.value + '}';
     });
@@ -324,7 +324,6 @@ AltDict.prototype.values = function () {
 };
 
 function DoubleDict() {
-    this['doubleDictMap'] = this['doubleDictMap'] || new Map();
     return this;
 }
 
@@ -390,17 +389,17 @@ function hashStuff() {
 }
 
 DoubleDict.prototype.get = function (a, b) {
-    var d = this['doubleDictMap'].get(a) || null;
-    return d === null ? null : (d.get(b) || null);
+    var d = this[a] || null;
+    return d === null ? null : (d[b] || null);
 };
 
 DoubleDict.prototype.set = function (a, b, o) {
-    var d = this['doubleDictMap'].get(a) || null;
+    var d = this[a] || null;
     if (d === null) {
-        d = new Map();
-        this['doubleDictMap'].set(a, d);
+        d = {};
+        this[a] = d;
     }
-    d.set(b, o);
+    d[b] = o;
 };
 
 
@@ -439,7 +438,7 @@ function equalArrays(a, b)
 
 exports.Hash = Hash;
 exports.Set = Set;
-exports.Dictionary = Dictionary;
+exports.Map = Map;
 exports.BitSet = BitSet;
 exports.AltDict = AltDict;
 exports.DoubleDict = DoubleDict;

--- a/runtime/JavaScript/src/antlr4/Utils.js
+++ b/runtime/JavaScript/src/antlr4/Utils.js
@@ -197,14 +197,14 @@ BitSet.prototype.toString = function () {
     return "{" + this.values().join(", ") + "}";
 };
 
-function Map(hashFunction, equalsFunction) {
+function Dictionary(hashFunction, equalsFunction) {
     this.data = {};
     this.hashFunction = hashFunction || standardHashCodeFunction;
     this.equalsFunction = equalsFunction || standardEqualsFunction;
     return this;
 }
 
-Object.defineProperty(Map.prototype, "length", {
+Object.defineProperty(Dictionary.prototype, "length", {
     get: function () {
         var l = 0;
         for (var hashKey in this.data) {
@@ -216,7 +216,7 @@ Object.defineProperty(Map.prototype, "length", {
     }
 });
 
-Map.prototype.put = function (key, value) {
+Dictionary.prototype.put = function (key, value) {
     var hashKey = "hash_" + this.hashFunction(key);
     if (hashKey in this.data) {
         var entries = this.data[hashKey];
@@ -236,7 +236,7 @@ Map.prototype.put = function (key, value) {
     }
 };
 
-Map.prototype.containsKey = function (key) {
+Dictionary.prototype.containsKey = function (key) {
     var hashKey = "hash_" + this.hashFunction(key);
     if(hashKey in this.data) {
         var entries = this.data[hashKey];
@@ -249,7 +249,7 @@ Map.prototype.containsKey = function (key) {
     return false;
 };
 
-Map.prototype.get = function (key) {
+Dictionary.prototype.get = function (key) {
     var hashKey = "hash_" + this.hashFunction(key);
     if(hashKey in this.data) {
         var entries = this.data[hashKey];
@@ -262,7 +262,7 @@ Map.prototype.get = function (key) {
     return null;
 };
 
-Map.prototype.entries = function () {
+Dictionary.prototype.entries = function () {
     var l = [];
     for (var key in this.data) {
         if (key.indexOf("hash_") === 0) {
@@ -273,21 +273,21 @@ Map.prototype.entries = function () {
 };
 
 
-Map.prototype.getKeys = function () {
+Dictionary.prototype.getKeys = function () {
     return this.entries().map(function(e) {
         return e.key;
     });
 };
 
 
-Map.prototype.getValues = function () {
+Dictionary.prototype.getValues = function () {
     return this.entries().map(function(e) {
             return e.value;
     });
 };
 
 
-Map.prototype.toString = function () {
+Dictionary.prototype.toString = function () {
     var ss = this.entries().map(function(entry) {
         return '{' + entry.key + ':' + entry.value + '}';
     });
@@ -324,6 +324,7 @@ AltDict.prototype.values = function () {
 };
 
 function DoubleDict() {
+    this['doubleDictMap'] = this['doubleDictMap'] || new Map();
     return this;
 }
 
@@ -389,17 +390,17 @@ function hashStuff() {
 }
 
 DoubleDict.prototype.get = function (a, b) {
-    var d = this[a] || null;
-    return d === null ? null : (d[b] || null);
+    var d = this['doubleDictMap'].get(a) || null;
+    return d === null ? null : (d.get(b) || null);
 };
 
 DoubleDict.prototype.set = function (a, b, o) {
-    var d = this[a] || null;
+    var d = this['doubleDictMap'].get(a) || null;
     if (d === null) {
-        d = {};
-        this[a] = d;
+        d = new Map();
+        this['doubleDictMap'].set(a, d);
     }
-    d[b] = o;
+    d.set(b, o);
 };
 
 
@@ -438,7 +439,7 @@ function equalArrays(a, b)
 
 exports.Hash = Hash;
 exports.Set = Set;
-exports.Map = Map;
+exports.Dictionary = Dictionary;
 exports.BitSet = BitSet;
 exports.AltDict = AltDict;
 exports.DoubleDict = DoubleDict;

--- a/runtime/JavaScript/src/antlr4/atn/ATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNSimulator.js
@@ -8,6 +8,7 @@
 var DFAState = require('./../dfa/DFAState').DFAState;
 var ATNConfigSet = require('./ATNConfigSet').ATNConfigSet;
 var getCachedPredictionContext = require('./../PredictionContext').getCachedPredictionContext;
+var Map = require('./../Utils').Map;
 
 function ATNSimulator(atn, sharedContextCache) {
 
@@ -44,7 +45,7 @@ ATNSimulator.prototype.getCachedContext = function(context) {
     if (this.sharedContextCache ===null) {
         return context;
     }
-    var visited = {};
+    var visited = new Map();
     return getCachedPredictionContext(context, this.sharedContextCache, visited);
 };
 

--- a/runtime/JavaScript/src/antlr4/atn/ATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNSimulator.js
@@ -44,7 +44,7 @@ ATNSimulator.prototype.getCachedContext = function(context) {
     if (this.sharedContextCache ===null) {
         return context;
     }
-    var visited = {};
+    var visited = new Map();
     return getCachedPredictionContext(context, this.sharedContextCache, visited);
 };
 

--- a/runtime/JavaScript/src/antlr4/atn/ATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNSimulator.js
@@ -44,7 +44,7 @@ ATNSimulator.prototype.getCachedContext = function(context) {
     if (this.sharedContextCache ===null) {
         return context;
     }
-    var visited = new Map();
+    var visited = {};
     return getCachedPredictionContext(context, this.sharedContextCache, visited);
 };
 

--- a/runtime/JavaScript/src/antlr4/atn/PredictionMode.js
+++ b/runtime/JavaScript/src/antlr4/atn/PredictionMode.js
@@ -10,7 +10,7 @@
 // ambiguities.
 
 var Set = require('./../Utils').Set;
-var Map = require('./../Utils').Dictionary;
+var Map = require('./../Utils').Map;
 var BitSet = require('./../Utils').BitSet;
 var AltDict = require('./../Utils').AltDict;
 var ATN = require('./ATN').ATN;

--- a/runtime/JavaScript/src/antlr4/atn/PredictionMode.js
+++ b/runtime/JavaScript/src/antlr4/atn/PredictionMode.js
@@ -10,7 +10,7 @@
 // ambiguities.
 
 var Set = require('./../Utils').Set;
-var Map = require('./../Utils').Map;
+var Map = require('./../Utils').Dictionary;
 var BitSet = require('./../Utils').BitSet;
 var AltDict = require('./../Utils').AltDict;
 var ATN = require('./ATN').ATN;


### PR DESCRIPTION
Javascript parser is leveraging {} to cache the contexts. Each time when calling Get,Set, the key is converted to string first. In some cases (nested functions), the performance is very bad due to this. When it deals with simple string like "abs(abs(abs(abs(abs(abs(abs(abs(abs(1)))))))))", it takes minutes to finish. The time can easily reach to hours, as time complexity looks like to be O(2^N). 
This change is to use Map to store the real object in the key to avoid that. After this change, the time is decreased to less than 1 second to handle that string.
I believe #2468 and #2523 will also be addressed by this PR.

This's a call stack when parsing nested functions. And I saw there were huge minor GCs caused by the toString().
![callstack](https://user-images.githubusercontent.com/4523716/65818566-82c1ef00-e1c7-11e9-8834-a4a73ec39abe.png)
