### PR TITLE
[Python 2, Python 3] Change all "readOnly" to "readonly"

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -303,3 +303,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/05/06, renancaraujo, Renan C. Araújo, renancaraujo@users.noreply.github.com
 2021/05/06, canastro, Ricardo Canastro, ricardocanastro@users.noreply.github.com
 2021/07/01, marcauberer, Marc Auberer, marc.auberer@chillibits.com
+2021/07/14, renzhentaxibaerde, Renzhentaxi Baerde, renzhentaxibaerde@gmail.com

--- a/runtime/Python2/src/antlr4/IntervalSet.py
+++ b/runtime/Python2/src/antlr4/IntervalSet.py
@@ -28,8 +28,8 @@ class Interval(object):
 class IntervalSet(object):
 
     def __init__(self):
-        self.intervals = None
-        self.readOnly = False
+        self.intervals = None # type: list | None
+        self.readonly = False
 
     def __iter__(self):
         if self.intervals is not None:

--- a/runtime/Python2/src/antlr4/atn/ATNDeserializationOptions.py
+++ b/runtime/Python2/src/antlr4/atn/ATNDeserializationOptions.py
@@ -7,15 +7,15 @@ class ATNDeserializationOptions(object):
     defaultOptions = None
 
     def __init__(self, copyFrom = None):
-        self.readOnly = False
+        self.readonly = False
         self.verifyATN = True if copyFrom is None else copyFrom.verifyATN
         self.generateRuleBypassTransitions = False if copyFrom is None else copyFrom.generateRuleBypassTransitions
 
     def __setattr__(self, key, value):
-        if key!="readOnly" and self.readOnly:
+        if key!="readonly" and self.readonly:
             raise Exception("The object is read only.")
         super(type(self), self).__setattr__(key,value)
 
 ATNDeserializationOptions.defaultOptions = ATNDeserializationOptions()
-ATNDeserializationOptions.defaultOptions.readOnly = True
+ATNDeserializationOptions.defaultOptions.readonly = True
 

--- a/runtime/Python3/src/antlr4/IntervalSet.py
+++ b/runtime/Python3/src/antlr4/IntervalSet.py
@@ -11,11 +11,11 @@ from antlr4.Token import Token
 IntervalSet = None
 
 class IntervalSet(object):
-    __slots__ = ('intervals', 'readOnly')
+    __slots__ = ('intervals', 'readonly')
 
     def __init__(self):
         self.intervals = None
-        self.readOnly = False
+        self.readonly = False
 
     def __iter__(self):
         if self.intervals is not None:

--- a/runtime/Python3/src/antlr4/atn/ATN.py
+++ b/runtime/Python3/src/antlr4/atn/ATN.py
@@ -63,7 +63,7 @@ class ATN(object):
         if s.nextTokenWithinRule is not None:
             return s.nextTokenWithinRule
         s.nextTokenWithinRule = self.nextTokensInContext(s, None)
-        s.nextTokenWithinRule.readOnly = True
+        s.nextTokenWithinRule.readonly = True
         return s.nextTokenWithinRule
 
     def nextTokens(self, s:ATNState, ctx:RuleContext = None):

--- a/runtime/Python3/src/antlr4/atn/ATNDeserializationOptions.py
+++ b/runtime/Python3/src/antlr4/atn/ATNDeserializationOptions.py
@@ -6,19 +6,19 @@
 ATNDeserializationOptions = None
 
 class ATNDeserializationOptions(object):
-    __slots__ = ('readOnly', 'verifyATN', 'generateRuleBypassTransitions')
+    __slots__ = ('readonly', 'verifyATN', 'generateRuleBypassTransitions')
 
     defaultOptions = None
 
     def __init__(self, copyFrom:ATNDeserializationOptions = None):
-        self.readOnly = False
+        self.readonly = False
         self.verifyATN = True if copyFrom is None else copyFrom.verifyATN
         self.generateRuleBypassTransitions = False if copyFrom is None else copyFrom.generateRuleBypassTransitions
 
     def __setattr__(self, key, value):
-        if key!="readOnly" and self.readOnly:
+        if key!="readonly" and self.readonly:
             raise Exception("The object is read only.")
         super(type(self), self).__setattr__(key,value)
 
 ATNDeserializationOptions.defaultOptions = ATNDeserializationOptions()
-ATNDeserializationOptions.defaultOptions.readOnly = True
+ATNDeserializationOptions.defaultOptions.readonly = True


### PR DESCRIPTION
Previously, in python2's runtime there was a typo where we used `readonly` when the property was actually `readOnly`.

After discussing with Eric on #3226, We decided to change all properties named `readOnly` to `readonly` since that is what the java runtime does.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->