### PR TITLE
Fix ExternalAntlr4Cpp.cmake to work with CMake 3.14

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -233,3 +233,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/28, lmy269, Mingyang Liu, lmy040758@gmail.com
 2019/10/31, a-square, Alexei Averchenko, lex.aver@gmail.com
 2019/11/11, foxeverl, Liu Xinfeng, liuxf1986[at]gmail[dot]com
+2019/11/17, felixn, Felix Nieuwenhuizhen, felix@tdlrali.com

--- a/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
+++ b/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
@@ -109,6 +109,12 @@ else()
 endif()
 
 # Seperate build step as rarely people want both
+set(ANTLR4_BUILD_DIR ${ANTLR4_ROOT})
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14.0")
+  # CMake 3.14 builds in above's SOURCE_SUBDIR when BUILD_IN_SOURCE is true
+  set(ANTLR4_BUILD_DIR ${ANTLR4_ROOT}/runtime/Cpp)
+endif()
+
 ExternalProject_Add_Step(
     antlr4_runtime
     build_static
@@ -118,7 +124,7 @@ ExternalProject_Add_Step(
     DEPENDS antlr4_runtime
     BYPRODUCTS ${ANTLR4_STATIC_LIBRARIES}
     EXCLUDE_FROM_MAIN 1
-    WORKING_DIRECTORY ${ANTLR4_ROOT})
+    WORKING_DIRECTORY ${ANTLR4_BUILD_DIR})
 ExternalProject_Add_StepTargets(antlr4_runtime build_static)
 
 add_library(antlr4_static STATIC IMPORTED)
@@ -135,7 +141,7 @@ ExternalProject_Add_Step(
     DEPENDS antlr4_runtime
     BYPRODUCTS ${ANTLR4_SHARED_LIBRARIES} ${ANTLR4_RUNTIME_LIBRARIES}
     EXCLUDE_FROM_MAIN 1
-    WORKING_DIRECTORY ${ANTLR4_ROOT})
+    WORKING_DIRECTORY ${ANTLR4_BUILD_DIR})
 ExternalProject_Add_StepTargets(antlr4_runtime build_shared)
 
 add_library(antlr4_shared SHARED IMPORTED)

--- a/runtime/Cpp/cmake/README.md
+++ b/runtime/Cpp/cmake/README.md
@@ -40,7 +40,8 @@ antlr_target(SampleGrammarLexer TLexer.g4 LEXER
              PACKAGE antlrcpptest)
 antlr_target(SampleGrammarParser TParser.g4 PARSER
              PACKAGE antlrcpptest
-             DEPENDS_ANTLR SampleGrammarLexer)
+             DEPENDS_ANTLR SampleGrammarLexer
+             COMPILE_FLAGS -lib ${ANTLR_SampleGrammarLexer_OUTPUT_DIR})
 
 # include generated files in project environment
 include_directories(${ANTLR_SampleGrammarLexer_OUTPUT_DIR})


### PR DESCRIPTION
CMake 3.14 introduced changes to the ExternalProject Module

> The ExternalProject module ExternalProject_Add() command learned to apply SOURCE_SUBDIR when BUILD_IN_SOURCE is also used. The BUILD_COMMAND is run in the given SOURCE_SUBDIR of the SOURCE_DIR.

https://cmake.org/cmake/help/v3.14/release/3.14.html#modules

This PR updates ExternalAntlr4Cpp.cmake to work with CMake 3.14.

Credit goes to https://github.com/empirical-soft/empirical-lang/pull/10