### PR TITLE
Fixed #3102 - Prerequisites usages in pom.xml

### DIFF
--- a/antlr4-maven-plugin/pom.xml
+++ b/antlr4-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
   <description>Maven plugin for ANTLR 4 grammars</description>
 
   <prerequisites>
-    <maven>3.0</maven>
+    <maven>3.0.5</maven>
   </prerequisites>
 
   <!-- Ancilliary information for completeness -->

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,31 @@
 		</testResources>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<!--
+				 ! The following only needed because the oss-parent uses the version hard coded in
+				 ! the build area instead of controlling that via pluginManagement.
+				 ! Solution: Do not use oss-parent anymore.
+			  -->
+				<version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.3.9</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+			<plugin>
 				<artifactId>maven-clean-plugin</artifactId>
 				<version>3.0.0</version>
 				<configuration>
@@ -160,6 +185,11 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.0.0-M3</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -16,10 +16,6 @@
 	<name>ANTLR 4 Runtime Tests (2nd generation)</name>
 	<description>A collection of tests for ANTLR 4 Runtime libraries.</description>
 
-	<prerequisites>
-		<maven>3.0</maven>
-	</prerequisites>
-
 	<inceptionYear>2009</inceptionYear>
 
 	<dependencies>

--- a/tool-testsuite/pom.xml
+++ b/tool-testsuite/pom.xml
@@ -16,10 +16,6 @@
   <name>ANTLR 4 Tool Tests</name>
   <description>A collection of tests for ANTLR 4 Runtime libraries.</description>
 
-  <prerequisites>
-    <maven>3.0</maven>
-  </prerequisites>
-
   <inceptionYear>2009</inceptionYear>
 
   <dependencies>


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->