### PR TITLE
Ignore .factorypath files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ xcuserdata
 javac-services.0.log
 javac-services.0.log.lck
 test/
+
+# Maven generated file
+.factorypath

--- a/contributors.txt
+++ b/contributors.txt
@@ -240,3 +240,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/02/02, carocad, Camilo Roca, carocad@unal.edu.co
 2020/02/10, julibert, Julián Bermúdez Ortega, julibert.dev@gmail.com
 2020/02/21, StochasticTinkr, Daniel Pitts, github@coloraura.com
+2020/02/21, quantumsheep, Nathanael Demacon, nathanael.dmc@outlook.fr


### PR DESCRIPTION
`.factorypath` files are generated by Maven and may be undesirable in future commits.