### PR TITLE
remove redundant slash in getting-started.md

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -304,6 +304,7 @@ YYYY/MM/DD, github id, Full name, email
 2021/05/06, canastro, Ricardo Canastro, ricardocanastro@users.noreply.github.com
 2021/07/01, marcauberer, Marc Auberer, marc.auberer@chillibits.com
 2021/07/14, renzhentaxibaerde, Renzhentaxi Baerde, renzhentaxibaerde@gmail.com
+2021/07/29, ksyx, Qixing Xue, qixingxue@outlook.com
 2021/07/29, rachidlamouri, Rachid Lamouri, rachidlamouri@gmail.com
 2021/08/02, minjoosur, Minjoo Sur, msur@salesforce.com
 2021/08/08, ansiemens, Yi-Hong Lin, ansiemens@gmail.com

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -138,4 +138,3 @@ The book has lots and lots of examples that should be useful too. You can downlo
 Also, there is a large collection of grammars for v4 at github:
 
 [https://github.com/antlr/grammars-v4](https://github.com/antlr/grammars-v4)
-/


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->