### PR TITLE
C++ target: escape ? character to prevent accidental trigraphs

### DIFF
--- a/tool/src/org/antlr/v4/codegen/Target.java
+++ b/tool/src/org/antlr/v4/codegen/Target.java
@@ -282,7 +282,7 @@ public abstract class Target {
 		return sb.toString();
 	}
 
-	private static boolean shouldUseUnicodeEscapeForCodePointInDoubleQuotedString(int codePoint) {
+	protected boolean shouldUseUnicodeEscapeForCodePointInDoubleQuotedString(int codePoint) {
 		// We don't want anyone passing 0x0A (newline) or 0x22
 		// (double-quote) here because Java treats \\u000A as
 		// a literal newline and \\u0022 as a literal

--- a/tool/src/org/antlr/v4/codegen/target/CppTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/CppTarget.java
@@ -47,6 +47,7 @@ public class CppTarget extends Target {
 
 	public CppTarget(CodeGenerator gen) {
 		super(gen, "Cpp");
+		targetCharValueEscape['?'] = "\\?";
 	}
 
 	public String getVersion() {
@@ -67,6 +68,18 @@ public class CppTarget extends Target {
 		badWords.addAll(Arrays.asList(cppKeywords));
 		badWords.add("rule");
 		badWords.add("parserRule");
+	}
+
+  @Override
+	protected boolean shouldUseUnicodeEscapeForCodePointInDoubleQuotedString(int codePoint) {
+		if (codePoint == '?') {
+			// in addition to the default escaped code points, also escape ? to prevent trigraphs
+			// ideally, we would escape ? with \?, but escaping as unicode \u003F works as well
+			return true;
+		}
+		else {
+			return super.shouldUseUnicodeEscapeForCodePointInDoubleQuotedString(codePoint);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
If grammars contain something like ?? as a lexer rule (e.g. `CONDITION_CONVERSION: '??';`), the generated C++ code will contain something like `"'??'"` in _literalNames. This can cause compiler warnings or even unintended behaviour, because sequences starting with two ? characters are interpreted as trigraphs.

Using an override of shouldUseUnicodeEscapeForCodePointInDoubleQuotedString in CppTarget
shouldUseUnicodeEscapeForCodePointInDoubleQuotedString in Target was changed from private static to protected to allow overriding

(It's possible to avoid this issue by using C++17 (drops support for trigraphs) and `-Wno-trigraphs`, but escaping the ? character is a universal fix).