### PR TITLE
Patch 1

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -285,3 +285,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/12/01, maxence-lefebvre, Maxence Lefebvre, maxence-lefebvre@users.noreply.github.com
 2020/12/03, electrum, David Phillips, david@acz.org
 2021/01/25, l215884529, Qiheng Liu, 13607681+l215884529@users.noreply.github.com
+2021/01/29, FuPeiJiang, Fu Pei Jiang, 42662615+FuPeiJiang@users.noreply.github.com

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -118,8 +118,8 @@ hello parrt
 ^D
 (The output:)
 (r hello parrt)
-(That ^D means EOF on unix; it's ^Z in Windows.) The -tree option prints the parse tree in LISP notation.
-It's nicer to look at parse trees visually.
+(That ^D means EOF on unix; it's Ctrl+Z in Windows, when you Ctrl+Z, it will display ^Z)
+The -tree option prints the parse tree in LISP notation. It's nicer to look at parse trees visually.
 $ grun Hello r -gui
 hello parrt
 ^D


### PR DESCRIPTION
^Z doesn't work, Ctrl+Z works
even though they both display ^Z

thanks to schandrasekhar: https://github.com/antlr/antlr4/issues/844#issuecomment-441673407

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->