### PR TITLE
Update contributors.txt

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -284,3 +284,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/11/26, mr-c, Michael R. Crusoe, 1330696+mr-c@users.noreply.github.com
 2020/12/01, maxence-lefebvre, Maxence Lefebvre, maxence-lefebvre@users.noreply.github.com
 2020/12/03, electrum, David Phillips, david@acz.org
+2021/01/10, zosrothko, Francis ANDRE, francis.andre.kampbell[at]orange.fr


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->
Adding 2021/01/10, zosrothko, Francis ANDRE, francis.andre.kampbell[at]orange.fr as new contributor.