### PR TITLE
[Swift] Migrate Swift runtime to Swift 5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,42 +74,42 @@ matrix:
             - clang-3.7
     - os: osx
       compiler: clang
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - TARGET=cpp
         - GROUP=LEXER
       stage: extended-test
     - os: osx
       compiler: clang
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - TARGET=cpp
         - GROUP=PARSER
       stage: extended-test
     - os: osx
       compiler: clang
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - TARGET=cpp
         - GROUP=RECURSION
       stage: extended-test
     - os: osx
       compiler: clang
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - TARGET=swift
         - GROUP=LEXER
       stage: main-test
     - os: osx
       compiler: clang
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - TARGET=swift
         - GROUP=PARSER
       stage: main-test
     - os: osx
       compiler: clang
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - TARGET=swift
         - GROUP=RECURSION
@@ -122,19 +122,19 @@ matrix:
        - GROUP=ALL
       stage: extended-test
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - TARGET=dotnet
         - GROUP=LEXER
       stage: extended-test
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - TARGET=dotnet
         - GROUP=PARSER
       stage: extended-test
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:
         - TARGET=dotnet
         - GROUP=RECURSION

--- a/.travis/run-tests-swift.sh
+++ b/.travis/run-tests-swift.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # here since environment variables doesn't pass
 # across scripts
 if [ $TRAVIS_OS_NAME == "linux" ]; then
-  export SWIFT_VERSION=swift-4.2.1
+  export SWIFT_VERSION=swift-5.0.1
   export SWIFT_HOME=$(pwd)/swift/$SWIFT_VERSION-RELEASE-ubuntu16.04/usr/bin/
   export PATH=$SWIFT_HOME:$PATH
 

--- a/contributors.txt
+++ b/contributors.txt
@@ -233,3 +233,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/28, lmy269, Mingyang Liu, lmy040758@gmail.com
 2019/10/31, a-square, Alexei Averchenko, lex.aver@gmail.com
 2019/11/11, foxeverl, Liu Xinfeng, liuxf1986[at]gmail[dot]com
+2019/11/18, mlilback, Mark Lilback, mark@lilback.com

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
@@ -133,7 +133,7 @@ open func emit() -> Token  {
 private func handleAcceptPositionForIdentifier() -> Bool {
 	let tokenText = getText()
 	var identifierLength = 0
-	while ((identifierLength \< tokenText.characters.count)  &&  isIdentifierChar(tokenText[tokenText.characters.index(tokenText.startIndex, offsetBy: identifierLength)])) {
+	while ((identifierLength \< tokenText.count)  &&  isIdentifierChar(tokenText[tokenText.index(tokenText.startIndex, offsetBy: identifierLength)])) {
 		identifierLength += 1
 	}
 
@@ -147,8 +147,8 @@ private func handleAcceptPositionForIdentifier() -> Bool {
 }
 
 private func handleAcceptPositionForKeyword(_ keyword:String) -> Bool  {
-	if  getInputStream()!.index() > _tokenStartCharIndex + keyword.characters.count   {
-		let offset = keyword.characters.count  - 1
+	if getInputStream()!.index() > _tokenStartCharIndex + keyword.count {
+		let offset = keyword.count - 1
 		(getInterpreter() as! PositionAdjustingLexerATNSimulator).resetAcceptPosition(getInputStream()!, _tokenStartCharIndex + offset, _tokenStartLine, _tokenStartCharPositionInLine + offset)
 		return true
 	}

--- a/runtime/Swift/Sources/Antlr4/DiagnosticErrorListener.swift
+++ b/runtime/Swift/Sources/Antlr4/DiagnosticErrorListener.swift
@@ -101,7 +101,7 @@ public class DiagnosticErrorListener: BaseErrorListener {
         let decision: Int = dfa.decision
         let ruleIndex: Int = dfa.atnStartState.ruleIndex!
 
-        var ruleNames: [String] = recognizer.getRuleNames()
+        let ruleNames: [String] = recognizer.getRuleNames()
         if ruleIndex < 0 || ruleIndex >= ruleNames.count {
             return String(decision)
         }

--- a/runtime/Swift/Sources/Antlr4/Parser.swift
+++ b/runtime/Swift/Sources/Antlr4/Parser.swift
@@ -941,7 +941,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
     public func getRuleInvocationStack(_ p: RuleContext?) -> [String] {
         var p = p
-        var ruleNames = getRuleNames()
+        let ruleNames = getRuleNames()
         var stack = [String]()
         while let pWrap = p {
             // compute what follows who invoked us

--- a/runtime/Swift/Sources/Antlr4/UnbufferedCharStream.swift
+++ b/runtime/Swift/Sources/Antlr4/UnbufferedCharStream.swift
@@ -343,6 +343,8 @@ fileprivate struct UInt8StreamIterator: IteratorProtocol {
             return nil
         case .opening, .open, .reading:
             break
+        @unknown default:
+            fatalError()
         }
 
         let count = stream.read(&buffer, maxLength: buffer.count)

--- a/runtime/Swift/Sources/Antlr4/VocabularySingle.swift
+++ b/runtime/Swift/Sources/Antlr4/VocabularySingle.swift
@@ -155,11 +155,9 @@ public class Vocabulary: Hashable {
         return String(tokenType)
     }
 
-    public var hashValue: Int {
-        return Unmanaged.passUnretained(self).toOpaque().hashValue
-//        return unsafeAddress(of: self).hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
     }
-
 }
 
 public func ==(lhs: Vocabulary, rhs: Vocabulary) -> Bool {

--- a/runtime/Swift/Sources/Antlr4/atn/ATNConfig.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNConfig.swift
@@ -126,20 +126,11 @@ public class ATNConfig: Hashable, CustomStringConvertible {
         }
     }
 
-    /// 
-    /// An ATN configuration is equal to another if both have
-    /// the same state, they predict the same alternative, and
-    /// syntactic/semantic contexts are the same.
-    /// 
-
-    public var hashValue: Int {
-        var hashCode = MurmurHash.initialize(7)
-        hashCode = MurmurHash.update(hashCode, state.stateNumber)
-        hashCode = MurmurHash.update(hashCode, alt)
-        hashCode = MurmurHash.update(hashCode, context)
-        hashCode = MurmurHash.update(hashCode, semanticContext)
-        return MurmurHash.finish(hashCode, 4)
-
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(state.stateNumber)
+        hasher.combine(alt)
+        hasher.combine(context)
+        hasher.combine(semanticContext)
     }
 
     public var description: String {
@@ -166,6 +157,11 @@ public class ATNConfig: Hashable, CustomStringConvertible {
     }
 }
 
+///
+/// An ATN configuration is equal to another if both have
+/// the same state, they predict the same alternative, and
+/// syntactic/semantic contexts are the same.
+///
 public func ==(lhs: ATNConfig, rhs: ATNConfig) -> Bool {
 
     if lhs === rhs {

--- a/runtime/Swift/Sources/Antlr4/atn/ATNConfigSet.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNConfigSet.swift
@@ -203,16 +203,16 @@ public final class ATNConfigSet: Hashable, CustomStringConvertible {
         return false
     }
 
-    public var hashValue: Int {
+    public func hash(into hasher: inout Hasher) {
         if isReadonly() {
             if cachedHashCode == -1 {
-                cachedHashCode = configsHashValue//configs.hashValue ;
+                cachedHashCode = configsHashValue
             }
-
-            return cachedHashCode
+            hasher.combine(cachedHashCode)
         }
-
-        return configsHashValue // configs.hashValue;
+        else {
+            hasher.combine(configsHashValue)
+        }
     }
 
     private var configsHashValue: Int {

--- a/runtime/Swift/Sources/Antlr4/atn/ATNDeserializer.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNDeserializer.swift
@@ -78,8 +78,8 @@ public class ATNDeserializer {
     /// 
     internal func isFeatureSupported(_ feature: UUID, _ actualUuid: UUID) -> Bool {
         let supported = ATNDeserializer.SUPPORTED_UUIDS
-        guard let featureIndex = supported.index(of: feature),
-            let actualIndex = supported.index(of: actualUuid) else {
+        guard let featureIndex = supported.firstIndex(of: feature),
+            let actualIndex = supported.firstIndex(of: actualUuid) else {
                 return false
         }
         return actualIndex >= featureIndex

--- a/runtime/Swift/Sources/Antlr4/atn/ATNState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNState.swift
@@ -123,10 +123,9 @@ public class ATNState: Hashable, CustomStringConvertible {
     public internal(set) final var nextTokenWithinRule: IntervalSet?
 
 
-    public var hashValue: Int {
-        return stateNumber
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(stateNumber)
     }
-
 
     public func isNonGreedyExitState() -> Bool {
         return false

--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNConfig.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNConfig.swift
@@ -72,22 +72,14 @@ public class LexerATNConfig: ATNConfig {
         return passedThroughNonGreedyDecision
     }
 
-    override
-    /*public func hashCode() -> Int {
-
-    }*/
-    public var hashValue: Int {
-        var hashCode = MurmurHash.initialize(7)
-        hashCode = MurmurHash.update(hashCode, state.stateNumber)
-        hashCode = MurmurHash.update(hashCode, alt)
-        hashCode = MurmurHash.update(hashCode, context)
-        hashCode = MurmurHash.update(hashCode, semanticContext)
-        hashCode = MurmurHash.update(hashCode, passedThroughNonGreedyDecision ? 1 : 0)
-        hashCode = MurmurHash.update(hashCode, lexerActionExecutor)
-        return MurmurHash.finish(hashCode, 6)
-
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(state.stateNumber)
+        hasher.combine(alt)
+        hasher.combine(context)
+        hasher.combine(semanticContext)
+        hasher.combine(passedThroughNonGreedyDecision)
+        hasher.combine(lexerActionExecutor)
     }
-
 }
 
 //useless

--- a/runtime/Swift/Sources/Antlr4/atn/LexerAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerAction.swift
@@ -56,7 +56,7 @@ public class LexerAction: Hashable {
         fatalError(#function + " must be overridden")
     }
 
-    public var hashValue: Int {
+    public func hash(into hasher: inout Hasher) {
         fatalError(#function + " must be overridden")
     }
 

--- a/runtime/Swift/Sources/Antlr4/atn/LexerActionExecutor.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerActionExecutor.swift
@@ -176,11 +176,9 @@ public class LexerActionExecutor: Hashable {
     }
 
 
-    public var hashValue: Int {
-        return self.hashCode
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(hashCode)
     }
-
-
 }
 
 public func ==(lhs: LexerActionExecutor, rhs: LexerActionExecutor) -> Bool {

--- a/runtime/Swift/Sources/Antlr4/atn/LexerChannelAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerChannelAction.swift
@@ -63,12 +63,9 @@ public final class LexerChannelAction: LexerAction, CustomStringConvertible {
     }
 
 
-    override
-    public var hashValue: Int {
-        var hash = MurmurHash.initialize()
-        hash = MurmurHash.update(hash, getActionType().rawValue)
-        hash = MurmurHash.update(hash, channel)
-        return MurmurHash.finish(hash, 2)
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(getActionType())
+        hasher.combine(channel)
     }
 
     public var description: String {

--- a/runtime/Swift/Sources/Antlr4/atn/LexerCustomAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerCustomAction.swift
@@ -92,23 +92,16 @@ public final class LexerCustomAction: LexerAction {
         try lexer.action(nil, ruleIndex, actionIndex)
     }
 
-    override
-    public var hashValue: Int {
-        var hash = MurmurHash.initialize()
-        hash = MurmurHash.update(hash, getActionType().rawValue)
-        hash = MurmurHash.update(hash, ruleIndex)
-        hash = MurmurHash.update(hash, actionIndex)
-        return MurmurHash.finish(hash, 3)
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(ruleIndex)
+        hasher.combine(actionIndex)
     }
-
 }
 
 public func ==(lhs: LexerCustomAction, rhs: LexerCustomAction) -> Bool {
-
     if lhs === rhs {
         return true
     }
-
 
     return lhs.ruleIndex == rhs.ruleIndex
             && lhs.actionIndex == rhs.actionIndex

--- a/runtime/Swift/Sources/Antlr4/atn/LexerIndexedCustomAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerIndexedCustomAction.swift
@@ -96,24 +96,17 @@ public final class LexerIndexedCustomAction: LexerAction {
     }
 
 
-    public override var hashValue: Int {
-        var hash = MurmurHash.initialize()
-        hash = MurmurHash.update(hash, offset)
-        hash = MurmurHash.update(hash, action)
-        return MurmurHash.finish(hash, 2)
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(offset)
+        hasher.combine(action)
     }
-
-
 }
 
 public func ==(lhs: LexerIndexedCustomAction, rhs: LexerIndexedCustomAction) -> Bool {
-
     if lhs === rhs {
         return true
     }
 
-
     return lhs.offset == rhs.offset
             && lhs.action == rhs.action
-
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LexerModeAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerModeAction.swift
@@ -62,25 +62,20 @@ public final class LexerModeAction: LexerAction, CustomStringConvertible {
     public func execute(_ lexer: Lexer) {
         lexer.mode(mode)
     }
-    override
-    public var hashValue: Int {
-        var hash = MurmurHash.initialize()
-        hash = MurmurHash.update(hash, getActionType().rawValue)
-        hash = MurmurHash.update(hash, mode)
-        return MurmurHash.finish(hash, 2)
+
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(mode)
     }
+
     public var description: String {
         return "mode(\(mode))"
     }
 }
 
 public func ==(lhs: LexerModeAction, rhs: LexerModeAction) -> Bool {
-
     if lhs === rhs {
         return true
     }
 
-
     return lhs.mode == rhs.mode
-
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LexerMoreAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerMoreAction.swift
@@ -56,14 +56,9 @@ public final class LexerMoreAction: LexerAction, CustomStringConvertible {
     }
 
 
-    override
-    public var hashValue: Int {
-        var hash = MurmurHash.initialize()
-        hash = MurmurHash.update(hash, getActionType().rawValue)
-        return MurmurHash.finish(hash, 1)
-
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
     }
-
 
     public var description: String {
         return "more"
@@ -71,8 +66,5 @@ public final class LexerMoreAction: LexerAction, CustomStringConvertible {
 }
 
 public func ==(lhs: LexerMoreAction, rhs: LexerMoreAction) -> Bool {
-
     return lhs === rhs
-
-
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LexerPopModeAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerPopModeAction.swift
@@ -57,21 +57,15 @@ public final class LexerPopModeAction: LexerAction, CustomStringConvertible {
     }
 
 
-    override
-    public var hashValue: Int {
-        var hash = MurmurHash.initialize()
-        hash = MurmurHash.update(hash, getActionType().rawValue)
-        return MurmurHash.finish(hash, 1)
-
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
     }
+
     public var description: String {
         return "popMode"
     }
 }
 
 public func ==(lhs: LexerPopModeAction, rhs: LexerPopModeAction) -> Bool {
-
     return lhs === rhs
-
-
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LexerPushModeAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerPushModeAction.swift
@@ -63,15 +63,10 @@ public final class LexerPushModeAction: LexerAction, CustomStringConvertible {
         lexer.pushMode(mode)
     }
 
-
-    override
-    public var hashValue: Int {
-        var hash = MurmurHash.initialize()
-        hash = MurmurHash.update(hash, getActionType().rawValue)
-        hash = MurmurHash.update(hash, mode)
-        return MurmurHash.finish(hash, 2)
-
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(mode)
     }
+
     public var description: String {
         return "pushMode(\(mode))"
     }
@@ -79,10 +74,8 @@ public final class LexerPushModeAction: LexerAction, CustomStringConvertible {
 
 
 public func ==(lhs: LexerPushModeAction, rhs: LexerPushModeAction) -> Bool {
-
     if lhs === rhs {
         return true
     }
-
     return lhs.mode == rhs.mode
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LexerSkipAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerSkipAction.swift
@@ -56,19 +56,15 @@ public final class LexerSkipAction: LexerAction, CustomStringConvertible {
     }
 
 
-    override
-    public var hashValue: Int {
-        var hash = MurmurHash.initialize()
-        hash = MurmurHash.update(hash, getActionType().rawValue)
-        return MurmurHash.finish(hash, 1)
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
     }
+
     public var description: String {
         return "skip"
     }
-
 }
 
 public func ==(lhs: LexerSkipAction, rhs: LexerSkipAction) -> Bool {
-
     return lhs === rhs
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LexerTypeAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerTypeAction.swift
@@ -62,24 +62,18 @@ public class LexerTypeAction: LexerAction, CustomStringConvertible {
     }
 
 
-    override
-    public var hashValue: Int {
-        var hash = MurmurHash.initialize()
-        hash = MurmurHash.update(hash, getActionType().rawValue)
-        hash = MurmurHash.update(hash, type)
-        return MurmurHash.finish(hash, 2)
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(type)
     }
+
     public var description: String {
         return "type(\(type))"
     }
-
 }
 
 public func ==(lhs: LexerTypeAction, rhs: LexerTypeAction) -> Bool {
-
     if lhs === rhs {
         return true
     }
-
     return lhs.type == rhs.type
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LookupATNConfig.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LookupATNConfig.swift
@@ -20,17 +20,12 @@ public class LookupATNConfig: Hashable {
         // dup
         config = old
     }
-    public var hashValue: Int {
 
-        var hashCode: Int = 7
-        hashCode = 31 * hashCode + config.state.stateNumber
-        hashCode = 31 * hashCode + config.alt
-        hashCode = 31 * hashCode + config.semanticContext.hashValue
-        return hashCode
-
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(config.state.stateNumber)
+        hasher.combine(config.alt)
+        hasher.combine(config.semanticContext)
     }
-
-
 }
 
 public func ==(lhs: LookupATNConfig, rhs: LookupATNConfig) -> Bool {

--- a/runtime/Swift/Sources/Antlr4/atn/ParseInfo.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParseInfo.swift
@@ -40,7 +40,7 @@ public class ParseInfo {
     /// full-context predictions during parsing.
     /// 
     public func getLLDecisions() -> Array<Int> {
-        var decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
+        let decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
         var LL: Array<Int> = Array<Int>()
         let length = decisions.count
         for i in 0..<length {
@@ -59,7 +59,7 @@ public class ParseInfo {
     /// _org.antlr.v4.runtime.atn.DecisionInfo#timeInPrediction_ for all decisions.
     /// 
     public func getTotalTimeInPrediction() -> Int64 {
-        var decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
+        let decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
         var t: Int64 = 0
         let length = decisions.count
         for i in 0..<length {
@@ -74,7 +74,7 @@ public class ParseInfo {
     /// _org.antlr.v4.runtime.atn.DecisionInfo#SLL_TotalLook_ for all decisions.
     /// 
     public func getTotalSLLLookaheadOps() -> Int64 {
-        var decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
+        let decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
         var k: Int64 = 0
         let length = decisions.count
         for i in 0..<length {
@@ -89,7 +89,7 @@ public class ParseInfo {
     /// _org.antlr.v4.runtime.atn.DecisionInfo#LL_TotalLook_ for all decisions.
     /// 
     public func getTotalLLLookaheadOps() -> Int64 {
-        var decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
+        let decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
         var k: Int64 = 0
         let length = decisions.count
         for i in 0..<length {
@@ -103,7 +103,7 @@ public class ParseInfo {
     /// across all decisions made during parsing.
     /// 
     public func getTotalSLLATNLookaheadOps() -> Int64 {
-        var decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
+        let decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
         var k: Int64 = 0
         let length = decisions.count
         for i in 0..<length {
@@ -117,7 +117,7 @@ public class ParseInfo {
     /// across all decisions made during parsing.
     /// 
     public func getTotalLLATNLookaheadOps() -> Int64 {
-        var decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
+        let decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
         var k: Int64 = 0
         let length = decisions.count
         for i in 0..<length {
@@ -135,7 +135,7 @@ public class ParseInfo {
     /// _#getTotalLLATNLookaheadOps_.
     /// 
     public func getTotalATNLookaheadOps() -> Int64 {
-        var decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
+        let decisions: [DecisionInfo] = atnSimulator.getDecisionInfo()
         var k: Int64 = 0
         let length = decisions.count
         for i in 0..<length {

--- a/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
@@ -559,7 +559,7 @@ open class ParserATNSimulator: ATNSimulator {
     /// already cached
     /// 
    func getExistingTargetState(_ previousD: DFAState, _ t: Int) -> DFAState? {
-        var edges = previousD.edges
+        let edges = previousD.edges
         if edges == nil || (t + 1) < 0 || (t + 1) >= (edges!.count) {
             return nil
         }

--- a/runtime/Swift/Sources/Antlr4/atn/PredictionContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PredictionContext.swift
@@ -668,7 +668,7 @@ public class PredictionContext: Hashable, CustomStringConvertible {
     }
 
     public func toString<T>(_ recog: Recognizer<T>) -> String {
-        return NSStringFromClass(PredictionContext.self)
+        return String(describing: PredictionContext.self)
         //		return toString(recog, ParserRuleContext.EMPTY);
     }
 

--- a/runtime/Swift/Sources/Antlr4/atn/PredictionContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PredictionContext.swift
@@ -105,8 +105,8 @@ public class PredictionContext: Hashable, CustomStringConvertible {
         return getReturnState(size() - 1) == PredictionContext.EMPTY_RETURN_STATE
     }
 
-    public final var hashValue: Int {
-        return cachedHashCode
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(cachedHashCode)
     }
 
     static func calculateEmptyHashCode() -> Int {

--- a/runtime/Swift/Sources/Antlr4/atn/SemanticContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/SemanticContext.swift
@@ -61,7 +61,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
         return self
     }
 
-    public var hashValue: Int {
+    public func hash(into hasher: inout Hasher) {
         fatalError(#function + " must be overridden")
     }
 
@@ -94,15 +94,11 @@ public class SemanticContext: Hashable, CustomStringConvertible {
             return try parser.sempred(localctx, ruleIndex, predIndex)
         }
 
-        override
-        public var hashValue: Int {
-            var hashCode = MurmurHash.initialize()
-            hashCode = MurmurHash.update(hashCode, ruleIndex)
-            hashCode = MurmurHash.update(hashCode, predIndex)
-            hashCode = MurmurHash.update(hashCode, isCtxDependent ? 1 : 0)
-            return MurmurHash.finish(hashCode, 3)
+        public override func hash(into hasher: inout Hasher) {
+            hasher.combine(ruleIndex)
+            hasher.combine(predIndex)
+            hasher.combine(isCtxDependent)
         }
-
 
         override
         public var description: String {
@@ -138,11 +134,8 @@ public class SemanticContext: Hashable, CustomStringConvertible {
         }
 
 
-        override
-        public var hashValue: Int {
-            var hashCode: Int = 1
-            hashCode = 31 * hashCode + precedence
-            return hashCode
+        public override func hash(into hasher: inout Hasher) {
+            hasher.combine(precedence)
         }
 
         override
@@ -214,12 +207,8 @@ public class SemanticContext: Hashable, CustomStringConvertible {
         }
 
 
-        override
-        public var hashValue: Int {
-            //MurmurHash.hashCode(opnds, AND.class.hashCode());
-            let seed = 1554547125
-            //NSStringFromClass(AND.self).hashValue
-            return MurmurHash.hashCode(opnds, seed)
+        public override func hash(into hasher: inout Hasher) {
+            hasher.combine(opnds)
         }
 
         /// 
@@ -323,11 +312,8 @@ public class SemanticContext: Hashable, CustomStringConvertible {
             return opnds
         }
 
-
-        override
-        public var hashValue: Int {
-
-            return MurmurHash.hashCode(opnds, NSStringFromClass(OR.self).hashValue)
+        public override func hash(into hasher: inout Hasher) {
+            hasher.combine(opnds)
         }
 
         /// 

--- a/runtime/Swift/Sources/Antlr4/atn/Transition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/Transition.swift
@@ -54,16 +54,16 @@ public class Transition {
 
     public static let serializationTypes: Dictionary<String, Int> = [
 
-            NSStringFromClass(EpsilonTransition.self): EPSILON,
-            NSStringFromClass(RangeTransition.self): RANGE,
-            NSStringFromClass(RuleTransition.self): RULE,
-            NSStringFromClass(PredicateTransition.self): PREDICATE,
-            NSStringFromClass(AtomTransition.self): ATOM,
-            NSStringFromClass(ActionTransition.self): ACTION,
-            NSStringFromClass(SetTransition.self): SET,
-            NSStringFromClass(NotSetTransition.self): NOT_SET,
-            NSStringFromClass(WildcardTransition.self): WILDCARD,
-            NSStringFromClass(PrecedencePredicateTransition.self): PRECEDENCE,
+            String(describing: EpsilonTransition.self): EPSILON,
+            String(describing: RangeTransition.self): RANGE,
+            String(describing: RuleTransition.self): RULE,
+            String(describing: PredicateTransition.self): PREDICATE,
+            String(describing: AtomTransition.self): ATOM,
+            String(describing: ActionTransition.self): ACTION,
+            String(describing: SetTransition.self): SET,
+            String(describing: NotSetTransition.self): NOT_SET,
+            String(describing: WildcardTransition.self): WILDCARD,
+            String(describing: PrecedencePredicateTransition.self): PRECEDENCE,
 
 
     ]

--- a/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
@@ -109,10 +109,8 @@ public final class DFAState: Hashable, CustomStringConvertible {
     }
 
 
-    public var hashValue: Int {
-        var hash = MurmurHash.initialize(7)
-        hash = MurmurHash.update(hash, configs.hashValue)
-        return MurmurHash.finish(hash, 1)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(configs)
     }
 
     public var description: String {

--- a/runtime/Swift/Sources/Antlr4/misc/BitSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/BitSet.swift
@@ -1053,7 +1053,7 @@ public class BitSet: Hashable, CustomStringConvertible {
     /// 
     /// - returns: the hash code value for this bit set
     /// 
-    public var hashValue: Int {
+    private var hashCode: Int {
         var h: Int64 = 1234
         var i: Int = wordsInUse
         i -= 1
@@ -1063,6 +1063,10 @@ public class BitSet: Hashable, CustomStringConvertible {
         }
 
         return Int(Int32((h >> 32) ^ h))
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(hashCode)
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/misc/Interval.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/Interval.swift
@@ -62,13 +62,12 @@ public class Interval: Hashable {
     }
 
 
-    public var hashValue: Int {
-        var hash: Int = 23
-        hash = hash * 31 + a
-        hash = hash * 31 + b
-        return hash
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(a)
+        hasher.combine(b)
     }
-    /// 
+
+    ///
     /// Does this start completely before other? Disjoint
     /// 
     public func startsBeforeDisjoint(_ other: Interval) -> Bool {

--- a/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
@@ -326,8 +326,8 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
             return nil // nothing in common with null set
         }
 
-        var myIntervals = self.intervals
-        var theirIntervals = (other as! IntervalSet).intervals
+        let myIntervals = self.intervals
+        let theirIntervals = (other as! IntervalSet).intervals
         var intersection: IntervalSet? = nil
         let mySize = myIntervals.count
         let theirSize = theirIntervals.count

--- a/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
@@ -470,25 +470,13 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
         return intervals
     }
 
-
-    public func hashCode() -> Int {
-        var hash = MurmurHash.initialize()
-        for I: Interval in intervals {
-            hash = MurmurHash.update(hash, I.a)
-            hash = MurmurHash.update(hash, I.b)
+    public func hash(into hasher: inout Hasher) {
+        for interval in intervals {
+            hasher.combine(interval.a)
+            hasher.combine(interval.b)
         }
-
-        return MurmurHash.finish(hash, intervals.count * 2)
     }
-    public var hashValue: Int {
-        var hash = MurmurHash.initialize()
-        for I: Interval in intervals {
-            hash = MurmurHash.update(hash, I.a)
-            hash = MurmurHash.update(hash, I.b)
-        }
 
-        return MurmurHash.finish(hash, intervals.count * 2)
-    }
     /// 
     /// Are two IntervalSets equal?  Because all intervals are sorted
     /// and disjoint, equals is a simple linear walk over both lists

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -848,11 +848,11 @@ StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMe
 	func getRuleIndex() -> Int {
 		return <parser.name>.RULE_<struct.derivedFromName>
 	}
-<if(struct.provideCopyFrom)> <! don't need copy unless we have subclasses !>
-	<! <accessLevelNotOpen(parser)> init() { }!>
+<if(struct.provideCopyFrom && struct.attrs)> <! don't need copy unless we have subclasses !>
 	<accessLevelOpenOK(parser)>
-	func copyFrom(_ ctx: <struct.name>) {
-		super.copyFrom(ctx)
+	override func copyFrom(_ ctx_: ParserRuleContext) {
+		super.copyFrom(ctx_)
+		let ctx = ctx_ as! <struct.name>
 		<struct.attrs:{a | self.<a.name> = ctx.<a.name>;}; separator="\n">
 	}
 <endif>


### PR DESCRIPTION
This switches from using the deprecated hashValue to hash(into:).  It also switches from using index to firstIndex (matching the change in the standard library).

In the test template, we switch to using String directly instead of String.characters.

Replace all uses of NSStringFromClass. Bridging from NSString to String in Swift 5 is a transcoding operation, so it is expensive.  Use String(describing:) instead of NSStringFromClass to avoid this cost.


Change the generation of the copyFrom method to work around SR-10260:

This bug in Swift 5's compiler causes a SIL verification error when calling super.foo without overriding foo in the subclass.  In our case, we are generating a copyFrom implementation in the subclass, and calling super.copyFrom.  Crucially, the subclass implementation uses the context subtype for the argument, which means that it doesn't actually override the superclass's implementation.  This then tickles the SIL verification bug.

Work around this by changing our autogenerated copyFrom definition to use ParserRuleContext as the argument type.  This means that it actually overrides the implementation in ParserRuleContext, and so the super.copyFrom call is generated correctly.


Change many uses of var to let, to fix compiler warnings in Swift 5.1.  This work is from Mark Lilback <mark@lilback.com>.

This also switches all the Travis macOS tests to use the Xcode 10.2 / Mojave image and changes the Linux Swift tests to download Swift 5.0.1.
