### PR TITLE
Added @foo::footer to go with @foo::header in Java target

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -230,3 +230,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/10, amorimjuliana, Juliana Amorim, juu.amorim@gmail.com
 2019/09/17, kaz, Kazuki Sawada, kazuki@6715.jp
 2019/09/28, lmy269, Mingyang Liu, lmy040758@gmail.com
+2019/10/11, PuppyPi, Sean [privacy], puppyofcodez@gmail.com

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -275,6 +275,8 @@ case <f.ruleIndex>:
 
 	<atn>
 }
+
+<namedActions.footer>
 >>
 
 vocabulary(literalNames, symbolicNames) ::= <<
@@ -960,6 +962,8 @@ public class <lexer.name> extends <superClass; null="Lexer"> {
 	<dumpActions(lexer, "", actionFuncs, sempredFuncs)>
 	<atn>
 }
+
+<namedActions.footer>
 >>
 
 SerializedATN(model) ::= <<


### PR DESCRIPTION
These two lines in this one file are all that's needed to support footers as well as headers in "impure" grammars!

This is important because with footers you can include a supertype in grammar file.  You could already add a class as a static nested class in ::members already, but not a superclass since classes can't extend any of their nested classes in Java (not for any technical reason I think, just philosophical java reasons I guess)

But including (non-public) superclasses inside grammars via footers allows them to use the same package selection mechanism the generated lexer/parser classes do, instead of hardcoding the package name into a separate file :>