### PR TITLE
fix a typo in the csharp-target doc

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -286,3 +286,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/12/03, electrum, David Phillips, david@acz.org
 2021/01/25, l215884529, Qiheng Liu, 13607681+l215884529@users.noreply.github.com
 2021/02/02, tsotnikov, Taras Sotnikov, taras.sotnikov@gmail.com
+2021/02/21, namasikanam, Xingyu Xie, namasikanam@gmail.com

--- a/doc/csharp-target.md
+++ b/doc/csharp-target.md
@@ -36,7 +36,7 @@ using Antlr4.Runtime.Tree;
      
 public void MyParseMethod() {
       String input = "your text to parse here";
-      ICharStream stream = CharStreams.fromstring(input);
+      ICharStream stream = CharStreams.fromString(input);
       ITokenSource lexer = new MyGrammarLexer(stream);
       ITokenStream tokens = new CommonTokenStream(lexer);
       MyGrammarParser parser = new MyGrammarParser(tokens);


### PR DESCRIPTION
```c#
CharStreams.fromstring(input);
```
should be fixed to
```c#
CharStreams.fromString(input);
```
so as to run functionally.
The code of this API is at [here](https://github.com/antlr/antlr4/blob/4b649103f31e0c0bc3bd0bb964efd0dea6b9f5a0/runtime/CSharp/src/CharStreams.cs#L88).