### PR TITLE
Implement runtime/Go Visit methods for the BaseParseTreeVisitor.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -286,3 +286,7 @@ YYYY/MM/DD, github id, Full name, email
 2020/12/03, electrum, David Phillips, david@acz.org
 2021/01/25, l215884529, Qiheng Liu, 13607681+l215884529@users.noreply.github.com
 2021/02/02, tsotnikov, Taras Sotnikov, taras.sotnikov@gmail.com
+2021/02/17, prnvbn, Pranav Bansal, prnvbn@gmail.com
+2021/02/17, Akshat-Tripathi, Akshat Tripathi, akshat.tripathi6568@gmail.com
+2021/02/17, tas2168, Akshat Tripathi, akshat.tripathi6568@gmail.com
+2021/02/17, vladsft, Vlad Safta, vladixsafta@yahoo.com

--- a/runtime/Go/antlr/tree.go
+++ b/runtime/Go/antlr/tree.go
@@ -58,16 +58,40 @@ type ParseTreeVisitor interface {
 	VisitChildren(node RuleNode) interface{}
 	VisitTerminal(node TerminalNode) interface{}
 	VisitErrorNode(node ErrorNode) interface{}
+	VisitNonTerminalChildren(node RuleNode) interface{}
 }
 
 type BaseParseTreeVisitor struct{}
 
 var _ ParseTreeVisitor = &BaseParseTreeVisitor{}
 
-func (v *BaseParseTreeVisitor) Visit(tree ParseTree) interface{}            { return nil }
-func (v *BaseParseTreeVisitor) VisitChildren(node RuleNode) interface{}     { return nil }
-func (v *BaseParseTreeVisitor) VisitTerminal(node TerminalNode) interface{} { return nil }
-func (v *BaseParseTreeVisitor) VisitErrorNode(node ErrorNode) interface{}   { return nil }
+func (v *BaseParseTreeVisitor) Visit(tree ParseTree) interface{} {
+	return tree.Accept(v)
+}
+
+func (v *BaseParseTreeVisitor) VisitChildren(node RuleNode) interface{} {
+
+	var result []interface{}
+	n := node.GetChildCount()
+	for i := 0; i < n; i++ {
+		if !v.shouldVisitNextChild(node, result) {
+			break
+		}
+
+		c := node.GetChild(i).(ParseTree)
+		childResult := c.Accept(v)
+		result = append(result, childResult)
+	}
+	return result
+}
+
+func (v *BaseParseTreeVisitor) shouldVisitNextChild(_ RuleNode, _ interface{}) bool {
+	return true
+}
+
+func (v *BaseParseTreeVisitor) VisitTerminal(node TerminalNode) interface{}        { return nil }
+func (v *BaseParseTreeVisitor) VisitErrorNode(node ErrorNode) interface{}          { return nil }
+func (v *BaseParseTreeVisitor) VisitNonTerminalChildren(node RuleNode) interface{} { return nil }
 
 // TODO
 //func (this ParseTreeVisitor) Visit(ctx) {


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->