### PR TITLE
Add contextImplements rule option

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -239,3 +239,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/11/18, mlilback, Mark Lilback, mark@lilback.com
 2020/02/02, carocad, Camilo Roca, carocad@unal.edu.co
 2020/02/10, julibert, Julián Bermúdez Ortega, julibert.dev@gmail.com
+2020/02/21, StochasticTinkr, Daniel Pitts, github@coloraura.com

--- a/tool/src/org/antlr/v4/codegen/model/decl/StructDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/StructDecl.java
@@ -12,9 +12,11 @@ import org.antlr.v4.codegen.model.ListenerDispatchMethod;
 import org.antlr.v4.codegen.model.ModelElement;
 import org.antlr.v4.codegen.model.OutputModelObject;
 import org.antlr.v4.codegen.model.VisitorDispatchMethod;
+import org.antlr.v4.codegen.model.chunk.ActionText;
 import org.antlr.v4.runtime.misc.OrderedHashSet;
 import org.antlr.v4.tool.Attribute;
 import org.antlr.v4.tool.Rule;
+import org.antlr.v4.tool.ast.RuleAST;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -46,6 +48,11 @@ public class StructDecl extends Decl {
 	public StructDecl(OutputModelFactory factory, Rule r) {
 		super(factory, factory.getGenerator().getTarget().getRuleFunctionContextStructName(r));
 		addDispatchMethods(r);
+		final RuleAST ast = r.ast;
+		final String contextImplements = ast.getOptionString("contextImplements");
+		if (contextImplements != null) {
+			implementInterface(new ActionText(this, contextImplements));
+		}
 		derivedFromName = r.name;
 		provideCopyFrom = r.hasAltSpecificContexts();
 	}

--- a/tool/src/org/antlr/v4/tool/Grammar.java
+++ b/tool/src/org/antlr/v4/tool/Grammar.java
@@ -88,6 +88,9 @@ public class Grammar implements AttributeResolver {
 	public static final Set<String> lexerOptions = parserOptions;
 
 	public static final Set<String> ruleOptions = new HashSet<String>();
+	static {
+		ruleOptions.add("contextImplements");
+	}
 
 	public static final Set<String> ParserBlockOptions = new HashSet<String>();
 


### PR DESCRIPTION
Allows a new "contextImplements" rule option. The value of this option will be used to add an `implements` clause on the Java class declaration of the rule's Context class.

I wasn't quite sure the most appropriate place to add this code, so if it belongs in another part of the processing, let me know and I can move it.  If there is any additional changes you would like, also let me know.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->