### PR TITLE
:ambulance: fix bad import

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -280,3 +280,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/10/20, adamwojs, Adam Wójs, adam[at]wojs.pl
 2020/10/24, cliid, Jiwu Jang, jiwujang@naver.com
 2020/11/05, MichelHartmann, Michel Hartmann, MichelHartmann@users.noreply.github.com
+2020/12/01, maxence-lefebvre, Maxence Lefebvre, maxence-lefebvre@users.noreply.github.com

--- a/runtime/JavaScript/src/antlr4/CharStreams.js
+++ b/runtime/JavaScript/src/antlr4/CharStreams.js
@@ -3,7 +3,7 @@
  * can be found in the LICENSE.txt file in the project root.
  */
 
-const {InputStream} = require('./InputStream');
+const InputStream = require('./InputStream');
 const fs = require("fs");
 
 /**


### PR DESCRIPTION
Hi,

As of today, `InputStream` is the default export of its module and not a named one.

![image](https://user-images.githubusercontent.com/15971247/100771606-e44ea080-33fe-11eb-8998-bf9863467fac.png)

The module `CharStreams` was trying to load the named one which does not exist.

Test case 

```javascript
console.log(require('antlr4').CharStreams.fromString('test'))
```

Expected

```
InputStream {
  name: '<empty>',
  strdata: 'test',
  decodeToUnicodeCodePoints: true,
  _index: 0,
  data: [ 116, 101, 115, 116 ],
  _size: 4
}
```

Actual

```
TypeError: InputStream is not a constructor
    at Object.fromString (node_modules\antlr4\src\antlr4\CharStreams.js:19:12)
```
