### PR TITLE
[C++ runtime] Add AntlrInputStream(std::string_view) constructor

### DIFF
--- a/runtime/Cpp/runtime/antlr4cpp-vs2019.vcxproj
+++ b/runtime/Cpp/runtime/antlr4cpp-vs2019.vcxproj
@@ -182,6 +182,7 @@
       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -201,6 +202,7 @@
       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -220,6 +222,7 @@
       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -239,6 +242,7 @@
       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -259,6 +263,7 @@
       </ForcedIncludeFiles>
       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -281,6 +286,7 @@
       </ForcedIncludeFiles>
       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -303,6 +309,7 @@
       </ForcedIncludeFiles>
       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -325,6 +332,7 @@
       </ForcedIncludeFiles>
       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/runtime/Cpp/runtime/src/ANTLRInputStream.h
+++ b/runtime/Cpp/runtime/src/ANTLRInputStream.h
@@ -25,11 +25,19 @@ namespace antlr4 {
     /// What is name or source of this char stream?
     std::string name;
 
+#if __cplusplus >= 201703L
+    ANTLRInputStream(std::string_view input = "");
+#else
     ANTLRInputStream(const std::string &input = "");
+#endif
     ANTLRInputStream(const char data_[], size_t numberOfActualCharsInArray);
     ANTLRInputStream(std::istream &stream);
 
+#if __cplusplus >= 201703L
+    virtual void load(std::string_view input);
+#else
     virtual void load(const std::string &input);
+#endif
     virtual void load(std::istream &stream);
 
     /// Reset the stream so that it's in the same state it was


### PR DESCRIPTION
Guarded by the `__cplusplus` macro as it is only available in C++17 or newer.

This avoids a copy if the input is actually `char const *` (due to implicit conversion to `std::string` in the pre-C++ 17 version), and performs the same if the input is actually `std::string`.