### PR TITLE
Changes for https://github.com/antlr/antlr4/issues/2693

### DIFF
--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/AmbiguityInfo.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/AmbiguityInfo.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2019 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -41,6 +41,9 @@ namespace Antlr4.Runtime.Atn
     /// <since>4.3</since>
     public class AmbiguityInfo : DecisionEventInfo
     {
+        /** The set of alternative numbers for this decision event that lead to a valid parse. */
+        public BitSet ambigAlts;
+
         /// <summary>
         /// Constructs a new instance of the
         /// <see cref="AmbiguityInfo"/>
@@ -48,9 +51,12 @@ namespace Antlr4.Runtime.Atn
         /// specified detailed ambiguity information.
         /// </summary>
         /// <param name="decision">The decision number</param>
-        /// <param name="state">
-        /// The final simulator state identifying the ambiguous
+        /// <param name="configs">The final configuration set identifying the ambiguous
         /// alternatives for the current input
+        /// </param>
+        /// <param name="ambigAlts">The set of alternatives in the decision that lead to a valid parse.
+        /// </param>
+        /// The predicted alt is the min(ambigAlts)
         /// </param>
         /// <param name="input">The input token stream</param>
         /// <param name="startIndex">The start index for the current prediction</param>
@@ -58,9 +64,18 @@ namespace Antlr4.Runtime.Atn
         /// The index at which the ambiguity was identified during
         /// prediction
         /// </param>
-        public AmbiguityInfo(int decision, SimulatorState state, ITokenStream input, int startIndex, int stopIndex)
-            : base(decision, state, input, startIndex, stopIndex, state.useContext)
+        /// <param name="fullCtx">@code true} if the ambiguity was identified during LL
+        /// prediction; otherwise, {@code false} if the ambiguity was identified
+        /// during SLL prediction
+        /// </param>
+        public AmbiguityInfo(int decision,
+                 ATNConfigSet configs,
+                 BitSet ambigAlts,
+                 ITokenStream input, int startIndex, int stopIndex,
+                 bool fullCtx)
+        : base(decision, configs, input, startIndex, stopIndex, fullCtx)
         {
+            this.ambigAlts = ambigAlts;
         }
     }
 }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ContextSensitivityInfo.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ContextSensitivityInfo.cs
@@ -35,9 +35,8 @@ namespace Antlr4.Runtime.Atn
         /// with the specified detailed context sensitivity information.
         /// </summary>
         /// <param name="decision">The decision number</param>
-        /// <param name="state">
-        /// The final simulator state containing the unique
-        /// alternative identified by full-context prediction
+        /// <param name="configs">The final configuration set identifying the ambiguous
+        /// alternatives for the current input
         /// </param>
         /// <param name="input">The input token stream</param>
         /// <param name="startIndex">The start index for the current prediction</param>
@@ -45,8 +44,8 @@ namespace Antlr4.Runtime.Atn
         /// The index at which the context sensitivity was
         /// identified during full-context prediction
         /// </param>
-        public ContextSensitivityInfo(int decision, SimulatorState state, ITokenStream input, int startIndex, int stopIndex)
-            : base(decision, state, input, startIndex, stopIndex, true)
+        public ContextSensitivityInfo(int decision, ATNConfigSet configs, ITokenStream input, int startIndex, int stopIndex)
+            : base(decision, configs, input, startIndex, stopIndex, true)
         {
         }
     }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/DecisionEventInfo.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/DecisionEventInfo.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2019 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -25,15 +25,13 @@ namespace Antlr4.Runtime.Atn
         /// <seealso cref="ATN.decisionToState"/>
         public readonly int decision;
 
-        /// <summary>
-        /// The simulator state containing additional information relevant to the
-        /// prediction state when the current event occurred, or
-        /// <see langword="null"/>
-        /// if no
-        /// additional information is relevant or available.
-        /// </summary>
-        [Nullable]
-        public readonly SimulatorState state;
+        /// <summary>The configuration set containing additional information relevant to the
+        /// prediction state when the current event occurred, or {@code null} if no
+        /// additional information is relevant or available.</summary>
+        /// <remarks>The configuration set containing additional information relevant to the
+        /// prediction state when the current event occurred, or {@code null} if no
+        /// additional information is relevant or available.</remarks>
+        public readonly ATNConfigSet configs;
 
         /// <summary>The input token stream which is being parsed.</summary>
         /// <remarks>The input token stream which is being parsed.</remarks>
@@ -63,14 +61,17 @@ namespace Antlr4.Runtime.Atn
         /// </summary>
         public readonly bool fullCtx;
 
-        public DecisionEventInfo(int decision, SimulatorState state, ITokenStream input, int startIndex, int stopIndex, bool fullCtx)
+        public DecisionEventInfo(int decision,
+            ATNConfigSet configs,
+            ITokenStream input, int startIndex, int stopIndex,
+            bool fullCtx)
         {
             this.decision = decision;
             this.fullCtx = fullCtx;
             this.stopIndex = stopIndex;
             this.input = input;
             this.startIndex = startIndex;
-            this.state = state;
+            this.configs = configs;
         }
     }
 }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ErrorInfo.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ErrorInfo.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2019 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -30,17 +30,18 @@ namespace Antlr4.Runtime.Atn
         /// specified detailed syntax error information.
         /// </summary>
         /// <param name="decision">The decision number</param>
-        /// <param name="state">
-        /// The final simulator state reached during prediction
-        /// prior to reaching the
-        /// <see cref="ATNSimulator.ERROR"/>
-        /// state
+        /// <param name="configs">The final configuration set reached during prediction
+        /// prior to reaching the {@link ATNSimulator#ERROR} state
         /// </param>
         /// <param name="input">The input token stream</param>
         /// <param name="startIndex">The start index for the current prediction</param>
         /// <param name="stopIndex">The index at which the syntax error was identified</param>
-        public ErrorInfo(int decision, SimulatorState state, ITokenStream input, int startIndex, int stopIndex)
-            : base(decision, state, input, startIndex, stopIndex, state.useContext)
+        /// <param name="fullCtx">{@code true} if the syntax error was identified during LL
+        /// prediction; otherwise, {@code false} if the syntax error was identified
+        /// during SLL prediction
+        /// </param>
+        public ErrorInfo(int decision, ATNConfigSet configs, ITokenStream input, int startIndex, int stopIndex, bool fullCtx)
+            : base(decision, configs, input, startIndex, stopIndex, fullCtx)
         {
         }
     }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/LookaheadEventInfo.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/LookaheadEventInfo.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2019 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -19,6 +19,13 @@ namespace Antlr4.Runtime.Atn
     /// <since>4.3</since>
     public class LookaheadEventInfo : DecisionEventInfo
     {
+        /// <summary>The alternative chosen by adaptivePredict(), not necessarily
+        ///  the outermost alt shown for a rule; left-recursive rules have
+        ///  user-level alts that differ from the rewritten rule with a (...) block
+        ///  and a (..)* loop.
+        /// </summary>
+        public int predictedAlt;
+
         /// <summary>
         /// Constructs a new instance of the
         /// <see cref="LookaheadEventInfo"/>
@@ -26,18 +33,14 @@ namespace Antlr4.Runtime.Atn
         /// the specified detailed lookahead information.
         /// </summary>
         /// <param name="decision">The decision number</param>
-        /// <param name="state">
-        /// The final simulator state containing the necessary
-        /// information to determine the result of a prediction, or
-        /// <see langword="null"/>
-        /// if
-        /// the final state is not available
+        /// <param name="configs">The final configuration set containing the necessary
+        /// information to determine the result of a prediction, or {@code null} if
+        /// the final configuration set is not available
         /// </param>
         /// <param name="input">The input token stream</param>
         /// <param name="startIndex">The start index for the current prediction</param>
         /// <param name="stopIndex">The index at which the prediction was finally made</param>
         /// <param name="fullCtx">
-        ///
         /// <see langword="true"/>
         /// if the current lookahead is part of an LL
         /// prediction; otherwise,
@@ -45,9 +48,10 @@ namespace Antlr4.Runtime.Atn
         /// if the current lookahead is part of
         /// an SLL prediction
         /// </param>
-        public LookaheadEventInfo(int decision, SimulatorState state, ITokenStream input, int startIndex, int stopIndex, bool fullCtx)
-            : base(decision, state, input, startIndex, stopIndex, fullCtx)
+        public LookaheadEventInfo(int decision, ATNConfigSet configs, int predictedAlt, ITokenStream input, int startIndex, int stopIndex, bool fullCtx)
+            : base(decision, configs, input, startIndex, stopIndex, fullCtx)
         {
+            this.predictedAlt = predictedAlt;
         }
     }
 }

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/PredicateEvalInfo.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/PredicateEvalInfo.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2019 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -49,7 +49,6 @@ namespace Antlr4.Runtime.Atn
         /// class with the
         /// specified detailed predicate evaluation information.
         /// </summary>
-        /// <param name="state">The simulator state</param>
         /// <param name="decision">The decision number</param>
         /// <param name="input">The input token stream</param>
         /// <param name="startIndex">The start index for the current prediction</param>
@@ -68,10 +67,15 @@ namespace Antlr4.Runtime.Atn
         /// <see cref="predictedAlt"/>
         /// for more information.
         /// </param>
+        /// <param name="fullCtx">{@code true} if the semantic context was
+        /// evaluated during LL prediction; otherwise, {@code false} if the semantic
+        /// context was evaluated during SLL prediction
+        /// </param>
+        ///
         /// <seealso cref="ParserATNSimulator.EvalSemanticContext(SemanticContext, ParserRuleContext, int, bool)"/>
         /// <seealso cref="SemanticContext.Eval"/>
-        public PredicateEvalInfo(SimulatorState state, int decision, ITokenStream input, int startIndex, int stopIndex, SemanticContext semctx, bool evalResult, int predictedAlt)
-            : base(decision, state, input, startIndex, stopIndex, state.useContext)
+        public PredicateEvalInfo(int decision, ITokenStream input, int startIndex, int stopIndex, SemanticContext semctx, bool evalResult, int predictedAlt, bool fullCtx)
+            : base(decision, new ATNConfigSet(), input, startIndex, stopIndex, fullCtx)
         {
             this.semctx = semctx;
             this.evalResult = evalResult;

--- a/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ProfilingATNSimulator.cs
+++ b/runtime/CSharp/runtime/CSharp/Antlr4.Runtime/Atn/ProfilingATNSimulator.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2019 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -71,7 +71,7 @@ namespace Antlr4.Runtime.Atn
 			{
 				decisions[decision].SLL_MaxLook = SLL_k;
 				decisions[decision].SLL_MaxLookEvent =
-						new LookaheadEventInfo(decision, null/*, alt*/, input, startIndex, sllStopIndex, false);
+						new LookaheadEventInfo(decision, null, alt, input, startIndex, sllStopIndex, false);
 			}
 
 			if (llStopIndex >= 0)
@@ -83,7 +83,7 @@ namespace Antlr4.Runtime.Atn
 				{
 					decisions[decision].LL_MaxLook = LL_k;
 					decisions[decision].LL_MaxLookEvent =
-							new LookaheadEventInfo(decision, null/*, alt*/, input, startIndex, llStopIndex, true);
+							new LookaheadEventInfo(decision, null, alt, input, startIndex, llStopIndex, true);
 				}
 			}
 
@@ -108,7 +108,7 @@ namespace Antlr4.Runtime.Atn
 			if (existingTargetState == ERROR)
 			{
 				decisions[currentDecision].errors.Add(
-						new ErrorInfo(currentDecision, null /*previousD.configs*/, input, startIndex, sllStopIndex)
+						new ErrorInfo(currentDecision, previousD.configSet, input, startIndex, sllStopIndex, false)
 				);
 			}
 		}
@@ -143,7 +143,7 @@ namespace Antlr4.Runtime.Atn
 			else { // no reach on current lookahead symbol. ERROR.
 				   // TODO: does not handle delayed errors per getSynValidOrSemInvalidAltThatFinishedDecisionEntryRule()
 				decisions[currentDecision].errors.Add(
-					new ErrorInfo(currentDecision, null /*closure*/, input, startIndex, llStopIndex)
+					new ErrorInfo(currentDecision, closure, input, startIndex, llStopIndex, true)
 				);
 			}
 		}
@@ -154,7 +154,7 @@ namespace Antlr4.Runtime.Atn
 			}
 			else { // no reach on current lookahead symbol. ERROR.
 				decisions[currentDecision].errors.Add(
-					new ErrorInfo(currentDecision, null /*closure*/, input, startIndex, sllStopIndex)
+					new ErrorInfo(currentDecision, closure, input, startIndex, sllStopIndex, false)
 				);
 			}
 		}
@@ -168,7 +168,7 @@ namespace Antlr4.Runtime.Atn
 			bool fullContext = llStopIndex >= 0;
 			int stopIndex = fullContext ? llStopIndex : sllStopIndex;
 			decisions[currentDecision].predicateEvals.Add(
-				new PredicateEvalInfo(null , currentDecision, input, startIndex, stopIndex, pred, result, alt/*, fullCtx*/)
+				new PredicateEvalInfo(currentDecision, input, startIndex, stopIndex, pred, result, alt, fullCtx)
 			);
 		}
 
@@ -193,14 +193,14 @@ namespace Antlr4.Runtime.Atn
 		if (prediction != conflictingAltResolvedBySLL)
 		{
 			decisions[currentDecision].contextSensitivities.Add(
-					new ContextSensitivityInfo(currentDecision, null /*configs*/, input, startIndex, stopIndex)
+					new ContextSensitivityInfo(currentDecision, configs, input, startIndex, stopIndex)
 			);
 		}
 			base.ReportContextSensitivity(dfa, prediction, configs, startIndex, stopIndex);
 	}
 
 	protected override void ReportAmbiguity(DFA dfa, DFAState D, int startIndex, int stopIndex, bool exact,
-		                                    BitSet ambigAlts, ATNConfigSet configSet)
+		                                    BitSet ambigAlts, ATNConfigSet configs)
 	{
 		int prediction;
 		if (ambigAlts != null)
@@ -208,22 +208,22 @@ namespace Antlr4.Runtime.Atn
 			prediction = ambigAlts.NextSetBit(0);
 		}
 		else {
-				prediction = configSet.GetAlts().NextSetBit(0);
+				prediction = configs.GetAlts().NextSetBit(0);
 		}
-			if (configSet.fullCtx && prediction != conflictingAltResolvedBySLL)
+			if (configs.fullCtx && prediction != conflictingAltResolvedBySLL)
 		{
 			// Even though this is an ambiguity we are reporting, we can
 			// still detect some context sensitivities.  Both SLL and LL
 			// are showing a conflict, hence an ambiguity, but if they resolve
 			// to different minimum alternatives we have also identified a
 			// context sensitivity.
-			decisions[currentDecision].contextSensitivities.Add( new ContextSensitivityInfo(currentDecision, null /*configs*/, input, startIndex, stopIndex) );
+			decisions[currentDecision].contextSensitivities.Add( new ContextSensitivityInfo(currentDecision, configs, input, startIndex, stopIndex) );
 		}
 		decisions[currentDecision].ambiguities.Add(
-			new AmbiguityInfo(currentDecision, null /*configs, ambigAlts*/,
-				              input, startIndex, stopIndex/*, configs.IsFullContext*/)
+			new AmbiguityInfo(currentDecision, configs, ambigAlts,
+				              input, startIndex, stopIndex, configs.fullCtx)
 		);
-		base.ReportAmbiguity(dfa, D, startIndex, stopIndex, exact, ambigAlts, configSet);
+		base.ReportAmbiguity(dfa, D, startIndex, stopIndex, exact, ambigAlts, configs);
 	}
 
 	// ---------------------------------------------------------------------


### PR DESCRIPTION
This is a fix for #2693. The change basically rolls over code from the Java runtime to the C# runtime that was never done. With the change, profiling now works. I posted this change a year ago, but because it was ignored until a few days ago, I closed that PR and re-did the PR with the changes here. I don't know what is going on with the Appveyor build of PHP, but the Git check-in is warning me about uncommited changes in ../runtime/PHP, which is a git submodule. I'm not changing anything in PHP, and this PR doesn't include changes to runtime/PHP. The build instructions say nothing about pulling the PHP submodule. The copyright dates are changed to 2019 (from my year-old PR), but every file should be updated Jan 1 with the new year via a script.