### PR TITLE
refactored AntlrInputStream.cs by removing a redundand if-statement

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -241,3 +241,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/02/10, julibert, Julián Bermúdez Ortega, julibert.dev@gmail.com
 2020/02/21, StochasticTinkr, Daniel Pitts, github@coloraura.com
 2020/03/17, XsongyangX, Song Yang, songyang1218@gmail.com
+2020/04/07, deniskyashif, Denis Kyashif, denis.kyashif@gmail.com

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/AntlrInputStream.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/AntlrInputStream.cs
@@ -48,8 +48,7 @@ namespace Antlr4.Runtime
                 System.Diagnostics.Debug.Assert(LA(1) == IntStreamConstants.EOF);
                 throw new InvalidOperationException("cannot consume EOF");
             }
-            //System.out.println("prev p="+p+", c="+(char)data[p]);
-            if (p < n)
+            else
             {
                 p++;
             }


### PR DESCRIPTION
signed contributors.txt

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->