### PR TITLE
Add Super property

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -134,12 +134,21 @@ package parser // <file.grammarName>
 import "github.com/antlr/antlr4/runtime/Go/antlr"
 
 type Base<file.grammarName>Visitor struct {
-	*antlr.BaseParseTreeVisitor
+        *antlr.BaseParseTreeVisitor
+        super antlr.ParseTreeVisitor
+}
+
+func (v *Base<file.grammarName>Visitor) SetSuper(super antlr.ParseTreeVisitor) {
+        v.super = super
 }
 
 <file.visitorNames:{lname |
 func (v *Base<file.grammarName>Visitor) Visit<lname; format="cap">(ctx *<lname; format="cap">Context) interface{\} {
-	return v.VisitChildren(ctx)
+        if v.super != nil {
+                return v.super.VisitChildren(ctx)
+        \}
+
+        return v.VisitChildren(ctx)
 \}}; separator="\n\n">
 
 >>


### PR DESCRIPTION
Add a super property to the Base*Visitor generated code allowing to only override the required Visitors vs implementing each one in its entirety.

Example code:

```
	type fooVisitor struct {
		*parser.BaseAnalyzerVisitor
	}

	is := antlr.NewInputStream("4+6")
	lexer := parser.NewAnalyzerLexer(is)
	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
	p := parser.NewAnalyzerParser(stream)

	fooVisitor := & fooVisitor{}
	fooVisitor.BaseAnalyzerVisitor = &parser.BaseAnalyzerVisitor{}
	
	// this is new
	fooVisitor.BaseAnalyzerVisitor.SetSuper(fooVisitor)
	fooVisitor.Visit(p.Prog())
```

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

NB: in draft until signed