### PR TITLE
Corrected/clarified the Linux C++ runtime compilation instructions

### DIFF
--- a/runtime/Cpp/README.md
+++ b/runtime/Cpp/README.md
@@ -62,7 +62,7 @@ Try run cmake -DCMAKE_ANDROID_NDK=/folder/of/android_ndkr17_and_above -DCMAKE_SY
 - make
 - DESTDIR=\<antlr4-dir\>/runtime/Cpp/run make install
 
-If you don't want to build the demo then simply run cmake without parameters.
+If you don't want to build the demo then replace the "cmake .. -DANTLR_JAR_LOCATION<...>" command in the above recipe with "cmake .." without any further parameters.
 There is another cmake script available in the subfolder cmake/ for those who prefer the superbuild cmake pattern.
 
 #### CMake Package support


### PR DESCRIPTION
Corrected/clarified the Linux C++ runtime compilation instructions WRT how to frobnicate the "cmake" command.