### PR TITLE
[Go] Thread-safe ANTLR codegen

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -242,3 +242,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/02/21, StochasticTinkr, Daniel Pitts, github@coloraura.com
 2020/03/17, XsongyangX, Song Yang, songyang1218@gmail.com
 2020/04/07, deniskyashif, Denis Kyashif, denis.kyashif@gmail.com
+2020/04/30, TristonianJones, Tristan Swadell, tswadell@google.com

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
@@ -103,6 +103,8 @@ PositionAdjustingLexerDef() ::= ""
 PositionAdjustingLexer() ::= <<
 func (p *PositionAdjustingLexer) NextToken() antlr.Token {
 	if _, ok := p.Interpreter.(*PositionAdjustingLexerATNSimulator); !ok {
+		lexerDeserializer := antlr.NewATNDeserializer(nil)
+		lexerAtn := lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
 		p.Interpreter = NewPositionAdjustingLexerATNSimulator(p, lexerAtn, p.Interpreter.DecisionToDFA(), p.Interpreter.SharedContextCache())
 		p.Virt = p
 	}

--- a/runtime/Go/antlr/lexer.go
+++ b/runtime/Go/antlr/lexer.go
@@ -278,7 +278,8 @@ func (b *BaseLexer) inputStream() CharStream {
 	return b.input
 }
 
-func (b *BaseLexer) setInputStream(input CharStream) {
+// SetInputStream resets the lexer input stream and associated lexer state.
+func (b *BaseLexer) SetInputStream(input CharStream) {
 	b.input = nil
 	b.tokenFactorySourcePair = &TokenSourceCharStreamPair{b, b.input}
 	b.reset()

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -205,10 +205,6 @@ func New<parser.name>(input antlr.TokenStream) *<parser.name> {
 	return this
 }
 
-var (
-	lexer
-)
-
 <if(namedActions.members)>
 
 <namedActions.members>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -151,9 +151,6 @@ var parserATN = <atn>
 var parserATN []uint16
 <endif>
 
-var deserializer = antlr.NewATNDeserializer(nil)
-var deserializedATN = deserializer.DeserializeFromUInt16(parserATN)
-
 <if(parser.literalNames)>
 var literalNames = []string{
 	<parser.literalNames; null="\"\"", separator=", ", wrap>,
@@ -179,21 +176,24 @@ var ruleNames = []string{
 var ruleNames []string
 <endif>
 
-var decisionToDFA = make([]*antlr.DFA, len(deserializedATN.DecisionToState))
-
-func init() {
-	for index, ds := range deserializedATN.DecisionToState {
-		decisionToDFA[index] = antlr.NewDFA(ds, index)
-	}
-}
-
 type <parser.name> struct {
 	<superClass; null="*antlr.BaseParser">
 }
 
+// New<parser.name> produces a new parser instance for the optional input antlr.TokenStream.
+//
+// The *<parser.name> instance produced may be reused by calling the SetInputStream method.
+// The initial parser configuration is expensive to construct, and the object is not thread-safe;
+// however, if used within a Golang sync.Pool, the construction cost amortizes well and the
+// objects can be used in a thread-safe manner.
 func New<parser.name>(input antlr.TokenStream) *<parser.name> {
 	this := new(<parser.name>)
-
+	deserializer := antlr.NewATNDeserializer(nil)
+	deserializedATN := deserializer.DeserializeFromUInt16(parserATN)
+	decisionToDFA := make([]*antlr.DFA, len(deserializedATN.DecisionToState))
+	for index, ds := range deserializedATN.DecisionToState {
+		decisionToDFA[index] = antlr.NewDFA(ds, index)
+	}
 	this.BaseParser = antlr.NewBaseParser(input)
 
 	this.Interpreter = antlr.NewParserATNSimulator(this, deserializedATN, decisionToDFA, antlr.NewPredictionContextCache())
@@ -204,6 +204,11 @@ func New<parser.name>(input antlr.TokenStream) *<parser.name> {
 
 	return this
 }
+
+var (
+	lexer
+)
+
 <if(namedActions.members)>
 
 <namedActions.members>
@@ -1375,9 +1380,6 @@ var serializedLexerAtn []uint16
 <endif>
 
 
-var lexerDeserializer = antlr.NewATNDeserializer(nil)
-var lexerAtn = lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
-
 var lexerChannelNames = []string{
 	"DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels:{c | "<c>"}; separator=", ", wrap><endif>,
 }
@@ -1412,7 +1414,6 @@ var lexerRuleNames = []string{
 var lexerRuleNames []string
 <endif>
 
-
 type <lexer.name> struct {
 	*<if(superClass)><superClass><else>antlr.BaseLexer<endif>
 	channelNames []string
@@ -1420,18 +1421,20 @@ type <lexer.name> struct {
 	// TODO: EOF string
 }
 
-var lexerDecisionToDFA = make([]*antlr.DFA, len(lexerAtn.DecisionToState))
-
-func init() {
+// New<lexer.name> produces a new lexer instance for the optional input antlr.CharStream.
+//
+// The *<lexer.name> instance produced may be reused by calling the SetInputStream method.
+// The initial lexer configuration is expensive to construct, and the object is not thread-safe;
+// however, if used within a Golang sync.Pool, the construction cost amortizes well and the
+// objects can be used in a thread-safe manner.
+func New<lexer.name>(input antlr.CharStream) *<lexer.name> {
+	l := new(<lexer.name>)
+	lexerDeserializer := antlr.NewATNDeserializer(nil)
+	lexerAtn := lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
+	lexerDecisionToDFA := make([]*antlr.DFA, len(lexerAtn.DecisionToState))
 	for index, ds := range lexerAtn.DecisionToState {
 		lexerDecisionToDFA[index] = antlr.NewDFA(ds, index)
 	}
-}
-
-func New<lexer.name>(input antlr.CharStream) *<lexer.name> {
-
-	l := new(<lexer.name>)
-
 	l.BaseLexer = antlr.NewBaseLexer(input)
 	l.Interpreter = antlr.NewLexerATNSimulator(l, lexerAtn, lexerDecisionToDFA, antlr.NewPredictionContextCache())
 


### PR DESCRIPTION
The ANTLR Go codegen allocates mutable global variables which can result in data races as evidenced in https://github.com/google/cel-go/pull/177 and reported in #2040. As a local workaround, global variables in the generated source were shifted into local variables within the `NewLexer` and `NewParser` functions. 

While the change made the generated code thread-safe, it came at a significant CPU and memory overhead in parse-heavy call paths. However, exporting the `SetInputStream` method on the `lexer.go` makes it possible to use `sync.Pool` objects with the modified codegen artifacts and reduces the parsing overhead to within striking distance of the prior non-thread-safe code.

To take advantage of such thread-safety and object reuse within ANTLR Go applications, developers would need to regen their grammars and incorporate the following pattern of use within their own code base:

```go
import (
  "sync"
  "github.com/antlr/antlr4/runtime/Go/antlr"
)

var(
  lexerPool *sync.Pool = &sync.Pool{ New: func() interface{} {
    return New<LexerName>(nil)
  }}
  parserPool *sync.Pool = &sync.Pool{ New: func() interface{} {
    return New<ParserName>(nil)
  }} 
)

func Parse(text string) antlr.ParseTree {
   lex := lexerPool.Get().(*<LexerName>)
   defer lexerPool.Put(lex)
   par := parserPool.Get().(*<ParserName>)
   defer parserPool.Put(par)

   lex.SetInputStream(antlr.NewInputStream(text))
   par.SetInputStream(antlr.NewCommonTokenStream(lex, 0))
   return par.<StartRule>()
}
```

All Go-related tests have been run and executed successfully following this change:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.antlr.v4.test.runtime.go.TestListeners
..Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.444 sec - in org.antlr.v4.test.runtime.go.TestListeners
Running org.antlr.v4.test.runtime.go.TestSemPredEvalLexer
.Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.974 sec - in org.antlr.v4.test.runtime.go.TestSemPredEvalLexer
Running org.antlr.v4.test.runtime.go.TestCompositeLexers
.Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.694 sec - in org.antlr.v4.test.runtime.go.TestCompositeLexers
Running org.antlr.v4.test.runtime.go.TestLexerErrors
..Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.991 sec - in org.antlr.v4.test.runtime.go.TestLexerErrors
Running org.antlr.v4.test.runtime.go.TestLexerExec
.....Tests run: 37, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 25.283 sec - in org.antlr.v4.test.runtime.go.TestLexerExec
Running org.antlr.v4.test.runtime.go.TestParserErrors
.....Tests run: 34, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 26.256 sec - in org.antlr.v4.test.runtime.go.TestParserErrors
Running org.antlr.v4.test.runtime.go.TestParseTrees
.Tests run: 10, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 7.979 sec - in org.antlr.v4.test.runtime.go.TestParseTrees
Running org.antlr.v4.test.runtime.go.TestParserExec
......Tests run: 37, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.849 sec - in org.antlr.v4.test.runtime.go.TestParserExec
Running org.antlr.v4.test.runtime.go.TestSets
.....Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.153 sec - in org.antlr.v4.test.runtime.go.TestSets
Running org.antlr.v4.test.runtime.go.TestFullContextParsing
..Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.256 sec - in org.antlr.v4.test.runtime.go.TestFullContextParsing
Running org.antlr.v4.test.runtime.go.TestPerformance
.Tests run: 7, Failures: 0, Errors: 0, Skipped: 5, Time elapsed: 2.369 sec - in org.antlr.v4.test.runtime.go.TestPerformance
Running org.antlr.v4.test.runtime.go.TestCompositeParsers
..Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.836 sec - in org.antlr.v4.test.runtime.go.TestCompositeParsers
Running org.antlr.v4.test.runtime.go.TestLeftRecursion
................Tests run: 98, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 78.905 sec - in org.antlr.v4.test.runtime.go.TestLeftRecursion
Running org.antlr.v4.test.runtime.go.TestSemPredEvalParser
....Tests run: 26, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 19.584 sec - in org.antlr.v4.test.runtime.go.TestSemPredEvalParser

Results :

Tests run: 340, Failures: 0, Errors: 0, Skipped: 8
```