### PR TITLE
travis: upgrade c++ build to focal & llvm 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - os: linux
       dist: focal
       compiler: clang
-      jdk: openjdk8
+      jdk: openjdk11
       env:
         - TARGET=cpp
         - CXX=g++-10
@@ -38,7 +38,7 @@ matrix:
     - os: linux
       dist: focal
       compiler: clang
-      jdk: openjdk8
+      jdk: openjdk11
       env:
         - TARGET=cpp
         - CXX=g++-10
@@ -55,7 +55,7 @@ matrix:
     - os: linux
       dist: focal
       compiler: clang
-      jdk: openjdk8
+      jdk: openjdk11
       env:
         - TARGET=cpp
         - CXX=g++-10

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,59 +19,56 @@ stages:
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: focal
       compiler: clang
       jdk: openjdk8
       env:
         - TARGET=cpp
-        - CXX=g++-5
+        - CXX=g++-10
         - GROUP=LEXER
       stage: main-test
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
           packages:
-            - g++-5
+            - g++-10
             - uuid-dev
-            - clang-3.7
+            - clang-10
     - os: linux
-      dist: trusty
+      dist: focal
       compiler: clang
       jdk: openjdk8
       env:
         - TARGET=cpp
-        - CXX=g++-5
+        - CXX=g++-10
         - GROUP=PARSER
       stage: main-test
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
           packages:
-            - g++-5
+            - g++-10
             - uuid-dev
-            - clang-3.7
+            - clang-10
     - os: linux
-      dist: trusty
+      dist: focal
       compiler: clang
       jdk: openjdk8
       env:
         - TARGET=cpp
-        - CXX=g++-5
+        - CXX=g++-10
         - GROUP=RECURSION
       stage: main-test
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
           packages:
-            - g++-5
+            - g++-10
             - uuid-dev
-            - clang-3.7
+            - clang-10
     - os: osx
       compiler: clang
       osx_image: xcode10.2

--- a/runtime/Cpp/runtime/src/Vocabulary.h
+++ b/runtime/Cpp/runtime/src/Vocabulary.h
@@ -22,7 +22,7 @@ namespace dfa {
     /// except <seealso cref="Token#EOF"/>.</para>
     static const Vocabulary EMPTY_VOCABULARY;
 
-    Vocabulary() = default;
+    Vocabulary() {}
     Vocabulary(Vocabulary const&) = default;
     virtual ~Vocabulary();
 


### PR DESCRIPTION
Alternative PR to #2908, upgrading only the c++ build

The first build shows that openjdk8 is not available with Ubuntu focal:
https://travis-ci.org/github/antlr/antlr4/builds/746825671
```
The command "~/bin/install-jdk.sh --target "/home/travis/openjdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "GPL" --cacerts" failed and exited with 3 during .
```

The second build shows the issues in the C++ runtime:
https://travis-ci.org/github/antlr/antlr4/builds/746909160
```
In file included from /tmp/BaseCppTest-main-1606808268300/TLexer.cpp:5:
In file included from /tmp/BaseCppTest-main-1606808268300/TLexer.h:7:
In file included from /home/travis/build/antlr/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/antlr4-runtime.h:126:
/home/travis/build/antlr/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/misc/InterpreterDataReader.h:20:5: error: call to implicitly-deleted default constructor of 'dfa::Vocabulary'
    InterpreterData() {}; // For invalid content.
    ^
/home/travis/build/antlr/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/Vocabulary.h:25:5: note: explicitly defaulted function was implicitly deleted here
    Vocabulary() = default;
    ^
/home/travis/build/antlr/antlr4/runtime-testsuite/target/classes/Cpp/runtime/src/Vocabulary.h:185:36: note: default constructor of 'Vocabulary' is implicitly deleted because field '_literalNames' of const-qualified type 'const std::vector<std::string>' (aka 'const vector<basic_string<char> >') would not be initialized
    std::vector<std::string> const _literalNames;
                                   ^
1 error generated.
```

The third build passes:
https://travis-ci.org/github/antlr/antlr4/builds/747024792?utm_source=github_status&utm_medium=notification