### PR TITLE
[PHP] Escape dollar sign in target string literal  

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -265,3 +265,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/09/15, rmcgregor1990, Robert McGregor, rmcgregor1990@gmail.com
 2020/09/16, trenki2, Markus Trenkwalder, trenki2[at]gmx[dot]net
 2020/10/08, Marti2203, Martin Mirchev, mirchevmartin2203@gmail.com
+2020/10/20, adamwojs, Adam Wójs, adam[at]wojs.pl

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/LexerExecDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/descriptors/LexerExecDescriptors.java
@@ -1057,4 +1057,33 @@ public class LexerExecDescriptors {
 			return new Pair<>(grammarName, grammar);
 		}
 	}
+
+	/**
+	 * This is a regression test for antlr/antlr4#2709 "PHP target generates
+	 * invalid output when $ is used as part of the literal in lexer rule"
+	 * https://github.com/antlr/antlr4/issues/2709
+	 */
+	public static class EscapeTargetStringLiteral extends BaseLexerTestDescriptor {
+		/**
+		[@0,0:-1='<EOF>',<-1>,1:0]
+		 */
+		@CommentHasStringValue
+		public String output;
+
+		public String errors = null;
+		public String startRule = "";
+		public String grammarName = "L";
+
+		/**
+		 lexer grammar L;
+		 ACTION_WITH_DOLLAR: '$ACTION';
+		 */
+		@CommentHasStringValue
+		public String grammar;
+
+		@Override
+		public boolean ignore(String targetName) {
+			return !targetName.equals("PHP");
+		}
+	}
 }

--- a/tool/src/org/antlr/v4/codegen/target/PHPTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/PHPTarget.java
@@ -102,4 +102,12 @@ public class PHPTarget extends Target {
 	protected void appendUnicodeEscapedCodePoint(int codePoint, StringBuilder sb) {
 		UnicodeEscapes.appendPythonStyleEscapedCodePoint(codePoint, sb);
 	}
+
+   @Override
+   public String getTargetStringLiteralFromANTLRStringLiteral(CodeGenerator generator, String literal, boolean addQuotes) {
+	   String targetStringLiteral = super.getTargetStringLiteralFromANTLRStringLiteral(generator, literal, addQuotes);
+	   targetStringLiteral = targetStringLiteral.replace("$", "\\$");
+
+	   return targetStringLiteral;
+   }
 }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

Fixed https://github.com/antlr/antlr4/issues/2709.

#### TODO:
- [X] Sign to `contributors.txt`
- [X] Add regression test 
- [x] Wait for CI confirmation (failed build: https://travis-ci.org/github/antlr/antlr4/jobs/737510118#L2792-L2807)
- [x] Implement patch