### PR TITLE
Cpp target: allow building runtime with newer C++ standards

### DIFF
--- a/runtime/Cpp/CMakeLists.txt
+++ b/runtime/Cpp/CMakeLists.txt
@@ -76,8 +76,13 @@ endif()
 
 # Initialize CXXFLAGS.
 if("${CMAKE_VERSION}" VERSION_GREATER 3.1.0)
-  set(CMAKE_CXX_STANDARD 11)
+  if(NOT DEFINED CMAKE_CXX_STANDARD)
+    # only set CMAKE_CXX_STANDARD if not already set
+    # this allows the standard to be set by the caller, for example with -DCMAKE_CXX_STANDARD:STRING=17
+    set(CMAKE_CXX_STANDARD 11)
+  endif()
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 else()
   set(CMAKE_CXX_FLAGS                "${CMAKE_CXX_FLAGS} -std=c++11")
   set(CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_CXX_FLAGS_DEBUG} -std=c++11")

--- a/runtime/Cpp/README.md
+++ b/runtime/Cpp/README.md
@@ -5,11 +5,11 @@ This folder contains the C++ runtime support for ANTLR.  See [the canonical antl
 ## Authors and major contributors
 
 ANTLR 4 is the result of substantial effort of the following people:
- 
+
 * [Terence Parr](http://www.cs.usfca.edu/~parrt/), parrt@cs.usfca.edu
   ANTLR project lead and supreme dictator for life
   [University of San Francisco](http://www.usfca.edu/)
-* [Sam Harwell](http://tunnelvisionlabs.com/) 
+* [Sam Harwell](http://tunnelvisionlabs.com/)
   Tool co-author, Java and C# target)
 
 The C++ target has been the work of the following people:
@@ -40,6 +40,7 @@ The minimum C++ version to compile the ANTLR C++ runtime with is C++11. The supp
 Include the antlr4-runtime.h umbrella header in your target application to get everything needed to use the library.
 
 If you are compiling with cmake, the minimum version required is cmake 2.8.
+By default, the libraries produced by the CMake build target C++11. If you want to target a different C++ standard, you can explicitly pass the standard - e.g. `-DCMAKE_CXX_STANDARD=17`.
 
 #### Compiling on Windows with Visual Studio using he Visual Studio projects
 Simply open the VS project from the runtime folder (VS 2013+) and build it.
@@ -69,5 +70,3 @@ If the CMake variable 'ANTLR4_INSTALL' is set, CMake Packages will be build and 
 They expose two packages: antlr4_runtime and antlr4_generator which can be referenced to ease up the use of the
 ANTLR Generator and runtime.
 Use and Sample can be found [here](cmake/Antlr4Package.md)
-
-

--- a/runtime/Cpp/cmake/Antlr4Package.md
+++ b/runtime/Cpp/cmake/Antlr4Package.md
@@ -2,17 +2,17 @@
 
 ## The `antlr4-generator` Package
 
-To use the Package you must insert a 
+To use the Package you must insert a
 ```cmake
 find_package(antlr4-generator REQUIRED)
 ```
 line in your `CMakeList.txt` file.
 
-The package exposes a function `antlr4_generate` that generates the required setup to call ANTLR for a 
+The package exposes a function `antlr4_generate` that generates the required setup to call ANTLR for a
 given input file during build.
 
 The following table lists the parameters that can be used with the function:
- 
+
 Argument# | Required  | Default | Use
 ----------|-----------|---------|---
 0 | Yes | n/a | Unique target name. It is used to generate CMake Variables to reference the various outputs of the generation
@@ -42,7 +42,7 @@ Output variable  | Meaning
 ```cmake
  # generate parser with visitor classes.
  # put the classes in C++ namespace 'antlrcpptest::'
- antlr4_generate( 
+ antlr4_generate(
    antlrcpptest_parser
    ${CMAKE_CURRENT_SOURCE_DIR}/TLexer.g4
    LEXER
@@ -56,7 +56,7 @@ Output variable  | Meaning
 
 ## The `antlr4-runtime` Package
 
-To use the Package you must insert a 
+To use the Package you must insert a
 ```cmake
 find_package(antlr4-runtime REQUIRED)
 ```
@@ -85,7 +85,7 @@ include_directories( ${ANTLR4_INCLUDE_DIR} )
 add_dependencies( Parsertest antlr4_shared )
 
 # add runtime to project link libraries
-target_link_libraries( Parsertest PRIVATE 
+target_link_libraries( Parsertest PRIVATE
                        antlr4_shared)
 ```
 
@@ -94,12 +94,12 @@ target_link_libraries( Parsertest PRIVATE
  # Bring in the required packages
  find_package(antlr4-runtime REQUIRED)
  find_package(antlr4-generator REQUIRED)
- 
+
  # Set path to generator
  set(ANTLR4_JAR_LOCATION ${PROJECT_SOURCE_DIR}/thirdparty/antlr/antlr-4.9.1-complete.jar)
- 
+
  # generate lexer
- antlr4_generate( 
+ antlr4_generate(
    antlrcpptest_lexer
    ${CMAKE_CURRENT_SOURCE_DIR}/TLexer.g4
    LEXER
@@ -107,9 +107,9 @@ target_link_libraries( Parsertest PRIVATE
    FALSE
    "antlrcpptest"
    )
- 
+
  # generate parser
- antlr4_generate( 
+ antlr4_generate(
    antlrcpptest_parser
    ${CMAKE_CURRENT_SOURCE_DIR}/TParser.g4
    PARSER
@@ -119,18 +119,18 @@ target_link_libraries( Parsertest PRIVATE
    "${ANTLR4_TOKEN_FILES_antlrcpptest_lexer}"
    "${ANTLR4_TOKEN_DIRECTORY_antlrcpptest_lexer}"
    )
- 
+
  # add directories for generated include files
  include_directories( ${PROJECT_BINARY_DIR} ${ANTLR4_INCLUDE_DIR} ${ANTLR4_INCLUDE_DIR_antlrcpptest_lexer} ${ANTLR4_INCLUDE_DIR_antlrcpptest_parser} )
- 
+
  # add generated source files
  add_executable( Parsertest main.cpp ${ANTLR4_SRC_FILES_antlrcpptest_lexer} ${ANTLR4_SRC_FILES_antlrcpptest_parser} )
- 
+
  # add required runtime library
  add_dependencies( Parsertest antlr4_shared )
- 
- target_link_libraries( Parsertest PRIVATE 
+
+ target_link_libraries( Parsertest PRIVATE
                         antlr4_shared)
- 
+
 ```
- 
+

--- a/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
+++ b/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
@@ -104,6 +104,7 @@ else()
       CMAKE_CACHE_ARGS
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
           -DWITH_STATIC_CRT:BOOL=${ANTLR4_WITH_STATIC_CRT}
+          # -DCMAKE_CXX_STANDARD:STRING=17 # if desired, compile the runtime with a different C++ standard
       INSTALL_COMMAND ""
       EXCLUDE_FROM_ALL 1)
 endif()

--- a/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
+++ b/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
@@ -88,6 +88,8 @@ if(ANTLR4_ZIP_REPOSITORY)
       CMAKE_CACHE_ARGS
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
           -DWITH_STATIC_CRT:BOOL=${ANTLR4_WITH_STATIC_CRT}
+          # -DCMAKE_CXX_STANDARD:STRING=17 # if desired, compile the runtime with a different C++ standard
+          # -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD} # alternatively, compile the runtime with the same C++ standard as the outer project
       INSTALL_COMMAND ""
       EXCLUDE_FROM_ALL 1)
 else()
@@ -105,6 +107,7 @@ else()
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
           -DWITH_STATIC_CRT:BOOL=${ANTLR4_WITH_STATIC_CRT}
           # -DCMAKE_CXX_STANDARD:STRING=17 # if desired, compile the runtime with a different C++ standard
+          # -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD} # alternatively, compile the runtime with the same C++ standard as the outer project
       INSTALL_COMMAND ""
       EXCLUDE_FROM_ALL 1)
 endif()

--- a/runtime/Cpp/cmake/README.md
+++ b/runtime/Cpp/cmake/README.md
@@ -129,6 +129,8 @@ The ANTLR C++ runtime source is downloaded from GitHub by default. However, user
 
 Visual C++ compiler users may want to additionally define `ANTLR4_WITH_STATIC_CRT` before including the file. Set `ANTLR4_WITH_STATIC_CRT` to true if ANTLR4 C++ runtime library should be compiled with `/MT` flag, otherwise will be compiled with `/MD` flag. This variable has a default value of `OFF`. Changing `ANTLR4_WITH_STATIC_CRT` after building the library may require reinitialization of CMake or `clean` for the library to get rebuilt.
 
+You may need to modify your local copy of ExternalAntlr4Cpp.cpp to modify some build settings. For example, to specify the C++ standard to use when building the runtime, add `-DCMAKE_CXX_STANDARD:STRING=17` to `CMAKE_CACHE_ARGS`.
+
 ### Examples
 
 To build and link ANTLR4 static library to a target one may call:

--- a/runtime/Cpp/cmake/antlr4-generator.cmake.in
+++ b/runtime/Cpp/cmake/antlr4-generator.cmake.in
@@ -88,7 +88,7 @@ function(antlr4_generate
   else()
     set(Antlr4_BuildListenerOption "-no-listener")
   endif ()
-  
+
   if ( ( ARGC GREATER_EQUAL 5 ) AND ARGV4 )
     set(Antlr4_BuildVisitorOption "-visitor")
 
@@ -101,7 +101,7 @@ function(antlr4_generate
   else()
     set(Antlr4_BuildVisitorOption "-no-visitor")
   endif ()
-  
+
   if ( (ARGC GREATER_EQUAL 6 ) AND (NOT ${ARGV5} STREQUAL "") )
     set(Antlr4_NamespaceOption "-package;${ARGV5}")
 
@@ -109,7 +109,7 @@ function(antlr4_generate
   else()
     set(Antlr4_NamespaceOption "")
   endif ()
-  
+
   if ( (ARGC GREATER_EQUAL 7 ) AND (NOT ${ARGV6} STREQUAL "") )
     set(Antlr4_AdditionalDependencies ${ARGV6})
   else()
@@ -157,7 +157,7 @@ function(antlr4_generate
 
   # export generated cpp files into list
   foreach(generated_file ${Antlr4_GeneratedTargets})
-  
+
     if (NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
       set_source_files_properties(
         ${generated_file}


### PR DESCRIPTION
Currently, the C++ runtime compilation is forced to used the C++11 standard, since CMAKE_CXX_STANDARD 11 is set in runtime/Cpp/CMakeLists.txt.
When linking an executable built with a newer C++ standard (for example, C++17) against the runtime build with C++11, the following linker error occurs:
```
FAILED: src/antlr/demo 
: && /usr/bin/clang++-11  -fuse-ld=lld src/antlr/CMakeFiles/demo.dir/src/demo.cpp.o src/antlr/CMakeFiles/demo.dir/antlr4cpp_generated_src/TLexer/TLexer.cpp.o src/antlr/CMakeFiles/demo.dir/antlr4cpp_generated_src/TParser/TParser.cpp.o -o src/antlr/demo  src/antlr/antlr4_runtime/src/antlr4_runtime/runtime/Cpp/dist/libantlr4-runtime.a && :
ld.lld: error: undefined symbol: antlr4::ANTLRInputStream::ANTLRInputStream(std::basic_string_view<char, std::char_traits<char> >)
>>> referenced by demo.cpp:20 (../src/antlr/src/demo.cpp:20)
>>>               src/antlr/CMakeFiles/demo.dir/src/demo.cpp.o:(main)
```

This occurs due to the following snippet in ANTLRInputStream.h:
```C++
#if __cplusplus >= 201703L
    ANTLRInputStream(std::string_view input = "");
#else
    ANTLRInputStream(const std::string &input = "");
#endif
```
-> the runtime - built with C++11 - contains a different constructor than an executable - built with C++17 - tries to use

This pull request allows overriding the C++ standard for the runtime build - default is still C++11.
Therefore, projects using the C++ can choose to build the runtime with a newer standard.

@mike-lischke - what do you think?