### PR TITLE
Fix regressions in travis Cpp tests

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -547,7 +547,7 @@ LeftRecursiveRuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs
 StructDeclHeader(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers) ::= <<
 class <file.exportMacro> <struct.name> : public <if (contextSuperClass)><contextSuperClass><else>antlr4::ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 public:
-  <attrs: {a | <a>;}; separator="\n">
+  <attrs: {a | <a>;}; separator = "\n">
   <if (ctorAttrs)><struct.name>(antlr4::ParserRuleContext *parent, size_t invokingState);<endif>
   <struct.name>(antlr4::ParserRuleContext *parent, size_t invokingState<ctorAttrs: {a | , <a>}>);
 <if (struct.provideCopyFrom)> <! don't need copy unless we have subclasses !>
@@ -601,7 +601,7 @@ class <file.exportMacro> <struct.name> : public <currentRule.name; format = "cap
 public:
   <struct.name>(<currentRule.name; format = "cap">Context *ctx);
 
-  <if (attrs)><attrs: {a | <a>}; separator = "\n"><endif>
+  <if (attrs)><attrs: {a | <a>;}; separator = "\n"><endif>
   <getters: {g | <g>}; separator = "\n">
   <dispatchMethods; separator = "\n">
 };


### PR DESCRIPTION
The testcase org.antlr.v4.test.runtime.cpp.TestParserExec was failing after #2806 removed duplicate semicolons from the declarations in generated Cpp header files.

The bug was triggered by TestParserExec because it includes a grammar with alternative labels:
```Antlr
grammar T;
start : a* EOF;
a
  : label=subrule {std::cout << $label.text << std::endl;} #One
  | label='y' {std::cout << $label.text << std::endl;} #Two
  ;
subrule : 'x';
WS : (' '|'\n') -> skip ;
```
Grammars without alternative labels (most?) were not affected.

The templates for StructDeclHeader and AltLabelStructDeclHeader differed in whether they appended semicolons to attributes:
StructDeclHeader: `<attrs: {a | <a>;}; separator="\n">`
AltLabelStructDeclHeader: git `<attrs: {a | <a>}; separator = "\n">`

