### PR TITLE
Fix #2727: improve setTokenFactory in Cpp target

### DIFF
--- a/runtime/Cpp/runtime/src/CommonTokenFactory.cpp
+++ b/runtime/Cpp/runtime/src/CommonTokenFactory.cpp
@@ -11,7 +11,7 @@
 
 using namespace antlr4;
 
-const Ref<TokenFactory<CommonToken>> CommonTokenFactory::DEFAULT = std::make_shared<CommonTokenFactory>();
+const std::unique_ptr<TokenFactory<CommonToken>> CommonTokenFactory::DEFAULT(new CommonTokenFactory);
 
 CommonTokenFactory::CommonTokenFactory(bool copyText_) : copyText(copyText_) {
 }

--- a/runtime/Cpp/runtime/src/CommonTokenFactory.h
+++ b/runtime/Cpp/runtime/src/CommonTokenFactory.h
@@ -22,7 +22,7 @@ namespace antlr4 {
      * This token factory does not explicitly copy token text when constructing
      * tokens.</p>
      */
-    static const Ref<TokenFactory<CommonToken>> DEFAULT;
+    static const std::unique_ptr<TokenFactory<CommonToken>> DEFAULT;
 
   protected:
     /**

--- a/runtime/Cpp/runtime/src/Lexer.cpp
+++ b/runtime/Cpp/runtime/src/Lexer.cpp
@@ -136,7 +136,7 @@ size_t Lexer::popMode() {
 }
 
 
-Ref<TokenFactory<CommonToken>> Lexer::getTokenFactory() {
+TokenFactory<CommonToken>* Lexer::getTokenFactory() {
   return _factory;
 }
 
@@ -284,7 +284,7 @@ size_t Lexer::getNumberOfSyntaxErrors() {
 void Lexer::InitializeInstanceFields() {
   _syntaxErrors = 0;
   token = nullptr;
-  _factory = CommonTokenFactory::DEFAULT;
+  _factory = CommonTokenFactory::DEFAULT.get();
   tokenStartCharIndex = INVALID_INDEX;
   tokenStartLine = 0;
   tokenStartCharPositionInLine = 0;

--- a/runtime/Cpp/runtime/src/Lexer.h
+++ b/runtime/Cpp/runtime/src/Lexer.h
@@ -31,7 +31,7 @@ namespace antlr4 {
 
   protected:
     /// How to create token objects.
-    Ref<TokenFactory<CommonToken>> _factory;
+    TokenFactory<CommonToken> *_factory;
 
   public:
     /// The goal of all lexer rules/methods is to create a token object.
@@ -100,7 +100,7 @@ namespace antlr4 {
       this->_factory = factory;
     }
 
-    virtual Ref<TokenFactory<CommonToken>> getTokenFactory() override;
+    virtual TokenFactory<CommonToken>* getTokenFactory() override;
 
     /// Set the char stream and reset the lexer
     virtual void setInputStream(IntStream *input) override;

--- a/runtime/Cpp/runtime/src/ListTokenSource.cpp
+++ b/runtime/Cpp/runtime/src/ListTokenSource.cpp
@@ -82,11 +82,11 @@ std::string ListTokenSource::getSourceName() {
   return "List";
 }
 
-Ref<TokenFactory<CommonToken>> ListTokenSource::getTokenFactory() {
+TokenFactory<CommonToken>* ListTokenSource::getTokenFactory() {
   return _factory;
 }
 
 void ListTokenSource::InitializeInstanceFields() {
   i = 0;
-  _factory = CommonTokenFactory::DEFAULT;
+  _factory = CommonTokenFactory::DEFAULT.get();
 }

--- a/runtime/Cpp/runtime/src/ListTokenSource.h
+++ b/runtime/Cpp/runtime/src/ListTokenSource.h
@@ -40,7 +40,7 @@ namespace antlr4 {
   private:
     /// This is the backing field for <seealso cref="#getTokenFactory"/> and
     /// <seealso cref="setTokenFactory"/>.
-    Ref<TokenFactory<CommonToken>> _factory = CommonTokenFactory::DEFAULT;
+    TokenFactory<CommonToken> *_factory = CommonTokenFactory::DEFAULT.get();
 
   public:
     /// Constructs a new <seealso cref="ListTokenSource"/> instance from the specified
@@ -79,7 +79,7 @@ namespace antlr4 {
       this->_factory = factory;
     }
 
-    virtual Ref<TokenFactory<CommonToken>> getTokenFactory() override;
+    virtual TokenFactory<CommonToken>* getTokenFactory() override;
 
   private:
     void InitializeInstanceFields();

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -208,7 +208,7 @@ size_t Parser::getNumberOfSyntaxErrors() {
   return _syntaxErrors;
 }
 
-Ref<TokenFactory<CommonToken>> Parser::getTokenFactory() {
+TokenFactory<CommonToken>* Parser::getTokenFactory() {
   return _input->getTokenSource()->getTokenFactory();
 }
 

--- a/runtime/Cpp/runtime/src/Parser.h
+++ b/runtime/Cpp/runtime/src/Parser.h
@@ -193,7 +193,7 @@ namespace antlr4 {
     /// <seealso cref= #notifyErrorListeners </seealso>
     virtual size_t getNumberOfSyntaxErrors();
 
-    virtual Ref<TokenFactory<CommonToken>> getTokenFactory() override;
+    virtual TokenFactory<CommonToken>* getTokenFactory() override;
 
     /// <summary>
     /// Tell our token source and error strategy about a new way to create tokens. </summary>

--- a/runtime/Cpp/runtime/src/Recognizer.h
+++ b/runtime/Cpp/runtime/src/Recognizer.h
@@ -138,7 +138,7 @@ namespace antlr4 {
 
     virtual void setInputStream(IntStream *input) = 0;
 
-    virtual Ref<TokenFactory<CommonToken>> getTokenFactory() = 0;
+    virtual TokenFactory<CommonToken>* getTokenFactory() = 0;
 
     template<typename T1>
     void setTokenFactory(TokenFactory<T1> *input);

--- a/runtime/Cpp/runtime/src/TokenSource.h
+++ b/runtime/Cpp/runtime/src/TokenSource.h
@@ -79,7 +79,7 @@ namespace antlr4 {
     /// creating <seealso cref="Token"/> objects from the input.
     /// </summary>
     /// <returns> The <seealso cref="TokenFactory"/> currently used by this token source. </returns>
-    virtual Ref<TokenFactory<CommonToken>> getTokenFactory() = 0;
+    virtual TokenFactory<CommonToken>* getTokenFactory() = 0;
   };
 
 } // namespace antlr4


### PR DESCRIPTION
Change the setTokenFactory template function in the Lexer, Parser, and
TokenSource classes to be parameterized by Factory type rather than by
token type. Change the setTokenFactory signature to require the
function argument to be a Ref of the Factory template parameter type
so it can be correctly converted and assigned to the token factory
member. The type of that member is Ref<TokenFactory<CommonToken>>,
which implies that the Factory template parameter must be of a type
convertible to TokenFactory<CommonToken>.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->