### PR TITLE
Avoid hash map resizing (or rehashing) in Utils#toMap

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/misc/Utils.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/Utils.java
@@ -128,7 +128,7 @@ public class Utils {
 	 *  converting rulenames to name&rarr;ruleindex map.
 	 */
 	public static Map<String, Integer> toMap(String[] keys) {
-		Map<String, Integer> m = new HashMap<String, Integer>();
+		Map<String, Integer> m = new HashMap<String, Integer>( keys.length, 1.0f );
 		for (int i=0; i<keys.length; i++) {
 			m.put(keys[i], i);
 		}


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

https://github.com/antlr/antlr4/issues/2937

We have multiple ways to avoid hash map resizing. The following common misuse usually won't achieve the goal:
```
new HashMap<>( keys. length );
```
for load factor is 0.75 not 1.0.

Another option is:
```
new HashMap<>( keys.length / 0.75, 0.75 );
```
A surprising common misuse of HashMap in Java.