### PR TITLE
Cpp/runtime: use utfcpp from system if possible

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -286,4 +286,5 @@ YYYY/MM/DD, github id, Full name, email
 2020/12/03, electrum, David Phillips, david@acz.org
 2021/01/25, l215884529, Qiheng Liu, 13607681+l215884529@users.noreply.github.com
 2021/02/02, tsotnikov, Taras Sotnikov, taras.sotnikov@gmail.com
+2021/02/10, jirislaby, Jiri Slaby, jirislaby@gmail.com
 2021/02/21, namasikanam, Xingyu Xie, namasikanam@gmail.com

--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -1,19 +1,3 @@
-
-include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
-
-set(THIRDPARTY_DIR ${CMAKE_BINARY_DIR}/runtime/thirdparty)
-set(UTFCPP_DIR ${THIRDPARTY_DIR}/utfcpp)
-ExternalProject_Add(
-  utfcpp
-  GIT_REPOSITORY        "git://github.com/nemtrif/utfcpp"
-  GIT_TAG               "v3.1.1"
-  SOURCE_DIR            ${UTFCPP_DIR}
-  UPDATE_DISCONNECTED   1
-  CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${UTFCPP_DIR}/install -Dgtest_force_shared_crt=ON
-  TEST_AFTER_INSTALL    1
-  STEP_TARGETS          build)
-
-
 include_directories(
   ${PROJECT_SOURCE_DIR}/runtime/src
   ${PROJECT_SOURCE_DIR}/runtime/src/atn
@@ -23,8 +7,6 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/runtime/src/tree
   ${PROJECT_SOURCE_DIR}/runtime/src/tree/pattern
   ${PROJECT_SOURCE_DIR}/runtime/src/tree/xpath
-  ${UTFCPP_DIR}/install/include/utf8cpp
-  ${UTFCPP_DIR}/install/include/utf8cpp/utf8
 )
 
 
@@ -50,8 +32,49 @@ add_custom_target(make_lib_output_dir ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_OUTPUT_DIR}
     )
 
-add_dependencies(antlr4_shared make_lib_output_dir utfcpp)
-add_dependencies(antlr4_static make_lib_output_dir utfcpp)
+add_dependencies(antlr4_shared make_lib_output_dir)
+add_dependencies(antlr4_static make_lib_output_dir)
+
+find_package(utf8cpp QUIET)
+
+set(INSTALL_utf8cpp FALSE)
+
+if (utf8cpp_FOUND)
+  target_link_libraries(antlr4_shared utf8cpp)
+  target_link_libraries(antlr4_static utf8cpp)
+else()
+
+  # older utf8cpp doesn't define the package above
+  find_path(utf8cpp_HEADER utf8.h
+    PATH_SUFFIXES utf8cpp
+    )
+
+  if (utf8cpp_HEADER)
+    include_directories(${utf8cpp_HEADER})
+  else()
+    include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
+    set(THIRDPARTY_DIR ${CMAKE_BINARY_DIR}/runtime/thirdparty)
+    set(UTFCPP_DIR ${THIRDPARTY_DIR}/utfcpp)
+    ExternalProject_Add(
+      utf8cpp
+      GIT_REPOSITORY        "git://github.com/nemtrif/utfcpp"
+      GIT_TAG               "v3.1.1"
+      SOURCE_DIR            ${UTFCPP_DIR}
+      UPDATE_DISCONNECTED   1
+      CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${UTFCPP_DIR}/install -Dgtest_force_shared_crt=ON
+      TEST_AFTER_INSTALL    1
+      STEP_TARGETS          build)
+
+    include_directories(
+      ${UTFCPP_DIR}/install/include/utf8cpp
+      ${UTFCPP_DIR}/install/include/utf8cpp/utf8
+      )
+
+    add_dependencies(antlr4_shared utf8cpp)
+    add_dependencies(antlr4_static utf8cpp)
+    set(INSTALL_utf8cpp TRUE)
+  endif()
+endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   target_link_libraries(antlr4_shared ${UUID_LIBRARIES})
@@ -131,13 +154,15 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/runtime/src/"
         FILES_MATCHING PATTERN "*.h"
         )
 
-install(FILES "${UTFCPP_DIR}/source/utf8.h"
-        DESTINATION "include/antlr4-runtime")
-install(DIRECTORY "${UTFCPP_DIR}/source/utf8"
-        DESTINATION "include/antlr4-runtime"
-        COMPONENT dev
-        FILES_MATCHING PATTERN "*.h"
-        )
+if (INSTALL_utf8cpp)
+  install(FILES "${UTFCPP_DIR}/source/utf8.h"
+	  DESTINATION "include/antlr4-runtime")
+  install(DIRECTORY "${UTFCPP_DIR}/source/utf8"
+	  DESTINATION "include/antlr4-runtime"
+	  COMPONENT dev
+	  FILES_MATCHING PATTERN "*.h"
+	  )
+endif()
 
 
 


### PR DESCRIPTION
Try to find system's `utf8cpp` first, instead of downloading it from github. `utf8cpp` 3 defines a cmake package, so we can use `find_package`. Older `utf8cpp`s don't, so we try also `find_path`. If all that fails, we still fall back to github download.

This is needed as distributions cannot download stuff from their build systems. And people want to use libraries/headers from the distribution anyway.

I had to reorder the file a bit, so that the libraries are defined through the `utf8cpp` detection.
