### PR TITLE
Clarify why mismatched input occurred by showing recognized token type

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -283,3 +283,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/11/05, MichelHartmann, Michel Hartmann, MichelHartmann@users.noreply.github.com
 2020/12/01, maxence-lefebvre, Maxence Lefebvre, maxence-lefebvre@users.noreply.github.com
 2020/12/03, electrum, David Phillips, david@acz.org
+2020/12/08, wbbradley, William Bradley, williambbradley@gmail.com

--- a/runtime/Go/antlr/error_strategy.go
+++ b/runtime/Go/antlr/error_strategy.go
@@ -558,6 +558,8 @@ func (d *DefaultErrorStrategy) GetTokenErrorDisplay(t Token) string {
 		} else {
 			s = "<" + strconv.Itoa(t.GetTokenType()) + ">"
 		}
+	} else {
+		s = fmt.Sprintf("%s <%s>", s, strconv.Itoa(t.GetTokenType()))
 	}
 	return d.escapeWSAndQuote(s)
 }


### PR DESCRIPTION
Users are encountering the mismatched input error and this is by design. However, the error message could be constructed to simplify the user experience. This PR suggests a fix in the Go runtime to always show the token type.

Example issue that folks are encountering: https://stackoverflow.com/questions/16364046/antlr4-mismatched-input