### PR TITLE
Added missing swift version of class ParseTreeProperty

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -243,3 +243,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/03/17, XsongyangX, Song Yang, songyang1218@gmail.com
 2020/04/07, deniskyashif, Denis Kyashif, denis.kyashif@gmail.com
 2020/04/30, TristonianJones, Tristan Swadell, tswadell@google.com
+2020/05/10, gomerser, Erik Gomersbach, gomerser@gomersba.ch

--- a/runtime/Swift/Sources/Antlr4/tree/ParseTreeProperty.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/ParseTreeProperty.swift
@@ -1,0 +1,15 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+import Foundation
+
+public class ParseTreeProperty<V> {
+  var annotations = Dictionary<ObjectIdentifier, V>()
+  
+  public init() {}
+  
+  open func get(_ node: ParseTree) -> V? { return annotations[ObjectIdentifier(node)] }
+  open func put(_ node: ParseTree, _ value: V) { annotations[ObjectIdentifier(node)] = value }
+  open func removeFrom(_ node: ParseTree) { annotations.removeValue(forKey: ObjectIdentifier(node)) }
+}


### PR DESCRIPTION
I have been converting the examples from "The Definitive ANTLR4 Reference" to Swift. One example in chapter 7 called listeners/TestEvaluatorWithProps.java references a class called  ParseTreeProperty. This class is currently missing from the Swift version of ANTLR4 and is the reason for - and content of - this pull request.