### PR TITLE
Export recognizer class for dart target

### DIFF
--- a/runtime/Dart/lib/antlr4.dart
+++ b/runtime/Dart/lib/antlr4.dart
@@ -19,3 +19,5 @@ export 'src/parser_rule_context.dart';
 export 'src/vocabulary.dart';
 export 'src/runtime_meta_data.dart';
 export 'src/token.dart';
+export 'src/recognizer.dart';
+export 'src/interval_set.dart';


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

fixes #3108 

Exports recognizer, interval and intervalset classes.