### PR TITLE
[Python] Fix index when combining inserts

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -302,3 +302,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/05/04, joakker, Joaquín León, joaquinandresleon108@gmail.com
 2021/05/06, renancaraujo, Renan C. Araújo, renancaraujo@users.noreply.github.com
 2021/05/06, canastro, Ricardo Canastro, ricardocanastro@users.noreply.github.com
+2021/06/10, JamesHutch, James Hutchinson, JamesHutch@users.noreply.github.com

--- a/runtime/Python2/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python2/src/antlr4/TokenStreamRewriter.py
@@ -170,13 +170,13 @@ class TokenStreamRewriter(object):
             if any((iop is None, not isinstance(iop, TokenStreamRewriter.InsertBeforeOp))):
                 continue
             prevInserts = [op for op in rewrites[:i] if isinstance(op, TokenStreamRewriter.InsertBeforeOp)]
-            for prev_index, prevIop in enumerate(prevInserts):
+            for prevIop in prevInserts:
                 if prevIop.index == iop.index and type(prevIop) is TokenStreamRewriter.InsertBeforeOp:
                     iop.text += prevIop.text
-                    rewrites[prev_index] = None
+                    rewrites[prevIop.instructionIndex] = None
                 elif prevIop.index == iop.index and type(prevIop) is TokenStreamRewriter.InsertAfterOp:
                     iop.text = prevIop.text + iop.text
-                    rewrites[prev_index] = None
+                    rewrites[prevIop.instructionIndex] = None
             # look for replaces where iop.index is in range; error
             prevReplaces = [op for op in rewrites[:i] if type(op) is TokenStreamRewriter.ReplaceOp]
             for rop in prevReplaces:

--- a/runtime/Python3/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python3/src/antlr4/TokenStreamRewriter.py
@@ -171,13 +171,13 @@ class TokenStreamRewriter(object):
             if any((iop is None, not isinstance(iop, TokenStreamRewriter.InsertBeforeOp))):
                 continue
             prevInserts = [op for op in rewrites[:i] if isinstance(op, TokenStreamRewriter.InsertBeforeOp)]
-            for prev_index, prevIop in enumerate(prevInserts):
+            for prevIop in prevInserts:
                 if prevIop.index == iop.index and type(prevIop) is TokenStreamRewriter.InsertBeforeOp:
                     iop.text += prevIop.text
-                    rewrites[prev_index] = None
+                    rewrites[prevIop.instructionIndex] = None
                 elif prevIop.index == iop.index and type(prevIop) is TokenStreamRewriter.InsertAfterOp:
                     iop.text = prevIop.text + iop.text
-                    rewrites[prev_index] = None
+                    rewrites[prevIop.instructionIndex] = None
             # look for replaces where iop.index is in range; error
             prevReplaces = [op for op in rewrites[:i] if isinstance(op, TokenStreamRewriter.ReplaceOp)]
             for rop in prevReplaces:


### PR DESCRIPTION
prevInserts list is the subset of rewrites, so indices taken from
enumerating its elements do not correspond to the correct indices in
rewrites. Use prevIop.instructionIndex instead, which matches the other
runtimes.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->