### PR TITLE
reflect requirement of Java ≥ 1.7

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -12,7 +12,7 @@ If you are going to integrate ANTLR into your existing build system using mvn, a
 
 ### UNIX
 
-0. Install Java (version 1.6 or higher)
+0. Install Java (version 1.7 or higher)
 1. Download
 ```
 $ cd /usr/local/lib


### PR DESCRIPTION
Java 1.6 didn`t work for me [tried <http://www.antlr.org/download/antlr-4.7.1-complete.jar> & <https://www.antlr.org/download/antlr-4.8-complete.jar>], documentation at <https://github.com/antlr/antlr4/blob/master/doc/building-antlr.md> says "As of 4.6, ANTLR tool and Java-target runtime requires Java 7."
