### PR TITLE
Clarify and expand documentation for runtime ParseTreeWalker

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -240,3 +240,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/02/02, carocad, Camilo Roca, carocad@unal.edu.co
 2020/02/10, julibert, Julián Bermúdez Ortega, julibert.dev@gmail.com
 2020/02/21, StochasticTinkr, Daniel Pitts, github@coloraura.com
+2020/03/17, XsongyangX, Song Yang, songyang1218@gmail.com

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Tree/ParseTreeWalker.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Tree/ParseTreeWalker.cs
@@ -9,6 +9,16 @@ namespace Antlr4.Runtime.Tree
     {
         public static readonly ParseTreeWalker Default = new ParseTreeWalker();
 
+        /// <summary>
+        /// Performs a walk on the given parse tree starting at the root and going down recursively
+	    /// with depth-first search. On each node, 
+        /// <see cref="ParseTreeWalker.EnterRule(IParseTreeListener, IRuleNode)"/> is called before
+	    /// recursively walking down into child nodes, then
+	    /// <see cref="ParseTreeWalker.ExitRule(IParseTreeListener, IRuleNode)"/>
+        /// is called after the recursive call to wind up.
+        /// </summary>
+        /// <param name="listener">The listener used by the walker to process grammar rules</param>
+        /// <param name="t">The parse tree to be walked on</param>
         public virtual void Walk(IParseTreeListener listener, IParseTree t)
         {
             if (t is IErrorNode)
@@ -35,13 +45,12 @@ namespace Antlr4.Runtime.Tree
         }
 
         /// <summary>
-        /// The discovery of a rule node, involves sending two events: the generic
-        /// <see cref="IParseTreeListener.EnterEveryRule(Antlr4.Runtime.ParserRuleContext)"/>
-        /// and a
-        /// <see cref="Antlr4.Runtime.RuleContext"/>
-        /// -specific event. First we trigger the generic and then
-        /// the rule specific. We to them in reverse order upon finishing the node.
+        /// Enters a grammar rule by first triggering the generic event 
+        /// <see cref="IParseTreeListener.EnterEveryRule"/>
+	    /// then by triggering the event specific to the given parse tree node
         /// </summary>
+        /// <param name="listener"> The listener responding to the trigger events </param>
+        /// <param name="r">The grammar rule containing the rule context</param>
         protected internal virtual void EnterRule(IParseTreeListener listener, IRuleNode r)
         {
             ParserRuleContext ctx = (ParserRuleContext)r.RuleContext;
@@ -49,6 +58,13 @@ namespace Antlr4.Runtime.Tree
             ctx.EnterRule(listener);
         }
 
+        /// <summary>
+        /// Exits a grammar rule by first triggering the event specific to the given parse tree node
+	    /// then by triggering the generic event 
+        /// <see cref="IParseTreeListener.ExitEveryRule"/>
+        /// </summary>
+        /// <param name="listener"> The listener responding to the trigger events </param>
+        /// <param name="r">The grammar rule containing the rule context</param>
         protected internal virtual void ExitRule(IParseTreeListener listener, IRuleNode r)
         {
             ParserRuleContext ctx = (ParserRuleContext)r.RuleContext;

--- a/runtime/Cpp/runtime/src/tree/ParseTreeWalker.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeWalker.h
@@ -16,31 +16,38 @@ namespace tree {
 
     virtual ~ParseTreeWalker();
     
-    /// <summary>
-    /// Performs a walk on the given parse tree starting at the root and going down recursively
-	/// with depth-first search. On each node, <seealso cref="ParseTreeWalker#enterRule"/> is called before
-    /// recursively walking down into child nodes, then
-    /// <seealso cref="ParseTreeWalker#exitRule"/> is called after the recursive call to wind up.
-	/// </summary>
-    /// <param name='listener'> The listener used by the walker to process grammar rules </param>
-	/// <param name='t'> The parse tree to be walked on </param>
+    /**
+    * <summary>
+    * Performs a walk on the given parse tree starting at the root and going down recursively
+	* with depth-first search. On each node, <seealso cref="ParseTreeWalker#enterRule"/> is called before
+    * recursively walking down into child nodes, then
+    * <seealso cref="ParseTreeWalker#exitRule"/> is called after the recursive call to wind up.
+	* </summary>
+    * <param name='listener'> The listener used by the walker to process grammar rules </param>
+	* <param name='t'> The parse tree to be walked on </param>
+    */
     virtual void walk(ParseTreeListener *listener, ParseTree *t) const;
 
   protected:
-    /// <summary>
-    /// Enters a grammar rule by first triggering the generic event <seealso cref="ParseTreeListener#enterEveryRule"/>
-	/// then by triggering the event specific to the given parse tree node
-	/// </summary>
-    /// <param name='listener'> The listener responding to the trigger events </param>
-	/// <param name='r'> The grammar rule containing the rule context </param>
+    
+    /**
+    * <summary>
+    * Enters a grammar rule by first triggering the generic event <seealso cref="ParseTreeListener#enterEveryRule"/>
+	* then by triggering the event specific to the given parse tree node
+	* </summary>
+    * <param name='listener'> The listener responding to the trigger events </param>
+	* <param name='r'> The grammar rule containing the rule context </param>
+    */
     virtual void enterRule(ParseTreeListener *listener, ParseTree *r) const;
     
-    /// <summary>
-    /// Exits a grammar rule by first triggering the event specific to the given parse tree node
-	/// then by triggering the generic event <seealso cref="ParseTreeListener#exitEveryRule"/>
-	/// </summary>
-    /// <param name='listener'> The listener responding to the trigger events </param>
-	/// <param name='r'> The grammar rule containing the rule context </param>
+    /**
+    * <summary>
+    * Exits a grammar rule by first triggering the event specific to the given parse tree node
+	* then by triggering the generic event <seealso cref="ParseTreeListener#exitEveryRule"/>
+	* </summary>
+    * <param name='listener'> The listener responding to the trigger events </param>
+	* <param name='r'> The grammar rule containing the rule context </param>
+    */
     virtual void exitRule(ParseTreeListener *listener, ParseTree *r) const;
   };
 

--- a/runtime/Cpp/runtime/src/tree/ParseTreeWalker.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeWalker.h
@@ -15,15 +15,32 @@ namespace tree {
     static ParseTreeWalker &DEFAULT;
 
     virtual ~ParseTreeWalker();
-
+    
+    /// <summary>
+    /// Performs a walk on the given parse tree starting at the root and going down recursively
+	/// with depth-first search. On each node, <seealso cref="ParseTreeWalker#enterRule"/> is called before
+    /// recursively walking down into child nodes, then
+    /// <seealso cref="ParseTreeWalker#exitRule"/> is called after the recursive call to wind up.
+	/// </summary>
+    /// <param name='listener'> The listener used by the walker to process grammar rules </param>
+	/// <param name='t'> The parse tree to be walked on </param>
     virtual void walk(ParseTreeListener *listener, ParseTree *t) const;
 
   protected:
-    /// The discovery of a rule node, involves sending two events: the generic
-    /// <seealso cref="ParseTreeListener#enterEveryRule"/> and a
-    /// <seealso cref="RuleContext"/>-specific event. First we trigger the generic and then
-    /// the rule specific. We do them in reverse order upon finishing the node.
+    /// <summary>
+    /// Enters a grammar rule by first triggering the generic event <seealso cref="ParseTreeListener#enterEveryRule"/>
+	/// then by triggering the event specific to the given parse tree node
+	/// </summary>
+    /// <param name='listener'> The listener responding to the trigger events </param>
+	/// <param name='r'> The grammar rule containing the rule context </param>
     virtual void enterRule(ParseTreeListener *listener, ParseTree *r) const;
+    
+    /// <summary>
+    /// Exits a grammar rule by first triggering the event specific to the given parse tree node
+	/// then by triggering the generic event <seealso cref="ParseTreeListener#exitEveryRule"/>
+	/// </summary>
+    /// <param name='listener'> The listener responding to the trigger events </param>
+	/// <param name='r'> The grammar rule containing the rule context </param>
     virtual void exitRule(ParseTreeListener *listener, ParseTree *r) const;
   };
 

--- a/runtime/Go/antlr/tree.go
+++ b/runtime/Go/antlr/tree.go
@@ -214,6 +214,10 @@ func NewParseTreeWalker() *ParseTreeWalker {
 	return new(ParseTreeWalker)
 }
 
+// Performs a walk on the given parse tree starting at the root and going down recursively
+// with depth-first search. On each node, EnterRule is called before
+// recursively walking down into child nodes, then
+// ExitRule is called after the recursive call to wind up.
 func (p *ParseTreeWalker) Walk(listener ParseTreeListener, t Tree) {
 	switch tt := t.(type) {
 	case ErrorNode:
@@ -231,10 +235,8 @@ func (p *ParseTreeWalker) Walk(listener ParseTreeListener, t Tree) {
 }
 
 //
-// The discovery of a rule node, involves sending two events: the generic
-// {@link ParseTreeListener//EnterEveryRule} and a
-// {@link RuleContext}-specific event. First we trigger the generic and then
-// the rule specific. We to them in reverse order upon finishing the node.
+// Enters a grammar rule by first triggering the generic event {@link ParseTreeListener//EnterEveryRule}
+// then by triggering the event specific to the given parse tree node
 //
 func (p *ParseTreeWalker) EnterRule(listener ParseTreeListener, r RuleNode) {
 	ctx := r.GetRuleContext().(ParserRuleContext)
@@ -242,6 +244,9 @@ func (p *ParseTreeWalker) EnterRule(listener ParseTreeListener, r RuleNode) {
 	ctx.EnterRule(listener)
 }
 
+// Exits a grammar rule by first triggering the event specific to the given parse tree node
+// then by triggering the generic event {@link ParseTreeListener//ExitEveryRule}
+//
 func (p *ParseTreeWalker) ExitRule(listener ParseTreeListener, r RuleNode) {
 	ctx := r.GetRuleContext().(ParserRuleContext)
 	ctx.ExitRule(listener)

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/ParseTreeWalker.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/ParseTreeWalker.java
@@ -7,12 +7,20 @@
 package org.antlr.v4.runtime.tree;
 
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.RuleContext;
 
 public class ParseTreeWalker {
     public static final ParseTreeWalker DEFAULT = new ParseTreeWalker();
 
-    public void walk(ParseTreeListener listener, ParseTree t) {
+
+	/**
+	 * Performs a walk on the given parse tree starting at the root and going down recursively
+	 * with depth-first search. On each node, {@link ParseTreeWalker#enterRule} is called before
+	 * recursively walking down into child nodes, then
+	 * {@link ParseTreeWalker#exitRule} is called after the recursive call to wind up.
+	 * @param listener The listener used by the walker to process grammar rules
+	 * @param t The parse tree to be walked on
+	 */
+	public void walk(ParseTreeListener listener, ParseTree t) {
 		if ( t instanceof ErrorNode) {
 			listener.visitErrorNode((ErrorNode)t);
 			return;
@@ -31,10 +39,10 @@ public class ParseTreeWalker {
     }
 
 	/**
-	 * The discovery of a rule node, involves sending two events: the generic
-	 * {@link ParseTreeListener#enterEveryRule} and a
-	 * {@link RuleContext}-specific event. First we trigger the generic and then
-	 * the rule specific. We to them in reverse order upon finishing the node.
+	 * Enters a grammar rule by first triggering the generic event {@link ParseTreeListener#enterEveryRule}
+	 * then by triggering the event specific to the given parse tree node
+	 * @param listener The listener responding to the trigger events
+	 * @param r The grammar rule containing the rule context
 	 */
     protected void enterRule(ParseTreeListener listener, RuleNode r) {
 		ParserRuleContext ctx = (ParserRuleContext)r.getRuleContext();
@@ -42,7 +50,14 @@ public class ParseTreeWalker {
 		ctx.enterRule(listener);
     }
 
-    protected void exitRule(ParseTreeListener listener, RuleNode r) {
+
+	/**
+	 * Exits a grammar rule by first triggering the event specific to the given parse tree node
+	 * then by triggering the generic event {@link ParseTreeListener#enterEveryRule}
+	 * @param listener The listener responding to the trigger events
+	 * @param r The grammar rule containing the rule context
+	 */
+	protected void exitRule(ParseTreeListener listener, RuleNode r) {
 		ParserRuleContext ctx = (ParserRuleContext)r.getRuleContext();
 		ctx.exitRule(listener);
 		listener.exitEveryRule(ctx);

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/ParseTreeWalker.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/ParseTreeWalker.java
@@ -53,7 +53,7 @@ public class ParseTreeWalker {
 
 	/**
 	 * Exits a grammar rule by first triggering the event specific to the given parse tree node
-	 * then by triggering the generic event {@link ParseTreeListener#enterEveryRule}
+	 * then by triggering the generic event {@link ParseTreeListener#exitEveryRule}
 	 * @param listener The listener responding to the trigger events
 	 * @param r The grammar rule containing the rule context
 	 */

--- a/runtime/JavaScript/src/antlr4/tree/Tree.js
+++ b/runtime/JavaScript/src/antlr4/tree/Tree.js
@@ -158,6 +158,15 @@ class ErrorNodeImpl extends TerminalNodeImpl {
 }
 
 class ParseTreeWalker {
+
+	/**
+	 * Performs a walk on the given parse tree starting at the root and going down recursively
+	 * with depth-first search. On each node, {@link ParseTreeWalker//enterRule} is called before
+	 * recursively walking down into child nodes, then
+	 * {@link ParseTreeWalker//exitRule} is called after the recursive call to wind up.
+	 * @param listener The listener used by the walker to process grammar rules
+	 * @param t The parse tree to be walked on
+	 */
 	walk(listener, t) {
 		const errorNode = t instanceof ErrorNode ||
 				(t.isErrorNode !== undefined && t.isErrorNode());
@@ -176,10 +185,10 @@ class ParseTreeWalker {
 	}
 
 	/**
-	 * The discovery of a rule node, involves sending two events: the generic
-	 * {@link ParseTreeListener//enterEveryRule} and a
-	 * {@link RuleContext}-specific event. First we trigger the generic and then
-	 * the rule specific. We to them in reverse order upon finishing the node.
+	 * Enters a grammar rule by first triggering the generic event {@link ParseTreeListener//enterEveryRule}
+	 * then by triggering the event specific to the given parse tree node
+	 * @param listener The listener responding to the trigger events
+	 * @param r The grammar rule containing the rule context
 	 */
 	enterRule(listener, r) {
 		const ctx = r.getRuleContext();
@@ -187,6 +196,12 @@ class ParseTreeWalker {
 		ctx.enterRule(listener);
 	}
 
+	/**
+	 * Exits a grammar rule by first triggering the event specific to the given parse tree node
+	 * then by triggering the generic event {@link ParseTreeListener//exitEveryRule}
+	 * @param listener The listener responding to the trigger events
+	 * @param r The grammar rule containing the rule context
+	 */
 	exitRule(listener, r) {
 		const ctx = r.getRuleContext();
 		ctx.exitRule(listener);

--- a/runtime/Python2/src/antlr4/tree/Tree.py
+++ b/runtime/Python2/src/antlr4/tree/Tree.py
@@ -136,6 +136,14 @@ class ParseTreeWalker(object):
     DEFAULT = None
 
     def walk(self, listener, t):
+        """
+	    Performs a walk on the given parse tree starting at the root and going down recursively
+	    with depth-first search. On each node, {@link ParseTreeWalker#enterRule} is called before
+	    recursively walking down into child nodes, then
+	    {@link ParseTreeWalker#exitRule} is called after the recursive call to wind up.
+	    @param listener The listener used by the walker to process grammar rules
+	    @param t The parse tree to be walked on
+        """
         if isinstance(t, ErrorNode):
             listener.visitErrorNode(t)
             return
@@ -154,11 +162,23 @@ class ParseTreeWalker(object):
     # the rule specific. We to them in reverse order upon finishing the node.
     #
     def enterRule(self, listener, r):
+        """
+	    Enters a grammar rule by first triggering the generic event {@link ParseTreeListener#enterEveryRule}
+	    then by triggering the event specific to the given parse tree node
+	    @param listener The listener responding to the trigger events
+	    @param r The grammar rule containing the rule context
+        """
         ctx = r.getRuleContext()
         listener.enterEveryRule(ctx)
         ctx.enterRule(listener)
 
     def exitRule(self, listener, r):
+        """
+	    Exits a grammar rule by first triggering the event specific to the given parse tree node
+	    then by triggering the generic event {@link ParseTreeListener#exitEveryRule}
+	    @param listener The listener responding to the trigger events
+	    @param r The grammar rule containing the rule context
+        """
         ctx = r.getRuleContext()
         ctx.exitRule(listener)
         listener.exitEveryRule(ctx)

--- a/runtime/Python3/src/antlr4/tree/Tree.py
+++ b/runtime/Python3/src/antlr4/tree/Tree.py
@@ -140,6 +140,14 @@ class ParseTreeWalker(object):
     DEFAULT = None
 
     def walk(self, listener:ParseTreeListener, t:ParseTree):
+        """
+	    Performs a walk on the given parse tree starting at the root and going down recursively
+	    with depth-first search. On each node, {@link ParseTreeWalker#enterRule} is called before
+	    recursively walking down into child nodes, then
+	    {@link ParseTreeWalker#exitRule} is called after the recursive call to wind up.
+	    @param listener The listener used by the walker to process grammar rules
+	    @param t The parse tree to be walked on
+        """
         if isinstance(t, ErrorNode):
             listener.visitErrorNode(t)
             return
@@ -158,11 +166,23 @@ class ParseTreeWalker(object):
     # the rule specific. We to them in reverse order upon finishing the node.
     #
     def enterRule(self, listener:ParseTreeListener, r:RuleNode):
+        """
+	    Enters a grammar rule by first triggering the generic event {@link ParseTreeListener#enterEveryRule}
+	    then by triggering the event specific to the given parse tree node
+	    @param listener The listener responding to the trigger events
+	    @param r The grammar rule containing the rule context
+        """
         ctx = r.getRuleContext()
         listener.enterEveryRule(ctx)
         ctx.enterRule(listener)
 
     def exitRule(self, listener:ParseTreeListener, r:RuleNode):
+        """
+	    Exits a grammar rule by first triggering the event specific to the given parse tree node
+	    then by triggering the generic event {@link ParseTreeListener#exitEveryRule}
+	    @param listener The listener responding to the trigger events
+	    @param r The grammar rule containing the rule context
+        """
         ctx = r.getRuleContext()
         ctx.exitRule(listener)
         listener.exitEveryRule(ctx)

--- a/runtime/Swift/Sources/Antlr4/tree/ParseTreeWalker.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/ParseTreeWalker.swift
@@ -10,6 +10,14 @@ public class ParseTreeWalker {
     public init() {
     }
 
+    /**
+	 * Performs a walk on the given parse tree starting at the root and going down recursively
+	 * with depth-first search. On each node, ParseTreeWalker.enterRule is called before
+	 * recursively walking down into child nodes, then
+	 * ParseTreeWalker.exitRule is called after the recursive call to wind up.
+	 * - Parameter listener: The listener used by the walker to process grammar rules
+	 * - Parameter t: The parse tree to be walked on
+	 */
     public func walk(_ listener: ParseTreeListener, _ t: ParseTree) throws {
         if let errNode = t as? ErrorNode {
             listener.visitErrorNode(errNode)
@@ -30,18 +38,24 @@ public class ParseTreeWalker {
         }
     }
 
-    /// 
-    /// The discovery of a rule node, involves sending two events: the generic
-    /// _org.antlr.v4.runtime.tree.ParseTreeListener#enterEveryRule_ and a
-    /// _org.antlr.v4.runtime.RuleContext_-specific event. First we trigger the generic and then
-    /// the rule specific. We to them in reverse order upon finishing the node.
-    /// 
+    /**
+	 * Enters a grammar rule by first triggering the generic event ParseTreeListener.enterEveryRule
+	 * then by triggering the event specific to the given parse tree node
+	 * - Parameter listener: The listener responding to the trigger events
+	 * - Parameter r: The grammar rule containing the rule context
+	 */
     internal func enterRule(_ listener: ParseTreeListener, _ r: RuleNode) throws {
         let ctx = r.getRuleContext() as! ParserRuleContext
         try listener.enterEveryRule(ctx)
         ctx.enterRule(listener)
     }
 
+    /**
+	 * Exits a grammar rule by first triggering the event specific to the given parse tree node
+	 * then by triggering the generic event ParseTreeListener.exitEveryRule
+	 * - Parameter listener: The listener responding to the trigger events
+	 * - Parameter r: The grammar rule containing the rule context
+	 */
     internal func exitRule(_ listener: ParseTreeListener, _ r: RuleNode) throws {
         let ctx = r.getRuleContext() as! ParserRuleContext
         ctx.exitRule(listener)


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->
My pull request based on the issue #2759 and the answer given by @ericvergnaud . I applied the changes to all target languages. Hopefully, the documentation style conforms to all the target languages and is accepted by each respective compiler.