### PR TITLE
Travis: use newer versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,59 +19,56 @@ stages:
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: focal
       compiler: clang
-      jdk: openjdk8
+      jdk: openjdk11
       env:
         - TARGET=cpp
-        - CXX=g++-5
+        - CXX=g++-10
         - GROUP=LEXER
       stage: main-test
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
           packages:
-            - g++-5
+            - g++-10
             - uuid-dev
-            - clang-3.7
+            - clang-10
     - os: linux
-      dist: trusty
+      dist: focal
       compiler: clang
-      jdk: openjdk8
+      jdk: openjdk11
       env:
         - TARGET=cpp
-        - CXX=g++-5
+        - CXX=g++-10
         - GROUP=PARSER
       stage: main-test
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
           packages:
-            - g++-5
+            - g++-10
             - uuid-dev
-            - clang-3.7
+            - clang-10
     - os: linux
-      dist: trusty
+      dist: focal
       compiler: clang
-      jdk: openjdk8
+      jdk: openjdk11
       env:
         - TARGET=cpp
-        - CXX=g++-5
+        - CXX=g++-10
         - GROUP=RECURSION
       stage: main-test
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
           packages:
-            - g++-5
+            - g++-10
             - uuid-dev
-            - clang-3.7
+            - clang-10
     - os: osx
       compiler: clang
       osx_image: xcode10.2
@@ -140,27 +137,30 @@ matrix:
         - GROUP=RECURSION
       stage: extended-test
     - os: linux
-      dist: trusty
-      jdk: openjdk7
+      dist: focal
+      jdk: openjdk11
       env: TARGET=java
       stage: extended-test
     - os: linux
-      jdk: openjdk8
+      dist: focal
+      jdk: openjdk11
       env: TARGET=java
       stage: smoke-test
     - os: linux
-      jdk: openjdk8
+      dist: focal
+      jdk: openjdk11
       env: TARGET=csharp
       stage: main-test
     - os: linux
-      jdk: openjdk8
+      dist: focal
+      jdk: openjdk11
       env: TARGET=dart
       stage: main-test
     - os: linux
+      dist: focal
       language: php
-      php:
-        - 7.2
-      jdk: openjdk8
+      php: 7.4
+      jdk: openjdk11
       env: TARGET=php
       stage: main-test
     - os: linux
@@ -185,30 +185,30 @@ matrix:
         - GROUP=RECURSION
       stage: extended-test
     - os: linux
-      jdk: openjdk8
+      dist: focal
+      jdk: openjdk11
       env: TARGET=python2
       stage: main-test
-    - os: linux
-      jdk: openjdk8
-      env: TARGET=python3
       addons:
         apt:
-          sources:
-            - deadsnakes # source required so it finds the package definition below
           packages:
-            - python3.7
+            - python2.7
+    - os: linux
+      dist: focal
+      jdk: openjdk11
+      env: TARGET=python3
       stage: main-test
     - os: linux
-      dist: trusty
-      jdk: openjdk8
+      dist: focal
+      jdk: openjdk11
       env: TARGET=javascript
       stage: main-test
       before_install:
         - nvm install 14 # otherwise it runs by default on node 8
         - f="./.travis/before-install-linux-javascript.sh"; ! [ -x "$f" ] || "$f"
     - os: linux
-      dist: trusty
-      jdk: openjdk8
+      dist: focal
+      jdk: openjdk11
       env: TARGET=go
       stage: main-test
 

--- a/.travis/before-install-linux-csharp.sh
+++ b/.travis/before-install-linux-csharp.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb http://download.mono-project.com/repo/debian xenial main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
 sudo apt-get update -qq
 sudo apt-get install -qq mono-complete

--- a/.travis/run-tests-python2.sh
+++ b/.travis/run-tests-python2.sh
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-python --version
+python2.7 --version
 
 mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=python2.* test
 
 cd ../runtime/Python2/tests
 
-python run.py
+python2.7 run.py

--- a/runtime/Cpp/runtime/src/Vocabulary.h
+++ b/runtime/Cpp/runtime/src/Vocabulary.h
@@ -22,7 +22,7 @@ namespace dfa {
     /// except <seealso cref="Token#EOF"/>.</para>
     static const Vocabulary EMPTY_VOCABULARY;
 
-    Vocabulary() = default;
+    Vocabulary() {}
     Vocabulary(Vocabulary const&) = default;
     virtual ~Vocabulary();
 


### PR DESCRIPTION
During investigation of https://github.com/antlr/antlr4/pull/2806#issuecomment-691701866, I noticed that the Cpp runtime tests were failing locally (with clang 10) with the following errors:
```
In file included from /tmp/BaseCppTest-main-1600443341009/Test.cpp:3:
In file included from /home/felix/src/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/antlr4-runtime.h:126:
/home/felix/src/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/misc/InterpreterDataReader.h:20:5: error: call to implicitly-deleted default constructor of 'dfa::Vocabulary'
    InterpreterData() {}; // For invalid content.
    ^
/home/felix/src/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/Vocabulary.h:25:5: note: explicitly defaulted function was implicitly deleted here
    Vocabulary() = default;
    ^
/home/felix/src/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/Vocabulary.h:185:36: note: default constructor of 'Vocabulary' is implicitly deleted because field '_literalNames' of const-qualified type 'const std::vector<std::string>' (aka 'const vector<basic_string<char> >') would not be initialized
    std::vector<std::string> const _literalNames;
                                   ^
1 warning and 1 error generated.
In file included from /tmp/BaseCppTest-main-1600443341009/TBaseVisitor.cpp:5:
In file included from /tmp/BaseCppTest-main-1600443341009/TBaseVisitor.h:7:
In file included from /home/felix/src/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/antlr4-runtime.h:32:
In file included from /home/felix/src/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/LexerInterpreter.h:10:
/home/felix/src/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/Vocabulary.h:25:5: warning: explicitly defaulted default constructor is implicitly deleted [-Wdefaulted-function-deleted]
    Vocabulary() = default;
    ^
/home/felix/src/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/Vocabulary.h:185:36: note: default constructor of 'Vocabulary' is implicitly deleted because field '_literalNames' of const-qualified type 'const std::vector<std::string>' (aka 'const vector<basic_string<char> >') would not be initialized
    std::vector<std::string> const _literalNames;
                                   ^
```

The travis builds were not showing the same errors, since they were running with clang-3.7 / g++-5.

This PR updates the Ubuntu version used for the travis builds to focal / 20.04, clang / g++ 10, and openjdk11, php7.4, and python3.8.
