### PR TITLE
Changed Python runtime Lexer.py, Parser.py to support version >= 3.5

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -263,3 +263,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/09/15, rmcgregor1990, Robert McGregor, rmcgregor1990@gmail.com
 2020/09/16, trenki2, Markus Trenkwalder, trenki2[at]gmx[dot]net
 2020/10/08, Marti2203, Martin Mirchev, mirchevmartin2203@gmail.com
+2020/10/11, cliid, Jiwu Jang, jiwujang@naver.com

--- a/runtime/Python3/src/antlr4/Lexer.py
+++ b/runtime/Python3/src/antlr4/Lexer.py
@@ -9,8 +9,12 @@
 #  of speed.
 #/
 from io import StringIO
-from typing.io import TextIO
+
 import sys
+if sys.version_info[1] > 5:
+    from typing import TextIO
+else:
+    from typing.io import TextIO
 from antlr4.CommonTokenFactory import CommonTokenFactory
 from antlr4.atn.LexerATNSimulator import LexerATNSimulator
 from antlr4.InputStream import InputStream

--- a/runtime/Python3/src/antlr4/Parser.py
+++ b/runtime/Python3/src/antlr4/Parser.py
@@ -3,7 +3,10 @@
 # Use of this file is governed by the BSD 3-clause license that
 # can be found in the LICENSE.txt file in the project root.
 import sys
-from typing.io import TextIO
+if sys.version_info[1] > 5:
+    from typing import TextIO
+else:
+    from typing.io import TextIO
 from antlr4.BufferedTokenStream import TokenStream
 from antlr4.CommonTokenFactory import TokenFactory
 from antlr4.error.ErrorStrategy import DefaultErrorStrategy


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->