### PR TITLE
Fixes a NullPointerException when using CommonToken#EMPTY_SOURCE 

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/DefaultErrorStrategy.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/DefaultErrorStrategy.java
@@ -596,7 +596,7 @@ public class DefaultErrorStrategy implements ANTLRErrorStrategy {
 			current = lookback;
 		}
 		return
-			recognizer.getTokenFactory().create(new Pair<TokenSource, CharStream>(current.getTokenSource(), current.getTokenSource().getInputStream()), expectedTokenType, tokenText,
+			recognizer.getTokenFactory().create(new Pair<TokenSource, CharStream>(current.getTokenSource(), current.getInputStream()), expectedTokenType, tokenText,
 							Token.DEFAULT_CHANNEL,
 							-1, -1,
 							current.getLine(), current.getCharPositionInLine());

--- a/runtime/Java/src/org/antlr/v4/runtime/ParserInterpreter.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ParserInterpreter.java
@@ -412,7 +412,7 @@ public class ParserInterpreter extends Parser {
 					expectedTokenType = ime.getExpectedTokens().getMinElement(); // get any element
 				}
 				Token errToken =
-					getTokenFactory().create(new Pair<TokenSource, CharStream>(tok.getTokenSource(), tok.getTokenSource().getInputStream()),
+					getTokenFactory().create(new Pair<TokenSource, CharStream>(tok.getTokenSource(), tok.getInputStream()),
 				                             expectedTokenType, tok.getText(),
 				                             Token.DEFAULT_CHANNEL,
 				                            -1, -1, // invalid start/stop
@@ -422,7 +422,7 @@ public class ParserInterpreter extends Parser {
 			else { // NoViableAlt
 				Token tok = e.getOffendingToken();
 				Token errToken =
-					getTokenFactory().create(new Pair<TokenSource, CharStream>(tok.getTokenSource(), tok.getTokenSource().getInputStream()),
+					getTokenFactory().create(new Pair<TokenSource, CharStream>(tok.getTokenSource(), tok.getInputStream()),
 				                             Token.INVALID_TYPE, tok.getText(),
 				                             Token.DEFAULT_CHANNEL,
 				                            -1, -1, // invalid start/stop


### PR DESCRIPTION
When using the `CommonToken(int)` or `CommonToken(int, String)` constructors, the `source` field in `CommonToken` is set to the `EMPTY_SOURCE` constant, which — being a dummy instance with `null` values — can eventually cause a NPE during any chained calls such as `token.getTokenSource().getInputStream()`. In this context `token.getInputStream()` might be far more appropriate.

Same issue might be present in other targets.
