### PR TITLE
Made some variable names more consistent with the other parts.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -230,3 +230,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/10, amorimjuliana, Juliana Amorim, juu.amorim@gmail.com
 2019/09/17, kaz, Kazuki Sawada, kazuki@6715.jp
 2019/09/28, lmy269, Mingyang Liu, lmy040758@gmail.com
+2019/10/21, euske, Yusuke Shinyama, euske@sde.cs.titech.ac.jp

--- a/runtime/Java/src/org/antlr/v4/runtime/DiagnosticErrorListener.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/DiagnosticErrorListener.java
@@ -76,8 +76,8 @@ public class DiagnosticErrorListener extends BaseErrorListener {
 		String decision = getDecisionDescription(recognizer, dfa);
 		BitSet conflictingAlts = getConflictingAlts(ambigAlts, configs);
 		String text = recognizer.getTokenStream().getText(Interval.of(startIndex, stopIndex));
-		String message = String.format(format, decision, conflictingAlts, text);
-		recognizer.notifyErrorListeners(message);
+		String msg = String.format(format, decision, conflictingAlts, text);
+		recognizer.notifyErrorListeners(msg);
 	}
 
 	@Override
@@ -91,8 +91,8 @@ public class DiagnosticErrorListener extends BaseErrorListener {
 		String format = "reportAttemptingFullContext d=%s, input='%s'";
 		String decision = getDecisionDescription(recognizer, dfa);
 		String text = recognizer.getTokenStream().getText(Interval.of(startIndex, stopIndex));
-		String message = String.format(format, decision, text);
-		recognizer.notifyErrorListeners(message);
+		String msg = String.format(format, decision, text);
+		recognizer.notifyErrorListeners(msg);
 	}
 
 	@Override
@@ -106,8 +106,8 @@ public class DiagnosticErrorListener extends BaseErrorListener {
 		String format = "reportContextSensitivity d=%s, input='%s'";
 		String decision = getDecisionDescription(recognizer, dfa);
 		String text = recognizer.getTokenStream().getText(Interval.of(startIndex, stopIndex));
-		String message = String.format(format, decision, text);
-		recognizer.notifyErrorListeners(message);
+		String msg = String.format(format, decision, text);
+		recognizer.notifyErrorListeners(msg);
 	}
 
 	protected String getDecisionDescription(Parser recognizer, DFA dfa) {

--- a/runtime/Java/src/org/antlr/v4/runtime/misc/FlexibleHashMap.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/FlexibleHashMap.java
@@ -64,9 +64,9 @@ public class FlexibleHashMap<K,V> implements Map<K, V> {
 		this.initialBucketCapacity = initialBucketCapacity;
 	}
 
-	private static <K, V> LinkedList<Entry<K, V>>[] createEntryListArray(int length) {
+	private static <K, V> LinkedList<Entry<K, V>>[] createEntryListArray(int capacity) {
 		@SuppressWarnings("unchecked")
-		LinkedList<Entry<K, V>>[] result = (LinkedList<Entry<K, V>>[])new LinkedList<?>[length];
+		LinkedList<Entry<K, V>>[] result = (LinkedList<Entry<K, V>>[])new LinkedList<?>[capacity];
 		return result;
 	}
 

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -927,8 +927,8 @@ public class Tool {
 		info("ANTLR Parser Generator  Version " + Tool.VERSION);
 		for (Option o : optionDefs) {
 			String name = o.name + (o.argType!=OptionArgType.NONE? " ___" : "");
-			String s = String.format(" %-19s %s", name, o.description);
-			info(s);
+			String msg = String.format(" %-19s %s", name, o.description);
+			info(msg);
 		}
 	}
 

--- a/tool/src/org/antlr/v4/automata/LexerATNFactory.java
+++ b/tool/src/org/antlr/v4/automata/LexerATNFactory.java
@@ -343,10 +343,10 @@ public class LexerATNFactory extends ParserATNFactory {
 	 */
 	@Override
 	public Handle stringLiteral(TerminalAST stringLiteralAST) {
-		String chars = stringLiteralAST.getText();
+		String literal = stringLiteralAST.getText();
 		ATNState left = newState(stringLiteralAST);
 		ATNState right;
-		String s = CharSupport.getStringFromGrammarStringLiteral(chars);
+		String s = CharSupport.getStringFromGrammarStringLiteral(literal);
 		if (s == null) {
 			// the lexer will already have given an error
 			return new Handle(left, left);

--- a/tool/src/org/antlr/v4/tool/Grammar.java
+++ b/tool/src/org/antlr/v4/tool/Grammar.java
@@ -1055,16 +1055,16 @@ public class Grammar implements AttributeResolver {
 	 * @param name The channel name.
 	 * @return The constant channel value assigned to the channel.
 	 */
-	public int defineChannelName(String name, int value) {
+	public int defineChannelName(String name, int channelValue) {
 		Integer prev = channelNameToValueMap.get(name);
 		if (prev != null) {
 			return prev;
 		}
 
-		channelNameToValueMap.put(name, value);
-		setChannelNameForValue(value, name);
-		maxChannelType = Math.max(maxChannelType, value);
-		return value;
+		channelNameToValueMap.put(name, channelValue);
+		setChannelNameForValue(channelValue, name);
+		maxChannelType = Math.max(maxChannelType, channelValue);
+		return channelValue;
 	}
 
 	/**

--- a/tool/src/org/antlr/v4/tool/GrammarInterpreterRuleContext.java
+++ b/tool/src/org/antlr/v4/tool/GrammarInterpreterRuleContext.java
@@ -38,7 +38,7 @@ public class GrammarInterpreterRuleContext extends InterpreterRuleContext {
 	}
 
 	@Override
-	public void setAltNumber(int altNumber) {
-		setOuterAltNum(altNumber);
+	public void setAltNumber(int altNum) {
+		setOuterAltNum(altNum);
 	}
 }


### PR DESCRIPTION
Hello, we're developing an automated system that detects inconsistent variable names in a large software project. Our system checks if each variable name is consistent with other variables in the project in its usage pattern, and proposes correct candidates if inconsistency is detected. This is a part of academic research that we hope to publish soon, but as a part of the evaluation, we applied our systems to your projects and got a few interesting results. We carefully reviewed our system output and manually created a patch to correct a few variable names. We would be delighted if this patch is found to be useful. If you have a question or suggestion regarding this patch, we'd happily answer. Thank you.