### PR TITLE
Revert "Throw error if lexer does not contain non-fragment rules"

### DIFF
--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestToolSyntaxErrors.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestToolSyntaxErrors.java
@@ -13,21 +13,16 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestToolSyntaxErrors extends BaseJavaToolTest {
-	static String[] A = {
-		// INPUT
+    static String[] A = {
+	    // INPUT
 		"grammar A;\n" +
 		"",
 		// YIELDS
-		"error(" + ErrorType.NO_RULES.code + "): A.g4::: grammar A has no non-fragment rules\n",
+		"error(" + ErrorType.NO_RULES.code + "): A.g4::: grammar A has no rules\n",
 
 		"lexer grammar A;\n" +
 		"",
-		"error(" + ErrorType.NO_RULES.code + "): A.g4::: grammar A has no non-fragment rules\n",
-
-		"lexer grammar A;\n" +
-		"fragment FRAGMENT: 'FRAGMENT';\n" +
-		"",
-		"error(" + ErrorType.NO_RULES.code + "): A.g4::: grammar A has no non-fragment rules\n",
+		"error(" + ErrorType.NO_RULES.code + "): A.g4::: grammar A has no rules\n",
 
 		"A;",
 		"error(" + ErrorType.SYNTAX_ERROR.code + "): A.g4:1:0: syntax error: 'A' came as a complete surprise to me\n",

--- a/tool/src/org/antlr/v4/semantics/BasicSemanticChecks.java
+++ b/tool/src/org/antlr/v4/semantics/BasicSemanticChecks.java
@@ -321,16 +321,7 @@ public class BasicSemanticChecks extends GrammarTreeVisitor {
 	}
 
 	void checkNumRules(GrammarAST rulesNode) {
-		Boolean emptyGrammar = true;
-
-		for (Rule rule : ruleCollector.rules.values()) {
-			if (!rule.isFragment()) {
-				emptyGrammar = false;
-				break;
-			}
-		}
-
-		if (emptyGrammar) {
+		if ( rulesNode.getChildCount()==0 ) {
 			GrammarAST root = (GrammarAST)rulesNode.getParent();
 			GrammarAST IDNode = (GrammarAST)root.getChild(0);
 			g.tool.errMgr.grammarError(ErrorType.NO_RULES, g.fileName,

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -341,7 +341,7 @@ public enum ErrorType {
 	 * <li>implicitly generated grammar <em>grammar</em> has no rules</li>
 	 * </ul>
 	 */
-	NO_RULES(99, "<if(arg2.implicitLexerOwner)>implicitly generated <endif>grammar <arg> has no non-fragment rules", ErrorSeverity.ERROR),
+	NO_RULES(99, "<if(arg2.implicitLexerOwner)>implicitly generated <endif>grammar <arg> has no rules", ErrorSeverity.ERROR),
 	/**
 	 * Compiler Error 105.
 	 *


### PR DESCRIPTION
Fix #3147

This reverts commit 67f608926137110cdc775c38f2f0e3abb7c66259.
