### PR TITLE
Fix codegen template for Go parser

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -287,3 +287,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/01/25, l215884529, Qiheng Liu, 13607681+l215884529@users.noreply.github.com
 2021/02/02, tsotnikov, Taras Sotnikov, taras.sotnikov@gmail.com
 2021/02/21, namasikanam, Xingyu Xie, namasikanam@gmail.com
+2021/03/01, preethamrn, Preetham Narayanareddy, preetham.narayanareddy@gmail.com

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -886,8 +886,8 @@ ThisRulePropertyRef_text(r) ::= "p.GetTokenStream().GetTextFromTokens(localctx.G
 ThisRulePropertyRef_ctx(r) ::= "<ctx(r)>"
 ThisRulePropertyRef_parser(r) ::= "p"
 
-NonLocalAttrRef(s) ::= "GetInvokingContext(<s.ruleIndex>).<s.name>"
-SetNonLocalAttr(s, rhsChunks) ::= "GetInvokingContext(<s.ruleIndex>).<s.name> = <rhsChunks>"
+NonLocalAttrRef(s) ::= "p.GetInvokingContext(<s.ruleIndex>).(*<s.ruleName; format={cap}>Context).<s.name>"
+SetNonLocalAttr(s, rhsChunks) ::= "p.GetInvokingContext(<s.ruleIndex>).(*<s.ruleName; format={cap}>Context).<s.name> = <rhsChunks>"
 
 AddToLabelList(a) ::= "<ctx(a.label)>.<a.listName> = append(<ctx(a.label)>.<a.listName>, <labelref(a.label)>)"
 


### PR DESCRIPTION
This fixes #2826. It adds the required pointer receiver and type assertion to the `GetInvokingContext` call.

No changes to the runtime are necessary.