### PR TITLE
C++ VS project updates for next ANTLR4 release

### DIFF
--- a/doc/releasing-antlr.md
+++ b/doc/releasing-antlr.md
@@ -379,7 +379,7 @@ There are links to the artifacts in [download.html](http://www.antlr.org/downloa
 
 The C++ target is the most complex one, because it addresses multiple platforms, which require individual handling. We have 4 scenarios to cover:
 
-* **Windows**: static and dynamic libraries for the VC++ runtime 2013 or 2015 (corresponding to Visual Studio 2013 or 2015) + header files. All that in 32 and 64bit, debug + release.
+* **Windows**: static and dynamic libraries for the VC++ runtime 2017 or 2019 (corresponding to Visual Studio 2017 or 2019) + header files. All that in 32 and 64bit, debug + release.
 * **MacOS**: static and dynamic release libraries + header files.
 * **iOS**: no prebuilt binaries, but just a zip of the source, including the XCode project to build everything from source.
 * **Linux**: no prebuilt binaries, but just a zip of the source code, including the cmake file to build everything from source there.
@@ -404,12 +404,12 @@ cd runtime/Cpp
 cp antlr4-cpp-runtime-source.zip ~/antlr/sites/website-antlr4/download/antlr4-cpp-runtime-4.7-source.zip
 ```
 
-On a Windows machine the build scripts checks if VS 2013 and/or VS 2015 are installed and builds binaries for each, if found. This script requires 7z to be installed (http://7-zip.org then do `set PATH=%PATH%;C:\Program Files\7-Zip\` from DOS not powershell).
+On a Windows machine the build scripts checks if VS 2017 and/or VS 2019 are installed and builds binaries for each, if found. This script requires 7z to be installed (http://7-zip.org then do `set PATH=%PATH%;C:\Program Files\7-Zip\` from DOS not powershell).
 
 ```bash
 cd runtime/Cpp
-deploy-windows.cmd
-cp runtime\bin\vs-2015\x64\Release DLL\antlr4-cpp-runtime-vs2015.zip ~/antlr/sites/website-antlr4/download/antlr4-cpp-runtime-4.7-vs2015.zip
+deploy-windows.cmd Community
+cp antlr4-cpp-runtime-vs2019.zip ~/antlr/sites/website-antlr4/download/antlr4-cpp-runtime-4.7-vs2019.zip
 ```
 
 Move target to website (**_rename to a specific ANTLR version first if needed_**):

--- a/runtime/Cpp/README.md
+++ b/runtime/Cpp/README.md
@@ -25,30 +25,30 @@ The C++ target has been the work of the following people:
 
 ## Project Status
 
-* Building on OS X, Windows, Android and Linux
+* Building on macOS, Windows, Android and Linux
 * No errors and warnings
 * Library linking
-* Some unit tests in the OSX project, for important base classes with almost 100% code coverage.
+* Some unit tests in the macOS project, for important base classes with almost 100% code coverage.
 * All memory allocations checked
 * Simple command line demo application working on all supported platforms.
 * All runtime tests pass.
 
 ### Build + Usage Notes
 
-The minimum C++ version to compile the ANTLR C++ runtime with is C++11. The supplied projects can built the runtime either as static or dynamic library, as both 32bit and 64bit arch. The OSX project contains a target for iOS and can also be built using cmake (instead of XCode).
+The minimum C++ version to compile the ANTLR C++ runtime with is C++11. The supplied projects can built the runtime either as static or dynamic library, as both 32bit and 64bit arch. The macOS project contains a target for iOS and can also be built using cmake (instead of XCode).
 
 Include the antlr4-runtime.h umbrella header in your target application to get everything needed to use the library.
 
 If you are compiling with cmake, the minimum version required is cmake 2.8.
 
-#### Compiling on Windows with Visual Studio prior to 2017
-Simply open the VS solution (VS 2013+) and build it.
+#### Compiling on Windows with Visual Studio using he Visual Studio projects
+Simply open the VS project from the runtime folder (VS 2013+) and build it.
 
-#### Compiling on Windows with Visual Studio VS2017
+#### Compiling on Windows using cmake with Visual Studio VS2017 and later
 Use the "Open Folder" Feature from the File->Open->Folder menu to open the runtime/Cpp directory.
 It will automatically use the CMake description to open up a Visual Studio Solution.
 
-#### Compiling on OSX
+#### Compiling on macOS
 Either open the included XCode project and build that or use the cmake compilation as described for linux.
 
 #### Compiling on Android

--- a/runtime/Cpp/deploy-windows.cmd
+++ b/runtime/Cpp/deploy-windows.cmd
@@ -5,52 +5,51 @@ if exist bin rmdir /S /Q runtime\bin
 if exist obj rmdir /S /Q runtime\obj
 if exist lib rmdir /S /Q lib
 if exist antlr4-runtime rmdir /S /Q antlr4-runtime
-if exist antlr4-cpp-runtime-vs2013.zip erase antlr4-cpp-runtime-vs2013.zip
-if exist antlr4-cpp-runtime-vs2015.zip erase antlr4-cpp-runtime-vs2015.zip
+if exist antlr4-cpp-runtime-vs2017.zip erase antlr4-cpp-runtime-vs2017.zip
+if exist antlr4-cpp-runtime-vs2019.zip erase antlr4-cpp-runtime-vs2019.zip
 
 rem Headers
 xcopy runtime\src\*.h antlr4-runtime\ /s
 
 rem Binaries
-rem VS 2013 disabled by default. Change the X to a C to enable it.
-if exist "X:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools\VsDevCmd.bat" (
-  call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools\VsDevCmd.bat"
+if exist "C:\Program Files (x86)\Microsoft Visual Studio 15.0\Common7\Tools\VsDevCmd.bat" (
+  call "C:\Program Files (x86)\Microsoft Visual Studio 15.0\Common7\Tools\VsDevCmd.bat"
 
   pushd runtime
-  msbuild antlr4cpp-vs2013.vcxproj /p:configuration="Release DLL" /p:platform=Win32
-  msbuild antlr4cpp-vs2013.vcxproj /p:configuration="Release DLL" /p:platform=x64
+  msbuild antlr4cpp-vs2017.vcxproj /p:configuration="Release DLL" /p:platform=Win32
+  msbuild antlr4cpp-vs2017.vcxproj /p:configuration="Release DLL" /p:platform=x64
   popd
   
-  7z a antlr4-cpp-runtime-vs2013.zip antlr4-runtime
+  7z a antlr4-cpp-runtime-vs2017.zip antlr4-runtime
   xcopy runtime\bin\*.dll lib\ /s
   xcopy runtime\bin\*.lib lib\ /s
-  7z a antlr4-cpp-runtime-vs2013.zip lib
+  7z a antlr4-cpp-runtime-vs2017.zip lib
   
   rmdir /S /Q lib
   rmdir /S /Q runtime\bin
   rmdir /S /Q runtime\obj
   
-  rem if exist antlr4-cpp-runtime-vs2013.zip copy antlr4-cpp-runtime-vs2013.zip ~/antlr/sites/website-antlr4/download
+  rem if exist antlr4-cpp-runtime-vs2017.zip copy antlr4-cpp-runtime-vs2017.zip ~/antlr/sites/website-antlr4/download
 )
 
-if exist "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat" (
-  call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
+if exist "C:\Program Files (x86)\Microsoft Visual Studio 16.0\Common7\Tools\VsDevCmd.bat" (
+  call "C:\Program Files (x86)\Microsoft Visual Studio 16.0\Common7\Tools\VsDevCmd.bat"
 
   pushd runtime
-  msbuild antlr4cpp-vs2015.vcxproj /p:configuration="Release DLL" /p:platform=Win32
-  msbuild antlr4cpp-vs2015.vcxproj /p:configuration="Release DLL" /p:platform=x64
+  msbuild antlr4cpp-vs2019.vcxproj /p:configuration="Release DLL" /p:platform=Win32
+  msbuild antlr4cpp-vs2019.vcxproj /p:configuration="Release DLL" /p:platform=x64
   popd
   
-  7z a antlr4-cpp-runtime-vs2015.zip antlr4-runtime
+  7z a antlr4-cpp-runtime-vs2019.zip antlr4-runtime
   xcopy runtime\bin\*.dll lib\ /s
   xcopy runtime\bin\*.lib lib\ /s
-  7z a antlr4-cpp-runtime-vs2015.zip lib
+  7z a antlr4-cpp-runtime-vs2019.zip lib
   
   rmdir /S /Q lib
   rmdir /S /Q runtime\bin
   rmdir /S /Q runtime\obj
   
-  rem if exist antlr4-cpp-runtime-vs2015.zip copy antlr4-cpp-runtime-vs2015.zip ~/antlr/sites/website-antlr4/download
+  rem if exist antlr4-cpp-runtime-vs2019.zip copy antlr4-cpp-runtime-vs2019.zip ~/antlr/sites/website-antlr4/download
 )
 
 rmdir /S /Q antlr4-runtime

--- a/runtime/Cpp/deploy-windows.cmd
+++ b/runtime/Cpp/deploy-windows.cmd
@@ -1,4 +1,7 @@
 @echo off
+setlocal
+
+if [%1] == [] goto Usage
 
 rem Clean left overs from previous builds if there are any
 if exist bin rmdir /S /Q runtime\bin
@@ -9,11 +12,14 @@ if exist antlr4-cpp-runtime-vs2017.zip erase antlr4-cpp-runtime-vs2017.zip
 if exist antlr4-cpp-runtime-vs2019.zip erase antlr4-cpp-runtime-vs2019.zip
 
 rem Headers
-xcopy runtime\src\*.h antlr4-runtime\ /s
+echo Copying header files ...
+xcopy runtime\src\*.h antlr4-runtime\ /s /q
 
 rem Binaries
-if exist "C:\Program Files (x86)\Microsoft Visual Studio 15.0\Common7\Tools\VsDevCmd.bat" (
-  call "C:\Program Files (x86)\Microsoft Visual Studio 15.0\Common7\Tools\VsDevCmd.bat"
+if exist "X:\Program Files (x86)\Microsoft Visual Studio\2017\%1\Common7\Tools\VsDevCmd.bat" (
+  echo.
+  
+  call "C:\Program Files (x86)\Microsoft Visual Studio\2017\%1\Common7\Tools\VsDevCmd.bat"
 
   pushd runtime
   msbuild antlr4cpp-vs2017.vcxproj /p:configuration="Release DLL" /p:platform=Win32
@@ -32,8 +38,11 @@ if exist "C:\Program Files (x86)\Microsoft Visual Studio 15.0\Common7\Tools\VsDe
   rem if exist antlr4-cpp-runtime-vs2017.zip copy antlr4-cpp-runtime-vs2017.zip ~/antlr/sites/website-antlr4/download
 )
 
-if exist "C:\Program Files (x86)\Microsoft Visual Studio 16.0\Common7\Tools\VsDevCmd.bat" (
-  call "C:\Program Files (x86)\Microsoft Visual Studio 16.0\Common7\Tools\VsDevCmd.bat"
+set VCTargetsPath=C:\Program Files (x86)\Microsoft Visual Studio\2019\%1\MSBuild\Microsoft\VC\v160\
+if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019\%1\Common7\Tools\VsDevCmd.bat" (
+  echo.
+
+  call "C:\Program Files (x86)\Microsoft Visual Studio\2019\%1\Common7\Tools\VsDevCmd.bat"
 
   pushd runtime
   msbuild antlr4cpp-vs2019.vcxproj /p:configuration="Release DLL" /p:platform=Win32
@@ -53,5 +62,18 @@ if exist "C:\Program Files (x86)\Microsoft Visual Studio 16.0\Common7\Tools\VsDe
 )
 
 rmdir /S /Q antlr4-runtime
+echo.
+echo === Build done ===
+
+goto end
+
+:Usage
+
+echo This script builds Visual Studio 2017 and/or 2019 libraries of the ANTLR4 runtime.
+echo You have to specify the name(s) of the VS type you have installed (Community, Professional etc.).
+echo.
+echo Example:
+echo   %0 Professional
+echo.
 
 :end

--- a/runtime/Cpp/deploy-windows.cmd
+++ b/runtime/Cpp/deploy-windows.cmd
@@ -16,6 +16,7 @@ echo Copying header files ...
 xcopy runtime\src\*.h antlr4-runtime\ /s /q
 
 rem Binaries
+rem VS 2017 disabled by default. Change the X to a C to enable it.
 if exist "X:\Program Files (x86)\Microsoft Visual Studio\2017\%1\Common7\Tools\VsDevCmd.bat" (
   echo.
   
@@ -70,7 +71,8 @@ goto end
 :Usage
 
 echo This script builds Visual Studio 2017 and/or 2019 libraries of the ANTLR4 runtime.
-echo You have to specify the name(s) of the VS type you have installed (Community, Professional etc.).
+echo You have to specify the type of your VS installation (Community, Professional etc.) to construct
+echo the correct build tools path.
 echo.
 echo Example:
 echo   %0 Professional

--- a/runtime/Cpp/runtime/antlr4cpp-vs2017.vcxproj
+++ b/runtime/Cpp/runtime/antlr4cpp-vs2017.vcxproj
@@ -123,49 +123,49 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug DLL|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\vs-2015\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)bin\vs-2017\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)obj\$(PlatformTarget)\$(Configuration)\$(ProjectName)\</IntDir>
     <TargetName>antlr4-runtime</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Static|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\vs-2015\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)bin\vs-2017\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)obj\$(PlatformTarget)\$(Configuration)\$(ProjectName)\</IntDir>
     <TargetName>antlr4-runtime</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug DLL|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\vs-2015\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)bin\vs-2017\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)obj\$(PlatformTarget)\$(Configuration)\$(ProjectName)\</IntDir>
     <TargetName>antlr4-runtime</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Static|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\vs-2015\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)bin\vs-2017\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)obj\$(PlatformTarget)\$(Configuration)\$(ProjectName)\</IntDir>
     <TargetName>antlr4-runtime</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release DLL|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\vs-2015\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)bin\vs-2017\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)obj\$(PlatformTarget)\$(Configuration)\$(ProjectName)\</IntDir>
     <TargetName>antlr4-runtime</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Static|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\vs-2015\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)bin\vs-2017\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)obj\$(PlatformTarget)\$(Configuration)\$(ProjectName)\</IntDir>
     <TargetName>antlr4-runtime</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release DLL|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\vs-2015\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)bin\vs-2017\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)obj\$(PlatformTarget)\$(Configuration)\$(ProjectName)\</IntDir>
     <TargetName>antlr4-runtime</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Static|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)bin\vs-2015\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)bin\vs-2017\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)obj\$(PlatformTarget)\$(Configuration)\$(ProjectName)\</IntDir>
     <TargetName>antlr4-runtime</TargetName>
   </PropertyGroup>

--- a/runtime/Cpp/runtime/antlr4cpp-vs2019.vcxproj
+++ b/runtime/Cpp/runtime/antlr4cpp-vs2019.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug Static|Win32">
       <Configuration>Debug Static</Configuration>
@@ -586,6 +586,7 @@
     <ClInclude Include="src\misc\IntervalSet.h" />
     <ClInclude Include="src\misc\MurmurHash.h" />
     <ClInclude Include="src\misc\Predicate.h" />
+    <ClInclude Include="src\misc\TestRig.h" />
     <ClInclude Include="src\NoViableAltException.h" />
     <ClInclude Include="src\Parser.h" />
     <ClInclude Include="src\ParserInterpreter.h" />

--- a/runtime/Cpp/runtime/antlr4cpp-vs2019.vcxproj.filters
+++ b/runtime/Cpp/runtime/antlr4cpp-vs2019.vcxproj.filters
@@ -336,6 +336,9 @@
     <ClInclude Include="src\misc\MurmurHash.h">
       <Filter>Header Files\misc</Filter>
     </ClInclude>
+    <ClInclude Include="src\misc\TestRig.h">
+      <Filter>Header Files\misc</Filter>
+    </ClInclude>
     <ClInclude Include="src\support\Arrays.h">
       <Filter>Header Files\support</Filter>
     </ClInclude>
@@ -528,14 +531,14 @@
     <ClInclude Include="src\antlr4-runtime.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\support\Any.h">
+      <Filter>Source Files\support</Filter>
+    </ClInclude>
     <ClInclude Include="src\tree\IterativeParseTreeWalker.h">
       <Filter>Header Files\tree</Filter>
     </ClInclude>
     <ClInclude Include="src\misc\InterpreterDataReader.h">
       <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="src\support\Any.h">
-      <Filter>Header Files\support</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -1348,6 +1348,8 @@ Parser* ParserATNSimulator::getParser() {
   return parser;
 }
 
+#pragma warning (disable:4996) // 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead. 
+
 bool ParserATNSimulator::getLrLoopSetting() {
   char *var = std::getenv("TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT");
   if (var == nullptr)
@@ -1355,6 +1357,8 @@ bool ParserATNSimulator::getLrLoopSetting() {
   std::string value(var);
   return value == "true" || value == "1";
 }
+
+#pragma warning (default:4996)
 
 void ParserATNSimulator::InitializeInstanceFields() {
   _mode = PredictionMode::LL;


### PR DESCRIPTION
This patch contains a few changes to build now VS 2017/19 binaries instead of VS 2013/15 (with the deployment script). Also a warning was fixed (suppressed) and the docs updated wrt. the C++ target.