### PR TITLE
Fix for #3079

### DIFF
--- a/runtime/CSharp/src/Atn/ATNSimulator.cs
+++ b/runtime/CSharp/src/Atn/ATNSimulator.cs
@@ -75,11 +75,6 @@ namespace Antlr4.Runtime.Atn
 			throw new Exception("This ATN simulator does not support clearing the DFA.");
 		}
 
-        protected void ConsoleWriteLine(string format, params object[] arg)
-        {
-            System.Console.WriteLine(format, arg);
-        }
-
         public PredictionContextCache getSharedContextCache()
 		{
 			return sharedContextCache;

--- a/runtime/CSharp/src/Atn/LexerATNSimulator.cs
+++ b/runtime/CSharp/src/Atn/LexerATNSimulator.cs
@@ -119,7 +119,7 @@ namespace Antlr4.Runtime.Atn
 			ATNState startState = atn.modeToStartState[mode];
             if (debug)
 			{
-				ConsoleWriteLine("matchATN mode " + mode + " start: " + startState);
+				Console.WriteLine("matchATN mode " + mode + " start: " + startState);
 			}
             int old_mode = mode;
 
@@ -136,7 +136,7 @@ namespace Antlr4.Runtime.Atn
 			int predict = ExecATN(input, next);
             if (debug)
 			{
-				ConsoleWriteLine("DFA after matchATN: " + decisionToDFA[old_mode].ToString());
+				Console.WriteLine("DFA after matchATN: " + decisionToDFA[old_mode].ToString());
 			}
             return predict;
 		}
@@ -146,7 +146,7 @@ namespace Antlr4.Runtime.Atn
             //System.out.println("enter exec index "+input.index()+" from "+ds0.configs);
             if (debug)
             {
-                ConsoleWriteLine("start state closure=" + ds0.configSet);
+                Console.WriteLine("start state closure=" + ds0.configSet);
 			}
             if (ds0.isAcceptState)
 			{
@@ -162,7 +162,7 @@ namespace Antlr4.Runtime.Atn
 			{ // while more work
                 if (debug)
                 {
-                    ConsoleWriteLine("execATN loop starting closure: " + s.configSet);
+                    Console.WriteLine("execATN loop starting closure: " + s.configSet);
 				}
                 // As we move src->trg, src->trg, we keep track of the previous trg to
                 // avoid looking up the DFA state again, which is expensive.
@@ -239,7 +239,7 @@ namespace Antlr4.Runtime.Atn
 			DFAState target = s.edges[t - MIN_DFA_EDGE];
 			if (debug && target != null)
 			{
-				ConsoleWriteLine("reuse state " + s.stateNumber + " edge to " + target.stateNumber);
+				Console.WriteLine("reuse state " + s.stateNumber + " edge to " + target.stateNumber);
 			}
 
 			return target;
@@ -323,7 +323,7 @@ namespace Antlr4.Runtime.Atn
 
 				if (debug)
 				{
-					ConsoleWriteLine("testing " + GetTokenName(t) + " at " + c.ToString(recog, true));
+					Console.WriteLine("testing " + GetTokenName(t) + " at " + c.ToString(recog, true));
 				}
 
 				int n = c.state.NumberOfTransitions;
@@ -357,7 +357,7 @@ namespace Antlr4.Runtime.Atn
 		{
 			if (debug)
 			{
-				ConsoleWriteLine("ACTION " + lexerActionExecutor);
+				Console.WriteLine("ACTION " + lexerActionExecutor);
 			}
 
 			// seek to after last char in token
@@ -411,7 +411,7 @@ namespace Antlr4.Runtime.Atn
 		{
 			if (debug)
 			{
-				ConsoleWriteLine("closure(" + config.ToString(recog, true) + ")");
+				Console.WriteLine("closure(" + config.ToString(recog, true) + ")");
 			}
 
 			if (config.state is RuleStopState)
@@ -420,10 +420,10 @@ namespace Antlr4.Runtime.Atn
 				{
 					if (recog != null)
 					{
-						ConsoleWriteLine("closure at " + recog.RuleNames[config.state.ruleIndex] + " rule stop " + config);
+						Console.WriteLine("closure at " + recog.RuleNames[config.state.ruleIndex] + " rule stop " + config);
 					}
 					else {
-						ConsoleWriteLine("closure at rule stop " + config);
+						Console.WriteLine("closure at rule stop " + config);
 					}
 				}
 
@@ -523,7 +523,7 @@ namespace Antlr4.Runtime.Atn
 					PredicateTransition pt = (PredicateTransition)t;
 					if (debug)
 					{
-						ConsoleWriteLine("EVAL rule " + pt.ruleIndex + ":" + pt.predIndex);
+						Console.WriteLine("EVAL rule " + pt.ruleIndex + ":" + pt.predIndex);
 					}
 					configs.hasSemanticContext = true;
 					if (EvaluatePredicate(input, pt.ruleIndex, pt.predIndex, speculative))
@@ -682,7 +682,7 @@ namespace Antlr4.Runtime.Atn
 
 			if (debug)
 			{
-				ConsoleWriteLine("EDGE " + p + " -> " + q + " upon " + ((char)t));
+				Console.WriteLine("EDGE " + p + " -> " + q + " upon " + ((char)t));
 			}
 
 			lock (p)

--- a/runtime/CSharp/src/Atn/ParserATNSimulator.cs
+++ b/runtime/CSharp/src/Atn/ParserATNSimulator.cs
@@ -284,8 +284,8 @@ namespace Antlr4.Runtime.Atn
 			this.parser = parser;
 			this.decisionToDFA = decisionToDFA;
 			//		DOTGenerator dot = new DOTGenerator(null);
-			//		ConsoleWriteLine(dot.getDOT(atn.rules.get(0), parser.getRuleNames()));
-			//		ConsoleWriteLine(dot.getDOT(atn.rules.get(1), parser.getRuleNames()));
+			//		Console.WriteLine(dot.getDOT(atn.rules.get(0), parser.getRuleNames()));
+			//		Console.WriteLine(dot.getDOT(atn.rules.get(1), parser.getRuleNames()));
 		}
 
 		public override void Reset()
@@ -306,7 +306,7 @@ namespace Antlr4.Runtime.Atn
 		{
 			if (debug || debug_list_atn_decisions)
 			{
-				ConsoleWriteLine("adaptivePredict decision " + decision +
+				Console.WriteLine("adaptivePredict decision " + decision +
 									   " exec LA(1)==" + GetLookaheadName(input) +
 								  " line " + input.LT(1).Line + ":" + input.LT(1).Column);
 			}
@@ -341,7 +341,7 @@ namespace Antlr4.Runtime.Atn
 					if (outerContext == null) outerContext = ParserRuleContext.EmptyContext;
 					if (debug || debug_list_atn_decisions)
 					{
-						ConsoleWriteLine("predictATN decision " + dfa.decision +
+						Console.WriteLine("predictATN decision " + dfa.decision +
 										   " exec LA(1)==" + GetLookaheadName(input) +
 										   ", outerContext=" + outerContext.ToString(parser));
 					}
@@ -373,7 +373,7 @@ namespace Antlr4.Runtime.Atn
 
 				int alt = ExecATN(dfa, s0, input, index, outerContext);
 				if (debug)
-					ConsoleWriteLine("DFA after predictATN: " + dfa.ToString(parser.Vocabulary));
+					Console.WriteLine("DFA after predictATN: " + dfa.ToString(parser.Vocabulary));
 				return alt;
 			}
 			finally
@@ -421,14 +421,14 @@ namespace Antlr4.Runtime.Atn
 		{
 			if (debug || debug_list_atn_decisions)
 			{
-				ConsoleWriteLine("execATN decision " + dfa.decision +
+				Console.WriteLine("execATN decision " + dfa.decision +
 								   " exec LA(1)==" + GetLookaheadName(input) +
 								   " line " + input.LT(1).Line + ":" + input.LT(1).Column);
 			}
 
 			DFAState previousD = s0;
 
-			if (debug) ConsoleWriteLine("s0 = " + s0);
+			if (debug) Console.WriteLine("s0 = " + s0);
 
 			int t = input.LA(1);
 
@@ -467,7 +467,7 @@ namespace Antlr4.Runtime.Atn
 					BitSet conflictingAlts = D.configSet.conflictingAlts;
 					if (D.predicates != null)
 					{
-						if (debug) ConsoleWriteLine("DFA state has preds in DFA sim LL failover");
+						if (debug) Console.WriteLine("DFA state has preds in DFA sim LL failover");
 						int conflictIndex = input.Index;
 						if (conflictIndex != startIndex)
 						{
@@ -477,7 +477,7 @@ namespace Antlr4.Runtime.Atn
 						conflictingAlts = EvalSemanticContext(D.predicates, outerContext, true);
 						if (conflictingAlts.Cardinality() == 1)
 						{
-							if (debug) ConsoleWriteLine("Full LL avoided");
+							if (debug) Console.WriteLine("Full LL avoided");
 							return conflictingAlts.NextSetBit(0);
 						}
 
@@ -489,7 +489,7 @@ namespace Antlr4.Runtime.Atn
 						}
 					}
 
-					if (dfa_debug) ConsoleWriteLine("ctx sensitive state " + outerContext + " in " + D);
+					if (dfa_debug) Console.WriteLine("ctx sensitive state " + outerContext + " in " + D);
 					bool fullCtx = true;
 					ATNConfigSet s0_closure =
 						ComputeStartState(dfa.atnStartState, outerContext, fullCtx);
@@ -587,7 +587,7 @@ namespace Antlr4.Runtime.Atn
 			if (debug)
 			{
 				ICollection<BitSet> altSubSets = PredictionMode.GetConflictingAltSubsets(reach.configs);
-				ConsoleWriteLine("SLL altSubSets=" + altSubSets +
+				Console.WriteLine("SLL altSubSets=" + StaticUtils.ToString(altSubSets) +
 								   ", configs=" + reach +
 								   ", predict=" + predictedAlt + ", allSubsetsConflict=" +
 									   PredictionMode.AllSubsetsConflict(altSubSets) + ", conflictingAlts=" +
@@ -656,7 +656,7 @@ namespace Antlr4.Runtime.Atn
 		{
 			if (debug || debug_list_atn_decisions)
 			{
-				ConsoleWriteLine("execATNWithFullContext " + s0);
+				Console.WriteLine("execATNWithFullContext " + s0);
 			}
 			bool fullCtx = true;
 			bool foundExactAmbig = false;
@@ -667,7 +667,7 @@ namespace Antlr4.Runtime.Atn
 			int predictedAlt;
 			while (true)
 			{ // while more work
-			  //			ConsoleWriteLine("LL REACH "+GetLookaheadName(input)+
+			  //			Console.WriteLine("LL REACH "+GetLookaheadName(input)+
 			  //							   " from configs.size="+previous.size()+
 			  //							   " line "+input.LT(1)Line+":"+input.LT(1).Column);
 				reach = ComputeReachSet(previous, t, fullCtx);
@@ -695,13 +695,13 @@ namespace Antlr4.Runtime.Atn
 				ICollection<BitSet> altSubSets = PredictionMode.GetConflictingAltSubsets(reach.configs);
 				if (debug)
 				{
-					ConsoleWriteLine("LL altSubSets=" + altSubSets +
+					Console.WriteLine("LL altSubSets=" + altSubSets +
 									   ", predict=" + PredictionMode.GetUniqueAlt(altSubSets) +
 									   ", ResolvesToJustOneViableAlt=" +
 										   PredictionMode.ResolvesToJustOneViableAlt(altSubSets));
 				}
 
-				//			ConsoleWriteLine("altSubSets: "+altSubSets);
+				//			Console.WriteLine("altSubSets: "+altSubSets);
 				//			System.err.println("reach="+reach+", "+reach.conflictingAlts);
 				reach.uniqueAlt = GetUniqueAlt(reach);
 				// unique prediction?
@@ -785,7 +785,7 @@ namespace Antlr4.Runtime.Atn
 		protected virtual ATNConfigSet ComputeReachSet(ATNConfigSet closure, int t, bool fullCtx)
 		{
 			if (debug)
-				ConsoleWriteLine("in computeReachSet, starting closure: " + closure);
+				Console.WriteLine("in computeReachSet, starting closure: " + closure);
 
 			if (mergeCache == null)
 			{
@@ -809,7 +809,7 @@ namespace Antlr4.Runtime.Atn
 			// First figure out where we can reach on input t
 			foreach (ATNConfig c in closure.configs)
 			{
-				if (debug) ConsoleWriteLine("testing " + GetTokenName(t) + " at " + c.ToString());
+				if (debug) Console.WriteLine("testing " + GetTokenName(t) + " at " + c.ToString());
 
 				if (c.state is RuleStopState)
 				{
@@ -1275,7 +1275,7 @@ namespace Antlr4.Runtime.Atn
 
 			// nonambig alts are null in altToPred
 			if (nPredAlts == 0) altToPred = null;
-			if (debug) ConsoleWriteLine("getPredsForAmbigAlts result " + Arrays.ToString(altToPred));
+			if (debug) Console.WriteLine("getPredsForAmbigAlts result " + Arrays.ToString(altToPred));
 			return altToPred;
 		}
 
@@ -1302,7 +1302,7 @@ namespace Antlr4.Runtime.Atn
 				return null;
 			}
 
-			//		ConsoleWriteLine(Arrays.toString(altToPred)+"->"+pairs);
+			//		Console.WriteLine(Arrays.toString(altToPred)+"->"+pairs);
 			return pairs.ToArray();
 		}
 
@@ -1452,12 +1452,12 @@ namespace Antlr4.Runtime.Atn
 				bool predicateEvaluationResult = EvalSemanticContext(pair.pred, outerContext, pair.alt, fullCtx);
 				if (debug || dfa_debug)
 				{
-					ConsoleWriteLine("eval pred " + pair + "=" + predicateEvaluationResult);
+					Console.WriteLine("eval pred " + pair + "=" + predicateEvaluationResult);
 				}
 
 				if (predicateEvaluationResult)
 				{
-					if (debug || dfa_debug) ConsoleWriteLine("PREDICT " + pair.alt);
+					if (debug || dfa_debug) Console.WriteLine("PREDICT " + pair.alt);
 					predictions[pair.alt] = true;
 					if (!complete)
 					{
@@ -1533,7 +1533,7 @@ namespace Antlr4.Runtime.Atn
 												bool treatEofAsEpsilon)
 		{
 			if (debug)
-				ConsoleWriteLine("closure(" + config.ToString(parser, true) + ")");
+				Console.WriteLine("closure(" + config.ToString(parser, true) + ")");
 
 			if (config.state is RuleStopState)
 			{
@@ -1552,7 +1552,7 @@ namespace Antlr4.Runtime.Atn
 							}
 							else {
 								// we have no context info, just chase follow links (if greedy)
-								if (debug) ConsoleWriteLine("FALLING off rule " +
+								if (debug) Console.WriteLine("FALLING off rule " +
 															  GetRuleName(config.state.ruleIndex));
 								Closure_(config, configSet, closureBusy, collectPredicates,
 										 fullCtx, depth, treatEofAsEpsilon);
@@ -1583,7 +1583,7 @@ namespace Antlr4.Runtime.Atn
 				}
 				else {
 					// else if we have no context info, just chase follow links (if greedy)
-					if (debug) ConsoleWriteLine("FALLING off rule " +
+					if (debug) Console.WriteLine("FALLING off rule " +
 												  GetRuleName(config.state.ruleIndex));
 				}
 			}
@@ -1608,7 +1608,7 @@ namespace Antlr4.Runtime.Atn
 				configs.Add(config, mergeCache);
 				// make sure to not return here, because EOF transitions can act as
 				// both epsilon transitions and non-epsilon transitions.
-				//            if ( debug ) ConsoleWriteLine("added config "+configs);
+				//            if ( debug ) Console.WriteLine("added config "+configs);
 			}
 
 			for (int i = 0; i < p.NumberOfTransitions; i++)
@@ -1650,7 +1650,7 @@ namespace Antlr4.Runtime.Atn
 						configs.dipsIntoOuterContext = true; // TODO: can remove? only care when we add to set per middle of this method
 						newDepth--;
 						if (debug)
-							ConsoleWriteLine("dips into outer ctx: " + c);
+							Console.WriteLine("dips into outer ctx: " + c);
 					}
 					else
 					{
@@ -1898,7 +1898,7 @@ namespace Antlr4.Runtime.Atn
 
 		protected ATNConfig ActionTransition(ATNConfig config, ActionTransition t)
 		{
-			if (debug) ConsoleWriteLine("ACTION edge " + t.ruleIndex + ":" + t.actionIndex);
+			if (debug) Console.WriteLine("ACTION edge " + t.ruleIndex + ":" + t.actionIndex);
 			return new ATNConfig(config, t.target);
 		}
 
@@ -1911,13 +1911,13 @@ namespace Antlr4.Runtime.Atn
 		{
 			if (debug)
 			{
-				ConsoleWriteLine("PRED (collectPredicates=" + collectPredicates + ") " +
+				Console.WriteLine("PRED (collectPredicates=" + collectPredicates + ") " +
 						pt.precedence + ">=_p" +
 						", ctx dependent=true");
 				if (parser != null)
 				{
-					ConsoleWriteLine("context surrounding pred is " +
-									   parser.GetRuleInvocationStack());
+					Console.WriteLine("context surrounding pred is " +
+									   StaticUtils.ToString(parser.GetRuleInvocationStack()));
 				}
 			}
 
@@ -1948,7 +1948,7 @@ namespace Antlr4.Runtime.Atn
 				c = new ATNConfig(config, pt.target);
 			}
 
-			if (debug) ConsoleWriteLine("config from pred transition=" + c);
+			if (debug) Console.WriteLine("config from pred transition=" + c);
 			return c;
 		}
 
@@ -1961,13 +1961,13 @@ namespace Antlr4.Runtime.Atn
 		{
 			if (debug)
 			{
-				ConsoleWriteLine("PRED (collectPredicates=" + collectPredicates + ") " +
+				Console.WriteLine("PRED (collectPredicates=" + collectPredicates + ") " +
 						pt.ruleIndex + ":" + pt.predIndex +
 						", ctx dependent=" + pt.isCtxDependent);
 				if (parser != null)
 				{
-					ConsoleWriteLine("context surrounding pred is " +
-									   parser.GetRuleInvocationStack());
+					Console.WriteLine("context surrounding pred is " +
+									   StaticUtils.ToString(parser.GetRuleInvocationStack()));
 				}
 			}
 
@@ -1999,7 +1999,7 @@ namespace Antlr4.Runtime.Atn
 				c = new ATNConfig(config, pt.target);
 			}
 
-			if (debug) ConsoleWriteLine("config from pred transition=" + c);
+			if (debug) Console.WriteLine("config from pred transition=" + c);
 			return c;
 		}
 
@@ -2008,7 +2008,7 @@ namespace Antlr4.Runtime.Atn
 		{
 			if (debug)
 			{
-				ConsoleWriteLine("CALL rule " + GetRuleName(t.target.ruleIndex) +
+				Console.WriteLine("CALL rule " + GetRuleName(t.target.ruleIndex) +
 								   ", ctx=" + config.context);
 			}
 
@@ -2192,7 +2192,7 @@ namespace Antlr4.Runtime.Atn
 		{
 			if (debug)
 			{
-				ConsoleWriteLine("EDGE " + from + " -> " + to + " upon " + GetTokenName(t));
+				Console.WriteLine("EDGE " + from + " -> " + to + " upon " + GetTokenName(t));
 			}
 
 			if (to == null)
@@ -2218,7 +2218,7 @@ namespace Antlr4.Runtime.Atn
 
 			if (debug)
 			{
-				ConsoleWriteLine("DFA=\n" + dfa.ToString(parser != null ? parser.Vocabulary : Vocabulary.EmptyVocabulary));
+				Console.WriteLine("DFA=\n" + dfa.ToString(parser != null ? parser.Vocabulary : Vocabulary.EmptyVocabulary));
 			}
 
 			return to;
@@ -2258,7 +2258,7 @@ namespace Antlr4.Runtime.Atn
 					D.configSet.IsReadOnly = true;
 				}
 				dfa.states.Put(D, D);
-				if (debug) ConsoleWriteLine("adding new DFA state: " + D);
+				if (debug) Console.WriteLine("adding new DFA state: " + D);
 				return D;
 			}
 		}
@@ -2268,7 +2268,7 @@ namespace Antlr4.Runtime.Atn
 			if (debug || retry_debug)
 			{
 				Interval interval = Interval.Of(startIndex, stopIndex);
-				ConsoleWriteLine("reportAttemptingFullContext decision=" + dfa.decision + ":" + configs +
+				Console.WriteLine("reportAttemptingFullContext decision=" + dfa.decision + ":" + configs +
 								   ", input=" + parser.TokenStream.GetText(interval));
 			}
 			if (parser != null)
@@ -2280,7 +2280,7 @@ namespace Antlr4.Runtime.Atn
 			if (debug || retry_debug)
 			{
 				Interval interval = Interval.Of(startIndex, stopIndex);
-				ConsoleWriteLine("ReportContextSensitivity decision=" + dfa.decision + ":" + configs +
+				Console.WriteLine("ReportContextSensitivity decision=" + dfa.decision + ":" + configs +
 								   ", input=" + parser.TokenStream.GetText(interval));
 			}
 			if (parser != null) parser.ErrorListenerDispatch.ReportContextSensitivity(parser, dfa, startIndex, stopIndex, prediction, null /*configs*/);
@@ -2297,7 +2297,7 @@ namespace Antlr4.Runtime.Atn
 			if (debug || retry_debug)
 			{
 				Interval interval = Interval.Of(startIndex, stopIndex);
-				ConsoleWriteLine("ReportAmbiguity " +
+				Console.WriteLine("ReportAmbiguity " +
 								   ambigAlts + ":" + configs +
 								   ", input=" + parser.TokenStream.GetText(interval));
 			}

--- a/runtime/CSharp/src/Misc/Utils.cs
+++ b/runtime/CSharp/src/Misc/Utils.cs
@@ -8,6 +8,14 @@ using System.Text;
 
 namespace Antlr4.Runtime.Misc
 {
+    public static class StaticUtils
+    {
+        public static string ToString<T>(this IEnumerable<T> list)
+        {
+            return "[" + Utils.Join(", ", list) + "]";
+        }
+    }
+
     public class Utils
     {
         public static string Join<T>(string separator, IEnumerable<T> items)

--- a/runtime/CSharp/tests/issue-2693/Test.sln
+++ b/runtime/CSharp/tests/issue-2693/Test.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31019.35
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "Test.csproj", "{FD11E8CC-1631-4FF3-9B44-F10084562311}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Antlr4", "..\..\src\Antlr4.csproj", "{A60B5000-4473-4D00-85C4-C3A4B469F608}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FD11E8CC-1631-4FF3-9B44-F10084562311}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD11E8CC-1631-4FF3-9B44-F10084562311}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD11E8CC-1631-4FF3-9B44-F10084562311}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD11E8CC-1631-4FF3-9B44-F10084562311}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A60B5000-4473-4D00-85C4-C3A4B469F608}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A60B5000-4473-4D00-85C4-C3A4B469F608}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A60B5000-4473-4D00-85C4-C3A4B469F608}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A60B5000-4473-4D00-85C4-C3A4B469F608}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2FFB66F7-2552-4F2B-B97E-77B5F8743ED4}
+	EndGlobalSection
+EndGlobal

--- a/runtime/CSharp/tests/issue-3079/Arithmetic.g4
+++ b/runtime/CSharp/tests/issue-3079/Arithmetic.g4
@@ -1,0 +1,33 @@
+
+// Template generated code from Antlr4BuildTasks.dotnet-antlr v 2.2
+
+grammar Arithmetic;
+
+file : expression (SEMI expression)* EOF;
+expression : expression POW expression | expression (TIMES | DIV) expression | expression (PLUS | MINUS) expression | LPAREN expression RPAREN | (PLUS | MINUS)* atom ;
+atom : scientific | variable ;
+scientific : SCIENTIFIC_NUMBER ;
+variable : VARIABLE ;
+
+VARIABLE : VALID_ID_START VALID_ID_CHAR* ;
+SCIENTIFIC_NUMBER : NUMBER (E SIGN? UNSIGNED_INTEGER)? ;
+LPAREN : '(' ;
+RPAREN : ')' ;
+PLUS : '+' ;
+MINUS : '-' ;
+TIMES : '*' ;
+DIV : '/' ;
+GT : '>' ;
+LT : '<' ;
+EQ : '=' ;
+POINT : '.' ;
+POW : '^' ;
+SEMI : ';' ;
+WS : [ \r\n\t] + -> channel(HIDDEN) ;
+
+fragment VALID_ID_START : ('a' .. 'z') | ('A' .. 'Z') | '_' ;
+fragment VALID_ID_CHAR : VALID_ID_START | ('0' .. '9') ;
+fragment NUMBER : ('0' .. '9') + ('.' ('0' .. '9') +)? ;
+fragment UNSIGNED_INTEGER : ('0' .. '9')+ ;
+fragment E : 'E' | 'e' ;
+fragment SIGN : ('+' | '-') ;

--- a/runtime/CSharp/tests/issue-3079/ErrorListener.cs
+++ b/runtime/CSharp/tests/issue-3079/ErrorListener.cs
@@ -1,0 +1,20 @@
+// Template generated code from Antlr4BuildTasks.dotnet-antlr v 2.2
+
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+public class ErrorListener<S> : ConsoleErrorListener<S>
+{
+    public bool had_error;
+
+    public override void SyntaxError(TextWriter output, IRecognizer recognizer, S offendingSymbol, int line,
+        int col, string msg, RecognitionException e)
+    {
+        had_error = true;
+        base.SyntaxError(output, recognizer, offendingSymbol, line, col, msg, e);
+    }
+}

--- a/runtime/CSharp/tests/issue-3079/Program.cs
+++ b/runtime/CSharp/tests/issue-3079/Program.cs
@@ -1,0 +1,110 @@
+// Template generated code from Antlr4BuildTasks.dotnet-antlr v 2.2
+
+using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Runtime.CompilerServices;
+
+public class Program
+{
+    public static Parser Parser { get; set; }
+    public static Lexer Lexer { get; set; }
+    public static ITokenStream TokenStream { get; set; }
+    public static IParseTree Tree { get; set; }
+    public static IParseTree Parse(string input)
+    {
+        var str = new AntlrInputStream(input);
+        var lexer = new ArithmeticLexer(str);
+        Lexer = lexer;
+        var tokens = new CommonTokenStream(lexer);
+        TokenStream = tokens;
+        var parser = new ArithmeticParser(tokens);
+        Parser = parser;
+        var tree = parser.file();
+        Tree = tree;
+        return tree;
+    }
+
+    static void Main(string[] args)
+    {
+        bool show_tree = false;
+        bool show_tokens = false;
+        string file_name = null;
+        string input = null;
+        for (int i = 0; i < args.Length; ++i)
+        {
+            if (args[i].Equals("-tokens"))
+            {
+                show_tokens = true;
+                continue;
+            }
+            else if (args[i].Equals("-tree"))
+            {
+                show_tree = true;
+                continue;
+            }
+            else if (args[i].Equals("-input"))
+                input = args[++i];
+            else if (args[i].Equals("-file"))
+                file_name = args[++i];
+        }
+        ICharStream str = null;
+        if (input == null && file_name == null)
+        {
+            StringBuilder sb = new StringBuilder();
+            int ch;
+            while ((ch = System.Console.Read()) != -1)
+            {
+                sb.Append((char)ch);
+            }
+            input = sb.ToString();
+            
+str = CharStreams.fromString(input);
+        } else if (input != null)
+        {
+            str = CharStreams.fromString(input);
+        } else if (file_name != null)
+        {
+            str = CharStreams.fromPath(file_name);
+        }
+        var lexer = new ArithmeticLexer(str);
+        if (show_tokens)
+        {
+            StringBuilder new_s = new StringBuilder();
+            for (int i = 0; ; ++i)
+            {
+                var ro_token = lexer.NextToken();
+                var token = (CommonToken)ro_token;
+                token.TokenIndex = i;
+                new_s.AppendLine(token.ToString());
+                if (token.Type == Antlr4.Runtime.TokenConstants.EOF)
+                    break;
+            }
+            System.Console.Error.WriteLine(new_s.ToString());
+            lexer.Reset();
+        }
+        var tokens = new CommonTokenStream(lexer);
+        var parser = new ArithmeticParser(tokens);
+        var listener_lexer = new ErrorListener<int>();
+        var listener_parser = new ErrorListener<IToken>();
+        lexer.AddErrorListener(listener_lexer);
+        parser.AddErrorListener(listener_parser);
+        var tree = parser.file();
+        if (listener_lexer.had_error || listener_parser.had_error)
+        {
+            System.Console.Error.WriteLine("parse failed.");
+        }
+        else
+        {
+            System.Console.Error.WriteLine("parse succeeded.");
+        }
+        if (show_tree)
+        {
+            System.Console.Error.WriteLine(tree.ToStringTree(parser));
+        }
+        System.Environment.Exit(listener_lexer.had_error || listener_parser.had_error ? 1 : 0);
+    }
+}

--- a/runtime/CSharp/tests/issue-3079/Test.csproj
+++ b/runtime/CSharp/tests/issue-3079/Test.csproj
@@ -1,0 +1,65 @@
+﻿<!-- Template generated code from Antlr4BuildTasks.dotnet-antlr v 2.2 -->
+<Project Sdk="Microsoft.NET.Sdk" >
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Antlr4 Include="Arithmetic.g4" />
+  </ItemGroup>
+  
+  <PropertyGroup>
+    <AntlrToolPath>../../../../tool/target/antlr4-*-SNAPSHOT-complete.jar</AntlrToolPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Antlr4.csproj" />
+    <PackageReference Include="Antlr4BuildTasks" Version = "8.13" PrivateAssets="all" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" >
+    <NoWarn>1701;1702;3021</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!--
+      need the CData since this blob is just going to
+      be embedded in a mini batch file by studio/msbuild
+    -->
+    <MyTester><![CDATA[
+
+set ERR=0
+for %%G in (..\examples\*) do (
+  setlocal EnableDelayedExpansion
+  set FILE=%%G
+  set X1=%%~xG
+  set X2=%%~nG
+  set X3=%%~pG
+  if !X1! neq .errors (
+    echo !FILE!
+    cat !FILE! | bin\Debug\net5.0\Test.exe
+    if not exist !FILE!.errors (
+      if ERRORLEVEL 1 set ERR=1
+    ) else (
+      echo Expected.
+    )
+  )
+)
+EXIT %ERR%
+
+]]></MyTester>
+</PropertyGroup>
+
+  <Target Name="Test" >
+    <Message Text="testing" />
+    <Exec Command="$(MyTester)" >
+       <Output TaskParameter="ExitCode" PropertyName ="ErrorCode" />
+    </Exec>
+    <Message Importance="high" Text="$(ErrorCode)"/>
+  </Target>
+
+</Project>

--- a/runtime/CSharp/tests/issue-3079/Test.sln
+++ b/runtime/CSharp/tests/issue-3079/Test.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31019.35
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "Test.csproj", "{1B229E17-E0E5-4D3B-8978-A4E61B9233E5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Antlr4", "..\..\src\Antlr4.csproj", "{95247929-4C60-4CDF-B202-1BAE1C12AA57}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1B229E17-E0E5-4D3B-8978-A4E61B9233E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B229E17-E0E5-4D3B-8978-A4E61B9233E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B229E17-E0E5-4D3B-8978-A4E61B9233E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B229E17-E0E5-4D3B-8978-A4E61B9233E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95247929-4C60-4CDF-B202-1BAE1C12AA57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95247929-4C60-4CDF-B202-1BAE1C12AA57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95247929-4C60-4CDF-B202-1BAE1C12AA57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95247929-4C60-4CDF-B202-1BAE1C12AA57}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4819731D-3C62-4CFA-A99C-09103728C086}
+	EndGlobalSection
+EndGlobal

--- a/runtime/CSharp/tests/issue-3079/readme.md
+++ b/runtime/CSharp/tests/issue-3079/readme.md
@@ -1,0 +1,10 @@
+# How to test Issue 3079
+
+1) Build the Antlr Tool first.
+2) `bash test.sh` in this directory.
+
+NB: The CSharp runtime source is modified by the test.sh script to
+change "debug = true;" for ParserATNSimulator.cs. There is no way to
+change the value of the static readonly variable using System.Reflection
+after the static initializer for the class has loaded. This is why
+it is change in the source here for this test and only this test.

--- a/runtime/CSharp/tests/issue-3079/test.sh
+++ b/runtime/CSharp/tests/issue-3079/test.sh
@@ -1,0 +1,8 @@
+#
+
+cat ../../src/Atn/ParserATNSimulator.cs > ParserATNSimulator.save
+cat ParserATNSimulator.save | sed 's/bool debug = false;/bool debug = true;/' > ../../src/Atn/ParserATNSimulator.cs
+dotnet restore
+dotnet build
+dotnet run -input "1+2"
+


### PR DESCRIPTION
This change request is a fix for #3079. Basically, if you want to debug the C# runtime, you will want to set ParserATNSimulator.debug to true, then run you tests. Unfortunately, the runtime crashes if you try. As I write this, I am currently chasing down yet another problem with the C# runtime. So, this is important to fix.

This problem goes back to [this change](https://github.com/antlr/antlr4/commit/ef49021c8b5e84e409b2a52b7cf7de59fda18348#diff-e4b2755a11fc5fdfaaa170fbab8c65f336360f94800879c0c3258c146cf7f62e) with the introduction of the wrapper function ConsoleWriteLine(), which interprets the first parameter as a format string. Unfortunately, "ToString()" of states and sets in the Antlr runtime are interpreted as C# formatting.

I looked over every other runtime target, and not a single one has a wrapper around the native runtime call. While it makes sense to encapsulate the native calls, C# should not be unique here. And, even if you do wrap Console.WriteLine(), you should have tested your code!

I changed all the calls to "ConsoleWriteLine()" back to "Console.WriteLine()" and added a regression test for one for this code (antlr4/runtime/CSharp/tests/issue-3079). The readme.md should be self explanitory.

This change request also includes a .sln file for antlr4/runtime/CSharp/tests/issue-2693. "dotnet build" does not work without relating the Antlr4 C# runtime with this program without a .sln.

--Ken