### PR TITLE
Javascript: migrate prototypical DFA objects to es6 classes

### DIFF
--- a/runtime/JavaScript/src/antlr4/dfa/DFA.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFA.js
@@ -4,43 +4,43 @@
  * can be found in the LICENSE.txt file in the project root.
  */
 
-var Set = require("../Utils").Set;
-var DFAState = require('./DFAState').DFAState;
-var StarLoopEntryState = require('../atn/ATNState').StarLoopEntryState;
-var ATNConfigSet = require('./../atn/ATNConfigSet').ATNConfigSet;
-var DFASerializer = require('./DFASerializer').DFASerializer;
-var LexerDFASerializer = require('./DFASerializer').LexerDFASerializer;
+const Set = require("../Utils").Set;
+const DFAState = require('./DFAState').DFAState;
+const StarLoopEntryState = require('../atn/ATNState').StarLoopEntryState;
+const ATNConfigSet = require('./../atn/ATNConfigSet').ATNConfigSet;
+const DFASerializer = require('./DFASerializer').DFASerializer;
+const LexerDFASerializer = require('./DFASerializer').LexerDFASerializer;
 
 
 
-function DFA(atnStartState, decision) {
-	if (decision === undefined) {
-		decision = 0;
+class DFA {
+	constructor(atnStartState, decision) {
+		if (decision === undefined) {
+			decision = 0;
+		}
+		// From which ATN state did we create this DFA?
+		this.atnStartState = atnStartState;
+		this.decision = decision;
+		// A set of all DFA states. Use {@link Map} so we can get old state back
+		// ({@link Set} only allows you to see if it's there).
+		this._states = new Set();
+		this.s0 = null;
+		// {@code true} if this DFA is for a precedence decision; otherwise,
+		// {@code false}. This is the backing field for {@link //isPrecedenceDfa},
+		// {@link //setPrecedenceDfa}.
+		this.precedenceDfa = false;
+		if (atnStartState instanceof StarLoopEntryState)
+		{
+			if (atnStartState.isPrecedenceDecision) {
+				this.precedenceDfa = true;
+				const precedenceState = new DFAState(null, new ATNConfigSet());
+				precedenceState.edges = [];
+				precedenceState.isAcceptState = false;
+				precedenceState.requiresFullContext = false;
+				this.s0 = precedenceState;
+			}
+		}
 	}
-	// From which ATN state did we create this DFA?
-	this.atnStartState = atnStartState;
-	this.decision = decision;
-	// A set of all DFA states. Use {@link Map} so we can get old state back
-	// ({@link Set} only allows you to see if it's there).
-	this._states = new Set();
-	this.s0 = null;
-	// {@code true} if this DFA is for a precedence decision; otherwise,
-	// {@code false}. This is the backing field for {@link //isPrecedenceDfa},
-	// {@link //setPrecedenceDfa}.
-	this.precedenceDfa = false;
-    if (atnStartState instanceof StarLoopEntryState)
-    {
-        if (atnStartState.isPrecedenceDecision) {
-            this.precedenceDfa = true;
-            var precedenceState = new DFAState(null, new ATNConfigSet());
-            precedenceState.edges = [];
-            precedenceState.isAcceptState = false;
-            precedenceState.requiresFullContext = false;
-            this.s0 = precedenceState;
-        }
-    }
-	return this;
-}
 
 // Get the start state for a specific precedence value.
 //
@@ -50,17 +50,16 @@ function DFA(atnStartState, decision) {
 //
 // @throws IllegalStateException if this is not a precedence DFA.
 // @see //isPrecedenceDfa()
-
-DFA.prototype.getPrecedenceStartState = function(precedence) {
-	if (!(this.precedenceDfa)) {
-		throw ("Only precedence DFAs may contain a precedence start state.");
+	getPrecedenceStartState(precedence) {
+		if (!(this.precedenceDfa)) {
+			throw ("Only precedence DFAs may contain a precedence start state.");
+		}
+		// s0.edges is never null for a precedence DFA
+		if (precedence < 0 || precedence >= this.s0.edges.length) {
+			return null;
+		}
+		return this.s0.edges[precedence] || null;
 	}
-	// s0.edges is never null for a precedence DFA
-	if (precedence < 0 || precedence >= this.s0.edges.length) {
-		return null;
-	}
-	return this.s0.edges[precedence] || null;
-};
 
 // Set the start state for a specific precedence value.
 //
@@ -71,19 +70,19 @@ DFA.prototype.getPrecedenceStartState = function(precedence) {
 // @throws IllegalStateException if this is not a precedence DFA.
 // @see //isPrecedenceDfa()
 //
-DFA.prototype.setPrecedenceStartState = function(precedence, startState) {
-	if (!(this.precedenceDfa)) {
-		throw ("Only precedence DFAs may contain a precedence start state.");
-	}
-	if (precedence < 0) {
-		return;
-	}
+	setPrecedenceStartState(precedence, startState) {
+		if (!(this.precedenceDfa)) {
+			throw ("Only precedence DFAs may contain a precedence start state.");
+		}
+		if (precedence < 0) {
+			return;
+		}
 
-	// synchronization on s0 here is ok. when the DFA is turned into a
-	// precedence DFA, s0 will be initialized once and not updated again
-	// s0.edges is never null for a precedence DFA
-	this.s0.edges[precedence] = startState;
-};
+		// synchronization on s0 here is ok. when the DFA is turned into a
+		// precedence DFA, s0 will be initialized once and not updated again
+		// s0.edges is never null for a precedence DFA
+		this.s0.edges[precedence] = startState;
+	}
 
 //
 // Sets whether this is a precedence DFA. If the specified value differs
@@ -101,53 +100,52 @@ DFA.prototype.setPrecedenceStartState = function(precedence, startState) {
 //
 // @param precedenceDfa {@code true} if this is a precedence DFA; otherwise,
 // {@code false}
-
-DFA.prototype.setPrecedenceDfa = function(precedenceDfa) {
-	if (this.precedenceDfa!==precedenceDfa) {
-		this._states = new DFAStatesSet();
-		if (precedenceDfa) {
-			var precedenceState = new DFAState(null, new ATNConfigSet());
-			precedenceState.edges = [];
-			precedenceState.isAcceptState = false;
-			precedenceState.requiresFullContext = false;
-			this.s0 = precedenceState;
-		} else {
-			this.s0 = null;
+	setPrecedenceDfa(precedenceDfa) {
+		if (this.precedenceDfa!==precedenceDfa) {
+			this._states = new DFAStatesSet();
+			if (precedenceDfa) {
+				const precedenceState = new DFAState(null, new ATNConfigSet());
+				precedenceState.edges = [];
+				precedenceState.isAcceptState = false;
+				precedenceState.requiresFullContext = false;
+				this.s0 = precedenceState;
+			} else {
+				this.s0 = null;
+			}
+			this.precedenceDfa = precedenceDfa;
 		}
-		this.precedenceDfa = precedenceDfa;
 	}
-};
-
-Object.defineProperty(DFA.prototype, "states", {
-	get : function() {
-		return this._states;
-	}
-});
 
 // Return a list of all states in this DFA, ordered by state number.
-DFA.prototype.sortedStates = function() {
-	var list = this._states.values();
-	return list.sort(function(a, b) {
-		return a.stateNumber - b.stateNumber;
-	});
-};
-
-DFA.prototype.toString = function(literalNames, symbolicNames) {
-	literalNames = literalNames || null;
-	symbolicNames = symbolicNames || null;
-	if (this.s0 === null) {
-		return "";
+	sortedStates() {
+		const list = this._states.values();
+		return list.sort(function(a, b) {
+			return a.stateNumber - b.stateNumber;
+		});
 	}
-	var serializer = new DFASerializer(this, literalNames, symbolicNames);
-	return serializer.toString();
-};
 
-DFA.prototype.toLexerString = function() {
-	if (this.s0 === null) {
-		return "";
+	toString(literalNames, symbolicNames) {
+		literalNames = literalNames || null;
+		symbolicNames = symbolicNames || null;
+		if (this.s0 === null) {
+			return "";
+		}
+		const serializer = new DFASerializer(this, literalNames, symbolicNames);
+		return serializer.toString();
 	}
-	var serializer = new LexerDFASerializer(this);
-	return serializer.toString();
-};
+
+	toLexerString() {
+		if (this.s0 === null) {
+			return "";
+		}
+		const serializer = new LexerDFASerializer(this);
+		return serializer.toString();
+	}
+
+	get states(){
+		return this._states;
+	}
+}
+
 
 exports.DFA = DFA;

--- a/runtime/JavaScript/src/antlr4/dfa/DFA.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFA.js
@@ -4,14 +4,12 @@
  * can be found in the LICENSE.txt file in the project root.
  */
 
-const Set = require("../Utils").Set;
-const DFAState = require('./DFAState').DFAState;
-const StarLoopEntryState = require('../atn/ATNState').StarLoopEntryState;
-const ATNConfigSet = require('./../atn/ATNConfigSet').ATNConfigSet;
-const DFASerializer = require('./DFASerializer').DFASerializer;
-const LexerDFASerializer = require('./DFASerializer').LexerDFASerializer;
-
-
+const {Set} = require("../Utils");
+const {DFAState} = require('./DFAState');
+const {StarLoopEntryState} = require('../atn/ATNState');
+const {ATNConfigSet} = require('./../atn/ATNConfigSet');
+const {DFASerializer} = require('./DFASerializer');
+const {LexerDFASerializer} = require('./DFASerializer');
 
 class DFA {
 	constructor(atnStartState, decision) {
@@ -148,4 +146,4 @@ class DFA {
 }
 
 
-exports.DFA = DFA;
+module.exports = { DFA };

--- a/runtime/JavaScript/src/antlr4/dfa/DFA.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFA.js
@@ -1,4 +1,3 @@
-//
 /* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
@@ -16,16 +15,22 @@ class DFA {
 		if (decision === undefined) {
 			decision = 0;
 		}
-		// From which ATN state did we create this DFA?
+		/**
+		 * From which ATN state did we create this DFA?
+		 */
 		this.atnStartState = atnStartState;
 		this.decision = decision;
-		// A set of all DFA states. Use {@link Map} so we can get old state back
-		// ({@link Set} only allows you to see if it's there).
+		/**
+		 * A set of all DFA states. Use {@link Map} so we can get old state back
+		 * ({@link Set} only allows you to see if it's there).
+		 */
 		this._states = new Set();
 		this.s0 = null;
-		// {@code true} if this DFA is for a precedence decision; otherwise,
-		// {@code false}. This is the backing field for {@link //isPrecedenceDfa},
-		// {@link //setPrecedenceDfa}.
+		/**
+		 * {@code true} if this DFA is for a precedence decision; otherwise,
+		 * {@code false}. This is the backing field for {@link //isPrecedenceDfa},
+		 * {@link //setPrecedenceDfa}
+		 */
 		this.precedenceDfa = false;
 		if (atnStartState instanceof StarLoopEntryState)
 		{
@@ -40,14 +45,16 @@ class DFA {
 		}
 	}
 
-// Get the start state for a specific precedence value.
-//
-// @param precedence The current precedence.
-// @return The start state corresponding to the specified precedence, or
-// {@code null} if no start state exists for the specified precedence.
-//
-// @throws IllegalStateException if this is not a precedence DFA.
-// @see //isPrecedenceDfa()
+	/**
+	 * Get the start state for a specific precedence value.
+	 *
+	 * @param precedence The current precedence.
+	 * @return The start state corresponding to the specified precedence, or
+	 * {@code null} if no start state exists for the specified precedence.
+	 *
+	 * @throws IllegalStateException if this is not a precedence DFA.
+	 * @see //isPrecedenceDfa()
+	 */
 	getPrecedenceStartState(precedence) {
 		if (!(this.precedenceDfa)) {
 			throw ("Only precedence DFAs may contain a precedence start state.");
@@ -59,15 +66,16 @@ class DFA {
 		return this.s0.edges[precedence] || null;
 	}
 
-// Set the start state for a specific precedence value.
-//
-// @param precedence The current precedence.
-// @param startState The start state corresponding to the specified
-// precedence.
-//
-// @throws IllegalStateException if this is not a precedence DFA.
-// @see //isPrecedenceDfa()
-//
+	/**
+	 * Set the start state for a specific precedence value.
+	 *
+	 * @param precedence The current precedence.
+	 * @param startState The start state corresponding to the specified
+	 * precedence.
+	 *
+	 * @throws IllegalStateException if this is not a precedence DFA.
+	 * @see //isPrecedenceDfa()
+	 */
 	setPrecedenceStartState(precedence, startState) {
 		if (!(this.precedenceDfa)) {
 			throw ("Only precedence DFAs may contain a precedence start state.");
@@ -76,28 +84,31 @@ class DFA {
 			return;
 		}
 
-		// synchronization on s0 here is ok. when the DFA is turned into a
-		// precedence DFA, s0 will be initialized once and not updated again
-		// s0.edges is never null for a precedence DFA
+		/**
+		 * synchronization on s0 here is ok. when the DFA is turned into a
+		 * precedence DFA, s0 will be initialized once and not updated again
+		 * s0.edges is never null for a precedence DFA
+		 */
 		this.s0.edges[precedence] = startState;
 	}
 
-//
-// Sets whether this is a precedence DFA. If the specified value differs
-// from the current DFA configuration, the following actions are taken;
-// otherwise no changes are made to the current DFA.
-//
-// <ul>
-// <li>The {@link //states} map is cleared</li>
-// <li>If {@code precedenceDfa} is {@code false}, the initial state
-// {@link //s0} is set to {@code null}; otherwise, it is initialized to a new
-// {@link DFAState} with an empty outgoing {@link DFAState//edges} array to
-// store the start states for individual precedence values.</li>
-// <li>The {@link //precedenceDfa} field is updated</li>
-// </ul>
-//
-// @param precedenceDfa {@code true} if this is a precedence DFA; otherwise,
-// {@code false}
+	/**
+	 * Sets whether this is a precedence DFA. If the specified value differs
+	 * from the current DFA configuration, the following actions are taken;
+	 * otherwise no changes are made to the current DFA.
+	 *
+	 * <ul>
+	 * <li>The {@link //states} map is cleared</li>
+	 * <li>If {@code precedenceDfa} is {@code false}, the initial state
+	 * {@link //s0} is set to {@code null}; otherwise, it is initialized to a new
+	 * {@link DFAState} with an empty outgoing {@link DFAState//edges} array to
+	 * store the start states for individual precedence values.</li>
+	 * <li>The {@link //precedenceDfa} field is updated</li>
+	 * </ul>
+	 *
+	 * @param precedenceDfa {@code true} if this is a precedence DFA; otherwise,
+	 * {@code false}
+	 */
 	setPrecedenceDfa(precedenceDfa) {
 		if (this.precedenceDfa!==precedenceDfa) {
 			this._states = new DFAStatesSet();
@@ -114,7 +125,9 @@ class DFA {
 		}
 	}
 
-// Return a list of all states in this DFA, ordered by state number.
+	/**
+	 * Return a list of all states in this DFA, ordered by state number.
+	 */
 	sortedStates() {
 		const list = this._states.values();
 		return list.sort(function(a, b) {

--- a/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
@@ -17,14 +17,14 @@ class DFASerializer {
        if(this.dfa.s0 === null) {
            return null;
        }
-       var buf = "";
-       var states = this.dfa.sortedStates();
-       for(var i=0;i<states.length;i++) {
-           var s = states[i];
+       let buf = "";
+       const states = this.dfa.sortedStates();
+       for(let i=0; i<states.length; i++) {
+           const s = states[i];
            if(s.edges!==null) {
-                var n = s.edges.length;
-                for(var j=0;j<n;j++) {
-                    var t = s.edges[j] || null;
+                const n = s.edges.length;
+                for(const j=0;j<n;j++) {
+                    const t = s.edges[j] || null;
                     if(t!==null && t.stateNumber !== 0x7FFFFFFF) {
                         buf = buf.concat(this.getStateString(s));
                         buf = buf.concat("-");
@@ -50,7 +50,7 @@ class DFASerializer {
     }
 
     getStateString(s) {
-        var baseStateStr = ( s.isAcceptState ? ":" : "") + "s" + s.stateNumber + ( s.requiresFullContext ? "^" : "");
+        const baseStateStr = ( s.isAcceptState ? ":" : "") + "s" + s.stateNumber + ( s.requiresFullContext ? "^" : "");
         if(s.isAcceptState) {
             if (s.predicates !== null) {
                 return baseStateStr + "=>" + s.predicates.toString();
@@ -66,7 +66,6 @@ class DFASerializer {
 class LexerDFASerializer extends DFASerializer {
     constructor(dfa) {
         super(dfa, null);
-        return this;
     }
 
     getEdgeLabel(i) {
@@ -74,7 +73,6 @@ class LexerDFASerializer extends DFASerializer {
     }
 }
 
-
-exports.DFASerializer = DFASerializer;
-exports.LexerDFASerializer = LexerDFASerializer;
+module.exports = { DFASerializer };
+module.exports = { LexerDFASerializer };
 

--- a/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
@@ -3,9 +3,9 @@
  * can be found in the LICENSE.txt file in the project root.
  */
 
-// A DFA walker that knows how to dump them to serialized strings.#/
-
-
+/**
+ * A DFA walker that knows how to dump them to serialized strings.
+ */
 class DFASerializer {
     constructor(dfa, literalNames, symbolicNames) {
         this.dfa = dfa;

--- a/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
@@ -6,73 +6,74 @@
 // A DFA walker that knows how to dump them to serialized strings.#/
 
 
-function DFASerializer(dfa, literalNames, symbolicNames) {
-	this.dfa = dfa;
-	this.literalNames = literalNames || [];
-	this.symbolicNames = symbolicNames || [];
-	return this;
-}
+class DFASerializer {
+    constructor(dfa, literalNames, symbolicNames) {
+        this.dfa = dfa;
+        this.literalNames = literalNames || [];
+        this.symbolicNames = symbolicNames || [];
+    }
 
-DFASerializer.prototype.toString = function() {
-   if(this.dfa.s0 === null) {
-       return null;
-   }
-   var buf = "";
-   var states = this.dfa.sortedStates();
-   for(var i=0;i<states.length;i++) {
-       var s = states[i];
-       if(s.edges!==null) {
-            var n = s.edges.length;
-            for(var j=0;j<n;j++) {
-                var t = s.edges[j] || null;
-                if(t!==null && t.stateNumber !== 0x7FFFFFFF) {
-                    buf = buf.concat(this.getStateString(s));
-                    buf = buf.concat("-");
-                    buf = buf.concat(this.getEdgeLabel(j));
-                    buf = buf.concat("->");
-                    buf = buf.concat(this.getStateString(t));
-                    buf = buf.concat('\n');
-                }
-            }
+    toString() {
+       if(this.dfa.s0 === null) {
+           return null;
        }
-   }
-   return buf.length===0 ? null : buf;
-};
-
-DFASerializer.prototype.getEdgeLabel = function(i) {
-    if (i===0) {
-        return "EOF";
-    } else if(this.literalNames !==null || this.symbolicNames!==null) {
-        return this.literalNames[i-1] || this.symbolicNames[i-1];
-    } else {
-        return String.fromCharCode(i-1);
+       var buf = "";
+       var states = this.dfa.sortedStates();
+       for(var i=0;i<states.length;i++) {
+           var s = states[i];
+           if(s.edges!==null) {
+                var n = s.edges.length;
+                for(var j=0;j<n;j++) {
+                    var t = s.edges[j] || null;
+                    if(t!==null && t.stateNumber !== 0x7FFFFFFF) {
+                        buf = buf.concat(this.getStateString(s));
+                        buf = buf.concat("-");
+                        buf = buf.concat(this.getEdgeLabel(j));
+                        buf = buf.concat("->");
+                        buf = buf.concat(this.getStateString(t));
+                        buf = buf.concat('\n');
+                    }
+                }
+           }
+       }
+       return buf.length===0 ? null : buf;
     }
-};
 
-DFASerializer.prototype.getStateString = function(s) {
-    var baseStateStr = ( s.isAcceptState ? ":" : "") + "s" + s.stateNumber + ( s.requiresFullContext ? "^" : "");
-    if(s.isAcceptState) {
-        if (s.predicates !== null) {
-            return baseStateStr + "=>" + s.predicates.toString();
+    getEdgeLabel(i) {
+        if (i===0) {
+            return "EOF";
+        } else if(this.literalNames !==null || this.symbolicNames!==null) {
+            return this.literalNames[i-1] || this.symbolicNames[i-1];
         } else {
-            return baseStateStr + "=>" + s.prediction.toString();
+            return String.fromCharCode(i-1);
         }
-    } else {
-        return baseStateStr;
     }
-};
 
-function LexerDFASerializer(dfa) {
-	DFASerializer.call(this, dfa, null);
-	return this;
+    getStateString(s) {
+        var baseStateStr = ( s.isAcceptState ? ":" : "") + "s" + s.stateNumber + ( s.requiresFullContext ? "^" : "");
+        if(s.isAcceptState) {
+            if (s.predicates !== null) {
+                return baseStateStr + "=>" + s.predicates.toString();
+            } else {
+                return baseStateStr + "=>" + s.prediction.toString();
+            }
+        } else {
+            return baseStateStr;
+        }
+    }
 }
 
-LexerDFASerializer.prototype = Object.create(DFASerializer.prototype);
-LexerDFASerializer.prototype.constructor = LexerDFASerializer;
+class LexerDFASerializer extends DFASerializer {
+    constructor(dfa) {
+        super(dfa, null);
+        return this;
+    }
 
-LexerDFASerializer.prototype.getEdgeLabel = function(i) {
-	return "'" + String.fromCharCode(i) + "'";
-};
+    getEdgeLabel(i) {
+        return "'" + String.fromCharCode(i) + "'";
+    }
+}
+
 
 exports.DFASerializer = DFASerializer;
 exports.LexerDFASerializer = LexerDFASerializer;

--- a/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
@@ -73,6 +73,5 @@ class LexerDFASerializer extends DFASerializer {
     }
 }
 
-module.exports = { DFASerializer };
-module.exports = { LexerDFASerializer };
+module.exports = { DFASerializer , LexerDFASerializer };
 

--- a/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFASerializer.js
@@ -23,7 +23,7 @@ class DFASerializer {
            const s = states[i];
            if(s.edges!==null) {
                 const n = s.edges.length;
-                for(const j=0;j<n;j++) {
+                for(let j=0;j<n;j++) {
                     const t = s.edges[j] || null;
                     if(t!==null && t.stateNumber !== 0x7FFFFFFF) {
                         buf = buf.concat(this.getStateString(s));

--- a/runtime/JavaScript/src/antlr4/dfa/DFAState.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFAState.js
@@ -12,15 +12,16 @@ var Set = Utils.Set;
 
 // Map a predicate to a predicted alternative.///
 
-function PredPrediction(pred, alt) {
-	this.alt = alt;
-	this.pred = pred;
-	return this;
-}
+class PredPrediction {
+	constructor(pred, alt) {
+		this.alt = alt;
+		this.pred = pred;
+	}
 
-PredPrediction.prototype.toString = function() {
-	return "(" + this.pred + ", " + this.alt + ")";
-};
+	toString() {
+		return "(" + this.pred + ", " + this.alt + ")";
+	}
+}
 
 // A DFA state represents a set of possible ATN configurations.
 // As Aho, Sethi, Ullman p. 117 says "The DFA uses its state
@@ -47,64 +48,65 @@ PredPrediction.prototype.toString = function() {
 // meaning that state was reached via a different set of rule invocations.</p>
 // /
 
-function DFAState(stateNumber, configs) {
-	if (stateNumber === null) {
-		stateNumber = -1;
+class DFAState {
+	constructor(stateNumber, configs) {
+		if (stateNumber === null) {
+			stateNumber = -1;
+		}
+		if (configs === null) {
+			configs = new ATNConfigSet();
+		}
+		this.stateNumber = stateNumber;
+		this.configs = configs;
+		// {@code edges[symbol]} points to target of symbol. Shift up by 1 so (-1)
+		// {@link Token//EOF} maps to {@code edges[0]}.
+		this.edges = null;
+		this.isAcceptState = false;
+		// if accept state, what ttype do we match or alt do we predict?
+		// This is set to {@link ATN//INVALID_ALT_NUMBER} when {@link
+		// //predicates}{@code !=null} or
+		// {@link //requiresFullContext}.
+		this.prediction = 0;
+		this.lexerActionExecutor = null;
+		// Indicates that this state was created during SLL prediction that
+		// discovered a conflict between the configurations in the state. Future
+		// {@link ParserATNSimulator//execATN} invocations immediately jumped doing
+		// full context prediction if this field is true.
+		this.requiresFullContext = false;
+		// During SLL parsing, this is a list of predicates associated with the
+		// ATN configurations of the DFA state. When we have predicates,
+		// {@link //requiresFullContext} is {@code false} since full context
+		// prediction evaluates predicates
+		// on-the-fly. If this is not null, then {@link //prediction} is
+		// {@link ATN//INVALID_ALT_NUMBER}.
+		//
+		// <p>We only use these for non-{@link //requiresFullContext} but
+		// conflicting states. That
+		// means we know from the context (it's $ or we don't dip into outer
+		// context) that it's an ambiguity not a conflict.</p>
+		//
+		// <p>This list is computed by {@link
+		// ParserATNSimulator//predicateDFAState}.</p>
+		this.predicates = null;
+		return this;
 	}
-	if (configs === null) {
-		configs = new ATNConfigSet();
-	}
-	this.stateNumber = stateNumber;
-	this.configs = configs;
-	// {@code edges[symbol]} points to target of symbol. Shift up by 1 so (-1)
-	// {@link Token//EOF} maps to {@code edges[0]}.
-	this.edges = null;
-	this.isAcceptState = false;
-	// if accept state, what ttype do we match or alt do we predict?
-	// This is set to {@link ATN//INVALID_ALT_NUMBER} when {@link
-	// //predicates}{@code !=null} or
-	// {@link //requiresFullContext}.
-	this.prediction = 0;
-	this.lexerActionExecutor = null;
-	// Indicates that this state was created during SLL prediction that
-	// discovered a conflict between the configurations in the state. Future
-	// {@link ParserATNSimulator//execATN} invocations immediately jumped doing
-	// full context prediction if this field is true.
-	this.requiresFullContext = false;
-	// During SLL parsing, this is a list of predicates associated with the
-	// ATN configurations of the DFA state. When we have predicates,
-	// {@link //requiresFullContext} is {@code false} since full context
-	// prediction evaluates predicates
-	// on-the-fly. If this is not null, then {@link //prediction} is
-	// {@link ATN//INVALID_ALT_NUMBER}.
-	//
-	// <p>We only use these for non-{@link //requiresFullContext} but
-	// conflicting states. That
-	// means we know from the context (it's $ or we don't dip into outer
-	// context) that it's an ambiguity not a conflict.</p>
-	//
-	// <p>This list is computed by {@link
-	// ParserATNSimulator//predicateDFAState}.</p>
-	this.predicates = null;
-	return this;
-}
 
 // Get the set of all alts mentioned by all ATN configurations in this
 // DFA state.
-DFAState.prototype.getAltSet = function() {
-	var alts = new Set();
-	if (this.configs !== null) {
-		for (var i = 0; i < this.configs.length; i++) {
-			var c = this.configs[i];
-			alts.add(c.alt);
+	getAltSet() {
+		var alts = new Set();
+		if (this.configs !== null) {
+			for (var i = 0; i < this.configs.length; i++) {
+				var c = this.configs[i];
+				alts.add(c.alt);
+			}
+		}
+		if (alts.length === 0) {
+			return null;
+		} else {
+			return alts;
 		}
 	}
-	if (alts.length === 0) {
-		return null;
-	} else {
-		return alts;
-	}
-};
 
 // Two {@link DFAState} instances are equal if their ATN configuration sets
 // are the same. This method is used to see if a state already exists.
@@ -117,30 +119,31 @@ DFAState.prototype.getAltSet = function() {
 // {@link ParserATNSimulator//addDFAState} we need to know if any other state
 // exists that has this exact set of ATN configurations. The
 // {@link //stateNumber} is irrelevant.</p>
-DFAState.prototype.equals = function(other) {
-	// compare set of ATN configurations in this set with other
-	return this === other ||
-			(other instanceof DFAState &&
-				this.configs.equals(other.configs));
-};
+	equals(other) {
+		// compare set of ATN configurations in this set with other
+		return this === other ||
+				(other instanceof DFAState &&
+					this.configs.equals(other.configs));
+	}
 
-DFAState.prototype.toString = function() {
-	var s = "" + this.stateNumber + ":" + this.configs;
-	if(this.isAcceptState) {
-        s = s + "=>";
-        if (this.predicates !== null)
-            s = s + this.predicates;
-        else
-            s = s + this.prediction;
-    }
-	return s;
-};
+	toString() {
+		var s = "" + this.stateNumber + ":" + this.configs;
+		if(this.isAcceptState) {
+			s = s + "=>";
+			if (this.predicates !== null)
+				s = s + this.predicates;
+			else
+				s = s + this.prediction;
+		}
+		return s;
+	}
 
-DFAState.prototype.hashCode = function() {
-	var hash = new Hash();
-	hash.update(this.configs);
-    return hash.finish();
-};
+	hashCode() {
+		var hash = new Hash();
+		hash.update(this.configs);
+		return hash.finish();
+	}
+}
 
 exports.DFAState = DFAState;
 exports.PredPrediction = PredPrediction;

--- a/runtime/JavaScript/src/antlr4/dfa/DFAState.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFAState.js
@@ -153,5 +153,4 @@ class DFAState {
 	}
 }
 
-module.exports = {DFAState};
-module.exports = {PredPrediction};
+module.exports = { DFAState, PredPrediction };

--- a/runtime/JavaScript/src/antlr4/dfa/DFAState.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFAState.js
@@ -1,15 +1,14 @@
-//
 /* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
-///
 
 const {ATNConfigSet} = require('./../atn/ATNConfigSet');
 const {Hash, Set} = require('./../Utils');
 
-// Map a predicate to a predicted alternative.///
-
+/**
+ * Map a predicate to a predicted alternative.
+ */
 class PredPrediction {
 	constructor(pred, alt) {
 		this.alt = alt;
@@ -21,31 +20,31 @@ class PredPrediction {
 	}
 }
 
-// A DFA state represents a set of possible ATN configurations.
-// As Aho, Sethi, Ullman p. 117 says "The DFA uses its state
-// to keep track of all possible states the ATN can be in after
-// reading each input symbol. That is to say, after reading
-// input a1a2..an, the DFA is in a state that represents the
-// subset T of the states of the ATN that are reachable from the
-// ATN's start state along some path labeled a1a2..an."
-// In conventional NFA&rarr;DFA conversion, therefore, the subset T
-// would be a bitset representing the set of states the
-// ATN could be in. We need to track the alt predicted by each
-// state as well, however. More importantly, we need to maintain
-// a stack of states, tracking the closure operations as they
-// jump from rule to rule, emulating rule invocations (method calls).
-// I have to add a stack to simulate the proper lookahead sequences for
-// the underlying LL grammar from which the ATN was derived.
-//
-// <p>I use a set of ATNConfig objects not simple states. An ATNConfig
-// is both a state (ala normal conversion) and a RuleContext describing
-// the chain of rules (if any) followed to arrive at that state.</p>
-//
-// <p>A DFA state may have multiple references to a particular state,
-// but with different ATN contexts (with same or different alts)
-// meaning that state was reached via a different set of rule invocations.</p>
-// /
-
+/**
+ * A DFA state represents a set of possible ATN configurations.
+ * As Aho, Sethi, Ullman p. 117 says "The DFA uses its state
+ * to keep track of all possible states the ATN can be in after
+ * reading each input symbol. That is to say, after reading
+ * input a1a2..an, the DFA is in a state that represents the
+ * subset T of the states of the ATN that are reachable from the
+ * ATN's start state along some path labeled a1a2..an."
+ * In conventional NFA&rarr;DFA conversion, therefore, the subset T
+ * would be a bitset representing the set of states the
+ * ATN could be in. We need to track the alt predicted by each
+ * state as well, however. More importantly, we need to maintain
+ * a stack of states, tracking the closure operations as they
+ * jump from rule to rule, emulating rule invocations (method calls).
+ * I have to add a stack to simulate the proper lookahead sequences for
+ * the underlying LL grammar from which the ATN was derived.
+ *
+ * <p>I use a set of ATNConfig objects not simple states. An ATNConfig
+ * is both a state (ala normal conversion) and a RuleContext describing
+ * the chain of rules (if any) followed to arrive at that state.</p>
+ *
+ * <p>A DFA state may have multiple references to a particular state,
+ * but with different ATN contexts (with same or different alts)
+ * meaning that state was reached via a different set of rule invocations.</p>
+ */
 class DFAState {
 	constructor(stateNumber, configs) {
 		if (stateNumber === null) {
@@ -56,41 +55,50 @@ class DFAState {
 		}
 		this.stateNumber = stateNumber;
 		this.configs = configs;
-		// {@code edges[symbol]} points to target of symbol. Shift up by 1 so (-1)
-		// {@link Token//EOF} maps to {@code edges[0]}.
+		/**
+		 * {@code edges[symbol]} points to target of symbol. Shift up by 1 so (-1)
+		 * {@link Token//EOF} maps to {@code edges[0]}.
+		 */
 		this.edges = null;
 		this.isAcceptState = false;
-		// if accept state, what ttype do we match or alt do we predict?
-		// This is set to {@link ATN//INVALID_ALT_NUMBER} when {@link
-		// //predicates}{@code !=null} or
-		// {@link //requiresFullContext}.
+		/**
+		 * if accept state, what ttype do we match or alt do we predict?
+		 * This is set to {@link ATN//INVALID_ALT_NUMBER} when {@link//predicates}
+		 * {@code !=null} or {@link //requiresFullContext}.
+		 */
 		this.prediction = 0;
 		this.lexerActionExecutor = null;
-		// Indicates that this state was created during SLL prediction that
-		// discovered a conflict between the configurations in the state. Future
-		// {@link ParserATNSimulator//execATN} invocations immediately jumped doing
-		// full context prediction if this field is true.
+		/**
+		 * Indicates that this state was created during SLL prediction that
+		 * discovered a conflict between the configurations in the state. Future
+		 * {@link ParserATNSimulator//execATN} invocations immediately jumped doing
+		 * full context prediction if this field is true.
+		 */
 		this.requiresFullContext = false;
-		// During SLL parsing, this is a list of predicates associated with the
-		// ATN configurations of the DFA state. When we have predicates,
-		// {@link //requiresFullContext} is {@code false} since full context
-		// prediction evaluates predicates
-		// on-the-fly. If this is not null, then {@link //prediction} is
-		// {@link ATN//INVALID_ALT_NUMBER}.
-		//
-		// <p>We only use these for non-{@link //requiresFullContext} but
-		// conflicting states. That
-		// means we know from the context (it's $ or we don't dip into outer
-		// context) that it's an ambiguity not a conflict.</p>
-		//
-		// <p>This list is computed by {@link
-		// ParserATNSimulator//predicateDFAState}.</p>
+		/**
+		 * During SLL parsing, this is a list of predicates associated with the
+		 * ATN configurations of the DFA state. When we have predicates,
+		 * {@link //requiresFullContext} is {@code false} since full context
+		 * prediction evaluates predicates
+		 * on-the-fly. If this is not null, then {@link //prediction} is
+		 * {@link ATN//INVALID_ALT_NUMBER}.
+		 *
+		 * <p>We only use these for non-{@link //requiresFullContext} but
+		 * conflicting states. That
+		 * means we know from the context (it's $ or we don't dip into outer
+		 * context) that it's an ambiguity not a conflict.</p>
+		 *
+		 * <p>This list is computed by {@link
+		 * ParserATNSimulator//predicateDFAState}.</p>
+		 */
 		this.predicates = null;
 		return this;
 	}
 
-// Get the set of all alts mentioned by all ATN configurations in this
-// DFA state.
+	/**
+	 * Get the set of all alts mentioned by all ATN configurations in this
+	 * DFA state.
+	 */
 	getAltSet() {
 		const alts = new Set();
 		if (this.configs !== null) {
@@ -106,17 +114,19 @@ class DFAState {
 		}
 	}
 
-// Two {@link DFAState} instances are equal if their ATN configuration sets
-// are the same. This method is used to see if a state already exists.
-//
-// <p>Because the number of alternatives and number of ATN configurations are
-// finite, there is a finite number of DFA states that can be processed.
-// This is necessary to show that the algorithm terminates.</p>
-//
-// <p>Cannot test the DFA state numbers here because in
-// {@link ParserATNSimulator//addDFAState} we need to know if any other state
-// exists that has this exact set of ATN configurations. The
-// {@link //stateNumber} is irrelevant.</p>
+	/**
+	 * Two {@link DFAState} instances are equal if their ATN configuration sets
+	 * are the same. This method is used to see if a state already exists.
+	 *
+	 * <p>Because the number of alternatives and number of ATN configurations are
+	 * finite, there is a finite number of DFA states that can be processed.
+	 * This is necessary to show that the algorithm terminates.</p>
+	 *
+	 * <p>Cannot test the DFA state numbers here because in
+	 * {@link ParserATNSimulator//addDFAState} we need to know if any other state
+	 * exists that has this exact set of ATN configurations. The
+	 * {@link //stateNumber} is irrelevant.</p>
+	 */
 	equals(other) {
 		// compare set of ATN configurations in this set with other
 		return this === other ||

--- a/runtime/JavaScript/src/antlr4/dfa/DFAState.js
+++ b/runtime/JavaScript/src/antlr4/dfa/DFAState.js
@@ -5,10 +5,8 @@
  */
 ///
 
-var ATNConfigSet = require('./../atn/ATNConfigSet').ATNConfigSet;
-var Utils = require('./../Utils');
-var Hash = Utils.Hash;
-var Set = Utils.Set;
+const {ATNConfigSet} = require('./../atn/ATNConfigSet');
+const {Hash, Set} = require('./../Utils');
 
 // Map a predicate to a predicted alternative.///
 
@@ -94,10 +92,10 @@ class DFAState {
 // Get the set of all alts mentioned by all ATN configurations in this
 // DFA state.
 	getAltSet() {
-		var alts = new Set();
+		const alts = new Set();
 		if (this.configs !== null) {
-			for (var i = 0; i < this.configs.length; i++) {
-				var c = this.configs[i];
+			for (let i = 0; i < this.configs.length; i++) {
+				const c = this.configs[i];
 				alts.add(c.alt);
 			}
 		}
@@ -127,7 +125,7 @@ class DFAState {
 	}
 
 	toString() {
-		var s = "" + this.stateNumber + ":" + this.configs;
+		let s = "" + this.stateNumber + ":" + this.configs;
 		if(this.isAcceptState) {
 			s = s + "=>";
 			if (this.predicates !== null)
@@ -139,11 +137,11 @@ class DFAState {
 	}
 
 	hashCode() {
-		var hash = new Hash();
+		const hash = new Hash();
 		hash.update(this.configs);
 		return hash.finish();
 	}
 }
 
-exports.DFAState = DFAState;
-exports.PredPrediction = PredPrediction;
+module.exports = {DFAState};
+module.exports = {PredPrediction};


### PR DESCRIPTION
This PR is a follow up on #2742 to refactor the DFA object declarations to:
- use es6 classes/inheritance instead of direct prototype manipulation. Es6 class declarations are really just syntactic sugar over prototype inheritance so this change should have no effect on the runtime itself.
- use const/let on variable declarations to improve variable scoping
- refactor comments to be JsDoc compatible which most IDEs can leverage to provide better developer feedback