### PR TITLE
Fix linker issue when compiling Cpp runtime with CMake and MSVC on Windows

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -258,3 +258,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/09/06, ArthurSonzogni, Sonzogni Arthur, arthursonzogni@gmail.com
 2020/09/12, Clcanny, Charles Ruan, a837940593@gmail.com
 2020/09/15, rmcgregor1990, Robert McGregor, rmcgregor1990@gmail.com
+2020/09/16, trenki2, Markus Trenkwalder, trenki2[at]gmx[dot]net

--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(
   GIT_TAG               "v3.1.1"
   SOURCE_DIR            ${UTFCPP_DIR}
   UPDATE_DISCONNECTED   1
-  CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${UTFCPP_DIR}/install
+  CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${UTFCPP_DIR}/install -Dgtest_force_shared_crt=ON
   TEST_AFTER_INSTALL    1
   STEP_TARGETS          build)
 


### PR DESCRIPTION
Trying to compile ANTLR from a fresh git checkout using cmake and msvc fails with linker errors.

```
3>gtestd.lib(gtest-all.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MDd_DynamicDebug' in test_checked_api.obj [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]
3>msvcprtd.lib(MSVCP140D.dll) : error LNK2005: "public: struct _Cvtvec __cdecl std::_Locinfo::_Getcvt(void)const " (?_Getcvt@_Locinfo@std@@QEBA?AU_Cvtvec@@XZ) already defined in gtestd.lib(gtest-all.obj) [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]
3>msvcprtd.lib(MSVCP140D.dll) : error LNK2005: "public: bool __cdecl std::ios_base::good(void)const " (?good@ios_base@std@@QEBA_NXZ) already defined in gtestd.lib(gtest-all.obj) [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]
3>msvcprtd.lib(MSVCP140D.dll) : error LNK2005: "public: int __cdecl std::ios_base::flags(void)const " (?flags@ios_base@std@@QEBAHXZ) already defined in gtestd.lib(gtest-all.obj) [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]
3>msvcprtd.lib(MSVCP140D.dll) : error LNK2005: "public: __int64 __cdecl std::ios_base::width(void)const " (?width@ios_base@std@@QEBA_JXZ) already defined in gtestd.lib(gtest-all.obj) [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]
3>msvcprtd.lib(MSVCP140D.dll) : error LNK2005: "public: __int64 __cdecl std::ios_base::width(__int64)" (?width@ios_base@std@@QEAA_J_J@Z) already defined in gtestd.lib(gtest-all.obj) [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]
3>msvcprtd.lib(MSVCP140D.dll) : error LNK2005: "protected: __cdecl std::basic_streambuf<char,struct std::char_traits<char> >::basic_streambuf<char,struct std::char_traits<char> >(void)" (??0?$basic_streambuf@DU?$char_traits@D@std@@@std@@IEAA@XZ) already defined in gtestd.lib(gtest-all.obj) [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]
3>msvcprtd.lib(MSVCP140D.dll) : error LNK2005: "public: virtual __cdecl std::basic_streambuf<char,struct std::char_traits<char> >::~basic_streambuf<char,struct std::char_traits<char> >(void)" (??1?$basic_streambuf@DU?$char_traits@D@std@@@std@@UEAA@XZ) already defined in gtestd.lib(gtest-all.obj) [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]
3>msvcprtd.lib(MSVCP140D.dll) : error LNK2005: "public: int __cdecl std::basic_streambuf<char,struct std::char_traits<char> >::sputc(char)" (?sputc@?$basic_streambuf@DU?$char_traits@D@std@@@std@@QEAAHD@Z) already defined in gtestd.lib(gtest-all.obj) [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]
3>msvcprtd.lib(MSVCP140D.dll) : error LNK2005: "public: __int64 __cdecl std::basic_streambuf<char,struct std::char_traits<char> >::sputn(char const *,__int64)" (?sputn@?$basic_streambuf@DU?$char_traits@D@std@@@std@@QEAA_JPEBD_J@Z) already defined in gtestd.lib(gtest-all.obj) [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]
3>msvcprtd.lib(MSVCP140D.dll) : error LNK2005: "protected: char * __cdecl std::basic_streambuf<char,struct std::char_traits<char> >::eback(void)const " (?eback@?$basic_streambuf@DU?$char_traits@D@std@@@std@@IEBAPEADXZ) already defined in gtestd.lib(gtest-all.obj) [F:\Development\antlr4\runtime\Cpp\build\runtime\utfcpp-prefix\src\utfcpp-build\tests\apitests.vcxproj]

...

```
Adding "-Dgtest_force_shared_crt=ON" to the CMAKE_ARGS of the ExternalProject_Add(utfcpp) avoids this issue.



<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->