### PR TITLE
Patch utfcpp build

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -293,3 +293,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/03/02, hackeris
 2021/03/03, xTachyon, Damian Andrei, xTachyon@users.noreply.github.com
 2021/04/07, b1f6c1c4, Jinzheng Tu, b1f6c1c4@gmail.com
+2021/04/24, bigerl, Alexander Bigerl, alexander [äät] bigerl [pkt] eu

--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -61,8 +61,7 @@ else()
       GIT_TAG               "v3.1.1"
       SOURCE_DIR            ${UTFCPP_DIR}
       UPDATE_DISCONNECTED   1
-      CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${UTFCPP_DIR}/install -Dgtest_force_shared_crt=ON
-      TEST_AFTER_INSTALL    1
+      CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${UTFCPP_DIR}/install -DUTF8_TESTS=off -DUTF8_SAMPLES=off
       STEP_TARGETS          build)
 
     include_directories(


### PR DESCRIPTION
As promised to @mike-lischke , here is the rebase of #3040 :

> It is unnecessary that each time the external dependency utfcpp is pulled, its tests are built and run. Also its samples are unnecessarily generated.
> I suggest to use the provided cmake to disable this behavior.
> You can find the documentation of the cmake options here: https://github.com/nemtrif/utfcpp/blob/v3.1.1/CMakeLists.txt#L10-L12
> 
> Let's make this build a little bit more green and not use unnecessary resources.

