### PR TITLE
Java: shrink critical section in LexerATNSimulator

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -687,17 +687,16 @@ public class LexerATNSimulator extends ATNSimulator {
 		}
 
 		DFA dfa = decisionToDFA[mode];
+		configs.setReadonly(true);
+		configs.hashCode(); // compute and cache outside of the synchronized block.
+
 		synchronized (dfa.states) {
 			DFAState existing = dfa.states.get(proposed);
 			if ( existing!=null ) return existing;
 
-			DFAState newState = proposed;
-
-			newState.stateNumber = dfa.states.size();
-			configs.setReadonly(true);
-			newState.configs = configs;
-			dfa.states.put(newState, newState);
-			return newState;
+			proposed.stateNumber = dfa.states.size();
+			dfa.states.put(proposed, proposed);
+			return proposed;
 		}
 	}
 


### PR DESCRIPTION
When using the same Lexer in many threads, the LexerATNSimulator.addDFAState
can be a bottleneck. The most expensive work in this section is computing the
hashCode of the ATNConfigSet. This happens twice, once when checking if the
state is already in the map, and once when inserting it. If we make the configs
readonly before both operations, the hashCode will be reused. Second, if we
compute the hashCode outside of the critical section it will be cached,
shortening the total time in that section.

Aside: in Java8, there are functions like `putIfAbsent` that will simplify this code
and reduce the number of operations. When if at all is Antlr considering bumping
the minimal language version?

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->