### PR TITLE
[C++] Performance improvement in finally

### DIFF
--- a/runtime/Cpp/runtime/src/antlr4-common.h
+++ b/runtime/Cpp/runtime/src/antlr4-common.h
@@ -34,7 +34,6 @@
 #include <exception>
 #include <bitset>
 #include <condition_variable>
-#include <functional>
 
 #ifndef USE_UTF8_INSTEAD_OF_CODECVT
   #include <codecvt>

--- a/runtime/Cpp/runtime/src/support/CPPUtils.cpp
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.cpp
@@ -202,12 +202,6 @@ namespace antlrcpp {
     return result;
   }
 
-  //----------------- FinallyAction ------------------------------------------------------------------------------------
-
-  FinalAction finally(std::function<void ()> f) {
-    return FinalAction(f);
-  }
-
   //----------------- SingleWriteMultipleRead --------------------------------------------------------------------------
 
   void SingleWriteMultipleReadLock::readLock() {


### PR DESCRIPTION
Before, to use `finally`, the compiler had to:
- set up the lambda;
- construct a `std::function` that could allocate if it wants to;
- call `finaly()`;
- the dtor of the `std::function` would call the lambda;

Neither MSVC nor GCC could inline any of the functions of `std::function`, the `finally` function, nor the lambda, even with LTO.

With this patch both MSVC and GCC can see through the object and inline the lambda directly into the function code, making it essentially free.
MSVC would occasionally still set up the `FinalAction` object even if it doesn't use it, but would inline the lambda anyway.

Should we migrate to a non-movable `FinalAction` wrapper that wouldn't need the `bool` field so MSVC would get the idea to not set up the object?

Anyway, this should still be faster and generate smaller code because the simpler logic.
@mike-lischke 