### PR TITLE
Add/docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:8-alpine as builder
+WORKDIR /opt/antlr4
+COPY . .
+ARG MAVEN_OPTS="-Xmx1G"
+RUN apk add --no-cache maven \
+    && mvn clean --projects tool --also-make \
+    && mvn -DskipTests install --projects tool --also-make \
+    && mv ./tool/target/antlr4-*-complete.jar antlr4-tool.jar
+
+FROM openjdk:8-alpine
+COPY --from=builder /opt/antlr4/antlr4-tool.jar /usr/local/lib/
+WORKDIR /work
+ENTRYPOINT ["java", "-Xmx500M", "-cp", "/usr/local/lib/antlr4-tool.jar", "org.antlr.v4.Tool"]

--- a/contributors.txt
+++ b/contributors.txt
@@ -242,3 +242,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/02/21, StochasticTinkr, Daniel Pitts, github@coloraura.com
 2020/03/17, XsongyangX, Song Yang, songyang1218@gmail.com
 2020/04/07, deniskyashif, Denis Kyashif, denis.kyashif@gmail.com
+2020/04/23, kaczmarj, Jakub Kaczmarzyk, jakub.kaczmarzyk@stonybrookmedicine.edu


### PR DESCRIPTION
This PR proposes adding a Dockerfile for building a Docker image of the antlr4 tool. The purpose of the Docker image is to provide a standard way of installing this tool without having to install dependencies (i.e., java).

Build the Docker image:

```
docker build --tag antlr4 /path/to/antlr4
```

The working directory of the image is `/work`, so grammars and other files you need to work with should be mounted to `/work`.

```
wget https://raw.githubusercontent.com/antlr/grammars-v4/master/json/JSON.g4
docker run --rm -v $(pwd):/work antlr4 -Dlanguage=Go JSON.g4
```

This PR is borne out of my own situations. I am running Linux and do not have java installed (I don't know how I've gotten this far without installing it). I wanted to use the antlr4 tool to generate a parser and lexer for a grammar, but I did not want to install dependencies temporarily. So instead I used a Docker image.