### PR TITLE
Swift InterpreterDataReader and deserialize fixes

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -287,3 +287,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/01/25, l215884529, Qiheng Liu, 13607681+l215884529@users.noreply.github.com
 2021/02/02, tsotnikov, Taras Sotnikov, taras.sotnikov@gmail.com
 2021/02/21, namasikanam, Xingyu Xie, namasikanam@gmail.com
+2021/02/26, ahooper, Andrew Hooper, ahooper at kos dot net

--- a/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
@@ -29,7 +29,7 @@ public class LexerInterpreter: Lexer {
 
         self._decisionToDFA = [DFA]()
         for i in 0 ..< atn.getNumberOfDecisions() {
-            _decisionToDFA[i] = DFA(atn.getDecisionState(i)!, i)
+            _decisionToDFA.append(DFA(atn.getDecisionState(i)!, i))
         }
         super.init(input)
         self._interp = LexerATNSimulator(self, atn, _decisionToDFA, _sharedContextCache)

--- a/runtime/Swift/Sources/Antlr4/ParserInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/ParserInterpreter.swift
@@ -76,7 +76,7 @@ public class ParserInterpreter: Parser {
         self.vocabulary = vocabulary
         self.decisionToDFA = [DFA]()
         for i in 0 ..< atn.getNumberOfDecisions() {
-            decisionToDFA[i] = DFA(atn.getDecisionState(i)!, i)
+            decisionToDFA.append(DFA(atn.getDecisionState(i)!, i))
         }
 
         // identify the ATN states where pushNewRecursionContext() must be called

--- a/runtime/Swift/Sources/Antlr4/misc/InterpreterDataReader.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/InterpreterDataReader.swift
@@ -1,0 +1,134 @@
+/// Copyright (c) 2021 The ANTLR Project. All rights reserved.
+/// Use of this file is governed by the BSD 3-clause license that
+/// can be found in the LICENSE.txt file in the project root.
+
+// A class to read plain text interpreter data produced by ANTLR.
+public class InterpreterDataReader {
+    
+    let filePath:String,
+        atn:ATN,
+        vocabulary:Vocabulary,
+        ruleNames:[String],
+        channelNames:[String], // Only valid for lexer grammars.
+        modeNames:[String] // ditto
+    
+    /**
+     * The structure of the data file is line based with empty lines
+     * separating the different parts. For lexers the layout is:
+     * token literal names:
+     * ...
+     *
+     * token symbolic names:
+     * ...
+     *
+     * rule names:
+     * ...
+     *
+     * channel names:
+     * ...
+     *
+     * mode names:
+     * ...
+     *
+     * atn:
+     * <a single line with comma separated int values> enclosed in a pair of squared brackets.
+     *
+     * Data for a parser does not contain channel and mode names.
+     */
+    enum Part {
+        case partName
+        case tokenLiteralNames
+        case tokenSymbolicNames
+        case ruleNames
+        case channelNames
+        case modeNames
+        case atn
+    }
+
+    enum Error: Swift.Error {
+        case dataError(String)
+    }
+    
+    public init(_ filePath:String) throws {
+        self.filePath = filePath
+        let contents = try String(contentsOfFile: filePath, encoding: String.Encoding.utf8)
+        var part = Part.partName,
+            literalNames = [String](),
+            symbolicNames = [String](),
+            ruleNames = [String](),
+            channelNames = [String](),
+            modeNames = [String](),
+            atnText = [Substring](),
+            fail:Error?
+        contents.enumerateLines { (line,stop) in
+            // throws have to be moved outside the enumerateLines block
+            if line == "" {
+                part = .partName
+            }
+            switch part {
+            case .partName:
+                switch line {
+                case "token literal names:":
+                    part = .tokenLiteralNames
+                case "token symbolic names:":
+                    part = .tokenSymbolicNames
+                case "rule names:":
+                    part = .ruleNames
+                case "channel names:":
+                    part = .channelNames
+                case "mode names:":
+                    part = .modeNames
+                case "atn:":
+                    part = .atn
+                case "":
+                    break
+                default:
+                    fail = Error.dataError("Unrecognized interpreter data part at "+line)
+                }
+            case .tokenLiteralNames:
+                literalNames.append((line == "null") ? "" : line)
+            case .tokenSymbolicNames:
+                symbolicNames.append((line == "null") ? "" : line)
+            case .ruleNames:
+                ruleNames.append(line)
+            case .channelNames:
+                channelNames.append(line)
+            case .modeNames:
+                modeNames.append(line)
+            case .atn:
+                if line.prefix(1) == "[" && line.suffix(1) == "]" {
+                    atnText = line.dropFirst().dropLast().split(separator:",")
+                } else {
+                    fail = Error.dataError("Missing bracket(s) at "+line)
+                }
+                part = .partName
+            }
+        }
+        if let fail = fail { throw fail }
+        vocabulary = Vocabulary(literalNames, symbolicNames)
+        self.ruleNames = ruleNames
+        self.channelNames = channelNames
+        self.modeNames = modeNames
+        let atnSerialized = atnText.map{Character(UnicodeScalar(UInt16($0.trimmingCharacters(in:.whitespaces))!)!)}
+        atn = try ATNDeserializer().deserialize(atnSerialized)
+    }
+        
+    public func createLexer(input: CharStream)throws->LexerInterpreter {
+        return try LexerInterpreter(filePath,
+                                    vocabulary,
+                                    ruleNames,
+                                    channelNames,
+                                    modeNames,
+                                    atn,
+                                    input)
+    }
+    
+    public func createParser(input: TokenStream)throws->ParserInterpreter {
+        return try ParserInterpreter(filePath,
+                                    vocabulary,
+                                    ruleNames,
+                                    atn,
+                                    input)
+    }
+
+}

--- a/runtime/Swift/Tests/Antlr4Tests/InterpreterDataTests.swift
+++ b/runtime/Swift/Tests/Antlr4Tests/InterpreterDataTests.swift
@@ -1,0 +1,50 @@
+/// Copyright (c) 2021 The ANTLR Project. All rights reserved.
+/// Use of this file is governed by the BSD 3-clause license that
+/// can be found in the LICENSE.txt file in the project root.
+
+import XCTest
+import Antlr4
+
+class InterpreterDataTests: XCTestCase {
+
+    // https://stackoverflow.com/a/57713176
+    let sourceDir = URL(fileURLWithPath:#file).deletingLastPathComponent()
+
+    func testLexerA() throws {
+        let input = ANTLRInputStream("abc")
+        let interpPath = sourceDir.appendingPathComponent("gen/LexerA.interp").path
+        let data = try InterpreterDataReader(interpPath)
+        let lexer = try data.createLexer(input:input)
+        let stream = CommonTokenStream(lexer)
+        try stream.fill()
+        let result = try stream.getText()
+        let expecting = "abc"
+        XCTAssertEqual(expecting, result)
+    }
+
+    func testLexerB() throws {
+        let input = ANTLRInputStream("x = 3 * 0 + 2 * 0;")
+        let interpPath = sourceDir.appendingPathComponent("gen/LexerB.interp").path
+        let data = try InterpreterDataReader(interpPath)
+        let lexer = try data.createLexer(input:input)
+        let stream = CommonTokenStream(lexer)
+        try stream.fill()
+        let result = try stream.getText()
+        let expecting = "x = 3 * 0 + 2 * 0;"
+        XCTAssertEqual(expecting, result)
+    }
+
+    func testCalculator() throws {
+        let input = "2 + 8 / 2"
+        let lexerInterpPath = sourceDir.appendingPathComponent("gen/VisitorCalcLexer.interp").path
+        let lexerInterpData = try InterpreterDataReader(lexerInterpPath)
+        let lexer = try lexerInterpData.createLexer(input:ANTLRInputStream(input))
+        let parserInterpPath = sourceDir.appendingPathComponent("gen/VisitorCalc.interp").path
+        let parserInterpData = try InterpreterDataReader(parserInterpPath)
+        let parser = try parserInterpData.makeParser(input:CommonTokenStream(lexer))
+
+        let context = try parser.parse(parser.getRuleIndex("s"))
+        XCTAssertEqual("(s (expr (expr 2) + (expr (expr 8) / (expr 2))) <EOF>)", context.toStringTree(parser))
+    }
+
+}


### PR DESCRIPTION
Swift runtime could not deserialize a Grammar.interp file. ATNDeserialize deserialize() failed initializing a Character with a -1 value. The data representation is changed to Int.

A class InterpreterDataReader is added to read Grammar.interp files, with unit tests.
