### PR TITLE
[C++ codegen] Remove use of the u8"" string literal prefix

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -192,23 +192,23 @@ atn::ATN <lexer.name>::_atn;
 std::vector\<uint16_t> <lexer.name>::_serializedATN;
 
 std::vector\<std::string> <lexer.name>::_ruleNames = {
-  <lexer.ruleNames: {r | u8"<r>"}; separator = ", ", wrap, anchor>
+  <lexer.ruleNames: {r | "<r>"}; separator = ", ", wrap, anchor>
 };
 
 std::vector\<std::string> <lexer.name>::_channelNames = {
-  "DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels: {c | u8"<c>"}; separator = ", ", wrap, anchor><endif>
+  "DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels: {c | "<c>"}; separator = ", ", wrap, anchor><endif>
 };
 
 std::vector\<std::string> <lexer.name>::_modeNames = {
-  <lexer.modes: {m | u8"<m>"}; separator = ", ", wrap, anchor>
+  <lexer.modes: {m | "<m>"}; separator = ", ", wrap, anchor>
 };
 
 std::vector\<std::string> <lexer.name>::_literalNames = {
-  <lexer.literalNames: {t | u8<t>}; null = "\"\"", separator = ", ", wrap, anchor>
+  <lexer.literalNames: {t | <t>}; null = "\"\"", separator = ", ", wrap, anchor>
 };
 
 std::vector\<std::string> <lexer.name>::_symbolicNames = {
-  <lexer.symbolicNames: {t | u8<t>}; null = "\"\"", separator = ", ", wrap, anchor>
+  <lexer.symbolicNames: {t | <t>}; null = "\"\"", separator = ", ", wrap, anchor>
 };
 
 dfa::Vocabulary <lexer.name>::_vocabulary(_literalNames, _symbolicNames);


### PR DESCRIPTION
Prior to C++20, the type of a "UTF-8 encoded string literal" is `char const *` - i.e. it is exactly the same as a non-prefixed string literal (they are semantically different, but technically the same).

Since C++20, the type of a UTF-8 encoded string literal is changed to `char8_t const *` - which is not convertable to `char const *`.  Even in C++20, there is no actual change to how characters are stored, only the type is changed (they are now semantically different, and supposed to be technically different - but nothing in the language actually uses the semantics).

In short, removing the u8"" prefix has no effect prior to C++20, and simply allows compilation to succeed since C++20.

Fixes #2844 