### PR TITLE
Fix 3052

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -284,3 +284,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/11/26, mr-c, Michael R. Crusoe, 1330696+mr-c@users.noreply.github.com
 2020/12/01, maxence-lefebvre, Maxence Lefebvre, maxence-lefebvre@users.noreply.github.com
 2020/12/03, electrum, David Phillips, david@acz.org
+2021/01/25, l215884529, Qiheng Liu, 13607681+l215884529@users.noreply.github.com

--- a/runtime/Python3/src/antlr4/Parser.py
+++ b/runtime/Python3/src/antlr4/Parser.py
@@ -453,7 +453,7 @@ class Parser (Recognizer):
     def getInvokingContext(self, ruleIndex:int):
         ctx = self._ctx
         while ctx is not None:
-            if ctx.ruleIndex == ruleIndex:
+            if ctx.getRuleIndex() == ruleIndex:
                 return ctx
             ctx = ctx.parentCtx
         return None


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

Fix #3052.

The problem is caused by an undefined `ruleIndex` attribute.
Calling `getRuleIndex()` method instead of accessing the `ruleIndex` attribute solves this problem.