### PR TITLE
Several improvements for C++ target

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -280,3 +280,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/10/20, adamwojs, Adam Wójs, adam[at]wojs.pl
 2020/10/24, cliid, Jiwu Jang, jiwujang@naver.com
 2020/11/05, MichelHartmann, Michel Hartmann, MichelHartmann@users.noreply.github.com
+2020/12/05, xTachyon, Damian Andrei, xTachyon@users.noreply.github.com

--- a/runtime/Cpp/CMakeLists.txt
+++ b/runtime/Cpp/CMakeLists.txt
@@ -71,8 +71,13 @@ else()
   set(MY_CXX_WARNING_FLAGS "  -Wall -pedantic -W")
 endif()
 
-# Define USE_UTF8_INSTEAD_OF_CODECVT macro.
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_UTF8_INSTEAD_OF_CODECVT")
+if(USE_UTF8_INSTEAD_OF_CODECVT)
+  # Define USE_UTF8_INSTEAD_OF_CODECVT macro.
+  message(STATUS "Using utfcpp library")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_UTF8_INSTEAD_OF_CODECVT")
+else()
+  message(STATUS "Using codecvt")
+endif()
 
 # Initialize CXXFLAGS.
 if("${CMAKE_VERSION}" VERSION_GREATER 3.1.0)
@@ -104,7 +109,7 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHE
     execute_process(
         COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
     # Just g++-5.0 and greater contain <codecvt> header. (test in ubuntu)
-    if(NOT (GCC_VERSION VERSION_GREATER 5.0 OR GCC_VERSION VERSION_EQUAL 5.0))
+    if(NOT (GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8))
         message(FATAL_ERROR "${PROJECT_NAME} requires g++ 5.0 or greater.")
     endif ()
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND ANDROID) 

--- a/runtime/Cpp/deploy-macos.sh
+++ b/runtime/Cpp/deploy-macos.sh
@@ -11,7 +11,7 @@ if [ ! -d utfcpp ]
 then
     git clone https://github.com/nemtrif/utfcpp.git utfcpp
     pushd utfcpp
-    git checkout tags/v3.1.1
+    git checkout tags/v3.1.2
     popd
 fi
 popd

--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -6,7 +6,7 @@ set(UTFCPP_DIR ${THIRDPARTY_DIR}/utfcpp)
 ExternalProject_Add(
   utfcpp
   GIT_REPOSITORY        "git://github.com/nemtrif/utfcpp"
-  GIT_TAG               "v3.1.1"
+  GIT_TAG               "v3.1.2"
   SOURCE_DIR            ${UTFCPP_DIR}
   UPDATE_DISCONNECTED   1
   CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${UTFCPP_DIR}/install -Dgtest_force_shared_crt=ON

--- a/runtime/Cpp/runtime/src/antlr4-common.h
+++ b/runtime/Cpp/runtime/src/antlr4-common.h
@@ -36,10 +36,6 @@
 #include <condition_variable>
 #include <functional>
 
-#ifndef USE_UTF8_INSTEAD_OF_CODECVT
-  #include <codecvt>
-#endif
-
 // Defines for the Guid class and other platform dependent stuff.
 #ifdef _WIN32
   #ifdef _MSC_VER

--- a/runtime/Cpp/runtime/src/atn/ATN.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATN.cpp
@@ -158,7 +158,7 @@ misc::IntervalSet ATN::getExpectedTokens(size_t stateNumber, RuleContext *contex
   }
 
   if (following.contains(Token::EPSILON)) {
-    expected.add(Token::EOF);
+    expected.add(static_cast<ssize_t>(Token::EOF));
   }
 
   return expected;

--- a/runtime/Cpp/runtime/src/atn/ATNState.h
+++ b/runtime/Cpp/runtime/src/atn/ATNState.h
@@ -70,7 +70,7 @@ namespace atn {
   ///
   /// <embed src="images/OptionalNonGreedy.svg" type="image/svg+xml"/>
   /// </summary>
-  class ANTLR4CPP_PUBLIC ATN;
+  class ATN;
 
   class ANTLR4CPP_PUBLIC ATNState {
   public:

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
@@ -82,20 +82,20 @@ void LL1Analyzer::_LOOK(ATNState *s, ATNState *stopState, Ref<PredictionContext>
   // ml: s can never be null, hence no need to check if stopState is != null.
   if (s == stopState) {
     if (ctx == nullptr) {
-      look.add(Token::EPSILON);
+      look.add(static_cast<ssize_t>(Token::EPSILON));
       return;
     } else if (ctx->isEmpty() && addEOF) {
-      look.add(Token::EOF);
+      look.add(static_cast<ssize_t>(Token::EOF));
       return;
     }
   }
 
   if (s->getStateType() == ATNState::RULE_STOP) {
     if (ctx == nullptr) {
-      look.add(Token::EPSILON);
+      look.add(static_cast<ssize_t>(Token::EPSILON));
       return;
     } else if (ctx->isEmpty() && addEOF) {
-      look.add(Token::EOF);
+      look.add(static_cast<ssize_t>(Token::EOF));
       return;
     }
 

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -1348,7 +1348,9 @@ Parser* ParserATNSimulator::getParser() {
   return parser;
 }
 
-#pragma warning (disable:4996) // 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead. 
+#ifdef _MSC_VER
+#pragma warning (disable:4996) // 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead.
+#endif
 
 bool ParserATNSimulator::getLrLoopSetting() {
   char *var = std::getenv("TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT");
@@ -1358,7 +1360,9 @@ bool ParserATNSimulator::getLrLoopSetting() {
   return value == "true" || value == "1";
 }
 
+#ifdef _MSC_VER
 #pragma warning (default:4996)
+#endif
 
 void ParserATNSimulator::InitializeInstanceFields() {
   _mode = PredictionMode::LL;

--- a/runtime/Cpp/runtime/src/support/CPPUtils.cpp
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.cpp
@@ -49,13 +49,15 @@ namespace antlrcpp {
             result += "\u00B7";
             break;
           }
-          // else fall through
 #ifndef _MSC_VER
-#if __has_cpp_attribute(clang::fallthrough)
+#   ifdef __has_cpp_attribute
+#       if __has_cpp_attribute(clang::fallthrough)
           [[clang::fallthrough]];
+#   endif
+#   elif __GNUC__ >= 7
+          __attribute__ ((fallthrough));
+#   endif
 #endif
-#endif
-
         default:
           result += c;
       }

--- a/runtime/Cpp/runtime/src/support/StringUtils.cpp
+++ b/runtime/Cpp/runtime/src/support/StringUtils.cpp
@@ -4,6 +4,11 @@
  */
 
 #include "support/StringUtils.h"
+#ifdef USE_UTF8_INSTEAD_OF_CODECVT
+#   include "utf8.h"
+#else
+#   include <codecvt>
+#endif
 
 namespace antlrcpp {
 
@@ -41,6 +46,60 @@ std::wstring s2ws(const std::string &str) {
 #endif
 
   return wide;
+}
+
+// For all conversions utf8 <-> utf32.
+// I wouldn't prefer wstring_convert because: according to
+// https://en.cppreference.com/w/cpp/locale/wstring_convert,
+// wstring_convert is deprecated in C++17.
+// utfcpp (https://github.com/nemtrif/utfcpp) is a substitution.
+#ifndef USE_UTF8_INSTEAD_OF_CODECVT
+    // VS 2015 and VS 2017 have different bugs in std::codecvt_utf8<char32_t> (VS 2013 works fine).
+#if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
+    typedef std::wstring_convert<std::codecvt_utf8<__int32>, __int32> UTF32Converter;
+#else
+    typedef std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> UTF32Converter;
+#endif
+#endif
+
+UTF32String utf8_to_utf32(const char* first, const char* last)
+{
+#ifndef USE_UTF8_INSTEAD_OF_CODECVT
+    thread_local UTF32Converter converter;
+
+  #if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
+    auto r = converter.from_bytes(first, last);
+    i32string s = reinterpret_cast<const int32_t *>(r.data());
+    return s;
+  #else
+    std::u32string s = converter.from_bytes(first, last);
+    return s;
+  #endif
+#else
+    UTF32String wide;
+    utf8::utf8to32(first, last, std::back_inserter(wide));
+    return wide;
+#endif
+}
+
+// The conversion functions fails in VS2017, so we explicitly use a workaround.
+std::string utf32_to_utf8(const std::u32string &data)
+{
+#ifndef USE_UTF8_INSTEAD_OF_CODECVT
+    // Don't make the converter static or we have to serialize access to it.
+  thread_local UTF32Converter converter;
+
+  #if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
+    const auto p = reinterpret_cast<const int32_t *>(data.data());
+    return converter.to_bytes(p, p + data.size());
+  #else
+    return converter.to_bytes(data);
+  #endif
+#else
+    std::string narrow;
+    utf8::utf32to8(data.begin(), data.end(), std::back_inserter(narrow));
+    return narrow;
+#endif
 }
 
 } // namespace antrlcpp

--- a/runtime/Cpp/runtime/src/support/StringUtils.h
+++ b/runtime/Cpp/runtime/src/support/StringUtils.h
@@ -7,66 +7,9 @@
 
 #include "antlr4-common.h"
 
-#ifdef USE_UTF8_INSTEAD_OF_CODECVT
-#include "utf8.h"
-#endif
-
 namespace antlrcpp {
-
-  // For all conversions utf8 <-> utf32.
-  // I wouldn't prefer wstring_convert because: according to
-  // https://en.cppreference.com/w/cpp/locale/wstring_convert,
-  // wstring_convert is deprecated in C++17.
-  // utfcpp (https://github.com/nemtrif/utfcpp) is a substitution.
-#ifndef USE_UTF8_INSTEAD_OF_CODECVT
-  // VS 2015 and VS 2017 have different bugs in std::codecvt_utf8<char32_t> (VS 2013 works fine).
-  #if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
-    typedef std::wstring_convert<std::codecvt_utf8<__int32>, __int32> UTF32Converter;
-  #else
-    typedef std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> UTF32Converter;
-  #endif
-#endif
-
-  // The conversion functions fails in VS2017, so we explicitly use a workaround.
-  template<typename T>
-  inline std::string utf32_to_utf8(T const& data)
-  {
-    #ifndef USE_UTF8_INSTEAD_OF_CODECVT
-      // Don't make the converter static or we have to serialize access to it.
-      thread_local UTF32Converter converter;
-
-      #if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
-        const auto p = reinterpret_cast<const int32_t *>(data.data());
-        return converter.to_bytes(p, p + data.size());
-      #else
-        return converter.to_bytes(data);
-      #endif
-    #else
-      std::string narrow;
-      utf8::utf32to8(data.begin(), data.end(), std::back_inserter(narrow));
-      return narrow;
-    #endif
-  }
-
-  inline UTF32String utf8_to_utf32(const char* first, const char* last)
-  {
-    #ifndef USE_UTF8_INSTEAD_OF_CODECVT
-      thread_local UTF32Converter converter;
-
-      #if defined(_MSC_VER) && _MSC_VER >= 1900 && _MSC_VER < 2000
-        auto r = converter.from_bytes(first, last);
-        i32string s = reinterpret_cast<const int32_t *>(r.data());
-        return s;
-      #else
-        std::u32string s = converter.from_bytes(first, last);
-        return s;
-      #endif
-    #else
-      UTF32String wide;
-      utf8::utf8to32(first, last, std::back_inserter(wide));
-      return wide;
-    #endif
-  }
+  std::string utf32_to_utf8(const UTF32String &data);
+  UTF32String utf8_to_utf32(const char* first, const char* last);
 
   void replaceAll(std::string &str, std::string const& from, std::string const& to);
 

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
@@ -103,7 +103,7 @@ ParseTreePattern ParseTreePatternMatcher::compile(const std::string &pattern, in
 #endif
   } catch (RecognitionException &re) {
     throw re;
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER < 190023026
+#if (defined(_MSC_FULL_VER) && _MSC_FULL_VER < 190023026) || __GNUC__ < 6
   } catch (std::exception &e) {
     // throw_with_nested is not available before VS 2015.
     throw e;


### PR DESCRIPTION
Hello. Here are some improvements for the C++ target, mostly focusing on being able to build it on GCC 4.8 properly.
List of changes:
- cmake option USE_UTF8_INSTEAD_OF_CODECVT, off by default;
- allow GCC 4.8;
- updated the utfcpp library to the last version because some macro names clashed with some antlr macros in the older version;
- moved the utf conversions in cpp, mostly because when using the utfcpp library, it leaks the header in whatever project is using antlr (also it's a good idea to export in headers only what's necessary);
- fixed all the other warnings and errors that I could find on GCC 10 and GCC 4.8;

Hope my changes will be to your liking and sorry if I missed something in the process of doing this PR.