### PR TITLE
Fix main entry point for JavaScript runtime npm package

### DIFF
--- a/runtime/JavaScript/src/antlr4/package.json
+++ b/runtime/JavaScript/src/antlr4/package.json
@@ -2,7 +2,7 @@
   "name": "antlr4",
   "version": "4.7.2",
   "description": "JavaScript runtime for ANTLR4",
-  "main": "src/antlr4/index.js",
+  "main": "index.js",
   "repository": "antlr/antlr4.git",
   "keywords": [
     "lexer",


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

The main entry point for JavaScript runtime package is not right: after publish to npm, the main field should point to index.js.

[https://unpkg.com/browse/antlr4@4.7.2/](https://unpkg.com/browse/antlr4@4.7.2/)