### PR TITLE
Fragments can be used only in another lexer rule error

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/Token.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Token.java
@@ -13,23 +13,28 @@ package org.antlr.v4.runtime;
 public interface Token {
 	public static final int INVALID_TYPE = 0;
 
-    /** During lookahead operations, this "token" signifies we hit rule end ATN state
-     *  and did not follow it despite needing to.
-     */
-    public static final int EPSILON = -2;
+	/**
+	 * During lookahead operations, this "token" signifies we hit rule end ATN state
+	 * and did not follow it despite needing to.
+	 */
+	public static final int EPSILON = -2;
+
+	public static final int FRAGMENT = -3;
 
 	public static final int MIN_USER_TOKEN_TYPE = 1;
 
-    public static final int EOF = IntStream.EOF;
+	public static final int EOF = IntStream.EOF;
 
-	/** All tokens go to the parser (unless skip() is called in that rule)
-	 *  on a particular "channel".  The parser tunes to a particular channel
-	 *  so that whitespace etc... can go to the parser on a "hidden" channel.
+	/**
+	 * All tokens go to the parser (unless skip() is called in that rule)
+	 * on a particular "channel".  The parser tunes to a particular channel
+	 * so that whitespace etc... can go to the parser on a "hidden" channel.
 	 */
 	public static final int DEFAULT_CHANNEL = 0;
 
-	/** Anything on different channel than DEFAULT_CHANNEL is not parsed
-	 *  by parser.
+	/**
+	 * Anything on different channel than DEFAULT_CHANNEL is not parsed
+	 * by parser.
 	 */
 	public static final int HIDDEN_CHANNEL = 1;
 
@@ -51,45 +56,54 @@ public interface Token {
 	 */
 	String getText();
 
-	/** Get the token type of the token */
+	/**
+	 * Get the token type of the token
+	 */
 	int getType();
 
-	/** The line number on which the 1st character of this token was matched,
-	 *  line=1..n
+	/**
+	 * The line number on which the 1st character of this token was matched,
+	 * line=1..n
 	 */
 	int getLine();
 
-	/** The index of the first character of this token relative to the
-	 *  beginning of the line at which it occurs, 0..n-1
+	/**
+	 * The index of the first character of this token relative to the
+	 * beginning of the line at which it occurs, 0..n-1
 	 */
 	int getCharPositionInLine();
 
-	/** Return the channel this token. Each token can arrive at the parser
-	 *  on a different channel, but the parser only "tunes" to a single channel.
-	 *  The parser ignores everything not on DEFAULT_CHANNEL.
+	/**
+	 * Return the channel this token. Each token can arrive at the parser
+	 * on a different channel, but the parser only "tunes" to a single channel.
+	 * The parser ignores everything not on DEFAULT_CHANNEL.
 	 */
 	int getChannel();
 
-	/** An index from 0..n-1 of the token object in the input stream.
-	 *  This must be valid in order to print token streams and
-	 *  use TokenRewriteStream.
-	 *
-	 *  Return -1 to indicate that this token was conjured up since
-	 *  it doesn't have a valid index.
+	/**
+	 * An index from 0..n-1 of the token object in the input stream.
+	 * This must be valid in order to print token streams and
+	 * use TokenRewriteStream.
+	 * <p>
+	 * Return -1 to indicate that this token was conjured up since
+	 * it doesn't have a valid index.
 	 */
 	int getTokenIndex();
 
-	/** The starting character index of the token
-	 *  This method is optional; return -1 if not implemented.
+	/**
+	 * The starting character index of the token
+	 * This method is optional; return -1 if not implemented.
 	 */
 	int getStartIndex();
 
-	/** The last character index of the token.
-	 *  This method is optional; return -1 if not implemented.
+	/**
+	 * The last character index of the token.
+	 * This method is optional; return -1 if not implemented.
 	 */
 	int getStopIndex();
 
-	/** Gets the {@link TokenSource} which created this token.
+	/**
+	 * Gets the {@link TokenSource} which created this token.
 	 */
 	TokenSource getTokenSource();
 

--- a/tool-testsuite/test/org/antlr/v4/test/tool/BaseJavaToolTest.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/BaseJavaToolTest.java
@@ -17,25 +17,29 @@ import static org.junit.Assert.assertEquals;
 
 public class BaseJavaToolTest extends BaseJavaTest {
 	public void testErrors(String[] pairs, boolean printTree) {
-        for (int i = 0; i < pairs.length; i+=2) {
-            String grammarStr = pairs[i];
-            String expect = pairs[i+1];
+		for (int i = 0; i < pairs.length; i += 2) {
+			String grammarStr = pairs[i];
+			String expect = pairs[i + 1];
 
 			String[] lines = grammarStr.split("\n");
 			String fileName = getFilenameFromFirstLineOfGrammar(lines[0]);
 			ErrorQueue equeue = BaseRuntimeTest.antlrOnString(tmpdir, null, fileName, grammarStr, false); // use default language target in case test overrides
 
-			String actual = equeue.toString(true);
-			actual = actual.replace(tmpdir + File.separator, "");
-//			System.err.println(actual);
+			String actual = getErrorString(equeue);
 			String msg = grammarStr;
-			msg = msg.replace("\n","\\n");
-			msg = msg.replace("\r","\\r");
-			msg = msg.replace("\t","\\t");
+			msg = msg.replace("\n", "\\n");
+			msg = msg.replace("\r", "\\r");
+			msg = msg.replace("\t", "\\t");
 
-            assertEquals("error in: "+msg,expect,actual);
-        }
-    }
+			assertEquals("error in: " + msg, expect, actual);
+		}
+	}
+
+	public String getErrorString(ErrorQueue equeue) {
+		String actual = equeue.toString(true);
+		actual = actual.replace(tmpdir + File.separator, "");
+		return actual;
+	}
 
 	public String getFilenameFromFirstLineOfGrammar(String line) {
 		String fileName = "A" + Tool.GRAMMAR_EXTENSION;

--- a/tool/src/org/antlr/v4/codegen/CodeGenerator.java
+++ b/tool/src/org/antlr/v4/codegen/CodeGenerator.java
@@ -11,6 +11,7 @@ import org.antlr.v4.codegen.model.OutputModelObject;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.tool.ErrorType;
 import org.antlr.v4.tool.Grammar;
+import org.antlr.v4.tool.Rule;
 import org.stringtemplate.v4.AutoIndentWriter;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
@@ -146,17 +147,23 @@ public class CodeGenerator {
 		// make constants for the token names
 		for (String t : g.tokenNameToTypeMap.keySet()) {
 			int tokenType = g.tokenNameToTypeMap.get(t);
-			if ( tokenType>=Token.MIN_USER_TOKEN_TYPE) {
+			if (tokenType>=Token.MIN_USER_TOKEN_TYPE) {
 				tokens.put(t, tokenType);
 			}
 		}
+		for (Rule rule : g.rules.values()) {
+			if (rule.isFragment()) {
+				tokens.put(rule.name, Token.FRAGMENT);
+			}
+		}
+
 		vocabFileST.add("tokens", tokens);
 
 		// now dump the strings
 		Map<String,Integer> literals = new LinkedHashMap<String,Integer>();
 		for (String literal : g.stringLiteralToTypeMap.keySet()) {
 			int tokenType = g.stringLiteralToTypeMap.get(literal);
-			if ( tokenType>=Token.MIN_USER_TOKEN_TYPE) {
+			if (tokenType>=Token.MIN_USER_TOKEN_TYPE) {
 				literals.put(literal, tokenType);
 			}
 		}
@@ -237,5 +244,4 @@ public class CodeGenerator {
 		String recognizerName = g.getRecognizerName();
 		return recognizerName+extST.render();
 	}
-
 }

--- a/tool/src/org/antlr/v4/parse/TokenVocabParser.java
+++ b/tool/src/org/antlr/v4/parse/TokenVocabParser.java
@@ -42,7 +42,7 @@ public class TokenVocabParser {
 		Tool tool = g.tool;
 		String vocabName = g.getOptionString("tokenVocab");
 		try {
-			Pattern tokenDefPattern = Pattern.compile("([^\n]+?)[ \\t]*?=[ \\t]*?([0-9]+)");
+			Pattern tokenDefPattern = Pattern.compile("([^\n]+?)[ \\t]*?=[ \\t]*?(\\-?[0-9]+)");
 			fis = new FileInputStream(fullFile);
 			InputStreamReader isr;
 			if (tool.grammarEncoding != null) {
@@ -149,7 +149,7 @@ public class TokenVocabParser {
 		if ( f.exists() ) {
 			return f;
 		}
-		
+
 		// Still not found? Use the grammar's subfolder then.
 		String fileDirectory;
 

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -1089,6 +1089,20 @@ public enum ErrorType {
 			"One of the token <arg> values unreachable. <arg2> is always overlapped by token <arg3>",
 			ErrorSeverity.WARNING),
 
+	/**
+	 * <p>Fragment rule can be used only in another lexer rule, not in parser rule</p>
+	 *
+	 * <pre>
+	 * root: FRAGMENT;  // error
+	 * fragment FRAGMENT: 'FRAGMENT';
+	 * </pre>
+	 */
+	FRAGMENT_RULE_CAN_BE_USED_ONLY_IN_ANOTHER_LEXER_RULE(
+			185,
+			"Fragment rule <arg> can be used only in another lexer rule, not in parser rule",
+			ErrorSeverity.ERROR
+	),
+
 	/*
 	 * Backward incompatibility errors
 	 */

--- a/tool/src/org/antlr/v4/tool/Grammar.java
+++ b/tool/src/org/antlr/v4/tool/Grammar.java
@@ -975,7 +975,9 @@ public class Grammar implements AttributeResolver {
 		Integer prev = tokenNameToTypeMap.get(name);
 		if ( prev!=null ) return prev;
 		tokenNameToTypeMap.put(name, ttype);
-		setTokenForType(ttype, name);
+		if (ttype >= Token.MIN_USER_TOKEN_TYPE) {
+			setTokenForType(ttype, name);
+		}
 		maxTokenType = Math.max(maxTokenType, ttype);
 		return ttype;
 	}


### PR DESCRIPTION
A more clear error message to avoid confusion if fragment lexer rules are used in parser rules; fix #3016, fix #2886