### PR TITLE
Fix clang compile error with --stdlib=libc++

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -251,3 +251,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/05/25, graknol, Sindre van der Linden, graknol@gmail.com
 2020/05/31, d-markey, David Markey, dmarkey@free.fr
 2020/07/01, sha-N, Shan M Mathews, admin@bluestarqatar.com
+2020/09/06, ArthurSonzogni, Sonzogni Arthur, arthursonzogni@gmail.com

--- a/runtime/Cpp/CMakeLists.txt
+++ b/runtime/Cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ if(NOT WITH_DEMO)
     FORCE)
 endif(NOT WITH_DEMO)
 
-option(WITH_LIBCXX "Building with clang++ and libc++(in Linux). To enable with: -DWITH_LIBCXX=On" On)
+option(WITH_LIBCXX "Building with clang++ and libc++(in Linux). To enable with: -DWITH_LIBCXX=On" Off)
 option(WITH_STATIC_CRT "(Visual C++) Enable to statically link CRT, which avoids requiring users to install the redistribution package.
  To disable with: -DWITH_STATIC_CRT=Off" On)
 


### PR DESCRIPTION
On linux. Most users haven't installed libc++-dev, but ANTLR is passing
the "--stdlib=libc++" argument. As a result, this won't compile. Users
will see:
```
/tmp/antlr4/runtime/Cpp/runtime/src/antlr4-common.h:8:10: fatal error:
'algorithm' file not found
```

This is caused by the "WITH_LIBCXX" option.
It was introduced by:
https://github.com/antlr/antlr4/commit/d46ef90aa03066300752895d57fc57a1c5aa8ee6

It causes the option "--stdlib=libc++" to be appended by default.

I believe its default value should have been left as "Off".

With "off" by default, clang will use its default C++ library, which is
always available.

The WITH_LIBCXX option is kept, being able to change the C++ library
might be useful?

BUG=https://github.com/antlr/antlr4/issues/2898

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->