### PR TITLE
[Cpp] Add option for different ANTLRErrorListener

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -305,3 +305,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/07/01, marcauberer, Marc Auberer, marc.auberer@chillibits.com
 2021/07/14, renzhentaxibaerde, Renzhentaxi Baerde, renzhentaxibaerde@gmail.com
 2021/08/02, minjoosur, Minjoo Sur, msur@salesforce.com
+2021/08/15, jnooree, Nuri Jung, jnooree@snu.ac.kr

--- a/runtime/Cpp/runtime/src/Lexer.cpp
+++ b/runtime/Cpp/runtime/src/Lexer.cpp
@@ -20,12 +20,11 @@
 using namespace antlrcpp;
 using namespace antlr4;
 
-Lexer::Lexer() : Recognizer() {
-  InitializeInstanceFields();
-  _input = nullptr;
+Lexer::Lexer(ANTLRErrorListener *listener) : Lexer(nullptr, listener) {
 }
 
-Lexer::Lexer(CharStream *input) : Recognizer(), _input(input) {
+Lexer::Lexer(CharStream *input, ANTLRErrorListener *listener)
+    : Recognizer(listener), _input(input) {
   InitializeInstanceFields();
 }
 

--- a/runtime/Cpp/runtime/src/Lexer.h
+++ b/runtime/Cpp/runtime/src/Lexer.h
@@ -88,8 +88,8 @@ namespace antlr4 {
     std::vector<size_t> modeStack;
     size_t mode;
 
-    Lexer();
-    Lexer(CharStream *input);
+    Lexer(ANTLRErrorListener *listener = &ConsoleErrorListener::INSTANCE);
+    Lexer(CharStream *input, ANTLRErrorListener *listener = &ConsoleErrorListener::INSTANCE);
     virtual ~Lexer() {}
 
     virtual void reset();

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -75,7 +75,8 @@ void Parser::TrimToSizeListener::exitEveryRule(ParserRuleContext * ctx) {
   ctx->children.shrink_to_fit();
 }
 
-Parser::Parser(TokenStream *input) {
+Parser::Parser(TokenStream *input, ANTLRErrorListener *listener)
+    : Recognizer(listener) {
   InitializeInstanceFields();
   setInputStream(input);
 }
@@ -645,4 +646,3 @@ void Parser::InitializeInstanceFields() {
   _tracer = nullptr;
   _ctx = nullptr;
 }
-

--- a/runtime/Cpp/runtime/src/Parser.h
+++ b/runtime/Cpp/runtime/src/Parser.h
@@ -44,7 +44,7 @@ namespace antlr4 {
       virtual void exitEveryRule(ParserRuleContext *ctx) override;
     };
 
-    Parser(TokenStream *input);
+    Parser(TokenStream *input, ANTLRErrorListener *listener = &ConsoleErrorListener::INSTANCE);
     virtual ~Parser();
 
     /// reset the parser's state

--- a/runtime/Cpp/runtime/src/Recognizer.cpp
+++ b/runtime/Cpp/runtime/src/Recognizer.cpp
@@ -22,9 +22,9 @@ using namespace antlr4::atn;
 std::map<const dfa::Vocabulary*, std::map<std::string, size_t>> Recognizer::_tokenTypeMapCache;
 std::map<std::vector<std::string>, std::map<std::string, size_t>> Recognizer::_ruleIndexMapCache;
 
-Recognizer::Recognizer() {
+Recognizer::Recognizer(ANTLRErrorListener *listener) {
   InitializeInstanceFields();
-  _proxListener.addErrorListener(&ConsoleErrorListener::INSTANCE);
+  _proxListener.addErrorListener(listener);
 }
 
 Recognizer::~Recognizer() {
@@ -164,4 +164,3 @@ void Recognizer::InitializeInstanceFields() {
   _stateNumber = ATNState::INVALID_STATE_NUMBER;
   _interpreter = nullptr;
 }
-

--- a/runtime/Cpp/runtime/src/Recognizer.h
+++ b/runtime/Cpp/runtime/src/Recognizer.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "ProxyErrorListener.h"
+#include "ConsoleErrorListener.h"
 
 namespace antlr4 {
 
@@ -19,7 +20,7 @@ namespace antlr4 {
     };
 #endif
 
-    Recognizer();
+    Recognizer(ANTLRErrorListener *listener = &ConsoleErrorListener::INSTANCE);
     Recognizer(Recognizer const&) = delete;
     virtual ~Recognizer();
 


### PR DESCRIPTION
Currently, a `Parser` or `Lexer` could only be instantiated with the default `ConsoleErrorListener` instance. However, it would be better to have an option for a custom `ErrorListener` object at the instantiation time, for both performance and readability.

This commit will add a parameter named `listener`, which has the default parameter of `&ConsoleErrorListener::INSTANCE` for API stability.