### PR TITLE
[C++ codegen] Add default cases to AltBlock and OptionalBlock

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -710,6 +710,8 @@ switch (getInterpreter\<atn::ParserATNSimulator>()->adaptivePredict(_input, <cho
   break;
 \}
 }; separator="\n">
+default:
+  break;
 }
 >>
 
@@ -724,6 +726,8 @@ switch (getInterpreter\<atn::ParserATNSimulator>()->adaptivePredict(_input, <cho
   break;
 \}
 }; separator = "\n">
+default:
+  break;
 }
 >>
 


### PR DESCRIPTION
All other switch statements have a default case (either "break" or "<error>"), but these two are missing.

Does not change functionality, simply fixes a warning - and allows a project to build with -Werror.