### PR TITLE
Drop maven2 artifact maven-project in favor of maven-core

### DIFF
--- a/antlr4-maven-plugin/pom.xml
+++ b/antlr4-maven-plugin/pom.xml
@@ -83,7 +83,6 @@
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
         <version>${mavenVersion}</version>
-        <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.maven</groupId>
@@ -96,11 +95,6 @@
         <artifactId>plexus-utils</artifactId>
         <version>3.0.15</version>
         <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>2.2.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The other maven artifacts are maven3 already.  The necessary classes are in maven-core, so give it compile scope instead of test scope.

My addition to contributors.txt is part of the first pull request I submitted: https://github.com/antlr/antlr4/pull/2739