### PR TITLE
Fix tests for go runtime

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/GoFileFilter.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/GoFileFilter.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+package org.antlr.v4.test.runtime.go;
+
+import java.io.File;
+import java.io.FilenameFilter;
+
+public class GoFileFilter implements FilenameFilter {
+    public boolean accept(File dir, String name) {
+        return name.endsWith(".go");
+    }
+}


### PR DESCRIPTION
Sorry this took so long, life got in the way 😅 

This PR fixes the errors in the go runtime tests by setting up a go module for each test and copying the runtime to a subdirectory. This way, we can use the same source that is already in the pr, instead of `go get`ing the version already in the github repo like in my previous PR.

Hopefully fixes #3175 