### PR TITLE
Invalid generated code and no rules error if only fragments are used

### DIFF
--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestToolSyntaxErrors.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestToolSyntaxErrors.java
@@ -13,16 +13,21 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestToolSyntaxErrors extends BaseJavaToolTest {
-    static String[] A = {
-	    // INPUT
+	static String[] A = {
+		// INPUT
 		"grammar A;\n" +
 		"",
 		// YIELDS
-		"error(" + ErrorType.NO_RULES.code + "): A.g4::: grammar A has no rules\n",
+		"error(" + ErrorType.NO_RULES.code + "): A.g4::: grammar A has no non-fragment rules\n",
 
 		"lexer grammar A;\n" +
 		"",
-		"error(" + ErrorType.NO_RULES.code + "): A.g4::: grammar A has no rules\n",
+		"error(" + ErrorType.NO_RULES.code + "): A.g4::: grammar A has no non-fragment rules\n",
+
+		"lexer grammar A;\n" +
+		"fragment FRAGMENT: 'FRAGMENT';\n" +
+		"",
+		"error(" + ErrorType.NO_RULES.code + "): A.g4::: grammar A has no non-fragment rules\n",
 
 		"A;",
 		"error(" + ErrorType.SYNTAX_ERROR.code + "): A.g4:1:0: syntax error: 'A' came as a complete surprise to me\n",

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -278,8 +278,10 @@ public partial class <csIdentifier.(parser.name)> : <superClass; null="Parser"> 
 	public const int
 		<parser.tokens:{k | <k>=<parser.tokens.(k)>}; separator=", ", wrap, anchor>;
 	<endif>
+	<if(parser.rules)>
 	public const int
 		<parser.rules:{r | RULE_<r.name> = <r.index>}; separator=", ", wrap, anchor>;
+	<endif>
 	public static readonly string[] ruleNames = {
 		<parser.ruleNames:{r | "<r>"}; separator=", ", wrap, anchor>
 	};
@@ -986,8 +988,10 @@ Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 public partial class <csIdentifier.(lexer.name)> : <superClass; null="Lexer"> {
 	protected static DFA[] decisionToDFA;
 	protected static PredictionContextCache sharedContextCache = new PredictionContextCache();
+	<if(lexer.tokens)>
 	public const int
 		<lexer.tokens:{k | <tokenType.(k)>=<lexer.tokens.(k)>}; separator=", ", wrap, anchor>;
+	<endif>
 	<if(lexer.channels)>
 	public const int
 		<lexer.channels:{k | <csIdentifier.(k)>=<lexer.channels.(k)>}; separator=", ", wrap, anchor>;

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -284,7 +284,7 @@ public:
   };
 <endif>
 
-<if (parser.tokens)>
+<if (parser.rules)>
   enum {
     <parser.rules: {r | Rule<r.name; format="cap"> = <r.index>}; separator=", ", wrap, anchor>
   };

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
@@ -223,7 +223,9 @@ Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
 
 Parser_(parser, funcs, atn, sempredFuncs, ctor, superClass) ::= <<
 <if(namedActions.definitions)><namedActions.definitions><endif>
+<if(parser.rules)>
 const int <parser.rules:{r | RULE_<r.name> = <r.index>}; separator=", ", wrap, anchor>;
+<endif>
 class <parser.name> extends <superClass; null="Parser"> {
   static final checkVersion = () => RuntimeMetaData.checkVersion('<file.ANTLRVersion>', RuntimeMetaData.VERSION);
   static const int TOKEN_EOF = IntStream.EOF;

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -234,8 +234,10 @@ public class <parser.name> extends <superClass; null="Parser"> {
 	public static final int
 		<parser.tokens:{k | <k>=<parser.tokens.(k)>}; separator=", ", wrap, anchor>;
 	<endif>
+	<if(parser.rules)>
 	public static final int
 		<parser.rules:{r | RULE_<r.name> = <r.index>}; separator=", ", wrap, anchor>;
+	<endif>
 	private static String[] makeRuleNames() {
 		return new String[] {
 			<parser.ruleNames:{r | "<r>"}; separator=", ", wrap, anchor>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -162,7 +162,9 @@ export default class <parser.name> extends <superClass; null="antlr4.Parser"> {
 <parser.tokens:{k | <parser.name>.<k> = <parser.tokens.(k)>;}; separator="\n", wrap, anchor>
 <endif>
 
+<if(parser.rules)>
 <parser.rules:{r | <parser.name>.RULE_<r.name> = <r.index>;}; separator="\n", wrap, anchor>
+<endif>
 
 <funcs:{f | <ruleContexts(f)>}; separator="\n">
 
@@ -816,7 +818,9 @@ export default class <lexer.name> extends <if(superClass)><superClass><else>antl
 }
 
 <lexer.name>.EOF = antlr4.Token.EOF;
+<if(lexer.tokens)>
 <lexer.tokens:{k | <lexer.name>.<k> = <lexer.tokens.(k)>;}; separator="\n", wrap, anchor>
+<endif>
 
 <if(lexer.channels)>
 <lexer.channels:{c| <lexer.name>.<c> = <lexer.channels.(c)>;}; separator="\n">

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
@@ -242,7 +242,9 @@ namespace<if(file.genPackage)> <file.genPackage><endif> {
 		public const <parser.tokens:{k | <k> = <parser.tokens.(k)>}; separator=", ", wrap, anchor>;
 		<endif>
 
+		<if(parser.rules)>
 		public const <parser.rules:{r | RULE_<r.name> = <r.index>}; separator=", ", wrap, anchor>;
+		<endif>
 
 		/**
 		 * @var array\<string>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -132,7 +132,9 @@ class <parser.name> ( <if(superClass)><superClass><else>Parser<endif> ):
 
     symbolicNames = [ <parser.symbolicNames:{t | u<t>}; null="u\"\<INVALID>\"", separator=", ", wrap, anchor> ]
 
+    <if(parser.rules)>
     <parser.rules:{r | RULE_<r.name> = <r.index>}; separator="\n", wrap, anchor>
+    <endif>
 
     ruleNames =  [ <parser.ruleNames:{r | u"<r>"}; separator=", ", wrap, anchor> ]
 
@@ -775,7 +777,9 @@ class <lexer.name>(<if(superClass)><superClass><else>Lexer<endif>):
     <rest(lexer.modes):{m| <m> = <i>}; separator="\n">
 
 <endif>
+    <if(lexer.tokens)>
     <lexer.tokens:{k | <k> = <lexer.tokens.(k)>}; separator="\n", wrap, anchor>
+    <endif>
 
     channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN"<if (lexer.channels)>, <lexer.channels:{c| u"<c>"}; separator=", ", wrap, anchor><endif> ]
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -145,7 +145,9 @@ class <parser.name> ( <if(superClass)><superClass><else>Parser<endif> ):
 
     symbolicNames = [ <parser.symbolicNames:{t | <t>}; null="\"\<INVALID>\"", separator=", ", wrap, anchor> ]
 
+    <if(parser.rules)>
     <parser.rules:{r | RULE_<r.name> = <r.index>}; separator="\n", wrap, anchor>
+    <endif>
 
     ruleNames =  [ <parser.ruleNames:{r | "<r>"}; separator=", ", wrap, anchor> ]
 
@@ -785,7 +787,9 @@ class <lexer.name>(<if(superClass)><superClass><else>Lexer<endif>):
     <rest(lexer.modes):{m| <m> = <i>}; separator="\n">
 
 <endif>
+    <if(lexer.tokens)>
     <lexer.tokens:{k | <k> = <lexer.tokens.(k)>}; separator="\n", wrap, anchor>
+    <endif>
 
     channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN"<if (lexer.channels)>, <lexer.channels:{c| u"<c>"}; separator=", ", wrap, anchor><endif> ]
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -252,10 +252,12 @@ Parser_(parser, funcs, atn, sempredFuncs, ctor, superClass) ::= <<
 	enum Tokens: Int {
 		case EOF = -1, <parser.tokens:{k | <k> = <parser.tokens.(k)>}; separator=", ", wrap, anchor>
 	}
-        <endif>
+	<endif>
 
 	<accessLevelNotOpen(parser)>
+	<if(parser.rules)>
 	static let <parser.rules:{r | RULE_<r.name> = <r.index>}; separator=", ", wrap, anchor>
+	<endif>
 
 	<accessLevelNotOpen(parser)>
 	static let ruleNames: [String] = [
@@ -977,7 +979,9 @@ Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 	internal static let _sharedContextCache = PredictionContextCache()
 
 	<accessLevelNotOpen(lexer)>
+	<if(lexer.tokens)>
 	static let <lexer.tokens:{k | <k>=<lexer.tokens.(k)>}; separator=", ", wrap, anchor>
+	<endif>
 
 	<if(lexer.channels)>
 	<accessLevelNotOpen(lexer)>

--- a/tool/src/org/antlr/v4/semantics/BasicSemanticChecks.java
+++ b/tool/src/org/antlr/v4/semantics/BasicSemanticChecks.java
@@ -321,7 +321,16 @@ public class BasicSemanticChecks extends GrammarTreeVisitor {
 	}
 
 	void checkNumRules(GrammarAST rulesNode) {
-		if ( rulesNode.getChildCount()==0 ) {
+		Boolean emptyGrammar = true;
+
+		for (Rule rule : ruleCollector.rules.values()) {
+			if (!rule.isFragment()) {
+				emptyGrammar = false;
+				break;
+			}
+		}
+
+		if (emptyGrammar) {
 			GrammarAST root = (GrammarAST)rulesNode.getParent();
 			GrammarAST IDNode = (GrammarAST)root.getChild(0);
 			g.tool.errMgr.grammarError(ErrorType.NO_RULES, g.fileName,

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -341,7 +341,7 @@ public enum ErrorType {
 	 * <li>implicitly generated grammar <em>grammar</em> has no rules</li>
 	 * </ul>
 	 */
-	NO_RULES(99, "<if(arg2.implicitLexerOwner)>implicitly generated <endif>grammar <arg> has no rules", ErrorSeverity.ERROR),
+	NO_RULES(99, "<if(arg2.implicitLexerOwner)>implicitly generated <endif>grammar <arg> has no non-fragment rules", ErrorSeverity.ERROR),
 	/**
 	 * Compiler Error 105.
 	 *


### PR DESCRIPTION
* Invalid code won't be generated even if tokens or rules are empty (all runtimes)
* Check parser.rules instead of parser.tokens in Cpp.stg (fix misprint)
* Fix throwing of "grammar has no rules" error, consider only not fragment rules

Fix #3000