### PR TITLE
Fixed exception clauses in JS template.

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -266,10 +266,9 @@ RuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,namedActions,fina
         <code>
         <postamble; separator="\n">
         <namedActions.after>
-    <if(exceptions)>
+    }<if(exceptions)>
     <exceptions; separator="\n">
-    <else>
-    } catch (re) {
+    <else> catch (re) {
     	if(re instanceof antlr4.error.RecognitionException) {
 	        localctx.exception = re;
 	        this._errHandler.reportError(this, re);


### PR DESCRIPTION
The generated exception clause block was missing a leading '}' to terminate the try block.

This addresses Issue #1741.