### PR TITLE
Fix CMake packaging

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -238,3 +238,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/11/17, felixn, Felix Nieuwenhuizhen, felix@tdlrali.com
 2019/11/18, mlilback, Mark Lilback, mark@lilback.com
 2020/02/02, carocad, Camilo Roca, carocad@unal.edu.co
+2020/02/10, julibert, Julián Bermúdez Ortega, julibert.dev@gmail.com

--- a/runtime/Cpp/CMakeLists.txt
+++ b/runtime/Cpp/CMakeLists.txt
@@ -141,11 +141,12 @@ if (ANTLR4_INSTALL)
   include(CMakePackageConfigHelpers)
 
   if(NOT ANTLR4_CMAKE_DIR)
-    set(ANTLR4_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/antlr4 CACHE STRING
+    set(ANTLR4_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake CACHE STRING
       "Installation directory for cmake files." FORCE )
   endif(NOT ANTLR4_CMAKE_DIR)
 
-  set(version_config ${PROJECT_BINARY_DIR}/antlr4-config-version.cmake)
+  set(version_runtime_config ${PROJECT_BINARY_DIR}/antlr4-runtime-config-version.cmake)
+  set(version_generator_config ${PROJECT_BINARY_DIR}/antlr4-generator-config-version.cmake)
   set(project_runtime_config ${PROJECT_BINARY_DIR}/antlr4-runtime-config.cmake)
   set(project_generator_config ${PROJECT_BINARY_DIR}/antlr4-generator-config.cmake)
   set(targets_export_name antlr4-targets)
@@ -159,31 +160,39 @@ if (ANTLR4_INSTALL)
   configure_package_config_file(
     cmake/antlr4-runtime.cmake.in
     ${project_runtime_config}
-    INSTALL_DESTINATION ${ANTLR4_CMAKE_DIR}
+    INSTALL_DESTINATION ${ANTLR4_CMAKE_DIR}/antlr4-runtime
     PATH_VARS 
     ANTLR4_INCLUDE_DIR
     ANTLR4_LIB_DIR )
   
-configure_package_config_file(
+  configure_package_config_file(
     cmake/antlr4-generator.cmake.in
     ${project_generator_config}
-    INSTALL_DESTINATION ${ANTLR4_CMAKE_DIR}
+    INSTALL_DESTINATION ${ANTLR4_CMAKE_DIR}/antlr4-generator
     PATH_VARS 
     ANTLR4_INCLUDE_DIR
     ANTLR4_LIB_DIR )
   
   write_basic_package_version_file(
-    ${version_config}
+    ${version_runtime_config}
+    VERSION ${ANTLR_VERSION}
+    COMPATIBILITY SameMajorVersion )
+
+  write_basic_package_version_file(
+    ${version_generator_config}
     VERSION ${ANTLR_VERSION}
     COMPATIBILITY SameMajorVersion )
 
   install(EXPORT ${targets_export_name}
-          DESTINATION ${ANTLR4_CMAKE_DIR} )
+          DESTINATION ${ANTLR4_CMAKE_DIR}/antlr4-runtime )
 
   install(FILES ${project_runtime_config}
-                ${project_generator_config}
-                ${version_config}
-          DESTINATION ${ANTLR4_CMAKE_DIR} )
+                ${version_runtime_config}
+          DESTINATION ${ANTLR4_CMAKE_DIR}/antlr4-runtime )
+
+  install(FILES ${project_generator_config}
+                ${version_generator_config}
+          DESTINATION ${ANTLR4_CMAKE_DIR}/antlr4-generator )
 
 endif(ANTLR4_INSTALL)
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->
This pull request fixes #2606. It installs `antrl4-generator` and `antlr4-runtime` in separate files following the CMake's [search procedure](https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure).