### PR TITLE
Add pretty print to Javascript toStringTree

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -304,3 +304,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/05/06, canastro, Ricardo Canastro, ricardocanastro@users.noreply.github.com
 2021/07/01, marcauberer, Marc Auberer, marc.auberer@chillibits.com
 2021/07/14, renzhentaxibaerde, Renzhentaxi Baerde, renzhentaxibaerde@gmail.com
+2021/07/19, tom-james-watson, Thomas Watson, antlr.contributors@tomjwatson.com

--- a/runtime/JavaScript/src/antlr4/tree/Trees.js
+++ b/runtime/JavaScript/src/antlr4/tree/Trees.js
@@ -14,26 +14,52 @@ const Trees = {
      *  node payloads to get the text for the nodes.  Detect
      *  parse trees and extract data appropriately.
      */
-    toStringTree: function(tree, ruleNames, recog) {
+    toStringTree: function(tree, ruleNames, recog, prettyPrint, indentLvl) {
         ruleNames = ruleNames || null;
         recog = recog || null;
+        prettyPrint = prettyPrint || false;
+        indentLvl = indentLvl || 0;
+
         if(recog!==null) {
             ruleNames = recog.ruleNames;
         }
+
         let s = Trees.getNodeText(tree, ruleNames);
         s = Utils.escapeWhitespace(s, false);
         const c = tree.getChildCount();
+
         if(c===0) {
+            if (prettyPrint) {
+                return `\n${" ".repeat(indentLvl)}${s}`;
+            }
             return s;
         }
-        let res = "(" + s + ' ';
+
+        let res = "(" + s + " ";
+        if (prettyPrint) {
+            res = `\n${" ".repeat(indentLvl)}${res}`;
+        }
+
         if(c>0) {
-            s = Trees.toStringTree(tree.getChild(0), ruleNames);
+            s = Trees.toStringTree(
+                tree.getChild(0), ruleNames, recog, prettyPrint, indentLvl + 1
+            );
             res = res.concat(s);
         }
+
         for(let i=1;i<c;i++) {
-            s = Trees.toStringTree(tree.getChild(i), ruleNames);
-            res = res.concat(' ' + s);
+            s = Trees.toStringTree(
+                tree.getChild(i), ruleNames, recog, prettyPrint, indentLvl + 1
+            );
+            if (prettyPrint) {
+                res = `${res}${" ".repeat(indentLvl)}${s}`;
+            } else {
+                res = res.concat(' ' + s);
+            }
+        }
+
+        if (prettyPrint) {
+            res = `${res}\n${" ".repeat(indentLvl)}`;
         }
         res = res.concat(")");
         return res;


### PR DESCRIPTION
Non-pretty (existing functionality):

```
> console.log(antlr4.tree.Trees.toStringTree(tree, tree.parser.ruleNames));
(parse (sql_stmt_list (sql_stmt (select_stmt (select_core select (result_column (expr (column_name (any_name id)))) , (result_column (expr (column_name (any_name first_name)))) from (table_or_subquery (table_name (any_name users)))))) ;) <EOF>)
```

Pretty:

```
> console.log(antlr4.tree.Trees.toStringTree(tree, tree.parser.ruleNames, null, true));
(parse 
 (sql_stmt_list 
  (sql_stmt 
   (select_stmt 
    (select_core 
     select    
     (result_column 
      (expr 
       (column_name 
        (any_name 
         id
        )
       )
      )
     )    
     ,    
     (result_column 
      (expr 
       (column_name 
        (any_name 
         first_name
        )
       )
      )
     )    
     from    
     (table_or_subquery 
      (table_name 
       (any_name 
        users
       )
      )
     )
    )
   )
  ) 
  ;
 )
 <EOF>
)
```
