### PR TITLE
Fix typo in ExternalAntlr4Cpp.cmake

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -290,3 +290,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/02/27, khmarbaise, Karl Heinz Marbaise, github@soebes.com
 2021/03/02, hackeris
 2021/03/03, xTachyon, Damian Andrei, xTachyon@users.noreply.github.com
+2021/04/07, b1f6c1c4, Jinzheng Tu, b1f6c1c4@gmail.com

--- a/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
+++ b/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
@@ -112,7 +112,7 @@ else()
       EXCLUDE_FROM_ALL 1)
 endif()
 
-# Seperate build step as rarely people want both
+# Separate build step as rarely people want both
 set(ANTLR4_BUILD_DIR ${ANTLR4_ROOT})
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14.0")
   # CMake 3.14 builds in above's SOURCE_SUBDIR when BUILD_IN_SOURCE is true


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->