### PR TITLE
idea: modify pull request template to encourage more through documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,22 @@
 <!--
-Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.
+Thank you for proposing a contribution to the ANTLR project. In order to accept
+changes from the outside world, all contributors must "sign" the [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt)
+certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre
+world of open-source ownership.
 
 Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
 -->
+
+## If applied, this pull request will...
+
+- Do something A.
+- Do something B.
+
+## Why is this change needed?
+
+- Because X…
+- Because Y…
+
+## References to relevant tickets, articles or other resources
+
+- https://codeinthehole.com/tips/a-useful-template-for-commit-messages/


### PR DESCRIPTION
## If applied, this pull request will...

- modify the pull request template according to the link below

## Why is this change needed?

- It is not needed but (to me) promoting (not enforcing) good documentation is 
always good especially for the future when no one remembers why some things were
done in certain ways 🤷‍♂️ 

## References to relevant tickets, articles or other resources

- https://codeinthehole.com/tips/a-useful-template-for-commit-messages/