### PR TITLE
Fix for #2940: fix data race warning in Go

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -290,3 +290,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/02/27, khmarbaise, Karl Heinz Marbaise, github@soebes.com
 2021/03/02, hackeris
 2021/03/03, xTachyon, Damian Andrei, xTachyon@users.noreply.github.com
+2021/03/26, minjoosur, Minjoo Sur, msur@salesforce.com

--- a/runtime/Go/antlr/dfa_serializer.go
+++ b/runtime/Go/antlr/dfa_serializer.go
@@ -34,7 +34,7 @@ func NewDFASerializer(dfa *DFA, literalNames, symbolicNames []string) *DFASerial
 }
 
 func (d *DFASerializer) String() string {
-	if d.dfa.s0 == nil {
+	if d.dfa.getS0() == nil {
 		return ""
 	}
 
@@ -116,7 +116,7 @@ func (l *LexerDFASerializer) getEdgeLabel(i int) string {
 }
 
 func (l *LexerDFASerializer) String() string {
-	if l.dfa.s0 == nil {
+	if l.dfa.getS0() == nil {
 		return ""
 	}
 

--- a/runtime/Go/antlr/dfa_state.go
+++ b/runtime/Go/antlr/dfa_state.go
@@ -6,6 +6,7 @@ package antlr
 
 import (
 	"fmt"
+	"sync"
 )
 
 // PredPrediction maps a predicate to a predicted alternative.
@@ -50,6 +51,7 @@ type DFAState struct {
 	// edges elements point to the target of the symbol. Shift up by 1 so (-1)
 	// Token.EOF maps to the first element.
 	edges []*DFAState
+	edgesMu	sync.RWMutex
 
 	isAcceptState bool
 
@@ -104,6 +106,36 @@ func (d *DFAState) GetAltSet() *Set {
 	}
 
 	return alts
+}
+
+func (d *DFAState) getEdges() []*DFAState {
+	d.edgesMu.RLock()
+	defer d.edgesMu.RUnlock()
+	return d.edges
+}
+
+func (d *DFAState) numEdges() int {
+	d.edgesMu.RLock()
+	defer d.edgesMu.RUnlock()
+	return len(d.edges)
+}
+
+func (d *DFAState) getIthEdge(i int) *DFAState {
+	d.edgesMu.RLock()
+	defer d.edgesMu.RUnlock()
+	return d.edges[i]
+}
+
+func (d *DFAState) setEdges(newEdges []*DFAState) {
+	d.edgesMu.Lock()
+	defer d.edgesMu.Unlock()
+	d.edges = newEdges
+}
+
+func (d *DFAState) setIthEdge(i int, edge *DFAState) {
+	d.edgesMu.Lock()
+	defer d.edgesMu.Unlock()
+	d.edges[i] = edge
 }
 
 func (d *DFAState) setPrediction(v int) {

--- a/runtime/Go/antlr/lexer_atn_simulator.go
+++ b/runtime/Go/antlr/lexer_atn_simulator.go
@@ -90,11 +90,11 @@ func (l *LexerATNSimulator) Match(input CharStream, mode int) int {
 
 	dfa := l.decisionToDFA[mode]
 
-	if dfa.s0 == nil {
+	if dfa.getS0() == nil {
 		return l.MatchATN(input)
 	}
 
-	return l.execATN(input, dfa.s0)
+	return l.execATN(input, dfa.getS0())
 }
 
 func (l *LexerATNSimulator) reset() {
@@ -202,11 +202,11 @@ func (l *LexerATNSimulator) execATN(input CharStream, ds0 *DFAState) int {
 // {@code t}, or {@code nil} if the target state for l edge is not
 // already cached
 func (l *LexerATNSimulator) getExistingTargetState(s *DFAState, t int) *DFAState {
-	if s.edges == nil || t < LexerATNSimulatorMinDFAEdge || t > LexerATNSimulatorMaxDFAEdge {
+	if s.getEdges() == nil || t < LexerATNSimulatorMinDFAEdge || t > LexerATNSimulatorMaxDFAEdge {
 		return nil
 	}
 
-	target := s.edges[t-LexerATNSimulatorMinDFAEdge]
+	target := s.getIthEdge(t-LexerATNSimulatorMinDFAEdge)
 	if LexerATNSimulatorDebug && target != nil {
 		fmt.Println("reuse state " + strconv.Itoa(s.stateNumber) + " edge to " + strconv.Itoa(target.stateNumber))
 	}
@@ -550,11 +550,11 @@ func (l *LexerATNSimulator) addDFAEdge(from *DFAState, tk int, to *DFAState, cfg
 	if LexerATNSimulatorDebug {
 		fmt.Println("EDGE " + from.String() + " -> " + to.String() + " upon " + strconv.Itoa(tk))
 	}
-	if from.edges == nil {
+	if from.getEdges() == nil {
 		// make room for tokens 1..n and -1 masquerading as index 0
-		from.edges = make([]*DFAState, LexerATNSimulatorMaxDFAEdge-LexerATNSimulatorMinDFAEdge+1)
+		from.setEdges(make([]*DFAState, LexerATNSimulatorMaxDFAEdge-LexerATNSimulatorMinDFAEdge+1))
 	}
-	from.edges[tk-LexerATNSimulatorMinDFAEdge] = to // connect
+	from.setIthEdge(tk-LexerATNSimulatorMinDFAEdge, to) // connect
 
 	return to
 }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->
This fixes #2940.
There was some missing and incorrect usage of locks which caused Data Race Warning on Go Target. 
I solved the problem by putting a lock on the correct spots and by making sure read/write are coming through getter and setters.
