### PR TITLE
Change utfcpp git url to use https

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -318,3 +318,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/09/23, skalt, Steven Kalt, kalt.steven@gmail.com
 2021/10/10, tools4origins, Erwan Guyomarc'h, contact@erwan-guyomarch.fr
 2021/10/25, jcking, Justin King, jcking@google.com
+2021/10/31, skef, Skef Iterum, github@skef.org

--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -57,7 +57,7 @@ else()
     set(UTFCPP_DIR ${THIRDPARTY_DIR}/utfcpp)
     ExternalProject_Add(
       utf8cpp
-      GIT_REPOSITORY        "git://github.com/nemtrif/utfcpp"
+      GIT_REPOSITORY        "https://github.com/nemtrif/utfcpp"
       GIT_TAG               "v3.1.1"
       SOURCE_DIR            ${UTFCPP_DIR}
       UPDATE_DISCONNECTED   1


### PR DESCRIPTION
I and others (e.g. https://github.com/npm/npm/issues/6285 ) have encountered reliability problems with git: github urls in certain contexts. These problems can be overridden with `git config --global url.https://github.com/.insteadOf git://github.com/` but just starting with the https url would be easier for everyone. 