### PR TITLE
fixing a typo, was role instead of rule

### DIFF
--- a/doc/lexer-rules.md
+++ b/doc/lexer-rules.md
@@ -123,7 +123,7 @@ ESC : '\\' . ; // match any escaped \x character
 
 <tr>
 <td>{«action»}</td><td>
-Lexer actions can appear anywhere as of 4.2, not just at the end of the outermost alternative. The lexer executes the actions at the appropriate input position, according to the placement of the action within the rule. To execute a single action for a role that has multiple alternatives, you can enclose the alts in parentheses and put the action afterwards:
+Lexer actions can appear anywhere as of 4.2, not just at the end of the outermost alternative. The lexer executes the actions at the appropriate input position, according to the placement of the action within the rule. To execute a single action for a rule that has multiple alternatives, you can enclose the alts in parentheses and put the action afterwards:
  	
 <pre>
 END : ('endif'|'end') {System.out.println("found an end");} ;


### PR DESCRIPTION
fixing a typo, was role instead of rule

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->