### PR TITLE
Fix enterXXX for alternative labels

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -257,3 +257,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/08/22, stevenjohnstone, Steven Johnstone, steven.james.johnstone@gmail.com
 2020/09/06, ArthurSonzogni, Sonzogni Arthur, arthursonzogni@gmail.com
 2020/09/12, Clcanny, Charles Ruan, a837940593@gmail.com
+2020/09/14, 3c1u, Hikaru Terazono, 3c1u@vulpesgames.tokyo

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
@@ -809,10 +809,6 @@ namespace Antlr4.Runtime
             {
                 AddContextToParseTree();
             }
-            if (_parseListeners != null)
-            {
-                TriggerEnterRuleEvent();
-            }
         }
 
         public virtual void ExitRule()
@@ -842,6 +838,10 @@ namespace Antlr4.Runtime
                 }
             }
             _ctx = localctx;
+            if (_parseListeners != null)
+            {
+                TriggerEnterRuleEvent();
+            }
         }
 
         /// <summary>Get the precedence level for the top-most precedence rule.</summary>

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
@@ -787,10 +787,6 @@ namespace Antlr4.Runtime
             {
                 AddContextToParseTree();
             }
-            if (_parseListeners != null)
-            {
-                TriggerEnterRuleEvent();
-            }
         }
 
         public virtual void EnterLeftFactoredRule(ParserRuleContext localctx, int state, int ruleIndex)
@@ -874,10 +870,6 @@ namespace Antlr4.Runtime
             _precedenceStack.Add(precedence);
             _ctx = localctx;
             _ctx.Start = _input.LT(1);
-            if (_parseListeners != null)
-            {
-                TriggerEnterRuleEvent();
-            }
         }
 
         // simulates rule entry for left-recursive rules

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -339,9 +339,6 @@ void Parser::enterRule(ParserRuleContext *localctx, size_t state, size_t /*ruleI
   if (_buildParseTrees) {
     addContextToParseTree();
   }
-  if (_parseListeners.size() > 0) {
-    triggerEnterRuleEvent();
-  }
 }
 
 void Parser::exitRule() {
@@ -373,6 +370,9 @@ void Parser::enterOuterAlt(ParserRuleContext *localctx, size_t altNum) {
     }
   }
   _ctx = localctx;
+  if (_parseListeners.size() > 0) {
+    triggerEnterRuleEvent();
+  }
 }
 
 int Parser::getPrecedence() const {

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -392,9 +392,6 @@ void Parser::enterRecursionRule(ParserRuleContext *localctx, size_t state, size_
   _precedenceStack.push_back(precedence);
   _ctx = localctx;
   _ctx->start = _input->LT(1);
-  if (!_parseListeners.empty()) {
-    triggerEnterRuleEvent(); // simulates rule entry for left-recursive rules
-  }
 }
 
 void Parser::pushNewRecursionContext(ParserRuleContext *localctx, size_t state, size_t /*ruleIndex*/) {

--- a/runtime/Dart/lib/src/parser.dart
+++ b/runtime/Dart/lib/src/parser.dart
@@ -523,9 +523,6 @@ abstract class Parser extends Recognizer<ParserATNSimulator> {
     _precedenceStack.add(precedence);
     _ctx = localctx;
     _ctx.start = _input.LT(1);
-    if (_parseListeners != null) {
-      triggerEnterRuleEvent(); // simulates rule entry for left-recursive rules
-    }
   }
 
   /// Like {@link #enterRule} but for recursive rules.

--- a/runtime/Dart/lib/src/parser.dart
+++ b/runtime/Dart/lib/src/parser.dart
@@ -475,7 +475,6 @@ abstract class Parser extends Recognizer<ParserATNSimulator> {
     _ctx = localctx;
     _ctx.start = _input.LT(1);
     if (_buildParseTrees) addContextToParseTree();
-    if (_parseListeners != null) triggerEnterRuleEvent();
   }
 
   void exitRule() {
@@ -503,6 +502,7 @@ abstract class Parser extends Recognizer<ParserATNSimulator> {
       }
     }
     _ctx = localctx;
+    if (_parseListeners != null) triggerEnterRuleEvent();
   }
 
   /// Get the precedence level for the top-most precedence rule.

--- a/runtime/Go/antlr/parser.go
+++ b/runtime/Go/antlr/parser.go
@@ -511,10 +511,6 @@ func (p *BaseParser) EnterRecursionRule(localctx ParserRuleContext, state, ruleI
 	p.precedenceStack.Push(precedence)
 	p.ctx = localctx
 	p.ctx.SetStart(p.input.LT(1))
-	if p.parseListeners != nil {
-		p.TriggerEnterRuleEvent() // simulates rule entry for
-		// left-recursive rules
-	}
 }
 
 //

--- a/runtime/Go/antlr/parser.go
+++ b/runtime/Go/antlr/parser.go
@@ -461,9 +461,6 @@ func (p *BaseParser) EnterRule(localctx ParserRuleContext, state, ruleIndex int)
 	if p.BuildParseTrees {
 		p.addContextToParseTree()
 	}
-	if p.parseListeners != nil {
-		p.TriggerEnterRuleEvent()
-	}
 }
 
 func (p *BaseParser) ExitRule() {
@@ -491,6 +488,9 @@ func (p *BaseParser) EnterOuterAlt(localctx ParserRuleContext, altNum int) {
 		}
 	}
 	p.ctx = localctx
+	if p.parseListeners != nil {
+		p.TriggerEnterRuleEvent()
+	}
 }
 
 // Get the precedence level for the top-most precedence rule.

--- a/runtime/Java/src/org/antlr/v4/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Parser.java
@@ -686,9 +686,6 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 		_precedenceStack.push(precedence);
 		_ctx = localctx;
 		_ctx.start = _input.LT(1);
-		if (_parseListeners != null) {
-			triggerEnterRuleEvent(); // simulates rule entry for left-recursive rules
-		}
 	}
 
 	/** Like {@link #enterRule} but for recursive rules.

--- a/runtime/Java/src/org/antlr/v4/runtime/Parser.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Parser.java
@@ -627,7 +627,6 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 		_ctx = localctx;
 		_ctx.start = _input.LT(1);
 		if (_buildParseTrees) addContextToParseTree();
-        if ( _parseListeners != null) triggerEnterRuleEvent();
 	}
 
     public void exitRule() {
@@ -656,6 +655,7 @@ public abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 			}
 		}
 		_ctx = localctx;
+        if ( _parseListeners != null) triggerEnterRuleEvent();
 	}
 
 	/**

--- a/runtime/JavaScript/src/antlr4/Parser.js
+++ b/runtime/JavaScript/src/antlr4/Parser.js
@@ -422,9 +422,6 @@ class Parser extends Recognizer {
 		if (this.buildParseTrees) {
 			this.addContextToParseTree();
 		}
-		if (this._parseListeners !== null) {
-			this.triggerEnterRuleEvent();
-		}
 	}
 
 	exitRule() {
@@ -448,6 +445,9 @@ class Parser extends Recognizer {
 			}
 		}
 		this._ctx = localctx;
+		if (this._parseListeners !== null) {
+			this.triggerEnterRuleEvent();
+		}
 	}
 
 	/**

--- a/runtime/JavaScript/src/antlr4/Parser.js
+++ b/runtime/JavaScript/src/antlr4/Parser.js
@@ -469,10 +469,6 @@ class Parser extends Recognizer {
 	   this._precedenceStack.push(precedence);
 	   this._ctx = localctx;
 	   this._ctx.start = this._input.LT(1);
-	   if (this._parseListeners !== null) {
-		   this.triggerEnterRuleEvent(); // simulates rule entry for
-		   									// left-recursive rules
-	   }
    }
 
 	// Like {@link //enterRule} but for recursive rules.

--- a/runtime/Python2/src/antlr4/Parser.py
+++ b/runtime/Python2/src/antlr4/Parser.py
@@ -394,8 +394,6 @@ class Parser (Recognizer):
         self._precedenceStack.append(precedence)
         self._ctx = localctx
         self._ctx.start = self._input.LT(1)
-        if self._parseListeners is not None:
-            self.triggerEnterRuleEvent() # simulates rule entry for left-recursive rules
 
     #
     # Like {@link #enterRule} but for recursive rules.

--- a/runtime/Python2/src/antlr4/Parser.py
+++ b/runtime/Python2/src/antlr4/Parser.py
@@ -357,8 +357,6 @@ class Parser (Recognizer):
         self._ctx.start = self._input.LT(1)
         if self.buildParseTrees:
             self.addContextToParseTree()
-        if self._parseListeners  is not None:
-            self.triggerEnterRuleEvent()
 
     def exitRule(self):
         self._ctx.stop = self._input.LT(-1)
@@ -377,6 +375,8 @@ class Parser (Recognizer):
                 self._ctx.parentCtx.removeLastChild()
                 self._ctx.parentCtx.addChild(localctx)
         self._ctx = localctx
+        if self._parseListeners  is not None:
+            self.triggerEnterRuleEvent()
 
     # Get the precedence level for the top-most precedence rule.
     #

--- a/runtime/Python3/src/antlr4/Parser.py
+++ b/runtime/Python3/src/antlr4/Parser.py
@@ -366,8 +366,6 @@ class Parser (Recognizer):
         self._ctx.start = self._input.LT(1)
         if self.buildParseTrees:
             self.addContextToParseTree()
-        if self._parseListeners  is not None:
-            self.triggerEnterRuleEvent()
 
     def exitRule(self):
         self._ctx.stop = self._input.LT(-1)
@@ -386,6 +384,8 @@ class Parser (Recognizer):
                 self._ctx.parentCtx.removeLastChild()
                 self._ctx.parentCtx.addChild(localctx)
         self._ctx = localctx
+        if self._parseListeners  is not None:
+            self.triggerEnterRuleEvent()
 
     # Get the precedence level for the top-most precedence rule.
     #

--- a/runtime/Python3/src/antlr4/Parser.py
+++ b/runtime/Python3/src/antlr4/Parser.py
@@ -403,8 +403,6 @@ class Parser (Recognizer):
         self._precedenceStack.append(precedence)
         self._ctx = localctx
         self._ctx.start = self._input.LT(1)
-        if self._parseListeners is not None:
-            self.triggerEnterRuleEvent() # simulates rule entry for left-recursive rules
 
     #
     # Like {@link #enterRule} but for recursive rules.

--- a/runtime/Swift/Sources/Antlr4/Parser.swift
+++ b/runtime/Swift/Sources/Antlr4/Parser.swift
@@ -669,9 +669,6 @@ open class Parser: Recognizer<ParserATNSimulator> {
         _precedenceStack.push(precedence)
         _ctx = localctx
         _ctx!.start = try _input.LT(1)
-        if _parseListeners != nil {
-            try triggerEnterRuleEvent() // simulates rule entry for left-recursive rules
-        }
     }
 
     /// Like _#enterRule_ but for recursive rules.


### PR DESCRIPTION
Moved `[tT]riggerEnterRuleEvent` from `enterRule` to `enterOuterAlt`. This will fix antlr/antlr4#802 for targets except Swift (of which target already has `triggerEnterRuleEvent` in `enterOuterAlt`).

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->