### PR TITLE
Fix one warning on non-MSVC compilers.

### DIFF
--- a/runtime/Cpp/CMakeLists.txt
+++ b/runtime/Cpp/CMakeLists.txt
@@ -66,7 +66,7 @@ if(WITH_DEMO)
 endif(WITH_DEMO)
 
 if(MSVC_VERSION)
-  set(MY_CXX_WARNING_FLAGS "  /W4")
+  set(MY_CXX_WARNING_FLAGS "  /W4 /wd4996")
 else()
   set(MY_CXX_WARNING_FLAGS "  -Wall -pedantic -W")
 endif()

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -1348,8 +1348,6 @@ Parser* ParserATNSimulator::getParser() {
   return parser;
 }
 
-#pragma warning (disable:4996) // 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead. 
-
 bool ParserATNSimulator::getLrLoopSetting() {
   char *var = std::getenv("TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT");
   if (var == nullptr)
@@ -1357,8 +1355,6 @@ bool ParserATNSimulator::getLrLoopSetting() {
   std::string value(var);
   return value == "true" || value == "1";
 }
-
-#pragma warning (default:4996)
 
 void ParserATNSimulator::InitializeInstanceFields() {
   _mode = PredictionMode::LL;


### PR DESCRIPTION
Some Microsoft's specific #pragma were left in the code. They causes the
following errors to be printed:
```
/tmp/antlr4/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp:1351:9:
warning: unknown pragma ignored [-Wunknown-pragmas]
may be unsafe. Consider using _dupenv_s instead.
        ^
/tmp/antlr4/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp:1361:9:
warning: unknown pragma ignored [-Wunknown-pragmas]
```

This patch removes the #pragma macros and uses the matching compiler
definition only on MSVC compiler.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->