### PR TITLE
added throws declaration missing from generated swift code

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -138,13 +138,13 @@ import Antlr4
 	 *
 	 * \<p>The default implementation does nothing.\</p>
 	 */
-	<accessLevelOpenOK(file)> func enterEveryRule(_ ctx: ParserRuleContext) { }
+	<accessLevelOpenOK(file)> func enterEveryRule(_ ctx: ParserRuleContext) throws { }
 	/**
 	 * {@inheritDoc\}
 	 *
 	 * \<p>The default implementation does nothing.\</p>
 	 */
-	<accessLevelOpenOK(file)> func exitEveryRule(_ ctx: ParserRuleContext) { }
+	<accessLevelOpenOK(file)> func exitEveryRule(_ ctx: ParserRuleContext) throws { }
 	/**
 	 * {@inheritDoc\}
 	 *


### PR DESCRIPTION
The ParseTreeProtocol defines enterEventRule and ExitEventRule as throws. The generated Listener and BaseListener are missing the throws clause, making it impossible for a subclass to throw an Error in these methods.