### PR TITLE
Fix C++ target README example

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -251,3 +251,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/05/25, graknol, Sindre van der Linden, graknol@gmail.com
 2020/05/31, d-markey, David Markey, dmarkey@free.fr
 2020/07/01, sha-N, Shan M Mathews, admin@bluestarqatar.com
+2020/08/22, stevenjohnstone, Steven Johnstone, steven.james.johnstone@gmail.com

--- a/doc/cpp-target.md
+++ b/doc/cpp-target.md
@@ -65,7 +65,7 @@ int main(int argc, const char* argv[]) {
 
   tree::ParseTree *tree = parser.key();
   TreeShapeListener listener;
-  tree::ParseTreeWalker::DEFAULT->walk(&listener, tree);
+  tree::ParseTreeWalker::DEFAULT.walk(&listener, tree);
 
   return 0;
 }


### PR DESCRIPTION
tree::ParseTreeWalker::DEFAULT is not a pointer

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->