### PR TITLE
Revert "Cpp target: No building tests/samples for external utfcpp"

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -291,5 +291,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/02/27, khmarbaise, Karl Heinz Marbaise, github@soebes.com
 2021/03/02, hackeris
 2021/03/03, xTachyon, Damian Andrei, xTachyon@users.noreply.github.com
-2021/04/08, bigerl, Alexander Bigerl, bigerl@mail.upb.de
 2021/04/07, b1f6c1c4, Jinzheng Tu, b1f6c1c4@gmail.com

--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -1,16 +1,3 @@
-include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
-
-set(THIRDPARTY_DIR ${CMAKE_BINARY_DIR}/runtime/thirdparty)
-set(UTFCPP_DIR ${THIRDPARTY_DIR}/utfcpp)
-ExternalProject_Add(
-  utfcpp
-  GIT_REPOSITORY        "git://github.com/nemtrif/utfcpp"
-  GIT_TAG               "v3.1.1"
-  SOURCE_DIR            ${UTFCPP_DIR}
-  UPDATE_DISCONNECTED   1
-  CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${UTFCPP_DIR}/install -DUTF8_TESTS=off -DUTF8_SAMPLES=off
-  STEP_TARGETS          build)
-
 include_directories(
   ${PROJECT_SOURCE_DIR}/runtime/src
   ${PROJECT_SOURCE_DIR}/runtime/src/atn


### PR DESCRIPTION
Reverts antlr/antlr4#3040

This seems to conflicts more than expected with previous patches for utfcpp. 