### PR TITLE
Fix for https://github.com/antlr/antlr4/issues/3049

### DIFF
--- a/runtime/CSharp/Antlr4.csproj
+++ b/runtime/CSharp/Antlr4.csproj
@@ -32,6 +32,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <RootNamespace>Antlr4.Runtime</RootNamespace>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This PR is for https://github.com/antlr/antlr4/issues/3049. It adds a line to Antlr4.csproj to build a .nupkg file by default, which is useful when compiling the C# code using dotnet.