### PR TITLE
Fix javadoc tags, bad HTML entities, and an incorrect @param name

### DIFF
--- a/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/MojoUtils.java
+++ b/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/MojoUtils.java
@@ -55,7 +55,7 @@ class MojoUtils {
      * directory and reflect the input organization of the grammar files.
      *
      * @param   sourceDirectory  The source directory {@link File} object
-     * @param   grammarFileName  The full path to the input grammar file
+     * @param   grammarFile      The full path to the input grammar file
      *
      * @return  The path to the grammar file relative to the source directory
      */

--- a/runtime/Java/src/org/antlr/v4/runtime/CharStreams.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CharStreams.java
@@ -24,7 +24,7 @@ import java.nio.file.Paths;
 
 /** This class represents the primary interface for creating {@link CharStream}s
  *  from a variety of sources as of 4.7.  The motivation was to support
- *  Unicode code points > U+FFFF.  {@link ANTLRInputStream} and
+ *  Unicode code points &gt; U+FFFF.  {@link ANTLRInputStream} and
  *  {@link ANTLRFileStream} are now deprecated in favor of the streams created
  *  by this interface.
  *

--- a/runtime/Java/src/org/antlr/v4/runtime/CodePointCharStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CodePointCharStream.java
@@ -16,7 +16,7 @@ import java.nio.charset.StandardCharsets;
  * code units.
  *
  * Use this if you need to parse input which potentially contains
- * Unicode values > U+FFFF.
+ * Unicode values &gt; U+FFFF.
  */
 public abstract class CodePointCharStream implements CharStream {
 	protected final int size;

--- a/runtime/Java/src/org/antlr/v4/runtime/ParserInterpreter.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ParserInterpreter.java
@@ -69,7 +69,7 @@ public class ParserInterpreter extends Parser {
 	protected final Deque<Pair<ParserRuleContext, Integer>> _parentContextStack =
 		new ArrayDeque<Pair<ParserRuleContext, Integer>>();
 
-	/** We need a map from (decision,inputIndex)->forced alt for computing ambiguous
+	/** We need a map from (decision,inputIndex)&rarr;forced alt for computing ambiguous
 	 *  parse trees. For now, we allow exactly one override.
 	 */
 	protected int overrideDecision = -1;

--- a/runtime/Java/src/org/antlr/v4/runtime/RuleContext.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/RuleContext.java
@@ -31,10 +31,10 @@ import java.util.List;
  *  Parser._ctx.
  *
  *  public final SContext s() throws RecognitionException {
- *      SContext _localctx = new SContext(_ctx, getState()); <-- create new node
- *      enterRule(_localctx, 0, RULE_s);                     <-- push it
+ *      SContext _localctx = new SContext(_ctx, getState()); &larr; create new node
+ *      enterRule(_localctx, 0, RULE_s);                     &larr; push it
  *      ...
- *      exitRule();                                          <-- pop back to _localctx
+ *      exitRule();                                          &larr; pop back to _localctx
  *      return _localctx;
  *  }
  *
@@ -48,9 +48,9 @@ import java.util.List;
  *  symbol s then call r1, which calls r2, the  would look like
  *  this:
  *
- *     SContext[-1]   <- root node (bottom of the stack)
- *     R1Context[p]   <- p in rule s called r1
- *     R2Context[q]   <- q in rule r1 called r2
+ *     SContext[-1]   &larr; root node (bottom of the stack)
+ *     R1Context[p]   &larr; p in rule s called r1
+ *     R2Context[q]   &larr; q in rule r1 called r2
  *
  *  So the top of the stack, _ctx, represents a call to the current
  *  rule and it holds the return address from another rule that invoke
@@ -163,7 +163,7 @@ public class RuleContext implements RuleNode {
 	 */
 	public void setAltNumber(int altNumber) { }
 
-	/** @since 4.7. {@see ParseTree#setParent} comment */
+	/** @since 4.7. @see ParseTree#setParent comment */
 	@Override
 	public void setParent(RuleContext parent) {
 		this.parent = parent;

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/CodePointTransitions.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/CodePointTransitions.java
@@ -13,14 +13,14 @@ import org.antlr.v4.runtime.misc.IntervalSet;
  * and {@link SetTransition} appropriately based on the range of the input.
  *
  * To keep the serialized ATN size small, we only inline atom and
- * range transitions for Unicode code points <= U+FFFF.
+ * range transitions for Unicode code points &le; U+FFFF.
  *
- * Whenever we encounter a Unicode code point > U+FFFF, we represent that
+ * Whenever we encounter a Unicode code point &gt; U+FFFF, we represent that
  * as a set transition (even if it is logically an atom or a range).
  */
 public abstract class CodePointTransitions {
 	/**
-	 * If {@code codePoint} is <= U+FFFF, returns a new {@link AtomTransition}.
+	 * If {@code codePoint} is &le; U+FFFF, returns a new {@link AtomTransition}.
 	 * Otherwise, returns a new {@link SetTransition}.
 	 */
 	public static Transition createWithCodePoint(ATNState target, int codePoint) {
@@ -34,7 +34,7 @@ public abstract class CodePointTransitions {
 
 	/**
 	 * If {@code codePointFrom} and {@code codePointTo} are both
-	 * <= U+FFFF, returns a new {@link RangeTransition}.
+	 * &le; U+FFFF, returns a new {@link RangeTransition}.
 	 * Otherwise, returns a new {@link SetTransition}.
 	 */
 	public static Transition createWithCodePointRange(

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/ParseTreeListener.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/ParseTreeListener.java
@@ -12,7 +12,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
  *  by {@link ParseTreeWalker}. E.g.,
  *
  *  	ParseTreeWalker walker = new ParseTreeWalker();
- *		walker.walk(myParseTreeListener, myParseTree); <-- triggers events in your listener
+ *		walker.walk(myParseTreeListener, myParseTree); &larr; triggers events in your listener
  *
  *  If you want to trigger events in multiple listeners during a single
  *  tree walk, you can use the ParseTreeDispatcher object available at

--- a/tool/src/org/antlr/v4/semantics/SymbolChecks.java
+++ b/tool/src/org/antlr/v4/semantics/SymbolChecks.java
@@ -373,7 +373,8 @@ public class SymbolChecks {
 	}
 
 	/**
-	 * {@return} list of simple string literals for rule {@param rule}
+	 * @param rule the rule
+	 * @return list of simple string literals for the rule
 	 */
 	private List<String> getSingleTokenValues(Rule rule)
 	{

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -996,7 +996,7 @@ public enum ErrorType {
 	 *
 	 * <p><em>name</em> is not a recognized token name</p>
 	 *
-	 * <pre>TOKEN: 'a' -> type(CHANNEL1); // error 175</pre>
+	 * <pre>TOKEN: 'a' &rarr; type(CHANNEL1); // error 175</pre>
 	 */
 	CONSTANT_VALUE_IS_NOT_A_RECOGNIZED_TOKEN_NAME(175, "<arg> is not a recognized token name", ErrorSeverity.ERROR),
 	/**
@@ -1004,7 +1004,7 @@ public enum ErrorType {
 	 *
 	 * <p><em>name</em>is not a recognized mode name</p>
 	 *
-	 * <pre>TOKEN: 'a' -> mode(MODE1); // error 176</pre>
+	 * <pre>TOKEN: 'a' &rarr; mode(MODE1); // error 176</pre>
 	 */
 	CONSTANT_VALUE_IS_NOT_A_RECOGNIZED_MODE_NAME(176, "<arg> is not a recognized mode name", ErrorSeverity.ERROR),
 	/**
@@ -1012,7 +1012,7 @@ public enum ErrorType {
 	 *
 	 * <p><em>name</em> is not a recognized channel name</p>
 	 *
-	 * <pre>TOKEN: 'a' -> channel(TOKEN1); // error 177</pre>
+	 * <pre>TOKEN: 'a' &rarr; channel(TOKEN1); // error 177</pre>
 	 */
 	CONSTANT_VALUE_IS_NOT_A_RECOGNIZED_CHANNEL_NAME(177, "<arg> is not a recognized channel name", ErrorSeverity.ERROR),
 	/*


### PR DESCRIPTION
This commit addresses a number of complaints from the javadoc tool.  I signed the contributor agreement in my first pull request: https://github.com/antlr/antlr4/pull/2739.