### PR TITLE
Javascript: fix some cyclic dependencies

### DIFF
--- a/runtime/JavaScript/src/antlr4/RuleContext.js
+++ b/runtime/JavaScript/src/antlr4/RuleContext.js
@@ -6,6 +6,7 @@
 const {RuleNode} = require('./tree/Tree');
 const {INVALID_INTERVAL} = require('./tree/Tree');
 const INVALID_ALT_NUMBER = require('./atn/ATN').INVALID_ALT_NUMBER || 0; // TODO: solve cyclic dependency to avoid || 0
+const Trees = require('./tree/Trees');
 
 class RuleContext extends RuleNode {
 	/** A rule context is a record of a single rule invocation. It knows
@@ -154,7 +155,4 @@ class RuleContext extends RuleNode {
 	}
 }
 
-//need to manage circular dependencies, so export now
 module.exports = RuleContext;
-
-const Trees = require('./tree/Trees');

--- a/runtime/JavaScript/src/antlr4/tree/Tree.js
+++ b/runtime/JavaScript/src/antlr4/tree/Tree.js
@@ -29,6 +29,10 @@ class RuleNode extends ParseTree {
 	constructor() {
 		super();
 	}
+
+	getRuleContext(){
+		throw new Error("missing interface implementation")
+	}
 }
 
 class TerminalNode extends ParseTree {

--- a/runtime/JavaScript/src/antlr4/tree/Trees.js
+++ b/runtime/JavaScript/src/antlr4/tree/Trees.js
@@ -5,9 +5,7 @@
 
 const Utils = require('./../Utils');
 const {Token} = require('./../Token');
-const {ErrorNode, TerminalNode} = require('./Tree');
-const ParserRuleContext = require('./../ParserRuleContext');
-const RuleContext = require('./../RuleContext');
+const {ErrorNode, TerminalNode, RuleNode} = require('./Tree');
 const ATN = require('./../atn/ATN');
 
 /** A set of utility routines useful for all kinds of ANTLR trees. */
@@ -49,8 +47,9 @@ const Trees = {
             ruleNames = recog.ruleNames;
         }
         if(ruleNames!==null) {
-            if (t instanceof RuleContext) {
-                const altNumber = t.getAltNumber();
+            if (t instanceof RuleNode) {
+                const context = t.getRuleContext()
+                const altNumber = context.getAltNumber();
                 if ( altNumber != (ATN.INVALID_ALT_NUMBER || 0) ) { // TODO: solve cyclic dependency to avoid || 0
                     return ruleNames[t.ruleIndex]+":"+altNumber;
                 }
@@ -116,7 +115,7 @@ const Trees = {
             if(t.symbol.type===index) {
                 nodes.push(t);
             }
-        } else if(!findTokens && (t instanceof ParserRuleContext)) {
+        } else if(!findTokens && (t instanceof RuleNode)) {
             if(t.ruleIndex===index) {
                 nodes.push(t);
             }


### PR DESCRIPTION
This PR is a follow up on #2749 specifically [this comment](https://github.com/antlr/antlr4/pull/2749#issuecomment-590068416)

This PR removes 2 of the 3 cyclic dependencies from before:
```bash
$ madge --circular src/antlr4/index.js 
Processed 47 files (1.1s) 

✖ Found 3 circular dependencies!

1) LL1Analyzer.js > PredictionContext.js > RuleContext.js > atn/ATN.js
2) RuleContext.js > tree/Trees.js > ParserRuleContext.js
3) RuleContext.js > tree/Trees.js
```

Number 2 and 3 are eliminated.

The solution for this specific case is to check for `RuleNode` interface since both `RuleContext` and `ParserRuleContext` implement it (`RuleNode -> RuleContext -> ParserRuleContext`) and since `RuleContext` is the only implementation of `RuleNode` the checks are equivalent.

NOTE: On Javascript the RuleNode didnt declare the getRuleContext as in Java so I added it to make it consistent and to make it work as described above.