### PR TITLE
allow multiple versions when locating python tool

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python/BasePythonTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python/BasePythonTest.java
@@ -5,6 +5,7 @@
  */
 package org.antlr.v4.test.runtime.python;
 
+import com.sun.codemodel.internal.JForEach;
 import org.antlr.v4.Tool;
 import org.antlr.v4.automata.ATNFactory;
 import org.antlr.v4.automata.ATNPrinter;
@@ -513,31 +514,33 @@ public abstract class BasePythonTest implements RuntimeTestSupport {
 		return null;
 	}
 
-	private String locateTool(String tool) {
+	private String locateTool(List<String> tools) {
 		String[] roots = {
 			"/opt/local/bin", "/usr/bin/", "/usr/local/bin/",
 		    "/Users/"+System.getProperty("user.name")+"/anaconda3/bin/"
 		};
 		for(String root : roots) {
-			if(new File(root + tool).exists()) {
-				return root+tool;
+			for (String tool : tools) {
+				if ( new File(root+tool).exists() ) {
+					return root+tool;
+				}
 			}
 		}
-		throw new RuntimeException("Could not locate " + tool);
+		throw new RuntimeException("Could not locate " + tools);
 	}
 
 	protected String locatePython() {
 		String propName = getPropertyPrefix() + "-python";
 		String prop = System.getProperty(propName);
 		if(prop==null || prop.length()==0)
-			prop = locateTool(getPythonExecutable());
+			prop = locateTool(getPythonExecutables());
 		File file = new File(prop);
 		if(!file.exists())
 			throw new RuntimeException("Missing system property:" + propName);
 		return file.getAbsolutePath();
 	}
 
-	protected abstract String getPythonExecutable();
+	protected abstract List<String> getPythonExecutables();
 
 	protected String locateRuntime() { return locateRuntime(getLanguage()); }
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/BasePython2Test.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/BasePython2Test.java
@@ -9,6 +9,10 @@ package org.antlr.v4.test.runtime.python2;
 import org.antlr.v4.test.runtime.python.BasePythonTest;
 import org.stringtemplate.v4.ST;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 
 public class BasePython2Test extends BasePythonTest {
@@ -19,8 +23,8 @@ public class BasePython2Test extends BasePythonTest {
 	}
 
 	@Override
-	protected String getPythonExecutable() {
-		return "python2.7";
+	protected List<String> getPythonExecutables() {
+		return Collections.singletonList("python2.7");
 	}
 
 	@Override

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/BasePython3Test.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/BasePython3Test.java
@@ -23,7 +23,7 @@ public class BasePython3Test extends BasePythonTest {
 	@Override
 	protected List<String> getPythonExecutables() {
 		return Arrays.asList("python3.7", "python3.8");
-	} // force 3.7
+	} // force 3.7 or 3.8
 
 	@Override
 	protected void writeLexerTestFile(String lexerName, boolean showDFA) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/BasePython3Test.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/BasePython3Test.java
@@ -8,6 +8,9 @@ package org.antlr.v4.test.runtime.python3;
 import org.antlr.v4.test.runtime.python.BasePythonTest;
 import org.stringtemplate.v4.ST;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.antlr.v4.test.runtime.BaseRuntimeTest.writeFile;
 
 public class BasePython3Test extends BasePythonTest {
@@ -18,8 +21,8 @@ public class BasePython3Test extends BasePythonTest {
 	}
 
 	@Override
-	protected String getPythonExecutable() {
-		return "python3.7";
+	protected List<String> getPythonExecutables() {
+		return Arrays.asList("python3.7", "python3.8");
 	} // force 3.7
 
 	@Override


### PR DESCRIPTION
Hi @ericvergnaud I updated to allow 3.8 in addition. required interface change to python test routines. hope this is ok.

```java
	protected List<String> getPythonExecutables() {
		return Arrays.asList("python3.7", "python3.8");
	} // force 3.7 or 3.8
```