### PR TITLE
Add "contextSuperClass" option to rule. Will overlap "contextSuperClass" option in grammar if both exist.

### DIFF
--- a/historical-contributors-agreement.txt
+++ b/historical-contributors-agreement.txt
@@ -328,3 +328,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/12/31, Biswa96, Biswapriyo Nath, nathbappai@gmail.com
 2022/03/07, chenquan, chenquan, chenquan.dev@gmail.com
 2022/03/15, hzeller, Henner Zeller, h.zeller@acm.org
+2021/07/21, XenoAmess, Jin Xu, xenoamess@gmail.com

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -30,7 +30,7 @@
 
 // args must be <object-model-object>, <fields-resulting-in-STs>
 
-ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
+ParserFile(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 <if(file.genPackage)>
 namespace <file.genPackage> {
@@ -860,7 +860,7 @@ CaptureNextTokenType(d) ::= "<d.varName> = TokenStream.LA(1);"
 
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,
            superClass={ParserRuleContext}) ::= <<
-public partial class <struct.escapedName> : <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
+public partial class <struct.escapedName> : <if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>ParserRuleContext<endif><endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 	<attrs:{a | public <a>;}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
 	<if(ctorAttrs)>public <struct.escapedName>(ParserRuleContext parent, int invokingState) : base(parent, invokingState) { }<endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -555,7 +555,7 @@ LeftRecursiveRuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs
 >>
 
 StructDeclHeader(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers) ::= <<
-class <file.exportMacro> <struct.escapedName> : public <if (contextSuperClass)><contextSuperClass><else>antlr4::ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
+class <file.exportMacro> <struct.escapedName> : public <if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>antlr4::ParserRuleContext<endif><endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 public:
   <attrs: {a | <a>;}; separator = "\n">
   <if (ctorAttrs)><struct.escapedName>(antlr4::ParserRuleContext *parent, size_t invokingState);<endif>
@@ -575,17 +575,17 @@ public:
 
 >>
 
-StructDecl(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers) ::= <<
+StructDecl(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers, ruleContextSuperClass) ::= <<
 //----------------- <struct.escapedName> ------------------------------------------------------------------
 
 <if (ctorAttrs)>
 <parser.name>::<struct.escapedName>::<struct.escapedName>(ParserRuleContext *parent, size_t invokingState)
-  : <if (contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>(parent, invokingState) {
+  : <if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>antlr4::ParserRuleContext<endif><endif>(parent, invokingState) {
 }
 <endif>
 
 <parser.name>::<struct.escapedName>::<struct.escapedName>(ParserRuleContext *parent, size_t invokingState<ctorAttrs: {a | , <a>}>)
-  : <if (contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>(parent, invokingState) {
+  : <if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>antlr4::ParserRuleContext<endif><endif>(parent, invokingState) {
   <struct.ctorAttrs: {a | this-><a.escapedName> = <a.escapedName>;}; separator="\n">
 }
 
@@ -597,7 +597,7 @@ size_t <parser.name>::<struct.escapedName>::getRuleIndex() const {
 
 <if (struct.provideCopyFrom)>
 void <parser.name>::<struct.escapedName>::copyFrom(<struct.escapedName> *ctx) {
-  <if (contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>::copyFrom(ctx);
+  <if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>antlr4::ParserRuleContext<endif><endif>::copyFrom(ctx);
   <struct.attrs: {a | this-><a.escapedName> = ctx-><a.escapedName>;}; separator = "\n">
 }
 <endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Files.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Files.stg
@@ -73,7 +73,7 @@ using namespace antlr4;
 
 >>
 
-ParserFileHeader(file, parser, namedActions, contextSuperClass) ::= <<
+ParserFileHeader(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion, namedActions.header)>
 
 #pragma once
@@ -93,7 +93,7 @@ ParserFileHeader(file, parser, namedActions, contextSuperClass) ::= <<
 <endif>
 >>
 
-ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
+ParserFile(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion, namedActions.header)>
 
 <namedActions.preinclude>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
@@ -40,7 +40,7 @@ dartTypeInitMap ::= [
 
 // args must be <object-model-object>, <fields-resulting-in-STs>
 
-ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
+ParserFile(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 import 'package:antlr4/antlr4.dart';
 
@@ -681,9 +681,9 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = tokenStream.LT(1);"
 CaptureNextTokenType(d) ::= "<d.varName> = tokenStream.LA(1)!;"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers)
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,ruleContextSuperClass)
   ::= <<
-class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif> {
+class <struct.escapedName> extends <if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>ParserRuleContext<endif><endif><if(interfaces)> implements <interfaces; separator=", "><endif> {
   <attrs:{a | <a>;}; separator="\n">
   <getters:{g | <g>}; separator="\n">
   <struct.escapedName>([ParserRuleContext? parent, int? invokingState<ctorAttrs:{a | , <a>}>]) : super(parent, invokingState)<if(struct.ctorAttrs)> {
@@ -694,7 +694,7 @@ class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><el
   int get ruleIndex => RULE_<struct.derivedFromName>;
 <if(struct.provideCopyFrom)> <! don't need copy unless we have subclasses !>
   @override
-  void copyFrom(<if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif> ctx) {
+  void copyFrom(<if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>ParserRuleContext<endif><endif> ctx) {
     super.copyFrom(ctx);
     <struct.attrs:{a | if((ctx as <struct.escapedName>).<a.escapedName> != null) this.<a.escapedName> = (ctx as <struct.escapedName>).<a.escapedName>;}; separator="\n">
   }

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -2,7 +2,7 @@ fileHeader(grammarFileName, ANTLRVersion) ::= <<
 // Code generated from <grammarFileName; format="java-escape"> by ANTLR <ANTLRVersion>. DO NOT EDIT.
 >>
 
-ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
+ParserFile(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 
 <if(file.genPackage)>
@@ -1014,7 +1014,7 @@ ListLabelName(label) ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = p.GetTokenStream().LT(1)"
 CaptureNextTokenType(d) ::= "<d.varName> = p.GetTokenStream().LA(1)"
 
-StructDecl(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers) ::= <<
+StructDecl(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers, ruleContextSuperClass) ::= <<
 // I<struct.escapedName> is an interface to support dynamic dispatch.
 type I<struct.escapedName> interface {
 	antlr.ParserRuleContext
@@ -1099,7 +1099,7 @@ Set<a.escapedName; format="cap">(<a.type>)}; separator="\n\n">
 }
 
 type <struct.escapedName> struct {
-	<if(contextSuperClass)>*<contextSuperClass><else>*antlr.BaseParserRuleContext<endif>
+	<if(ruleContextSuperClass)>*<ruleContextSuperClass><else><if(grammarContextSuperClass)>*<grammarContextSuperClass><else>*antlr.BaseParserRuleContext<endif><endif>
 	parser antlr.Parser
 	<if(attrs)>
 	<attrs; separator="\n">
@@ -1108,7 +1108,7 @@ type <struct.escapedName> struct {
 
 func NewEmpty<struct.escapedName>() *<struct.escapedName> {
 	var p = new(<struct.escapedName>)
-	p.<if(contextSuperClass)><contextSuperClass><else>BaseParserRuleContext<endif> = <if(contextSuperClass)>New<contextSuperClass><else>antlr.NewBaseParserRuleContext<endif>(nil, -1)
+	p.<if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>BaseParserRuleContext<endif><endif> = <if(ruleContextSuperClass)>New<ruleContextSuperClass><else><if(grammarContextSuperClass)>New<grammarContextSuperClass><else>antlr.NewBaseParserRuleContext<endif><endif>(nil, -1)
 	p.RuleIndex = <parser.name>RULE_<struct.derivedFromName>
 	return p
 }
@@ -1118,7 +1118,7 @@ func (*<struct.escapedName>) Is<struct.escapedName>() {}
 func New<struct.escapedName>(parser antlr.Parser, parent antlr.ParserRuleContext, invokingState int<struct.ctorAttrs:{a | , <a.escapedName> <a.type>}>) *<struct.escapedName> {
 	var p = new(<struct.escapedName>)
 
-	p.<if(contextSuperClass)><contextSuperClass><else>BaseParserRuleContext<endif> = <if(contextSuperClass)>New<contextSuperClass><else>antlr.NewBaseParserRuleContext<endif>(parent, invokingState)
+	p.<if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>BaseParserRuleContext<endif><endif> = <if(ruleContextSuperClass)>New<ruleContextSuperClass><else><if(grammarContextSuperClass)>New<grammarContextSuperClass><else>antlr.NewBaseParserRuleContext<endif><endif>(parent, invokingState)
 
 	p.parser = parser
 	p.RuleIndex = <parser.name>RULE_<struct.derivedFromName>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -42,7 +42,7 @@ javaTypeInitMap ::= [
 
 // args must be <object-model-object>, <fields-resulting-in-STs>
 
-ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
+ParserFile(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 <if(file.genPackage)>
 package <file.genPackage>;
@@ -782,10 +782,10 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = _input.LT(1);"
 CaptureNextTokenType(d) ::= "<d.varName> = _input.LA(1);"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers)
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,ruleContextSuperClass)
 	::= <<
 @SuppressWarnings("CheckReturnValue")
-public static class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif> {
+public static class <struct.escapedName> extends <if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>ParserRuleContext<endif><endif><if(interfaces)> implements <interfaces; separator=", "><endif> {
 	<attrs:{a | public <a>;}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
 	<if(ctorAttrs)>public <struct.escapedName>(ParserRuleContext parent, int invokingState) { super(parent, invokingState); }<endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -46,7 +46,7 @@ javascriptTypeInitMap ::= [
 
 // args must be <object-model-object>, <fields-resulting-in-STs>
 
-ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
+ParserFile(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 import antlr4 from 'antlr4';
 <if(file.genListener)>
@@ -657,8 +657,8 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = self._input.LT(1)"
 CaptureNextTokenType(d) ::= "<d.varName> = this._input.LA(1);"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers) ::= <<
-class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>antlr4.ParserRuleContext<endif> {
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,ruleContextSuperClass) ::= <<
+class <struct.escapedName> extends <if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>antlr4.ParserRuleContext<endif><endif> {
 
     constructor(parser, parent, invokingState<struct.ctorAttrs:{a | , <a.escapedName>}>) {
         if(parent===undefined) {

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
@@ -39,7 +39,7 @@ phpTypeInitMap ::= [
 
 // args must be <object-model-object>, <fields-resulting-in-STs>
 
-ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
+ParserFile(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 <parser>
 >>
@@ -923,8 +923,8 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "$<d.varName> = \$this->input->LT(1);"
 CaptureNextTokenType(d) ::= "$<d.varName> = $this->input->LA(1);"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers) ::= <<
-class <struct.name> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif>
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,ruleContextSuperClass) ::= <<
+class <struct.name> extends <if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>ParserRuleContext<endif><endif><if(interfaces)> implements <interfaces; separator=", "><endif>
 {
 <PropertiesDecl(struct)>
 	public function __construct(?ParserRuleContext $parent, ?int $invokingState = null<ctorAttrs:{a | , ?<a> = null}>)

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -46,7 +46,7 @@ pythonTypeInitMap ::= [
 
 // args must be <object-model-object>, <fields-resulting-in-STs>
 
-ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
+ParserFile(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 # encoding: utf-8
 from __future__ import print_function
@@ -637,8 +637,8 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = self._input.LT(1)"
 CaptureNextTokenType(d) ::= "<d.varName> = self._input.LA(1)"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers) ::= <<
-class <struct.escapedName>(<if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>):
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,ruleContextSuperClass) ::= <<
+class <struct.escapedName>(<if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>ParserRuleContext<endif><endif>):
 
     def __init__(self, parser, parent=None, invokingState=-1<struct.ctorAttrs:{a | , <a.escapedName>=None}>):
         super(<parser.name>.<struct.name>, self).__init__(parent, invokingState)

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -46,7 +46,7 @@ pythonTypeInitMap ::= [
 
 // args must be <object-model-object>, <fields-resulting-in-STs>
 
-ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
+ParserFile(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 # encoding: utf-8
 from antlr4 import *
@@ -650,8 +650,8 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = self._input.LT(1)"
 CaptureNextTokenType(d) ::= "<d.varName> = self._input.LA(1)"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers) ::= <<
-class <struct.escapedName>(<if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>):
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,ruleContextSuperClass) ::= <<
+class <struct.escapedName>(<if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>ParserRuleContext<endif><endif>):
     __slots__ = 'parser'
 
     def __init__(self, parser, parent:ParserRuleContext=None, invokingState:int=-1<struct.ctorAttrs:{a | , <a.escapedName><if(a.type)>:<a.type><endif>=None}>):

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -51,7 +51,7 @@ SwiftTypeMap ::= [
 accessLevelOpenOK(obj) ::= "<obj.accessLevel; null=\"open\">"
 accessLevelNotOpen(obj) ::= "<obj.accessLevel; null=\"public\">"
 
-ParserFile(file, parser, namedActions,contextSuperClass) ::= <<
+ParserFile(file, parser, namedActions, grammarContextSuperClass) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 <if(file.genPackage)>
 <!package <file.genPackage>;!>
@@ -815,7 +815,7 @@ CaptureNextTokenType(d) ::= "<d.varName> = try _input.LA(1)"
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,
            superClass={ParserRuleContext}) ::= <<
 
-<accessLevelNotOpen(parser)> class <struct.escapedName>: <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
+<accessLevelNotOpen(parser)> class <struct.escapedName>: <if(ruleContextSuperClass)><ruleContextSuperClass><else><if(grammarContextSuperClass)><grammarContextSuperClass><else>ParserRuleContext<endif><endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 	<attrs:{a | <accessLevelOpenOK(parser)> var <a>}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
 	<! <if(ctorAttrs)> <accessLevelNotOpen(parser)> init(_ parent: ParserRuleContext,_ invokingState: Int) { super.init(parent, invokingState)  }<endif> !>

--- a/tool/src/org/antlr/v4/codegen/model/ParserFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/ParserFile.java
@@ -21,7 +21,7 @@ public class ParserFile extends OutputFile {
 	public boolean genVisitor; // from -visitor cmd-line
 	@ModelElement public Parser parser;
 	@ModelElement public Map<String, Action> namedActions;
-	@ModelElement public ActionChunk contextSuperClass;
+	@ModelElement public ActionChunk grammarContextSuperClass;
 	public String grammarName;
 
 	public ParserFile(OutputModelFactory factory, String fileName) {
@@ -29,14 +29,15 @@ public class ParserFile extends OutputFile {
 		Grammar g = factory.getGrammar();
 		namedActions = buildNamedActions(factory.getGrammar());
 		genPackage = g.tool.genPackage;
-		exportMacro = factory.getGrammar().getOptionString("exportMacro");
+		exportMacro = g.getOptionString("exportMacro");
 		// need the below members in the ST for Python, C++
 		genListener = g.tool.gen_listener;
 		genVisitor = g.tool.gen_visitor;
 		grammarName = g.name;
 
-		if (g.getOptionString("contextSuperClass") != null) {
-			contextSuperClass = new ActionText(null, g.getOptionString("contextSuperClass"));
+		final String contextSuperClassOptionString = g.getOptionString("contextSuperClass");
+		if (contextSuperClassOptionString != null) {
+			grammarContextSuperClass = new ActionText(null, contextSuperClassOptionString);
 		}
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/decl/StructDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/StructDecl.java
@@ -12,9 +12,12 @@ import org.antlr.v4.codegen.model.ListenerDispatchMethod;
 import org.antlr.v4.codegen.model.ModelElement;
 import org.antlr.v4.codegen.model.OutputModelObject;
 import org.antlr.v4.codegen.model.VisitorDispatchMethod;
+import org.antlr.v4.codegen.model.chunk.ActionChunk;
+import org.antlr.v4.codegen.model.chunk.ActionText;
 import org.antlr.v4.runtime.misc.OrderedHashSet;
 import org.antlr.v4.tool.Attribute;
 import org.antlr.v4.tool.Rule;
+import org.antlr.v4.tool.ast.RuleAST;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,6 +35,7 @@ public class StructDecl extends Decl {
 	@ModelElement public List<? super DispatchMethod> dispatchMethods;
 	@ModelElement public List<OutputModelObject> interfaces;
 	@ModelElement public List<OutputModelObject> extensionMembers;
+	@ModelElement public ActionChunk ruleContextSuperClass;
 
 	// Track these separately; Go target needs to generate getters/setters
 	// Do not make them templates; we only need the Decl object not the ST
@@ -52,6 +56,10 @@ public class StructDecl extends Decl {
 		addDispatchMethods(r);
 		derivedFromName = r.name;
 		provideCopyFrom = r.hasAltSpecificContexts();
+		final String contextSuperClassOptionString = r.ast.getOptionString("contextSuperClass");
+		if (contextSuperClassOptionString != null) {
+			ruleContextSuperClass = new ActionText(null, contextSuperClassOptionString);
+		}
 	}
 
 	public void addDispatchMethods(Rule r) {

--- a/tool/src/org/antlr/v4/tool/Grammar.java
+++ b/tool/src/org/antlr/v4/tool/Grammar.java
@@ -89,6 +89,7 @@ public class Grammar implements AttributeResolver {
 
 	public static final Set<String> lexerRuleOptions = new HashSet<>();
 	static {
+		lexerRuleOptions.add("contextSuperClass");
 		lexerRuleOptions.add(caseInsensitiveOptionName);
 	}
 


### PR DESCRIPTION

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

as title.