### PR TITLE
Fix #3093 - The antlr4-maven-plugin is not marked as thread safe

### DIFF
--- a/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/Antlr4Mojo.java
+++ b/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/Antlr4Mojo.java
@@ -55,7 +55,7 @@ import java.util.Set;
 	name = "antlr4",
 	defaultPhase = LifecyclePhase.GENERATE_SOURCES,
 	requiresDependencyResolution = ResolutionScope.COMPILE,
-	requiresProject = true)
+	requiresProject = true, threadSafe = true)
 public class Antlr4Mojo extends AbstractMojo {
 
     // First, let's deal with the options that the ANTLR tool itself

--- a/contributors.txt
+++ b/contributors.txt
@@ -287,3 +287,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/01/25, l215884529, Qiheng Liu, 13607681+l215884529@users.noreply.github.com
 2021/02/02, tsotnikov, Taras Sotnikov, taras.sotnikov@gmail.com
 2021/02/21, namasikanam, Xingyu Xie, namasikanam@gmail.com
+2021/02/27, khmarbaise, Karl Heinz Marbaise, github@soebes.com


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->