### PR TITLE
Fix placement of @members in Javascript target lexers

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -230,3 +230,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/10, amorimjuliana, Juliana Amorim, juu.amorim@gmail.com
 2019/09/17, kaz, Kazuki Sawada, kazuki@6715.jp
 2019/09/28, lmy269, Mingyang Liu, lmy040758@gmail.com
+2019/10/29, tehbone, Tabari Alexander, tehbone@gmail.com

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -815,6 +815,7 @@ var decisionsToDFA = atn.decisionToState.map( function(ds, index) { return new a
 function <lexer.name>(input) {
 	<if(superClass)><superClass><else>antlr4.Lexer<endif>.call(this, input);
     this._interp = new antlr4.atn.LexerATNSimulator(this, atn, decisionsToDFA, new antlr4.PredictionContextCache());
+	<namedActions.members>
     return this;
 }
 
@@ -849,8 +850,6 @@ Object.defineProperty(<lexer.name>.prototype, "atn", {
 <lexer.name>.prototype.ruleNames = [ <lexer.ruleNames:{r | "<r>"}; separator=", ", wrap, anchor> ];
 
 <lexer.name>.prototype.grammarFileName = "<lexer.grammarFileName>";
-
-<namedActions.members>
 
 <dumpActions(lexer, "", actionFuncs, sempredFuncs)>
 


### PR DESCRIPTION
When @members is used in the lexer grammar, the content gets placed in an arbitrary location that is out of scope of the generated lexer. The template was updated so the content gets placed in the constructor, allowing for the creation of class members. This is consistent with the placement of members for parser grammars in the Javascript target.