### PR TITLE
reflect requirement of Java ≥ 1.7

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -12,7 +12,7 @@ If you are going to integrate ANTLR into your existing build system using mvn, a
 
 ### UNIX
 
-0. Install Java (version 1.6 or higher)
+0. Install Java (version 1.7 or higher)
 1. Download
 ```
 $ cd /usr/local/lib


### PR DESCRIPTION
Java 1.6 didn`t work for me [tried <http://tunnelvisionlabs.com/downloads/antlr/2013-07-21-antlrworks-2.1.zip> & <http://tunnelvisionlabs.com/downloads/antlr/2013-07-21-antlrworks-2.1.zip>], documentation at <https://github.com/antlr/antlr4/blob/master/doc/building-antlr.md> says "As of 4.6, ANTLR tool and Java-target runtime requires Java 7."

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->