### PR TITLE
Made C# Trace Listener usable for most cases

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -258,3 +258,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/09/06, ArthurSonzogni, Sonzogni Arthur, arthursonzogni@gmail.com
 2020/09/12, Clcanny, Charles Ruan, a837940593@gmail.com
 2020/09/15, rmcgregor1990, Robert McGregor, rmcgregor1990@gmail.com
+2020/10/08, Marti2203, Martin Mirchev, mirchevmartin2203@gmail.com

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Parser.cs
@@ -22,20 +22,20 @@ namespace Antlr4.Runtime
 #if !PORTABLE
         public class TraceListener : IParseTreeListener
         {
-            private readonly TextWriter Output;
 
-            public TraceListener(TextWriter output) {
-                Output = output;
+            public TraceListener(TextWriter output,Parser enclosing) {
+                _output = output;
+                _enclosing = enclosing;
             }
 
             public virtual void EnterEveryRule(ParserRuleContext ctx)
             {
-                Output.WriteLine("enter   " + this._enclosing.RuleNames[ctx.RuleIndex] + ", LT(1)=" + this._enclosing._input.LT(1).Text);
+                _output.WriteLine("enter   " + this._enclosing.RuleNames[ctx.RuleIndex] + ", LT(1)=" + this._enclosing._input.LT(1).Text);
             }
 
             public virtual void ExitEveryRule(ParserRuleContext ctx)
             {
-                Output.WriteLine("exit    " + this._enclosing.RuleNames[ctx.RuleIndex] + ", LT(1)=" + this._enclosing._input.LT(1).Text);
+                _output.WriteLine("exit    " + this._enclosing.RuleNames[ctx.RuleIndex] + ", LT(1)=" + this._enclosing._input.LT(1).Text);
             }
 
             public virtual void VisitErrorNode(IErrorNode node)
@@ -46,15 +46,17 @@ namespace Antlr4.Runtime
             {
                 ParserRuleContext parent = (ParserRuleContext)((IRuleNode)node.Parent).RuleContext;
                 IToken token = node.Symbol;
-                Output.WriteLine("consume " + token + " rule " + this._enclosing.RuleNames[parent.RuleIndex]);
+                _output.WriteLine("consume " + token + " rule " + this._enclosing.RuleNames[parent.RuleIndex]);
             }
 
             internal TraceListener(Parser _enclosing)
             {
                 this._enclosing = _enclosing;
+                _output = Console.Out;
             }
 
             private readonly Parser _enclosing;
+            private readonly TextWriter _output;
         }
 #endif
 


### PR DESCRIPTION
Previously, when using the internal constructor, the trace listener had no text stream and it threw a null pointer exception. I have chosen the default stream to be Console.Out If somebody wants to create an instance of Trace Listener they will have to include a Parser and a Text Writer such that no such errors are thrown.