### PR TITLE
fix bug for javascript runtime: 'getRuleContext()' not exist.

### DIFF
--- a/runtime/JavaScript/src/antlr4/tree/Tree.js
+++ b/runtime/JavaScript/src/antlr4/tree/Tree.js
@@ -195,9 +195,11 @@ class ParseTreeWalker {
 	 * @param r The grammar rule containing the rule context
 	 */
 	enterRule(listener, r) {
-		const ctx = r.getRuleContext();
-		listener.enterEveryRule(ctx);
-		ctx.enterRule(listener);
+		if(r.getRuleContext) {
+			const ctx = r.getRuleContext();
+			listener.enterEveryRule(ctx);
+			ctx.enterRule(listener);
+		}
 	}
 
 	/**
@@ -207,9 +209,11 @@ class ParseTreeWalker {
 	 * @param r The grammar rule containing the rule context
 	 */
 	exitRule(listener, r) {
-		const ctx = r.getRuleContext();
-		ctx.exitRule(listener);
-		listener.exitEveryRule(ctx);
+		if(r.getRuleContext) {
+			const ctx = r.getRuleContext();
+			ctx.exitRule(listener);
+			listener.exitEveryRule(ctx);
+		}
 	}
 }
 


### PR DESCRIPTION


JavaScript runtime for ANTLR4 failed to run because  'getRuleContext()' property is not exist for 'TerminalNodeImpl'. 

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->