### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 script:
   - |
     cd runtime-testsuite;
-    travis_wait 40 ../.travis/run-tests-$TARGET.sh
+ ../.travis/run-tests-$TARGET.sh
     rc=$?
     cat target/surefire-reports/*.dumpstream || true
     exit $rc


### PR DESCRIPTION
According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.