### PR TITLE
make Python2 runtime keep consistent with Java

### DIFF
--- a/runtime/Python2/src/antlr4/BufferedTokenStream.py
+++ b/runtime/Python2/src/antlr4/BufferedTokenStream.py
@@ -196,17 +196,17 @@ class BufferedTokenStream(TokenStream):
 
 
     # Given a starting index, return the index of the next token on channel.
-    #  Return i if tokens[i] is on channel.  Return -1 if there are no tokens
-    #  on channel between i and EOF.
+    #  Return i if tokens[i] is on channel.  Return the index of the EOF toekn
+    #  if there are no tokens on channel between i and EOF.
     #/
     def nextTokenOnChannel(self, i, channel):
         self.sync(i)
         if i>=len(self.tokens):
-            return -1
+            return len(self.tokens) - 1
         token = self.tokens[i]
         while token.channel!=channel:
             if token.type==Token.EOF:
-                return -1
+                return i
             i += 1
             self.sync(i)
             token = self.tokens[i]


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->
As mentioned in #3236 , I checked the Python2 runtime.