### PR TITLE
Cpp runtime generation fixes, when treat warnings as errors enabled

### DIFF
--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.h
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -18,7 +18,7 @@ namespace antlr4 {
   public:
     DefaultErrorStrategy();
     DefaultErrorStrategy(DefaultErrorStrategy const& other) = delete;
-    virtual ~DefaultErrorStrategy();
+    virtual ~DefaultErrorStrategy() override;
 
     DefaultErrorStrategy& operator = (DefaultErrorStrategy const& other) = delete;
 

--- a/runtime/Cpp/runtime/src/Lexer.h
+++ b/runtime/Cpp/runtime/src/Lexer.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -77,7 +77,7 @@ namespace antlr4 {
 
     Lexer();
     Lexer(CharStream *input);
-    virtual ~Lexer() {}
+    virtual ~Lexer() override {}
 
     virtual void reset();
 

--- a/runtime/Cpp/runtime/src/LexerInterpreter.h
+++ b/runtime/Cpp/runtime/src/LexerInterpreter.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -21,7 +21,7 @@ namespace antlr4 {
                      const std::vector<std::string> &ruleNames, const std::vector<std::string> &channelNames,
                      const std::vector<std::string> &modeNames, const atn::ATN &atn, CharStream *input);
 
-    ~LexerInterpreter();
+    ~LexerInterpreter() override;
 
     virtual const atn::ATN& getATN() const override;
     virtual std::string getGrammarFileName() const override;

--- a/runtime/Cpp/runtime/src/Parser.h
+++ b/runtime/Cpp/runtime/src/Parser.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -21,7 +21,7 @@ namespace antlr4 {
     class TraceListener : public tree::ParseTreeListener {
     public:
       TraceListener(Parser *outerInstance);
-      virtual ~TraceListener();
+      virtual ~TraceListener() override;
 
       virtual void enterEveryRule(ParserRuleContext *ctx) override;
       virtual void visitTerminal(tree::TerminalNode *node) override;
@@ -36,7 +36,7 @@ namespace antlr4 {
     public:
       static TrimToSizeListener INSTANCE;
 
-      virtual ~TrimToSizeListener();
+      virtual ~TrimToSizeListener() override;
 
       virtual void enterEveryRule(ParserRuleContext *ctx) override;
       virtual void visitTerminal(tree::TerminalNode *node) override;
@@ -45,7 +45,7 @@ namespace antlr4 {
     };
 
     Parser(TokenStream *input);
-    virtual ~Parser();
+    virtual ~Parser() override;
 
     /// reset the parser's state
     virtual void reset();

--- a/runtime/Cpp/runtime/src/ParserInterpreter.h
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -34,7 +34,7 @@ namespace antlr4 {
       const std::vector<std::string>& ruleNames, const atn::ATN &atn, TokenStream *input);
     ParserInterpreter(const std::string &grammarFileName, const dfa::Vocabulary &vocabulary,
                       const std::vector<std::string> &ruleNames, const atn::ATN &atn, TokenStream *input);
-    ~ParserInterpreter();
+    ~ParserInterpreter() override;
 
     virtual void reset() override;
 

--- a/runtime/Cpp/runtime/src/ParserRuleContext.h
+++ b/runtime/Cpp/runtime/src/ParserRuleContext.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -67,7 +67,7 @@ namespace antlr4 {
 
     ParserRuleContext();
     ParserRuleContext(ParserRuleContext *parent, size_t invokingStateNumber);
-    virtual ~ParserRuleContext() {}
+    virtual ~ParserRuleContext() override {}
 
     /** COPY a ctx (I'm deliberately not using copy constructor) to avoid
      *  confusion with creating node with parent. Does not copy children

--- a/runtime/Cpp/runtime/src/UnbufferedTokenStream.h
+++ b/runtime/Cpp/runtime/src/UnbufferedTokenStream.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -14,7 +14,7 @@ namespace antlr4 {
     UnbufferedTokenStream(TokenSource *tokenSource);
     UnbufferedTokenStream(TokenSource *tokenSource, int bufferSize);
     UnbufferedTokenStream(const UnbufferedTokenStream& other) = delete;
-    virtual ~UnbufferedTokenStream();
+    virtual ~UnbufferedTokenStream() override;
 
     UnbufferedTokenStream& operator = (const UnbufferedTokenStream& other) = delete;
 

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -86,7 +86,7 @@ namespace atn {
 
     LexerATNSimulator(const ATN &atn, std::vector<dfa::DFA> &decisionToDFA, PredictionContextCache &sharedContextCache);
     LexerATNSimulator(Lexer *recog, const ATN &atn, std::vector<dfa::DFA> &decisionToDFA, PredictionContextCache &sharedContextCache);
-    virtual ~LexerATNSimulator () {}
+    virtual ~LexerATNSimulator () override {}
 
     virtual void copyState(LexerATNSimulator *simulator);
     virtual size_t match(CharStream *input, size_t mode);

--- a/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.h
+++ b/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -13,7 +13,7 @@ namespace dfa {
   class ANTLR4CPP_PUBLIC LexerDFASerializer : public DFASerializer {
   public:
     LexerDFASerializer(DFA *dfa);
-    virtual ~LexerDFASerializer();
+    virtual ~LexerDFASerializer() override;
 
   protected:
     virtual std::string getEdgeLabel(size_t i) const override;

--- a/runtime/Cpp/runtime/src/misc/InterpreterDataReader.h
+++ b/runtime/Cpp/runtime/src/misc/InterpreterDataReader.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -17,7 +17,7 @@ namespace misc {
     std::vector<std::string> channels; // Only valid for lexer grammars.
     std::vector<std::string> modes; // ditto
 
-    InterpreterData() {}; // For invalid content.
+    InterpreterData() {} // For invalid content.
     InterpreterData(std::vector<std::string> const& literalNames, std::vector<std::string> const& symbolicNames);
   };
 

--- a/runtime/Cpp/runtime/src/support/Any.h
+++ b/runtime/Cpp/runtime/src/support/Any.h
@@ -105,7 +105,7 @@ struct ANTLR4CPP_PUBLIC Any
 
 private:
   struct Base {
-    virtual ~Base() {};
+    virtual ~Base() {}
     virtual Base* clone() const = 0;
   };
 

--- a/runtime/Cpp/runtime/src/tree/pattern/TagChunk.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/TagChunk.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -37,7 +37,7 @@ namespace pattern {
     /// <exception cref="IllegalArgumentException"> if {@code tag} is {@code null} or
     /// empty. </exception>
     TagChunk(const std::string &tag);
-    virtual ~TagChunk();
+    virtual ~TagChunk() override;
 
     /// <summary>
     /// Construct a new instance of <seealso cref="TagChunk"/> using the specified label

--- a/runtime/Cpp/runtime/src/tree/pattern/TextChunk.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/TextChunk.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -29,7 +29,7 @@ namespace pattern {
     /// <exception cref="IllegalArgumentException"> if {@code text} is {@code null}. </exception>
   public:
     TextChunk(const std::string &text);
-    virtual ~TextChunk();
+    virtual ~TextChunk() override;
 
     /// <summary>
     /// Gets the raw text of this chunk.

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.h
@@ -14,7 +14,7 @@ public:
   };
 
   XPathLexer(antlr4::CharStream *input);
-  ~XPathLexer();
+  ~XPathLexer() override;
 
   virtual std::string getGrammarFileName() const override;
   virtual const std::vector<std::string>& getRuleNames() const override;

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -64,7 +64,7 @@ public:
 <endif>
 
   <lexer.name>(antlr4::CharStream *input);
-  ~<lexer.name>();
+  ~<lexer.name>() override;
 
   <namedActions.members>
   virtual std::string getGrammarFileName() const override;
@@ -291,11 +291,11 @@ public:
 <endif>
 
   <parser.name>(antlr4::TokenStream *input);
-  ~<parser.name>();
+  ~<parser.name> override();
 
   virtual std::string getGrammarFileName() const override;
-  virtual const antlr4::atn::ATN& getATN() const override { return _atn; };
-  virtual const std::vector\<std::string>& getTokenNames() const override { return _tokenNames; }; // deprecated: use vocabulary instead.
+  virtual const antlr4::atn::ATN& getATN() const override { return _atn; }
+  virtual const std::vector\<std::string>& getTokenNames() const override { return _tokenNames; } // deprecated: use vocabulary instead.
   virtual const std::vector\<std::string>& getRuleNames() const override;
   virtual antlr4::dfa::Vocabulary& getVocabulary() const override;
 


### PR DESCRIPTION
Hello,

I've tried to use your project and found a few minor issues in C++ runtime generation target. It does not work for C++ projects when warnings treated as errors. I am new to ANTLR, and I've tried to fix it. Seems I've found all places, at least which I've used. 

Best regards,
Vitaliy