### PR TITLE
Making compatibility with actions and predicates in Go better

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -298,6 +298,7 @@ YYYY/MM/DD, github id, Full name, email
 2021/04/24, bigerl, Alexander Bigerl, alexander [äät] bigerl [pkt] eu
 2021/05/02, michalharakal, Michal Harakal, michal.harakal@users.noreply.github.com
 2021/05/03, redexp, Sergii Kliuchnyk, redexp@users.noreply.github.com
+2021/05/03, mitar, Mi Tar, mitar.git@tnode.com
 2021/05/04, joakker, Joaquín León, joaquinandresleon108@gmail.com
 2021/05/06, renancaraujo, Renan C. Araújo, renancaraujo@users.noreply.github.com
 2021/05/06, canastro, Ricardo Canastro, ricardocanastro@users.noreply.github.com

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -325,6 +325,9 @@ func (l *<lexer.name>) Sempred(localctx antlr.RuleContext, ruleIndex, predIndex 
  */
 RuleActionFunction(r, actions) ::= <<
 func (l *<lexer.name>) <r.name; format="cap">_Action(localctx <if(r.factory.grammar.lexer)>antlr.RuleContext<else>*<r.ctxType><endif>, actionIndex int) {
+	this := l
+	_ = this
+
 	switch actionIndex {
 	<if(actions)>
 	<actions:{index | case <index>:
@@ -343,6 +346,9 @@ func (l *<lexer.name>) <r.name; format="cap">_Action(localctx <if(r.factory.gram
  */
 RuleSempredFunction(r, actions) ::= <<
 func (p *<r.factory.grammar.recognizerName>) <r.name; format="cap">_Sempred(localctx antlr.RuleContext, predIndex int) bool {
+	this := p
+	_ = this
+
 	switch predIndex {
 	<if(actions)>
 	<actions:{index | case <index>:
@@ -367,6 +373,9 @@ RuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs, namedAction
 
 <endif>
 func (p *<parser.name>) <currentRule.name; format="cap">(<currentRule.args:{a | <a.name> <a.type>}; separator=", ">) (localctx I<currentRule.ctxType>) {
+	this := p
+	_ = this
+
 	localctx = New<currentRule.ctxType>(p, p.GetParserRuleContext(), p.GetState()<currentRule.args:{a | , <a.name>}>)
 	p.EnterRule(localctx, <currentRule.startState>, <parser.name>RULE_<currentRule.name>)
 	<if(namedActions.init)>
@@ -440,6 +449,9 @@ func (p *<parser.name>) <currentRule.name; format="cap">(<args:{a | <a.name> <a.
 }
 
 func (p *<parser.name>) <currentRule.name>(_p int<args:{a | , <a.name> <a.type>}>) (localctx I<currentRule.ctxType>) {
+	this := p
+	_ = this
+
 	var _parentctx antlr.ParserRuleContext = p.GetParserRuleContext()
 	_parentState := p.GetState()
 	localctx = New<currentRule.ctxType>(p, p.GetParserRuleContext(), _parentState<args:{a | , <a.name>}>)


### PR DESCRIPTION
This change is a simple workaround which makes grammars which use actions and predicates calling something on `this` work also in Go.

See https://github.com/antlr/grammars-v4/issues/2177 for a bit of background. This change would allow compiling JavaScript grammar with antlr with a bit less manually patching. (There are few more steps to do to get it working.)