### PR TITLE
[Doc] Fix wrong commands in Get Started

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -24,14 +24,14 @@ and put it somewhere rational like `/usr/local/lib`.
 
 2. Add `antlr-4.9-complete.jar` to your `CLASSPATH`:
 ```
-$ export CLASSPATH=".:/usr/local/lib/antlr-4.9-complete.jar.jar:$CLASSPATH"
+$ export CLASSPATH=".:/usr/local/lib/antlr-4.9-complete.jar:$CLASSPATH"
 ```
 It's also a good idea to put this in your `.bash_profile` or whatever your startup script is.
 
 3. Create aliases for the ANTLR Tool, and `TestRig`.
 ```
-$ alias antlr4='java -Xmx500M -cp "/usr/local/lib/antlr-4.9-complete.jar.jar:$CLASSPATH" org.antlr.v4.Tool'
-$ alias grun='java -Xmx500M -cp "/usr/local/lib/antlr-4.9-complete.jar.jar:$CLASSPATH" org.antlr.v4.gui.TestRig'
+$ alias antlr4='java -Xmx500M -cp "/usr/local/lib/antlr-4.9-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
+$ alias grun='java -Xmx500M -cp "/usr/local/lib/antlr-4.9-complete.jar:$CLASSPATH" org.antlr.v4.gui.TestRig'
 ```
 
 ### WINDOWS
@@ -41,7 +41,7 @@ $ alias grun='java -Xmx500M -cp "/usr/local/lib/antlr-4.9-complete.jar.jar:$CLAS
 0. Install Java (version 1.7 or higher)
 1. Download antlr-4.9-complete.jar (or whatever version) from [https://www.antlr.org/download/](https://www.antlr.org/download/)
 Save to your directory for 3rd party Java libraries, say `C:\Javalib`
-2. Add `antlr-4.9-complete.jar.jar` to CLASSPATH, either:
+2. Add `antlr-4.9-complete.jar` to CLASSPATH, either:
   * Permanently: Using System Properties dialog > Environment variables > Create or append to `CLASSPATH` variable
   * Temporarily, at command line:
 ```


### PR DESCRIPTION
Hi,

While I was following the Get Started documentation.
I encountered errors when executing the guiding commands and I felt confused.
It took me a while to recognize that `.jar` were redundant and caused the errors.
I propose to remove these from the documentation, then others could avoid this.

Thanks,
BQC