### PR TITLE
Documentation: Added Missing lexer/parermodifier clarification in example

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -231,3 +231,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/17, kaz, Kazuki Sawada, kazuki@6715.jp
 2019/09/28, lmy269, Mingyang Liu, lmy040758@gmail.com
 2019/10/31, a-square, Alexei Averchenko, lex.aver@gmail.com
+2019/11/05, listba, Ben List, ben.list89@gmail.com

--- a/doc/lexicon.md
+++ b/doc/lexicon.md
@@ -26,8 +26,8 @@ The Javadoc comments are hidden from the parser and are ignored at the moment.  
 Token names always start with a capital letter and so do lexer rules as defined by Java’s `Character.isUpperCase` method. Parser rule names always start with a lowercase letter (those that fail `Character.isUpperCase`). The initial character can be followed by uppercase and lowercase letters, digits, and underscores. Here are some sample names:
 
 ```
-ID, LPAREN, RIGHT_CURLY // token names/rules
-expr, simpleDeclarator, d2, header_file // rule names
+ID, LPAREN, RIGHT_CURLY // token names/lexer rules
+expr, simpleDeclarator, d2, header_file // parser rule names
 ```
 
 Like Java, ANTLR accepts Unicode characters in ANTLR names:


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->