### PR TITLE
[PHP] Fix AppVeyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,8 @@ image: Visual Studio 2017
 build: off
 install:
   - git submodule update --init --recursive
-  - cinst -y php composer
+  - cinst -y php --params "/InstallDir:C:\tools\php"
+  - cinst -y composer
 build_script:
   - mvn -DskipTests install --batch-mode
   - msbuild /target:restore /target:rebuild /property:Configuration=Release /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:detailed runtime/CSharp/runtime/CSharp/Antlr4.dotnet.sln
@@ -14,7 +15,7 @@ build_script:
 after_build: 
   - msbuild /target:pack /property:Configuration=Release /verbosity:detailed runtime/CSharp/runtime/CSharp/Antlr4.dotnet.sln
 test_script:
-  - mvn install -Dantlr-php-php="C:\tools\php73\php.exe" -Dantlr-python2-python="C:\Python27\python.exe" -Dantlr-python3-python="C:\Python35\python.exe" -Dantlr-javascript-nodejs="C:\Program Files (x86)\nodejs\node.exe" --batch-mode
+  - mvn install -Dantlr-php-php="C:\tools\php\php.exe" -Dantlr-python2-python="C:\Python27\python.exe" -Dantlr-python3-python="C:\Python35\python.exe" -Dantlr-javascript-nodejs="C:\Program Files (x86)\nodejs\node.exe" --batch-mode
 artifacts:
 - path: 'runtime\**\*.nupkg'  
   name: NuGet


### PR DESCRIPTION
Install PHP to C:\tools\php.  This fixes the AppVeyor tests, because
they were looking in C:\tools\php73, but the Chocolatey package has
recently moved to 7.4.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->