### PR TITLE
[Swift] Changes to Mutex-es to guard the staticly shared [DFA]

### DIFF
--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
@@ -72,16 +72,6 @@ open class LexerATNSimulator: ATNSimulator {
     public private(set) final var decisionToDFA: [DFA]
     
     internal var mode = Lexer.DEFAULT_MODE
-    
-    /// 
-    /// mutex for DFAState change
-    /// 
-    private let dfaStateMutex = Mutex()
-    
-    /// 
-    /// mutex for changes to all DFAStates map
-    /// 
-    private let dfaStatesMutex = Mutex()
 
     /// 
     /// Used during DFA/ATN exec to record the most recent accept configuration info
@@ -675,7 +665,7 @@ open class LexerATNSimulator: ATNSimulator {
             print("EDGE \(p) -> \(q) upon \(t)")
         }
 
-        dfaStateMutex.synchronized {
+        p.mutex.synchronized {
             if p.edges == nil {
                 //  make room for tokens 1..n and -1 masquerading as index 0
                 p.edges = [DFAState?](repeating: nil, count: LexerATNSimulator.MAX_DFA_EDGE - LexerATNSimulator.MIN_DFA_EDGE + 1)
@@ -709,7 +699,7 @@ open class LexerATNSimulator: ATNSimulator {
 
         let dfa = decisionToDFA[mode]
 
-        return dfaStatesMutex.synchronized {
+        return dfa.statesMutex.synchronized {
             if let existing = dfa.states[proposed] {
                 return existing
             }

--- a/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
@@ -277,16 +277,6 @@ open class ParserATNSimulator: ATNSimulator {
     internal var _startIndex = 0
     internal var _outerContext: ParserRuleContext!
     internal var _dfa: DFA?
-    
-    /// 
-    /// mutex for DFAState change
-    /// 
-    private let dfaStateMutex = Mutex()
-    
-    /// 
-    /// mutex for changes in a DFAStates map
-    /// 
-    private let dfaStatesMutex = Mutex()
 
 //    /// Testing only!
 //    public convenience init(_ atn : ATN, _ decisionToDFA : [DFA],
@@ -1965,7 +1955,7 @@ open class ParserATNSimulator: ATNSimulator {
         if t < -1 || t > atn.maxTokenType {
             return to
         }
-        dfaStateMutex.synchronized {
+        from.mutex.synchronized {
             [unowned self] in
             if from.edges == nil {
                 from.edges = [DFAState?](repeating: nil, count: self.atn.maxTokenType + 1 + 1)       //new DFAState[atn.maxTokenType+1+1];
@@ -2001,7 +1991,7 @@ open class ParserATNSimulator: ATNSimulator {
             return D
         }
         
-        return dfaStatesMutex.synchronized {
+        return dfa.statesMutex.synchronized {
             if let existing = dfa.states[D] {
                 return existing
             }

--- a/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
@@ -29,7 +29,12 @@ public class DFA: CustomStringConvertible {
     /// 
     /// mutex for DFAState changes.
     /// 
-    private let dfaStateMutex = Mutex()
+    internal private(set) var dfaStateMutex = Mutex()
+    
+    ///
+    /// mutex for states changes.
+    ///
+    internal private(set) var statesMutex = Mutex()
 
     public convenience init(_ atnStartState: DecisionState) {
         self.init(atnStartState, 0)

--- a/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
@@ -26,11 +26,6 @@ public class DFA: CustomStringConvertible {
     /// 
     private let precedenceDfa: Bool
     
-    /// 
-    /// mutex for DFAState changes.
-    /// 
-    internal private(set) var dfaStateMutex = Mutex()
-    
     ///
     /// mutex for states changes.
     ///
@@ -118,7 +113,7 @@ public class DFA: CustomStringConvertible {
 
         // synchronization on s0 here is ok. when the DFA is turned into a
         // precedence DFA, s0 will be initialized once and not updated again
-        dfaStateMutex.synchronized {
+        s0.mutex.synchronized {
             // s0.edges is never null for a precedence DFA
             if precedence >= edges.count {
                 let increase = [DFAState?](repeating: nil, count: (precedence + 1 - edges.count))

--- a/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
@@ -76,6 +76,11 @@ public final class DFAState: Hashable, CustomStringConvertible {
     /// 
 
     public internal(set) var predicates: [PredPrediction]?
+    
+    ///
+    /// mutex for states changes.
+    ///
+    internal private(set) var mutex = Mutex()
 
     /// 
     /// Map a predicate to a predicted alternative.

--- a/runtime/Swift/Tests/Antlr4Tests/Threading.g4
+++ b/runtime/Swift/Tests/Antlr4Tests/Threading.g4
@@ -1,0 +1,6 @@
+grammar Threading;
+
+NUMBER : [0-9] ;
+WS : [ \r\n\t] + -> skip ;
+
+operation : l=NUMBER op='+' r=NUMBER ;

--- a/runtime/Swift/Tests/Antlr4Tests/Threading.g4
+++ b/runtime/Swift/Tests/Antlr4Tests/Threading.g4
@@ -1,6 +1,18 @@
 grammar Threading;
 
-NUMBER : [0-9] ;
-WS : [ \r\n\t] + -> skip ;
+s
+    :   expr EOF
+    ;
 
-operation : l=NUMBER op='+' r=NUMBER ;
+expr
+    :   INT                     # number
+    |   expr (MUL | DIV) expr   # multiply
+    |   expr (ADD | SUB) expr   # add
+    ;
+
+INT : [0-9]+;
+MUL : '*';
+DIV : '/';
+ADD : '+';
+SUB : '-';
+WS : [ \t]+ -> channel(HIDDEN);

--- a/runtime/Swift/Tests/Antlr4Tests/ThreadingTests.swift
+++ b/runtime/Swift/Tests/Antlr4Tests/ThreadingTests.swift
@@ -1,0 +1,35 @@
+/// Copyright (c) 2012-2021 The ANTLR Project. All rights reserved.
+/// Use of this file is governed by the BSD 3-clause license that
+/// can be found in the LICENSE.txt file in the project root.
+
+import XCTest
+import Antlr4
+
+class ThreadingTests: XCTestCase {
+    static let allTests = [
+        ("testParallelExecution", testParallelExecution),
+    ]
+
+    ///
+    /// This test verifies parallel execution of the parser
+    ///
+    func testParallelExecution() throws {
+        let expectation = expectation(description: "Waiting on async-task")
+        expectation.expectedFulfillmentCount = 100
+        for _ in 0...100 {
+            DispatchQueue.global().async {
+                let lexer = ThreadingLexer(ANTLRInputStream("1+1"))
+                let tokenStream = CommonTokenStream(lexer)
+                let parser = try? ThreadingParser(tokenStream)
+
+                let _ = try? parser?.operation()
+
+                expectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 30.0) { (_) in
+            print("Completed")
+        }
+    }
+}

--- a/runtime/Swift/Tests/Antlr4Tests/ThreadingTests.swift
+++ b/runtime/Swift/Tests/Antlr4Tests/ThreadingTests.swift
@@ -14,15 +14,24 @@ class ThreadingTests: XCTestCase {
     /// This test verifies parallel execution of the parser
     ///
     func testParallelExecution() throws {
+        let input = [
+            "2 * 8 - 4",
+            "2 + 8 / 4",
+            "2 - 8 - 4",
+            "2 * 8 * 4",
+            "2 / 8 / 4",
+            "2 + 8 + 4",
+            "890",
+        ]
         let expectation = expectation(description: "Waiting on async-task")
-        expectation.expectedFulfillmentCount = 100
-        for _ in 0...100 {
+        expectation.expectedFulfillmentCount = 77
+        for i in 0...77 {
             DispatchQueue.global().async {
-                let lexer = ThreadingLexer(ANTLRInputStream("1+1"))
+                let lexer = ThreadingLexer(ANTLRInputStream(input[i % 7]))
                 let tokenStream = CommonTokenStream(lexer)
                 let parser = try? ThreadingParser(tokenStream)
 
-                let _ = try? parser?.operation()
+                let _ = try? parser?.s()
 
                 expectation.fulfill()
             }

--- a/runtime/Swift/Tests/Antlr4Tests/ThreadingTests.swift
+++ b/runtime/Swift/Tests/Antlr4Tests/ThreadingTests.swift
@@ -24,8 +24,8 @@ class ThreadingTests: XCTestCase {
             "890",
         ]
         let expectation = expectation(description: "Waiting on async-task")
-        expectation.expectedFulfillmentCount = 77
-        for i in 0...77 {
+        expectation.expectedFulfillmentCount = 100
+        for i in 1...100 {
             DispatchQueue.global().async {
                 let lexer = ThreadingLexer(ANTLRInputStream(input[i % 7]))
                 let tokenStream = CommonTokenStream(lexer)


### PR DESCRIPTION
Request for review: @janyou, @ewanmellor, @hanjoes, @rmehta33 

By sharing the mutex in the same way as the DFA array it becomes possible to run in parallel

Fixes #3271