### PR TITLE
Improve python3 performance by adding __slots__

### DIFF
--- a/runtime/Python3/src/antlr4/BufferedTokenStream.py
+++ b/runtime/Python3/src/antlr4/BufferedTokenStream.py
@@ -27,6 +27,7 @@ class TokenStream(object):
 
 
 class BufferedTokenStream(TokenStream):
+    __slots__ = ('tokenSource', 'tokens', 'index', 'fetchedEOF')
 
     def __init__(self, tokenSource:Lexer):
         # The {@link TokenSource} from which tokens for this stream are fetched.

--- a/runtime/Python3/src/antlr4/CommonTokenFactory.py
+++ b/runtime/Python3/src/antlr4/CommonTokenFactory.py
@@ -15,6 +15,8 @@ class TokenFactory(object):
     pass
 
 class CommonTokenFactory(TokenFactory):
+    __slots__ = 'copyText'
+
     #
     # The default {@link CommonTokenFactory} instance.
     #

--- a/runtime/Python3/src/antlr4/CommonTokenStream.py
+++ b/runtime/Python3/src/antlr4/CommonTokenStream.py
@@ -35,6 +35,7 @@ from antlr4.Token import Token
 
 
 class CommonTokenStream(BufferedTokenStream):
+    __slots__ = 'channel'
 
     def __init__(self, lexer:Lexer, channel:int=Token.DEFAULT_CHANNEL):
         super().__init__(lexer)

--- a/runtime/Python3/src/antlr4/FileStream.py
+++ b/runtime/Python3/src/antlr4/FileStream.py
@@ -14,6 +14,7 @@ from antlr4.InputStream import InputStream
 
 
 class FileStream(InputStream):
+    __slots__ = 'fileName'
 
     def __init__(self, fileName:str, encoding:str='ascii', errors:str='strict'):
         super().__init__(self.readDataFrom(fileName, encoding, errors))

--- a/runtime/Python3/src/antlr4/InputStream.py
+++ b/runtime/Python3/src/antlr4/InputStream.py
@@ -12,6 +12,7 @@ from antlr4.Token import Token
 
 
 class InputStream (object):
+    __slots__ = ('name', 'strdata', '_index', 'data', '_size')
 
     def __init__(self, data: str):
         self.name = "<empty>"

--- a/runtime/Python3/src/antlr4/IntervalSet.py
+++ b/runtime/Python3/src/antlr4/IntervalSet.py
@@ -11,6 +11,7 @@ from antlr4.Token import Token
 IntervalSet = None
 
 class IntervalSet(object):
+    __slots__ = ('intervals', 'readOnly')
 
     def __init__(self):
         self.intervals = None

--- a/runtime/Python3/src/antlr4/LL1Analyzer.py
+++ b/runtime/Python3/src/antlr4/LL1Analyzer.py
@@ -14,6 +14,7 @@ from antlr4.atn.Transition import WildcardTransition, NotSetTransition, Abstract
 
 
 class LL1Analyzer (object):
+    __slots__ = 'atn'
 
     #* Special value added to the lookahead sets to indicate that we hit
     #  a predicate during analysis if {@code seeThruPreds==false}.

--- a/runtime/Python3/src/antlr4/Lexer.py
+++ b/runtime/Python3/src/antlr4/Lexer.py
@@ -28,6 +28,11 @@ class TokenSource(object):
 
 
 class Lexer(Recognizer, TokenSource):
+    __slots__ = (
+        '_input', '_output', '_factory', '_tokenFactorySourcePair', '_token',
+        '_tokenStartCharIndex', '_tokenStartLine', '_tokenStartColumn',
+        '_hitEOF', '_channel', '_type', '_modeStack', '_mode', '_text'
+    )
 
     DEFAULT_MODE = 0
     MORE = -2
@@ -322,4 +327,3 @@ class Lexer(Recognizer, TokenSource):
             else:
                 # TODO: Do we lose character or line position information?
                 self._input.consume()
-

--- a/runtime/Python3/src/antlr4/ListTokenSource.py
+++ b/runtime/Python3/src/antlr4/ListTokenSource.py
@@ -18,6 +18,7 @@ from antlr4.Token import Token
 
 
 class ListTokenSource(TokenSource):
+    __slots__ = ('tokens', 'sourceName', 'pos', 'eofToken', '_factory')
 
     # Constructs a new {@link ListTokenSource} instance from the specified
     # collection of {@link Token} objects and source name.

--- a/runtime/Python3/src/antlr4/Parser.py
+++ b/runtime/Python3/src/antlr4/Parser.py
@@ -23,6 +23,7 @@ from antlr4.tree.ParseTreePatternMatcher import ParseTreePatternMatcher
 from antlr4.tree.Tree import ParseTreeListener, TerminalNode, ErrorNode
 
 class TraceListener(ParseTreeListener):
+    __slots__ = '_parser'
 
     def __init__(self, parser):
         self._parser = parser
@@ -44,7 +45,11 @@ class TraceListener(ParseTreeListener):
 
 # self is all the parsing support code essentially; most of it is error recovery stuff.#
 class Parser (Recognizer):
+    __slots__ = (
+        '_input', '_output', '_errHandler', '_precedenceStack', '_ctx',
+        'buildParseTrees', '_tracer', '_parseListeners', '_syntaxErrors'
 
+    )
     # self field maps from the serialized ATN string to the deserialized {@link ATN} with
     # bypass alternatives.
     #

--- a/runtime/Python3/src/antlr4/ParserInterpreter.py
+++ b/runtime/Python3/src/antlr4/ParserInterpreter.py
@@ -32,6 +32,11 @@ from antlr4.error.Errors import RecognitionException, UnsupportedOperationExcept
 
 
 class ParserInterpreter(Parser):
+    __slots__ = (
+        'grammarFileName', 'atn', 'tokenNames', 'ruleNames', 'decisionToDFA',
+        'sharedContextCache', '_parentContextStack',
+        'pushRecursionContextStates'
+    )
 
     def __init__(self, grammarFileName:str, tokenNames:list, ruleNames:list, atn:ATN, input:TokenStream):
         super().__init__(input)

--- a/runtime/Python3/src/antlr4/ParserRuleContext.py
+++ b/runtime/Python3/src/antlr4/ParserRuleContext.py
@@ -34,7 +34,7 @@ from antlr4.tree.Tree import ParseTreeListener, ParseTree, TerminalNodeImpl, Err
 ParserRuleContext = None
 
 class ParserRuleContext(RuleContext):
-
+    __slots__ = ('children', 'start', 'stop', 'exception')
     def __init__(self, parent:ParserRuleContext = None, invokingStateNumber:int = None ):
         super().__init__(parent, invokingStateNumber)
         #* If we are debugging or building a parse tree for a visitor,

--- a/runtime/Python3/src/antlr4/Recognizer.py
+++ b/runtime/Python3/src/antlr4/Recognizer.py
@@ -11,6 +11,7 @@ from antlr4.error.ErrorListener import ProxyErrorListener, ConsoleErrorListener
 RecognitionException = None
 
 class Recognizer(object):
+    __slots__ = ('_listeners', '_interp', '_stateNumber')
 
     tokenTypeMapCache = dict()
     ruleIndexMapCache = dict()

--- a/runtime/Python3/src/antlr4/RuleContext.py
+++ b/runtime/Python3/src/antlr4/RuleContext.py
@@ -33,7 +33,7 @@ RuleContext = None
 Parser = None
 
 class RuleContext(RuleNode):
-
+    __slots__ = ('parentCtx', 'invokingState')
     EMPTY = None
 
     def __init__(self, parent:RuleContext=None, invokingState:int=-1):
@@ -225,4 +225,3 @@ class RuleContext(RuleNode):
 
             buf.write("]")
             return buf.getvalue()
-

--- a/runtime/Python3/src/antlr4/Token.py
+++ b/runtime/Python3/src/antlr4/Token.py
@@ -10,6 +10,7 @@ from io import StringIO
 
 
 class Token (object):
+    __slots__ = ('source', 'type', 'channel', 'start', 'stop', 'tokenIndex', 'line', 'column', '_text')
 
     INVALID_TYPE = 0
 
@@ -67,7 +68,6 @@ class Token (object):
         return self.source[1]
 
 class CommonToken(Token):
-
 
     # An empty {@link Pair} which is used as the default value of
     # {@link #source} for tokens that do not have a source.

--- a/runtime/Python3/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python3/src/antlr4/TokenStreamRewriter.py
@@ -11,6 +11,8 @@ from antlr4.CommonTokenStream import CommonTokenStream
 
 
 class TokenStreamRewriter(object):
+    __slots__ = ('tokens', 'programs', 'lastRewriteTokenIndexes')
+
     DEFAULT_PROGRAM_NAME = "default"
     PROGRAM_INIT_SIZE = 100
     MIN_TOKEN_INDEX = 0
@@ -99,7 +101,7 @@ class TokenStreamRewriter(object):
 
     def getProgram(self, program_name):
         return self.programs.setdefault(program_name, [])
-        
+
     def getDefaultText(self):
         return self.getText(self.DEFAULT_PROGRAM_NAME, 0, len(self.tokens.tokens) - 1)
 
@@ -195,6 +197,7 @@ class TokenStreamRewriter(object):
         return reduced
 
     class RewriteOperation(object):
+        __slots__ = ('tokens', 'index', 'text', 'instructionIndex')
 
         def __init__(self, tokens, index, text=""):
             """
@@ -233,8 +236,9 @@ class TokenStreamRewriter(object):
 
     class InsertAfterOp(InsertBeforeOp):
         pass
-            
+
     class ReplaceOp(RewriteOperation):
+        __slots__ = 'last_index'
 
         def __init__(self, from_idx, to_idx, tokens, text):
             super(TokenStreamRewriter.ReplaceOp, self).__init__(tokens, from_idx, text)
@@ -244,7 +248,7 @@ class TokenStreamRewriter(object):
             if self.text:
                 buf.write(self.text)
             return self.last_index + 1
-            
+
         def __str__(self):
             if self.text:
                 return '<ReplaceOp@{}..{}:"{}">'.format(self.tokens.get(self.index), self.tokens.get(self.last_index),

--- a/runtime/Python3/src/antlr4/atn/ATN.py
+++ b/runtime/Python3/src/antlr4/atn/ATN.py
@@ -12,6 +12,11 @@ from antlr4.atn.ATNState import ATNState, DecisionState
 
 
 class ATN(object):
+    __slots__ = (
+        'grammarType', 'maxTokenType', 'states', 'decisionToState',
+        'ruleToStartState', 'ruleToStopState', 'modeNameToStartState',
+        'ruleToTokenType', 'lexerActions', 'modeToStartState'
+    )
 
     INVALID_ALT_NUMBER = 0
 
@@ -58,7 +63,7 @@ class ATN(object):
         if s.nextTokenWithinRule is not None:
             return s.nextTokenWithinRule
         s.nextTokenWithinRule = self.nextTokensInContext(s, None)
-        s.nextTokenWithinRule.readonly = True
+        s.nextTokenWithinRule.readOnly = True
         return s.nextTokenWithinRule
 
     def nextTokens(self, s:ATNState, ctx:RuleContext = None):

--- a/runtime/Python3/src/antlr4/atn/ATNConfig.py
+++ b/runtime/Python3/src/antlr4/atn/ATNConfig.py
@@ -21,6 +21,10 @@ from antlr4.atn.SemanticContext import SemanticContext
 ATNConfig = None
 
 class ATNConfig(object):
+    __slots__ = (
+        'state', 'alt', 'context', 'semanticContext', 'reachesIntoOuterContext',
+        'precedenceFilterSuppressed'
+    )
 
     def __init__(self, state:ATNState=None, alt:int=None, context:PredictionContext=None, semantic:SemanticContext=None, config:ATNConfig=None):
         if config is not None:
@@ -110,6 +114,7 @@ class ATNConfig(object):
 LexerATNConfig = None
 
 class LexerATNConfig(ATNConfig):
+    __slots__ = ('lexerActionExecutor', 'passedThroughNonGreedyDecision')
 
     def __init__(self, state:ATNState, alt:int=None, context:PredictionContext=None, semantic:SemanticContext=SemanticContext.NONE,
                  lexerActionExecutor:LexerActionExecutor=None, config:LexerATNConfig=None):

--- a/runtime/Python3/src/antlr4/atn/ATNConfigSet.py
+++ b/runtime/Python3/src/antlr4/atn/ATNConfigSet.py
@@ -20,6 +20,12 @@ from antlr4.error.Errors import UnsupportedOperationException, IllegalStateExcep
 ATNSimulator = None
 
 class ATNConfigSet(object):
+    __slots__ = (
+        'configLookup', 'fullCtx', 'readonly', 'configs', 'uniqueAlt',
+        'conflictingAlts', 'hasSemanticContext', 'dipsIntoOuterContext',
+        'cachedHashCode'
+    )
+
     #
     # The reason that we need this is because we don't want the hash map to use
     # the standard hash code and equals. We need all configurations with the same
@@ -204,6 +210,3 @@ class OrderedATNConfigSet(ATNConfigSet):
 
     def __init__(self):
         super().__init__()
-
-
-

--- a/runtime/Python3/src/antlr4/atn/ATNDeserializationOptions.py
+++ b/runtime/Python3/src/antlr4/atn/ATNDeserializationOptions.py
@@ -6,6 +6,7 @@
 ATNDeserializationOptions = None
 
 class ATNDeserializationOptions(object):
+    __slots__ = ('readOnly', 'verifyATN', 'generateRuleBypassTransitions')
 
     defaultOptions = None
 
@@ -21,4 +22,3 @@ class ATNDeserializationOptions(object):
 
 ATNDeserializationOptions.defaultOptions = ATNDeserializationOptions()
 ATNDeserializationOptions.defaultOptions.readOnly = True
-

--- a/runtime/Python3/src/antlr4/atn/ATNDeserializer.py
+++ b/runtime/Python3/src/antlr4/atn/ATNDeserializer.py
@@ -31,6 +31,7 @@ SERIALIZED_VERSION = 3
 SERIALIZED_UUID = ADDED_UNICODE_SMP
 
 class ATNDeserializer (object):
+    __slots__ = ('deserializationOptions', 'data', 'pos', 'uuid')
 
     def __init__(self, options : ATNDeserializationOptions = None):
         if options is None:

--- a/runtime/Python3/src/antlr4/atn/ATNSimulator.py
+++ b/runtime/Python3/src/antlr4/atn/ATNSimulator.py
@@ -10,6 +10,7 @@ from antlr4.dfa.DFAState import DFAState
 
 
 class ATNSimulator(object):
+    __slots__ = ('atn', 'sharedContextCache', '__dict__')
 
     # Must distinguish between missing edge and edge we know leads nowhere#/
     ERROR = DFAState(configs=ATNConfigSet())
@@ -44,4 +45,3 @@ class ATNSimulator(object):
             return context
         visited = dict()
         return getCachedPredictionContext(context, self.sharedContextCache, visited)
-

--- a/runtime/Python3/src/antlr4/atn/ATNState.py
+++ b/runtime/Python3/src/antlr4/atn/ATNState.py
@@ -69,6 +69,10 @@ from antlr4.atn.Transition import Transition
 INITIAL_NUM_TRANSITIONS = 4
 
 class ATNState(object):
+    __slots__ = (
+        'atn', 'stateNumber', 'stateType', 'ruleIndex', 'epsilonOnlyTransitions',
+        'transitions', 'nextTokenWithinRule',
+    )
 
     # constants for serialization
     INVALID_TYPE = 0
@@ -148,7 +152,7 @@ class BasicState(ATNState):
 
 
 class DecisionState(ATNState):
-
+    __slots__ = ('decision', 'nonGreedy')
     def __init__(self):
         super().__init__()
         self.decision = -1
@@ -156,6 +160,7 @@ class DecisionState(ATNState):
 
 #  The start of a regular {@code (...)} block.
 class BlockStartState(DecisionState):
+    __slots__ = 'endState'
 
     def __init__(self):
         super().__init__()
@@ -169,6 +174,7 @@ class BasicBlockStartState(BlockStartState):
 
 # Terminal node of a simple {@code (a|b|c)} block.
 class BlockEndState(ATNState):
+    __slots__ = 'startState'
 
     def __init__(self):
         super().__init__()
@@ -187,6 +193,7 @@ class RuleStopState(ATNState):
         self.stateType = self.RULE_STOP
 
 class RuleStartState(ATNState):
+    __slots__ = ('stopState', 'isPrecedenceRule')
 
     def __init__(self):
         super().__init__()
@@ -209,6 +216,7 @@ class PlusLoopbackState(DecisionState):
 #  real decision-making note for {@code A+}.
 #
 class PlusBlockStartState(BlockStartState):
+    __slots__ = 'loopBackState'
 
     def __init__(self):
         super().__init__()
@@ -230,6 +238,7 @@ class StarLoopbackState(ATNState):
 
 
 class StarLoopEntryState(DecisionState):
+    __slots__ = ('loopBackState', 'isPrecedenceDecision')
 
     def __init__(self):
         super().__init__()
@@ -240,6 +249,7 @@ class StarLoopEntryState(DecisionState):
 
 # Mark the end of a * or + loop.
 class LoopEndState(ATNState):
+    __slots__ = 'loopBackState'
 
     def __init__(self):
         super().__init__()

--- a/runtime/Python3/src/antlr4/atn/LexerATNSimulator.py
+++ b/runtime/Python3/src/antlr4/atn/LexerATNSimulator.py
@@ -34,6 +34,7 @@ from antlr4.dfa.DFAState import DFAState
 from antlr4.error.Errors import LexerNoViableAltException, UnsupportedOperationException
 
 class SimState(object):
+    __slots__ = ('index', 'line', 'column', 'dfaState')
 
     def __init__(self):
         self.reset()
@@ -49,6 +50,10 @@ Lexer = None
 LexerATNSimulator = None
 
 class LexerATNSimulator(ATNSimulator):
+    __slots__ = (
+        'decisionToDFA', 'recog', 'startIndex', 'line', 'column', 'mode',
+        'DEFAULT_MODE', 'MAX_CHAR_VALUE', 'prevAccept'
+    )
 
     debug = False
     dfa_debug = False
@@ -57,8 +62,6 @@ class LexerATNSimulator(ATNSimulator):
     MAX_DFA_EDGE = 127 # forces unicode to stay in ATN
 
     ERROR = None
-
-    match_calls = 0
 
     def __init__(self, recog:Lexer, atn:ATN, decisionToDFA:list, sharedContextCache:PredictionContextCache):
         super().__init__(atn, sharedContextCache)
@@ -89,7 +92,6 @@ class LexerATNSimulator(ATNSimulator):
         self.startIndex = simulator.startIndex
 
     def match(self, input:InputStream , mode:int):
-        self.match_calls += 1
         self.mode = mode
         mark = input.mark()
         try:

--- a/runtime/Python3/src/antlr4/atn/LexerAction.py
+++ b/runtime/Python3/src/antlr4/atn/LexerAction.py
@@ -22,6 +22,7 @@ class LexerActionType(IntEnum):
     TYPE = 7        #The type of a {@link LexerTypeAction} action.
 
 class LexerAction(object):
+    __slots__ = ('actionType', 'isPositionDependent')
 
     def __init__(self, action:LexerActionType):
         self.actionType = action
@@ -39,7 +40,7 @@ class LexerAction(object):
 #
 # <p>The {@code skip} command does not have any parameters, so this action is
 # implemented as a singleton instance exposed by {@link #INSTANCE}.</p>
-class LexerSkipAction(LexerAction ):
+class LexerSkipAction(LexerAction):
 
     # Provides a singleton instance of this parameterless lexer action.
     INSTANCE = None
@@ -58,6 +59,7 @@ LexerSkipAction.INSTANCE = LexerSkipAction()
 #  Implements the {@code type} lexer action by calling {@link Lexer#setType}
 # with the assigned type.
 class LexerTypeAction(LexerAction):
+    __slots__ = 'type'
 
     def __init__(self, type:int):
         super().__init__(LexerActionType.TYPE)
@@ -84,6 +86,7 @@ class LexerTypeAction(LexerAction):
 # Implements the {@code pushMode} lexer action by calling
 # {@link Lexer#pushMode} with the assigned mode.
 class LexerPushModeAction(LexerAction):
+    __slots__ = 'mode'
 
     def __init__(self, mode:int):
         super().__init__(LexerActionType.PUSH_MODE)
@@ -152,6 +155,7 @@ LexerMoreAction.INSTANCE = LexerMoreAction()
 # Implements the {@code mode} lexer action by calling {@link Lexer#mode} with
 # the assigned mode.
 class LexerModeAction(LexerAction):
+    __slots__ = 'mode'
 
     def __init__(self, mode:int):
         super().__init__(LexerActionType.MODE)
@@ -186,6 +190,7 @@ class LexerModeAction(LexerAction):
 # command argument could not be evaluated when the grammar was compiled.</p>
 
 class LexerCustomAction(LexerAction):
+    __slots__ = ('ruleIndex', 'actionIndex')
 
     # Constructs a custom lexer action with the specified rule and action
     # indexes.
@@ -220,6 +225,7 @@ class LexerCustomAction(LexerAction):
 # Implements the {@code channel} lexer action by calling
 # {@link Lexer#setChannel} with the assigned channel.
 class LexerChannelAction(LexerAction):
+    __slots__ = 'channel'
 
     # Constructs a new {@code channel} action with the specified channel value.
     # @param channel The channel value to pass to {@link Lexer#setChannel}.
@@ -255,6 +261,7 @@ class LexerChannelAction(LexerAction):
 # lexer actions, see {@link LexerActionExecutor#append} and
 # {@link LexerActionExecutor#fixOffsetBeforeMatch}.</p>
 class LexerIndexedCustomAction(LexerAction):
+    __slots__ = ('offset', 'action')
 
     # Constructs a new indexed custom action by associating a character offset
     # with a {@link LexerAction}.

--- a/runtime/Python3/src/antlr4/atn/LexerActionExecutor.py
+++ b/runtime/Python3/src/antlr4/atn/LexerActionExecutor.py
@@ -20,6 +20,7 @@ Lexer = None
 LexerActionExecutor = None
 
 class LexerActionExecutor(object):
+    __slots__ = ('lexerActions', 'hashCode')
 
     def __init__(self, lexerActions:list=list()):
         self.lexerActions = lexerActions

--- a/runtime/Python3/src/antlr4/atn/ParserATNSimulator.py
+++ b/runtime/Python3/src/antlr4/atn/ParserATNSimulator.py
@@ -255,6 +255,10 @@ from antlr4.error.Errors import NoViableAltException
 
 
 class ParserATNSimulator(ATNSimulator):
+    __slots__ = (
+        'parser', 'decisionToDFA', 'predictionMode', '_input', '_startIndex',
+        '_outerContext', '_dfa', 'mergeCache'
+    )
 
     debug = False
     debug_list_atn_decisions = False
@@ -1643,4 +1647,3 @@ class ParserATNSimulator(ATNSimulator):
                                ", input=" + self.parser.getTokenStream().getText(startIndex, stopIndex))
         if self.parser is not None:
             self.parser.getErrorListenerDispatch().reportAmbiguity(self.parser, dfa, startIndex, stopIndex, exact, ambigAlts, configs)
-

--- a/runtime/Python3/src/antlr4/atn/SemanticContext.py
+++ b/runtime/Python3/src/antlr4/atn/SemanticContext.py
@@ -95,6 +95,7 @@ def filterPrecedencePredicates(collection:set):
 
 
 class Predicate(SemanticContext):
+    __slots__ = ('ruleIndex', 'predIndex', 'isCtxDependent')
 
     def __init__(self, ruleIndex:int=-1, predIndex:int=-1, isCtxDependent:bool=False):
         self.ruleIndex = ruleIndex
@@ -153,6 +154,7 @@ class PrecedencePredicate(SemanticContext):
 # is false.
 del AND
 class AND(SemanticContext):
+    __slots__ = 'opnds'
 
     def __init__(self, a:SemanticContext, b:SemanticContext):
         operands = set()
@@ -238,6 +240,7 @@ class AND(SemanticContext):
 # contexts is true.
 del OR
 class OR (SemanticContext):
+    __slots__ = 'opnds'
 
     def __init__(self, a:SemanticContext, b:SemanticContext):
         operands = set()

--- a/runtime/Python3/src/antlr4/atn/Transition.py
+++ b/runtime/Python3/src/antlr4/atn/Transition.py
@@ -26,6 +26,8 @@ ATNState = None
 RuleStartState = None
 
 class Transition (object):
+    __slots__ = ('target','isEpsilon','label')
+
     # constants for serialization
     EPSILON			= 1
     RANGE			= 2
@@ -66,6 +68,7 @@ class Transition (object):
 
 # TODO: make all transitions sets? no, should remove set edges
 class AtomTransition(Transition):
+    __slots__ = ('label_', 'serializationType')
 
     def __init__(self, target:ATNState, label:int):
         super().__init__(target)
@@ -85,6 +88,7 @@ class AtomTransition(Transition):
         return str(self.label_)
 
 class RuleTransition(Transition):
+    __slots__ = ('ruleIndex', 'precedence', 'followState', 'serializationType')
 
     def __init__(self, ruleStart:RuleStartState, ruleIndex:int, precedence:int, followState:ATNState):
         super().__init__(ruleStart)
@@ -99,6 +103,7 @@ class RuleTransition(Transition):
 
 
 class EpsilonTransition(Transition):
+    __slots__ = ('serializationType', 'outermostPrecedenceReturn')
 
     def __init__(self, target, outermostPrecedenceReturn=-1):
         super(EpsilonTransition, self).__init__(target)
@@ -113,6 +118,7 @@ class EpsilonTransition(Transition):
         return "epsilon"
 
 class RangeTransition(Transition):
+    __slots__ = ('serializationType', 'start', 'stop')
 
     def __init__(self, target:ATNState, start:int, stop:int):
         super().__init__(target)
@@ -139,6 +145,7 @@ class AbstractPredicateTransition(Transition):
 
 
 class PredicateTransition(AbstractPredicateTransition):
+    __slots__ = ('serializationType', 'ruleIndex', 'predIndex', 'isCtxDependent')
 
     def __init__(self, target:ATNState, ruleIndex:int, predIndex:int, isCtxDependent:bool):
         super().__init__(target)
@@ -158,6 +165,7 @@ class PredicateTransition(AbstractPredicateTransition):
         return "pred_" + str(self.ruleIndex) + ":" + str(self.predIndex)
 
 class ActionTransition(Transition):
+    __slots__ = ('serializationType', 'ruleIndex', 'actionIndex', 'isCtxDependent')
 
     def __init__(self, target:ATNState, ruleIndex:int, actionIndex:int=-1, isCtxDependent:bool=False):
         super().__init__(target)
@@ -175,6 +183,7 @@ class ActionTransition(Transition):
 
 # A transition containing a set of values.
 class SetTransition(Transition):
+    __slots__ = 'serializationType'
 
     def __init__(self, target:ATNState, set:IntervalSet):
         super().__init__(target)
@@ -207,6 +216,7 @@ class NotSetTransition(SetTransition):
 
 
 class WildcardTransition(Transition):
+    __slots__ = 'serializationType'
 
     def __init__(self, target:ATNState):
         super().__init__(target)
@@ -220,6 +230,7 @@ class WildcardTransition(Transition):
 
 
 class PrecedencePredicateTransition(AbstractPredicateTransition):
+    __slots__ = ('serializationType', 'precedence')
 
     def __init__(self, target:ATNState, precedence:int):
         super().__init__(target)

--- a/runtime/Python3/src/antlr4/dfa/DFA.py
+++ b/runtime/Python3/src/antlr4/dfa/DFA.py
@@ -11,6 +11,7 @@ from antlr4.error.Errors import IllegalStateException
 
 
 class DFA(object):
+    __slots__ = ('atnStartState', 'decision', '_states', 's0', 'precedenceDfa')
 
     def __init__(self, atnStartState:DecisionState, decision:int=0):
         # From which ATN state did we create this DFA?
@@ -130,4 +131,3 @@ class DFA(object):
         from antlr4.dfa.DFASerializer import LexerDFASerializer
         serializer = LexerDFASerializer(self)
         return str(serializer)
-

--- a/runtime/Python3/src/antlr4/dfa/DFASerializer.py
+++ b/runtime/Python3/src/antlr4/dfa/DFASerializer.py
@@ -12,6 +12,7 @@ from antlr4.dfa.DFAState import DFAState
 
 
 class DFASerializer(object):
+    __slots__ = ('dfa', 'literalNames', 'symbolicNames')
 
     def __init__(self, dfa:DFA, literalNames:list=None, symbolicNames:list=None):
         self.dfa = dfa

--- a/runtime/Python3/src/antlr4/dfa/DFAState.py
+++ b/runtime/Python3/src/antlr4/dfa/DFAState.py
@@ -11,6 +11,8 @@ from antlr4.atn.SemanticContext import SemanticContext
 
 
 class PredPrediction(object):
+    __slots__ = ('alt', 'pred')
+
     def __init__(self, pred:SemanticContext, alt:int):
         self.alt = alt
         self.pred = pred
@@ -43,6 +45,10 @@ class PredPrediction(object):
 #  meaning that state was reached via a different set of rule invocations.</p>
 #/
 class DFAState(object):
+    __slots__ = (
+        'stateNumber', 'configs', 'edges', 'isAcceptState', 'prediction',
+        'lexerActionExecutor', 'requiresFullContext', 'predicates'
+    )
 
     def __init__(self, stateNumber:int=-1, configs:ATNConfigSet=ATNConfigSet()):
         self.stateNumber = stateNumber

--- a/runtime/Python3/src/antlr4/tree/Chunk.py
+++ b/runtime/Python3/src/antlr4/tree/Chunk.py
@@ -8,6 +8,7 @@ class Chunk(object):
     pass
 
 class TagChunk(Chunk):
+    __slots__ = ('tag', 'label')
 
     def __init__(self, tag:str, label:str=None):
         self.tag = tag
@@ -20,10 +21,10 @@ class TagChunk(Chunk):
             return self.label + ":" + self.tag
 
 class TextChunk(Chunk):
+    __slots__ = 'text'
 
     def __init__(self, text:str):
         self.text = text
 
     def __str__(self):
         return "'" + self.text + "'"
-

--- a/runtime/Python3/src/antlr4/tree/ParseTreeMatch.py
+++ b/runtime/Python3/src/antlr4/tree/ParseTreeMatch.py
@@ -14,7 +14,7 @@ from antlr4.tree.Tree import ParseTree
 
 
 class ParseTreeMatch(object):
-
+    __slots__ = ('tree', 'pattern', 'labels', 'mismatchedNode')
     #
     # Constructs a new instance of {@link ParseTreeMatch} from the specified
     # parse tree and pattern.

--- a/runtime/Python3/src/antlr4/tree/ParseTreePattern.py
+++ b/runtime/Python3/src/antlr4/tree/ParseTreePattern.py
@@ -14,6 +14,7 @@ from antlr4.xpath.XPath import XPath
 
 
 class ParseTreePattern(object):
+    __slots__ = ('matcher', 'patternRuleIndex', 'pattern', 'patternTree')
 
     # Construct a new instance of the {@link ParseTreePattern} class.
     #

--- a/runtime/Python3/src/antlr4/tree/ParseTreePatternMatcher.py
+++ b/runtime/Python3/src/antlr4/tree/ParseTreePatternMatcher.py
@@ -89,6 +89,7 @@ class StartRuleDoesNotConsumeFullPattern(Exception):
 
 
 class ParseTreePatternMatcher(object):
+    __slots__ = ('lexer', 'parser', 'start', 'stop', 'escape')
 
     # Constructs a {@link ParseTreePatternMatcher} or from a {@link Lexer} and
     # {@link Parser} object. The lexer input stream is altered for tokenizing

--- a/runtime/Python3/src/antlr4/tree/RuleTagToken.py
+++ b/runtime/Python3/src/antlr4/tree/RuleTagToken.py
@@ -13,7 +13,8 @@ from antlr4.Token import Token
 
 
 class RuleTagToken(Token):
-   #
+    __slots__ = ('label', 'ruleName')
+    #
     # Constructs a new instance of {@link RuleTagToken} with the specified rule
     # name, bypass token type, and label.
     #

--- a/runtime/Python3/src/antlr4/tree/TokenTagToken.py
+++ b/runtime/Python3/src/antlr4/tree/TokenTagToken.py
@@ -13,7 +13,7 @@ from antlr4.Token import CommonToken
 
 
 class TokenTagToken(CommonToken):
-
+    __slots__ = ('tokenName', 'label')
     # Constructs a new instance of {@link TokenTagToken} with the specified
     # token name, type, and label.
     #

--- a/runtime/Python3/src/antlr4/tree/Tree.py
+++ b/runtime/Python3/src/antlr4/tree/Tree.py
@@ -80,6 +80,7 @@ class ParseTreeListener(object):
 del ParserRuleContext
 
 class TerminalNodeImpl(TerminalNode):
+    __slots__ = ('parentCtx', 'symbol')
 
     def __init__(self, symbol:Token):
         self.parentCtx = None

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -652,6 +652,7 @@ CaptureNextTokenType(d) ::= "<d.varName> = self._input.LA(1)"
 
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers) ::= <<
 class <struct.name>(<if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>):
+    __slots__ = 'parser'
 
     def __init__(self, parser, parent:ParserRuleContext=None, invokingState:int=-1<struct.ctorAttrs:{a | , <a.name><if(a.type)>:<a.type><endif>=None}>):
         super().__init__(parent, invokingState)


### PR DESCRIPTION
# Summary
Python isn't exactly known for its performance, but this PR is my attempt at squeezing out a few more percent of speedup from the Python3 runtime.
This change adds the `__slots__` variable to most classes in the Antlr runtime in order to explicitly declare class members and avoid the use of the slower `__dict__`-based member storage mechanism. This results in faster Python class instance creation, as well as member access.
A benchmark I ran showed roughly 10% improvement in performance.

# Compatibility considerations
For normal "sane" uses of the Antlr runtime, this change is backwards compatible with the current runtime API and should have no effect on behavior.
The side effect of `__slots__` usage is that one is no longer able to dynamically assign new variables to class instances. There are also some caveats with Python weakref usage. I can't quite imagine why someone may need to stuff their own variables on-top of runtime classes, but then again, you never know what other users will do :smile:.

This limitation can be removed by adding `__dict__` and `__weakref__` back into the `__slots__` definition. (possibly at a small performance cost)
The current implementation omits this for now.

See python docs for more details: https://docs.python.org/3/reference/datamodel.html#slots

# Other changes made
The following other changes were made to correct issues and allow `__slots__` to be used:
* In `ATN.py`, fixed capitalization of an assignment to `<IntervalSet>.readOnly`
  * The class `IntervalSet` initializes a member `readOnly`, but this was being assigned as `readonly` in `ATN.py`
  * Looks like a typo.
* In `LexerATNSimulator.py`, removed the `match_calls` counter.
  * This was initialized as a class variable but incremented in an instance variable which is incompatible with `__slots__`.
  * Looks like this was used while debugging at one point and not actually necessary, as it is not referenced anywhere.

# Benchmark
I ran some comparison benchmarks on some sample code from one of my projects. Also including stats using the [speedy-antlr-tool](https://speedy-antlr-tool.readthedocs.io/en/latest/) accelerator.
Inputs are using the lexer/parser for [SystemRDL](https://github.com/SystemRDL/systemrdl-compiler) as well as one of the testcase files. Measured time elapsed for 1000 iterations via timeit.

| Benchmark              | seconds |
|------------------------|---------|
| Baseline               | 134.42  |
| Baseline + slots       | 121.65  |
| "speedy-antlr"         | 14.58   |
| "speedy-antlr" + slots | 13.47   |

It isn't much, but the addition of `__slots__` improves performance by roughly 10% in both the baseline Python3 parser, as well as the accelerated version. I expect this also depends somewhat on the grammar used.


# Other notes
I ran the unit-tests in `runtime/Python3/test/run.py` without issues. Not sure how exhaustive these are.
My name is already signed in `contributors.txt` which is why you don't see it in this PR's diff.