### PR TITLE
Corrected Webpack configuration in JavaScript documentation

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -263,3 +263,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/09/15, rmcgregor1990, Robert McGregor, rmcgregor1990@gmail.com
 2020/09/16, trenki2, Markus Trenkwalder, trenki2[at]gmx[dot]net
 2020/10/08, Marti2203, Martin Mirchev, mirchevmartin2203@gmail.com
+2020/10/16, adarshbhat, Adarsh Bhat, mail@adarshbhat.com

--- a/doc/javascript-target.md
+++ b/doc/javascript-target.md
@@ -68,7 +68,7 @@ The steps to create your parsing code are the following:
  
 You are now ready to bundle your parsing code as follows:
  - following webpack specs, create a webpack.config file
- - in the `webpack.config` file, exclude node.js only modules using: `node: { module: "empty", net: "empty", fs: "empty" }`
+ - in the `webpack.config` file, exclude node.js only modules using: `resolve: { fallback: { fs: false } }`
  - from the cmd line, navigate to the directory containing webpack.config and type: webpack
  
 This will produce a single js file containing all your parsing code. Easy to include in your web pages!

--- a/doc/javascript-target.md
+++ b/doc/javascript-target.md
@@ -68,7 +68,10 @@ The steps to create your parsing code are the following:
  
 You are now ready to bundle your parsing code as follows:
  - following webpack specs, create a webpack.config file
- - in the `webpack.config` file, exclude node.js only modules using: `resolve: { fallback: { fs: false } }`
+ - For Webpack version 5,
+   - in the `webpack.config` file, exclude node.js only modules using: `resolve: { fallback: { fs: false } }`
+ - For older versions of Webpack,
+   - in the `webpack.config` file, exclude node.js only modules using: `node: { module: "empty", net: "empty", fs: "empty" }`
  - from the cmd line, navigate to the directory containing webpack.config and type: webpack
  
 This will produce a single js file containing all your parsing code. Easy to include in your web pages!


### PR DESCRIPTION
When using the JavaScript code generated by antlr4 in a web browser environment, we have to make exceptions for certain node.js based global modules. The configuration provided in documentation is incorrect and no longer works on new versions of Webpack. This PR attempts to correct the documentation with new configuration that works. Thanks to the Webpack team for pointing out the correct approach.

My understanding is that even after switching to ES6, we will still need this configuration.