### PR TITLE
C++-Runtime UB in TokenStreamRewriter

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -237,3 +237,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/11/11, foxeverl, Liu Xinfeng, liuxf1986[at]gmail[dot]com
 2019/11/17, felixn, Felix Nieuwenhuizhen, felix@tdlrali.com
 2019/11/18, mlilback, Mark Lilback, mark@lilback.com
+2020/02/01, lSoleyl, David Olszowka, lsoleyl[plus]github[at]gmail[dot]com

--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
@@ -327,14 +327,14 @@ std::unordered_map<size_t, TokenStreamRewriter::RewriteOperation*> TokenStreamRe
       if (iop->index == rop->index) {
         // E.g., insert before 2, delete 2..2; update replace
         // text to include insert before, kill insert
-        delete rewrites[iop->instructionIndex];
-        rewrites[iop->instructionIndex] = nullptr;
         rop->text = iop->text + (!rop->text.empty() ? rop->text : "");
-      }
+        rewrites[iop->instructionIndex] = nullptr;
+        delete iop;
+      } 
       else if (iop->index > rop->index && iop->index <= rop->lastIndex) {
         // delete insert as it's a no-op.
-        delete rewrites[iop->instructionIndex];
         rewrites[iop->instructionIndex] = nullptr;
+        delete iop;
       }
     }
     // Drop any prior replaces contained within
@@ -342,8 +342,8 @@ std::unordered_map<size_t, TokenStreamRewriter::RewriteOperation*> TokenStreamRe
     for (auto prevRop : prevReplaces) {
       if (prevRop->index >= rop->index && prevRop->lastIndex <= rop->lastIndex) {
         // delete replace as it's a no-op.
-        delete rewrites[prevRop->instructionIndex];
         rewrites[prevRop->instructionIndex] = nullptr;
+        delete prevRop;
         continue;
       }
       // throw exception unless disjoint or identical
@@ -351,12 +351,12 @@ std::unordered_map<size_t, TokenStreamRewriter::RewriteOperation*> TokenStreamRe
       // Delete special case of replace (text==null):
       // D.i-j.u D.x-y.v    | boundaries overlap    combine to max(min)..max(right)
       if (prevRop->text.empty() && rop->text.empty() && !disjoint) {
-        delete rewrites[prevRop->instructionIndex];
-        rewrites[prevRop->instructionIndex] = nullptr; // kill first delete
         rop->index = std::min(prevRop->index, rop->index);
         rop->lastIndex = std::max(prevRop->lastIndex, rop->lastIndex);
-        std::cout << "new rop " << rop << std::endl;
-      }
+
+        rewrites[prevRop->instructionIndex] = nullptr; // kill first delete
+        delete prevRop;
+      } 
       else if (!disjoint) {
         throw IllegalArgumentException("replace op boundaries of " + rop->toString() +
                                        " overlap with previous " + prevRop->toString());
@@ -379,8 +379,8 @@ std::unordered_map<size_t, TokenStreamRewriter::RewriteOperation*> TokenStreamRe
                                           // whole token buffer so no lazy eval issue with any templates
         iop->text = catOpText(&iop->text, &prevIop->text);
         // delete redundant prior insert
-        delete rewrites[prevIop->instructionIndex];
         rewrites[prevIop->instructionIndex] = nullptr;
+        delete prevIop;
       }
     }
     // look for replaces where iop.index is in range; error


### PR DESCRIPTION
The pattern:

    delete rewrites[iop->instructionIndex];
    rewrites[iop->instructionIndex] = nullptr;

was used throughout this method and is undefined behavior because `iop` and `rewrites[iop->instructionIndex]` actually refer to the same object and thus the object's fields are accessed after the object itself has been deleted. This has caused crashes in my application, which are fixed by this commit.

I fixed this by rearranging the object deletions to be performed after any code, which still references them.

I also removed the seemingly out of place `std::cout << "new rop" << rop << std::endl;` statement.