### PR TITLE
fix: use 32bit murmur3 same with java, implement array2dhashset which…

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -305,3 +305,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/07/01, marcauberer, Marc Auberer, marc.auberer@chillibits.com
 2021/07/14, renzhentaxibaerde, Renzhentaxi Baerde, renzhentaxibaerde@gmail.com
 2021/08/02, minjoosur, Minjoo Sur, msur@salesforce.com
+2021/08/05, jjeffcaii, Jeff Tsai, caiweiwei.cww@alibaba-inc.com

--- a/runtime/Go/antlr/atn_config.go
+++ b/runtime/Go/antlr/atn_config.go
@@ -251,7 +251,7 @@ func (l *LexerATNConfig) hash() int {
 		f = 0
 	}
 	h := murmurInit(7)
-	h = murmurUpdate(h, l.state.hash())
+	h = murmurUpdate(h, l.state.GetStateNumber())
 	h = murmurUpdate(h, l.alt)
 	h = murmurUpdate(h, l.context.hash())
 	h = murmurUpdate(h, l.semanticContext.hash())

--- a/runtime/Go/antlr/dfa_serializer.go
+++ b/runtime/Go/antlr/dfa_serializer.go
@@ -7,6 +7,7 @@ package antlr
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // DFASerializer is a DFA walker that knows how to dump them to serialized
@@ -112,7 +113,12 @@ func NewLexerDFASerializer(dfa *DFA) *LexerDFASerializer {
 }
 
 func (l *LexerDFASerializer) getEdgeLabel(i int) string {
-	return "'" + string(i) + "'"
+	var sb strings.Builder
+	sb.Grow(6)
+	sb.WriteByte('\'')
+	sb.WriteRune(rune(i))
+	sb.WriteByte('\'')
+	return sb.String()
 }
 
 func (l *LexerDFASerializer) String() string {

--- a/runtime/Go/antlr/dfa_state.go
+++ b/runtime/Go/antlr/dfa_state.go
@@ -50,8 +50,8 @@ type DFAState struct {
 
 	// edges elements point to the target of the symbol. Shift up by 1 so (-1)
 	// Token.EOF maps to the first element.
-	edges []*DFAState
-	edgesMu	sync.RWMutex
+	edges   []*DFAState
+	edgesMu sync.RWMutex
 
 	isAcceptState bool
 
@@ -92,16 +92,16 @@ func NewDFAState(stateNumber int, configs ATNConfigSet) *DFAState {
 }
 
 // GetAltSet gets the set of all alts mentioned by all ATN configurations in d.
-func (d *DFAState) GetAltSet() *Set {
-	alts := NewSet(nil, nil)
+func (d *DFAState) GetAltSet() Set {
+	alts := NewArray2DHashSet(nil, nil)
 
 	if d.configs != nil {
 		for _, c := range d.configs.GetItems() {
-			alts.add(c.GetAlt())
+			alts.Add(c.GetAlt())
 		}
 	}
 
-	if alts.length() == 0 {
+	if alts.Len() == 0 {
 		return nil
 	}
 
@@ -173,26 +173,11 @@ func (d *DFAState) String() string {
 		}
 	}
 
-	return fmt.Sprintf("%d:%s%s", fmt.Sprint(d.configs), s)
+	return fmt.Sprintf("%d:%s%s", d.stateNumber, fmt.Sprint(d.configs), s)
 }
 
 func (d *DFAState) hash() int {
-	h := murmurInit(11)
-
-	c := 1
-	if d.isAcceptState {
-		if d.predicates != nil {
-			for _, p := range d.predicates {
-				h = murmurUpdate(h, p.alt)
-				h = murmurUpdate(h, p.pred.hash())
-				c += 2
-			}
-		} else {
-			h = murmurUpdate(h, d.prediction)
-			c += 1
-		}
-	}
-
+	h := murmurInit(7)
 	h = murmurUpdate(h, d.configs.hash())
-	return murmurFinish(h, c)
+	return murmurFinish(h, 1)
 }

--- a/runtime/Go/antlr/interval_set.go
+++ b/runtime/Go/antlr/interval_set.go
@@ -226,16 +226,28 @@ func (i *IntervalSet) StringVerbose(literalNames []string, symbolicNames []strin
 func (i *IntervalSet) toCharString() string {
 	names := make([]string, len(i.intervals))
 
+	var sb strings.Builder
+
 	for j := 0; j < len(i.intervals); j++ {
 		v := i.intervals[j]
 		if v.Stop == v.Start+1 {
 			if v.Start == TokenEOF {
 				names = append(names, "<EOF>")
 			} else {
-				names = append(names, ("'" + string(v.Start) + "'"))
+				sb.WriteByte('\'')
+				sb.WriteRune(rune(v.Start))
+				sb.WriteByte('\'')
+				names = append(names, sb.String())
+				sb.Reset()
 			}
 		} else {
-			names = append(names, "'"+string(v.Start)+"'..'"+string(v.Stop-1)+"'")
+			sb.WriteByte('\'')
+			sb.WriteRune(rune(v.Start))
+			sb.WriteString("'..'")
+			sb.WriteRune(rune(v.Stop - 1))
+			sb.WriteByte('\'')
+			names = append(names, sb.String())
+			sb.Reset()
 		}
 	}
 	if len(names) > 1 {

--- a/runtime/Go/antlr/lexer_action.go
+++ b/runtime/Go/antlr/lexer_action.go
@@ -414,10 +414,9 @@ func (l *LexerIndexedCustomAction) execute(lexer Lexer) {
 
 func (l *LexerIndexedCustomAction) hash() int {
 	h := murmurInit(0)
-	h = murmurUpdate(h, l.actionType)
 	h = murmurUpdate(h, l.offset)
 	h = murmurUpdate(h, l.lexerAction.hash())
-	return murmurFinish(h, 3)
+	return murmurFinish(h, 2)
 }
 
 func (l *LexerIndexedCustomAction) equals(other LexerAction) bool {

--- a/runtime/Go/antlr/lexer_atn_simulator.go
+++ b/runtime/Go/antlr/lexer_atn_simulator.go
@@ -7,6 +7,7 @@ package antlr
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 var (
@@ -206,7 +207,7 @@ func (l *LexerATNSimulator) getExistingTargetState(s *DFAState, t int) *DFAState
 		return nil
 	}
 
-	target := s.getIthEdge(t-LexerATNSimulatorMinDFAEdge)
+	target := s.getIthEdge(t - LexerATNSimulatorMinDFAEdge)
 	if LexerATNSimulatorDebug && target != nil {
 		fmt.Println("reuse state " + strconv.Itoa(s.stateNumber) + " edge to " + strconv.Itoa(target.stateNumber))
 	}
@@ -299,7 +300,7 @@ func (l *LexerATNSimulator) getReachableConfigSet(input CharStream, closure ATNC
 
 func (l *LexerATNSimulator) accept(input CharStream, lexerActionExecutor *LexerActionExecutor, startIndex, index, line, charPos int) {
 	if LexerATNSimulatorDebug {
-		fmt.Printf("ACTION %s\n", lexerActionExecutor)
+		fmt.Printf("ACTION %v\n", lexerActionExecutor)
 	}
 	// seek to after last char in token
 	input.Seek(index)
@@ -630,7 +631,13 @@ func (l *LexerATNSimulator) GetTokenName(tt int) string {
 		return "EOF"
 	}
 
-	return "'" + string(tt) + "'"
+	var sb strings.Builder
+	sb.Grow(6)
+	sb.WriteByte('\'')
+	sb.WriteRune(rune(tt))
+	sb.WriteByte('\'')
+
+	return sb.String()
 }
 
 func resetSimState(sim *SimState) {

--- a/runtime/Go/antlr/ll1_analyzer.go
+++ b/runtime/Go/antlr/ll1_analyzer.go
@@ -38,7 +38,7 @@ func (la *LL1Analyzer) getDecisionLookahead(s ATNState) []*IntervalSet {
 	look := make([]*IntervalSet, count)
 	for alt := 0; alt < count; alt++ {
 		look[alt] = NewIntervalSet()
-		lookBusy := NewSet(nil, nil)
+		lookBusy := NewArray2DHashSet(nil, nil)
 		seeThruPreds := false // fail to get lookahead upon pred
 		la.look1(s.GetTransitions()[alt].getTarget(), nil, BasePredictionContextEMPTY, look[alt], lookBusy, NewBitSet(), seeThruPreds, false)
 		// Wipe out lookahead for la alternative if we found nothing
@@ -75,7 +75,7 @@ func (la *LL1Analyzer) Look(s, stopState ATNState, ctx RuleContext) *IntervalSet
 	if ctx != nil {
 		lookContext = predictionContextFromRuleContext(s.GetATN(), ctx)
 	}
-	la.look1(s, stopState, lookContext, r, NewSet(nil, nil), NewBitSet(), seeThruPreds, true)
+	la.look1(s, stopState, lookContext, r, NewArray2DHashSet(nil, nil), NewBitSet(), seeThruPreds, true)
 	return r
 }
 
@@ -109,22 +109,22 @@ func (la *LL1Analyzer) Look(s, stopState ATNState, ctx RuleContext) *IntervalSet
 // outermost context is reached. This parameter has no effect if {@code ctx}
 // is {@code nil}.
 
-func (la *LL1Analyzer) look2(s, stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy *Set, calledRuleStack *BitSet, seeThruPreds, addEOF bool, i int) {
+func (la *LL1Analyzer) look2(s, stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy Set, calledRuleStack *BitSet, seeThruPreds, addEOF bool, i int) {
 
 	returnState := la.atn.states[ctx.getReturnState(i)]
 	la.look1(returnState, stopState, ctx.GetParent(i), look, lookBusy, calledRuleStack, seeThruPreds, addEOF)
 
 }
 
-func (la *LL1Analyzer) look1(s, stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy *Set, calledRuleStack *BitSet, seeThruPreds, addEOF bool) {
+func (la *LL1Analyzer) look1(s, stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy Set, calledRuleStack *BitSet, seeThruPreds, addEOF bool) {
 
 	c := NewBaseATNConfig6(s, 0, ctx)
 
-	if lookBusy.contains(c) {
+	if lookBusy.Contains(c) {
 		return
 	}
 
-	lookBusy.add(c)
+	lookBusy.Add(c)
 
 	if s == stopState {
 		if ctx == nil {
@@ -148,13 +148,13 @@ func (la *LL1Analyzer) look1(s, stopState ATNState, ctx PredictionContext, look 
 		}
 
 		if ctx != BasePredictionContextEMPTY {
-	        removed := calledRuleStack.contains(s.GetRuleIndex())
-            defer func() {
-                if removed {
-                    calledRuleStack.add(s.GetRuleIndex())
-                }
-            }()
-        	calledRuleStack.remove(s.GetRuleIndex())
+			removed := calledRuleStack.contains(s.GetRuleIndex())
+			defer func() {
+				if removed {
+					calledRuleStack.add(s.GetRuleIndex())
+				}
+			}()
+			calledRuleStack.remove(s.GetRuleIndex())
 			// run thru all possible stack tops in ctx
 			for i := 0; i < ctx.length(); i++ {
 				returnState := la.atn.states[ctx.getReturnState(i)]
@@ -198,7 +198,7 @@ func (la *LL1Analyzer) look1(s, stopState ATNState, ctx PredictionContext, look 
 	}
 }
 
-func (la *LL1Analyzer) look3(stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy *Set, calledRuleStack *BitSet, seeThruPreds, addEOF bool, t1 *RuleTransition) {
+func (la *LL1Analyzer) look3(stopState ATNState, ctx PredictionContext, look *IntervalSet, lookBusy Set, calledRuleStack *BitSet, seeThruPreds, addEOF bool, t1 *RuleTransition) {
 
 	newContext := SingletonBasePredictionContextCreate(ctx, t1.followState.GetStateNumber())
 

--- a/runtime/Go/antlr/testing_assert_test.go
+++ b/runtime/Go/antlr/testing_assert_test.go
@@ -69,7 +69,7 @@ func isNil(object interface{}) bool {
 
 func (a *assert) Panics(f func()) bool {
 	if funcDidPanic, panicValue := didPanic(f); !funcDidPanic {
-		return a.Fail(fmt.Sprintf("func %#v should panic\n\r\tPanic value:\t%v", f, panicValue))
+		return a.Fail(fmt.Sprintf("func %p should panic\n\r\tPanic value:\t%v", f, panicValue))
 	}
 
 	return true

--- a/runtime/Go/antlr/transition.go
+++ b/runtime/Go/antlr/transition.go
@@ -7,6 +7,7 @@ package antlr
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 //  atom, set, epsilon, action, predicate, rule transitions.
@@ -236,7 +237,13 @@ func (t *RangeTransition) Matches(symbol, minVocabSymbol, maxVocabSymbol int) bo
 }
 
 func (t *RangeTransition) String() string {
-	return "'" + string(t.start) + "'..'" + string(t.stop) + "'"
+	var sb strings.Builder
+	sb.WriteByte('\'')
+	sb.WriteRune(rune(t.start))
+	sb.WriteString("'..'")
+	sb.WriteRune(rune(t.stop))
+	sb.WriteByte('\'')
+	return sb.String()
 }
 
 type AbstractPredicateTransition interface {

--- a/runtime/Go/antlr/utils.go
+++ b/runtime/Go/antlr/utils.go
@@ -47,35 +47,6 @@ func (s *IntStack) Push(e int) {
 	*s = append(*s, e)
 }
 
-type Set struct {
-	data             map[int][]interface{}
-	hashcodeFunction func(interface{}) int
-	equalsFunction   func(interface{}, interface{}) bool
-}
-
-func NewSet(
-	hashcodeFunction func(interface{}) int,
-	equalsFunction func(interface{}, interface{}) bool) *Set {
-
-	s := new(Set)
-
-	s.data = make(map[int][]interface{})
-
-	if hashcodeFunction != nil {
-		s.hashcodeFunction = hashcodeFunction
-	} else {
-		s.hashcodeFunction = standardHashFunction
-	}
-
-	if equalsFunction == nil {
-		s.equalsFunction = standardEqualsFunction
-	} else {
-		s.equalsFunction = equalsFunction
-	}
-
-	return s
-}
-
 func standardEqualsFunction(a interface{}, b interface{}) bool {
 
 	ac, oka := a.(comparable)
@@ -98,72 +69,6 @@ func standardHashFunction(a interface{}) int {
 
 type hasher interface {
 	hash() int
-}
-
-func (s *Set) length() int {
-	return len(s.data)
-}
-
-func (s *Set) add(value interface{}) interface{} {
-
-	key := s.hashcodeFunction(value)
-
-	values := s.data[key]
-
-	if s.data[key] != nil {
-		for i := 0; i < len(values); i++ {
-			if s.equalsFunction(value, values[i]) {
-				return values[i]
-			}
-		}
-
-		s.data[key] = append(s.data[key], value)
-		return value
-	}
-
-	v := make([]interface{}, 1, 10)
-	v[0] = value
-	s.data[key] = v
-
-	return value
-}
-
-func (s *Set) contains(value interface{}) bool {
-
-	key := s.hashcodeFunction(value)
-
-	values := s.data[key]
-
-	if s.data[key] != nil {
-		for i := 0; i < len(values); i++ {
-			if s.equalsFunction(value, values[i]) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func (s *Set) values() []interface{} {
-	var l []interface{}
-
-	for _, v := range s.data {
-		l = append(l, v...)
-	}
-
-	return l
-}
-
-func (s *Set) String() string {
-	r := ""
-
-	for _, av := range s.data {
-		for _, v := range av {
-			r += fmt.Sprint(v)
-		}
-	}
-
-	return r
 }
 
 type BitSet struct {
@@ -353,65 +258,38 @@ func PrintArrayJavaStyle(sa []string) string {
 	return buffer.String()
 }
 
-// The following routines were lifted from bits.rotate* available in Go 1.9.
-
-const uintSize = 32 << (^uint(0) >> 32 & 1) // 32 or 64
-
-// rotateLeft returns the value of x rotated left by (k mod UintSize) bits.
-// To rotate x right by k bits, call RotateLeft(x, -k).
-func rotateLeft(x uint, k int) uint {
-	if uintSize == 32 {
-		return uint(rotateLeft32(uint32(x), k))
-	}
-	return uint(rotateLeft64(uint64(x), k))
-}
-
-// rotateLeft32 returns the value of x rotated left by (k mod 32) bits.
-func rotateLeft32(x uint32, k int) uint32 {
-	const n = 32
-	s := uint(k) & (n - 1)
-	return x<<s | x>>(n-s)
-}
-
-// rotateLeft64 returns the value of x rotated left by (k mod 64) bits.
-func rotateLeft64(x uint64, k int) uint64 {
-	const n = 64
-	s := uint(k) & (n - 1)
-	return x<<s | x>>(n-s)
-}
-
-
 // murmur hash
-const (
-	c1_32 uint = 0xCC9E2D51
-	c2_32 uint = 0x1B873593
-	n1_32 uint = 0xE6546B64
-)
-
 func murmurInit(seed int) int {
 	return seed
 }
 
-func murmurUpdate(h1 int, k1 int) int {
-	var k1u uint
-	k1u = uint(k1) * c1_32
-	k1u = rotateLeft(k1u, 15)
-	k1u *= c2_32
+func murmurUpdate(h int, value int) int {
+	const c1 uint32 = 0xCC9E2D51
+	const c2 uint32 = 0x1B873593
+	const r1 uint32 = 15
+	const r2 uint32 = 13
+	const m uint32 = 5
+	const n uint32 = 0xE6546B64
 
-	var h1u = uint(h1) ^ k1u
-	k1u = rotateLeft(k1u, 13)
-	h1u = h1u*5 + 0xe6546b64
-	return int(h1u)
+	k := uint32(value)
+	k *= c1
+	k = (k << r1) | (k >> (32 - r1))
+	k *= c2
+
+	hash := uint32(h) ^ k
+	hash = (hash << r2) | (hash >> (32 - r2))
+	hash = hash*m + n
+	return int(hash)
 }
 
-func murmurFinish(h1 int, numberOfWords int) int {
-	var h1u uint = uint(h1)
-	h1u ^= uint(numberOfWords * 4)
-	h1u ^= h1u >> 16
-	h1u *= uint(0x85ebca6b)
-	h1u ^= h1u >> 13
-	h1u *= 0xc2b2ae35
-	h1u ^= h1u >> 16
+func murmurFinish(h int, numberOfWords int) int {
+	var hash = uint32(h)
+	hash ^= uint32(numberOfWords) << 2
+	hash ^= hash >> 16
+	hash *= 0x85ebca6b
+	hash ^= hash >> 13
+	hash *= 0xc2b2ae35
+	hash ^= hash >> 16
 
-	return int(h1u)
+	return int(hash)
 }

--- a/runtime/Go/antlr/utils_set.go
+++ b/runtime/Go/antlr/utils_set.go
@@ -1,0 +1,237 @@
+package antlr
+
+import "math"
+
+const (
+	_initalCapacity       = 16
+	_initalBucketCapacity = 8
+	_loadFactor           = 0.75
+)
+
+var _ Set = (*Array2DHashSet)(nil)
+
+type Set interface {
+	Add(value interface{}) (added interface{})
+	Len() int
+	Get(value interface{}) (found interface{})
+	Contains(value interface{}) bool
+	Values() []interface{}
+	Each(f func(interface{}) bool)
+}
+
+type Array2DHashSet struct {
+	buckets          [][]interface{}
+	hashcodeFunction func(interface{}) int
+	equalsFunction   func(interface{}, interface{}) bool
+
+	n         int // How many elements in set
+	threshold int // when to expand
+
+	currentPrime          int // jump by 4 primes each expand or whatever
+	initialBucketCapacity int
+}
+
+func (as *Array2DHashSet) Each(f func(interface{}) bool) {
+	if as.Len() < 1 {
+		return
+	}
+
+	for _, bucket := range as.buckets {
+		for _, o := range bucket {
+			if o == nil {
+				break
+			}
+			if !f(o) {
+				return
+			}
+		}
+	}
+}
+
+func (as *Array2DHashSet) Values() []interface{} {
+	if as.Len() < 1 {
+		return nil
+	}
+
+	values := make([]interface{}, 0, as.Len())
+	as.Each(func(i interface{}) bool {
+		values = append(values, i)
+		return true
+	})
+	return values
+}
+
+func (as *Array2DHashSet) Contains(value interface{}) bool {
+	return as.Get(value) != nil
+}
+
+func (as *Array2DHashSet) Add(value interface{}) interface{} {
+	if as.n > as.threshold {
+		as.expand()
+	}
+	return as.innerAdd(value)
+}
+
+func (as *Array2DHashSet) expand() {
+	old := as.buckets
+
+	as.currentPrime += 4
+
+	var (
+		newCapacity      = len(as.buckets) << 1
+		newTable         = as.createBuckets(newCapacity)
+		newBucketLengths = make([]int, len(newTable))
+	)
+
+	as.buckets = newTable
+	as.threshold = int(float64(newCapacity) * _loadFactor)
+
+	for _, bucket := range old {
+		if bucket == nil {
+			continue
+		}
+
+		for _, o := range bucket {
+			if o == nil {
+				break
+			}
+
+			b := as.getBuckets(o)
+			bucketLength := newBucketLengths[b]
+			var newBucket []interface{}
+			if bucketLength == 0 {
+				// new bucket
+				newBucket = as.createBucket(as.initialBucketCapacity)
+				newTable[b] = newBucket
+			} else {
+				newBucket = newTable[b]
+				if bucketLength == len(newBucket) {
+					// expand
+					newBucketCopy := make([]interface{}, len(newBucket)<<1)
+					copy(newBucketCopy[:bucketLength], newBucket)
+					newBucket = newBucketCopy
+					newTable[b] = newBucket
+				}
+			}
+
+			newBucket[bucketLength] = o
+			newBucketLengths[b]++
+		}
+	}
+}
+
+func (as *Array2DHashSet) Len() int {
+	return as.n
+}
+
+func (as *Array2DHashSet) Get(o interface{}) interface{} {
+	if o == nil {
+		return nil
+	}
+
+	b := as.getBuckets(o)
+	bucket := as.buckets[b]
+	if bucket == nil { // no bucket
+		return nil
+	}
+
+	for _, e := range bucket {
+		if e == nil {
+			return nil // empty slot; not there
+		}
+		if as.equalsFunction(e, o) {
+			return e
+		}
+	}
+
+	return nil
+}
+
+func (as *Array2DHashSet) innerAdd(o interface{}) interface{} {
+	b := as.getBuckets(o)
+
+	bucket := as.buckets[b]
+
+	// new bucket
+	if bucket == nil {
+		bucket = as.createBucket(as.initialBucketCapacity)
+		bucket[0] = o
+
+		as.buckets[b] = bucket
+		as.n++
+		return o
+	}
+
+	// look for it in bucket
+	for i := 0; i < len(bucket); i++ {
+		existing := bucket[i]
+		if existing == nil { // empty slot; not there, add.
+			bucket[i] = o
+			as.n++
+			return o
+		}
+
+		if as.equalsFunction(existing, o) { // found existing, quit
+			return existing
+		}
+	}
+
+	// full bucket, expand and add to end
+	oldLength := len(bucket)
+	bucketCopy := make([]interface{}, oldLength<<1)
+	copy(bucketCopy[:oldLength], bucket)
+	bucket = bucketCopy
+	as.buckets[b] = bucket
+	bucket[oldLength] = o
+	as.n++
+	return o
+}
+
+func (as *Array2DHashSet) getBuckets(value interface{}) int {
+	hash := as.hashcodeFunction(value)
+	return hash & (len(as.buckets) - 1)
+}
+
+func (as *Array2DHashSet) createBuckets(cap int) [][]interface{} {
+	return make([][]interface{}, cap)
+}
+
+func (as *Array2DHashSet) createBucket(cap int) []interface{} {
+	return make([]interface{}, cap)
+}
+
+func NewArray2DHashSetWithCap(
+	hashcodeFunction func(interface{}) int,
+	equalsFunction func(interface{}, interface{}) bool,
+	initCap int,
+	initBucketCap int,
+) *Array2DHashSet {
+	if hashcodeFunction == nil {
+		hashcodeFunction = standardHashFunction
+	}
+
+	if equalsFunction == nil {
+		equalsFunction = standardEqualsFunction
+	}
+
+	ret := &Array2DHashSet{
+		hashcodeFunction: hashcodeFunction,
+		equalsFunction:   equalsFunction,
+
+		n:         0,
+		threshold: int(math.Floor(_initalCapacity * _loadFactor)),
+
+		currentPrime:          1,
+		initialBucketCapacity: initBucketCap,
+	}
+
+	ret.buckets = ret.createBuckets(initCap)
+	return ret
+}
+
+func NewArray2DHashSet(
+	hashcodeFunction func(interface{}) int,
+	equalsFunction func(interface{}, interface{}) bool,
+) *Array2DHashSet {
+	return NewArray2DHashSetWithCap(hashcodeFunction, equalsFunction, _initalCapacity, _initalBucketCapacity)
+}


### PR DESCRIPTION
Hi All:

This PR fixes several serious performance problem in Go runtime:
1. the `murmur3` implementation in Go SDK has some problem, it's not consistent with Java.
2. some hash code implementation is not correct, some of them are not consistent with Java.
3. the `Set` implementation which based on `map[int][]interface{}` has poor performance, it is not consistent with Java,  I implement the `Array2DHashSet` instead, this implementation is same with Java.
4. the hash cache is now fixed for `PredictionContext`.

Many problems have been raised, and I think this PR will fix them, please check these issues:
https://github.com/antlr/antlr4/issues/2888
https://github.com/antlr/grammars-v4/issues/2272
https://github.com/antlr/antlr4/issues/2152

The core problem in Golang runtime: it wastes too much time on hash code computing because of the incorrect `Murmur3` and `Set` and `hasher` implementation. Compare the Java and the original Go runtime, Go computes murmur3 *~80,000,000* times, but the Java runtime only *~600,000* times.

Here's my benchmark in my MBP '16 2019, the g4 files are copied from https://github.com/antlr/grammars-v4/tree/master/sql/mysql/Positive-Technologies, the original Go runtime cost *4.8s*, and this PR costs *171ms*.

Benchmark:

```go
	begin := time.Now()
	var sql string

	sql = "SELECT DATE_FORMAT(IF(COUNT(*)>0,'2021-01-02','2020-01-01'),'%Y') AS cc FROM student WHERE uid BETWEEN 1 AND 5"
	//sql = "SELECT 1"

	is := antlr.NewInputStream(sql)
	lexer := p.NewMySqlLexer(antlrx.NewCaseChangingStream(is, true))
	//lexer := p.NewMySqlLexer(is)

	ts := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)

	mp := p.NewMySqlParser(ts)
	//mp.GetInterpreter().SetPredictionMode(antlr.PredictionModeSLL)
	mp.RemoveErrorListeners()
	mp.SetErrorHandler(antlr.NewBailErrorStrategy())

	_ = mp.Root()

	fmt.Println("cost:", time.Since(begin)) 
        // COST:
        // BEFORE: 4.853549529s
        // AFTER: 171ms
        // JAVA: 20ms
```

