### PR TITLE
[Swift] remove usages of return where it can be omitted

### DIFF
--- a/runtime/Swift/Sources/Antlr4/ANTLRFileStream.swift
+++ b/runtime/Swift/Sources/Antlr4/ANTLRFileStream.swift
@@ -21,6 +21,6 @@ public class ANTLRFileStream: ANTLRInputStream {
 
     override
     public func getSourceName() -> String {
-        return fileName
+        fileName
     }
 }

--- a/runtime/Swift/Sources/Antlr4/ANTLRInputStream.swift
+++ b/runtime/Swift/Sources/Antlr4/ANTLRInputStream.swift
@@ -94,7 +94,7 @@ public class ANTLRInputStream: CharStream {
     }
 
     public func LT(_ i: Int) -> Int {
-        return LA(i)
+        LA(i)
     }
 
     /// 
@@ -103,11 +103,11 @@ public class ANTLRInputStream: CharStream {
     /// be returned from LA(1).
     /// 
     public func index() -> Int {
-        return p
+        p
     }
 
     public func size() -> Int {
-        return n
+        n
     }
 
     /// 
@@ -115,7 +115,7 @@ public class ANTLRInputStream: CharStream {
     /// 
 
     public func mark() -> Int {
-        return -1
+        -1
     }
 
     public func release(_ marker: Int) {
@@ -149,10 +149,10 @@ public class ANTLRInputStream: CharStream {
     }
 
     public func getSourceName() -> String {
-        return name ?? ANTLRInputStream.UNKNOWN_SOURCE_NAME
+        name ?? ANTLRInputStream.UNKNOWN_SOURCE_NAME
     }
 
     public func toString() -> String {
-        return String(data)
+        String(data)
     }
 }

--- a/runtime/Swift/Sources/Antlr4/BufferedTokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/BufferedTokenStream.swift
@@ -66,17 +66,17 @@ public class BufferedTokenStream: TokenStream {
 
 
     public func getTokenSource() -> TokenSource {
-        return tokenSource
+        tokenSource
     }
 
 
     public func index() -> Int {
-        return p
+        p
     }
 
 
     public func mark() -> Int {
-        return 0
+        0
     }
 
     public func release(_ marker: Int) {
@@ -95,7 +95,7 @@ public class BufferedTokenStream: TokenStream {
 
 
     public func size() -> Int {
-        return tokens.count
+        tokens.count
     }
 
 
@@ -201,7 +201,7 @@ public class BufferedTokenStream: TokenStream {
     }
 
     public func LA(_ i: Int) throws -> Int {
-        return try LT(i)!.getType()
+        try LT(i)!.getType()
     }
 
     internal func LB(_ k: Int) throws -> Token? {
@@ -245,7 +245,7 @@ public class BufferedTokenStream: TokenStream {
     /// - returns: The adjusted target token index.
     /// 
     internal func adjustSeekIndex(_ i: Int) throws -> Int {
-        return i
+        i
     }
 
     internal final func lazyInit() throws {
@@ -270,11 +270,11 @@ public class BufferedTokenStream: TokenStream {
     }
 
     public func getTokens() -> [Token] {
-        return tokens
+        tokens
     }
 
     public func getTokens(_ start: Int, _ stop: Int) throws -> [Token]? {
-        return try getTokens(start, stop, nil)
+        try getTokens(start, stop, nil)
     }
 
     /// 
@@ -443,14 +443,14 @@ public class BufferedTokenStream: TokenStream {
 
 
     public func getSourceName() -> String {
-        return tokenSource.getSourceName()
+        tokenSource.getSourceName()
     }
 
     /// 
     /// Get the text of all tokens in this buffer.
     /// 
     public func getText() throws -> String {
-        return try getText(Interval.of(0, size() - 1))
+        try getText(Interval.of(0, size() - 1))
     }
 
     public func getText(_ interval: Interval) throws -> String {
@@ -472,7 +472,7 @@ public class BufferedTokenStream: TokenStream {
 
 
     public func getText(_ ctx: RuleContext) throws -> String {
-        return try getText(ctx.getSourceInterval())
+        try getText(ctx.getSourceInterval())
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/CommonToken.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonToken.swift
@@ -127,7 +127,7 @@ public class CommonToken: WritableToken {
 
 
     public func getType() -> Int {
-        return type
+        type
     }
 
 
@@ -174,12 +174,12 @@ public class CommonToken: WritableToken {
     }
 
     public func getLine() -> Int {
-        return line
+        line
     }
 
 
     public func getCharPositionInLine() -> Int {
-        return charPositionInLine
+        charPositionInLine
     }
 
 
@@ -189,7 +189,7 @@ public class CommonToken: WritableToken {
 
 
     public func getChannel() -> Int {
-        return channel
+        channel
     }
 
 
@@ -204,7 +204,7 @@ public class CommonToken: WritableToken {
 
 
     public func getStartIndex() -> Int {
-        return start
+        start
     }
 
     public func setStartIndex(_ start: Int) {
@@ -213,7 +213,7 @@ public class CommonToken: WritableToken {
 
 
     public func getStopIndex() -> Int {
-        return stop
+        stop
     }
 
     public func setStopIndex(_ stop: Int) {
@@ -222,7 +222,7 @@ public class CommonToken: WritableToken {
 
 
     public func getTokenIndex() -> Int {
-        return index
+        index
     }
 
 
@@ -232,20 +232,20 @@ public class CommonToken: WritableToken {
 
 
     public func getTokenSource() -> TokenSource? {
-        return source.tokenSource
+        source.tokenSource
     }
 
 
     public func getInputStream() -> CharStream? {
-        return source.stream
+        source.stream
     }
 
     public func getTokenSourceAndStream() -> TokenSourceAndStream {
-        return source
+        source
     }
 
     public var description: String {
-        return toString(nil)
+        toString(nil)
     }
 
     public func toString(_ r: Recognizer<ATNSimulator>?) -> String {
@@ -271,7 +271,7 @@ public class CommonToken: WritableToken {
 
     public var visited: Bool {
         get {
-            return _visited
+            _visited
         }
 
         set {

--- a/runtime/Swift/Sources/Antlr4/CommonTokenFactory.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonTokenFactory.swift
@@ -83,6 +83,6 @@ public class CommonTokenFactory: TokenFactory {
 
 
     public func create(_ type: Int, _ text: String) -> Token {
-        return CommonToken(type, text)
+        CommonToken(type, text)
     }
 }

--- a/runtime/Swift/Sources/Antlr4/CommonTokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/CommonTokenStream.swift
@@ -68,7 +68,7 @@ public class CommonTokenStream: BufferedTokenStream {
 
     override
     internal func adjustSeekIndex(_ i: Int) throws -> Int {
-        return try nextTokenOnChannel(i, channel)
+        try nextTokenOnChannel(i, channel)
     }
 
     override

--- a/runtime/Swift/Sources/Antlr4/DefaultErrorStrategy.swift
+++ b/runtime/Swift/Sources/Antlr4/DefaultErrorStrategy.swift
@@ -70,7 +70,7 @@ open class DefaultErrorStrategy: ANTLRErrorStrategy {
     }
 
     open func inErrorRecoveryMode(_ recognizer: Parser) -> Bool {
-        return errorRecoveryMode
+        errorRecoveryMode
     }
 
     /// 
@@ -551,7 +551,7 @@ open class DefaultErrorStrategy: ANTLRErrorStrategy {
     /// override this method to create the appropriate tokens.
     /// 
     open func getTokenStream(_ recognizer: Parser) -> TokenStream {
-        return recognizer.getInputStream() as! TokenStream
+        recognizer.getInputStream() as! TokenStream
     }
 
     open func getMissingSymbol(_ recognizer: Parser) throws -> Token {
@@ -582,7 +582,7 @@ open class DefaultErrorStrategy: ANTLRErrorStrategy {
 
 
     open func getExpectedTokens(_ recognizer: Parser) throws -> IntervalSet {
-        return try recognizer.getExpectedTokens()
+        try recognizer.getExpectedTokens()
     }
 
     /// 
@@ -610,11 +610,11 @@ open class DefaultErrorStrategy: ANTLRErrorStrategy {
     }
 
     open func getSymbolText(_ symbol: Token) -> String? {
-        return symbol.getText()
+        symbol.getText()
     }
 
     open func getSymbolType(_ symbol: Token) -> Int {
-        return symbol.getType()
+        symbol.getType()
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/DiagnosticErrorListener.swift
+++ b/runtime/Swift/Sources/Antlr4/DiagnosticErrorListener.swift
@@ -126,7 +126,7 @@ public class DiagnosticErrorListener: BaseErrorListener {
     /// returns the set of alternatives represented in `configs`.
     /// 
     internal func getConflictingAlts(_ reportedAlts: BitSet?, _ configs: ATNConfigSet) -> BitSet {
-        return reportedAlts ?? configs.getAltBitSet()
+        reportedAlts ?? configs.getAltBitSet()
     }
 }
 

--- a/runtime/Swift/Sources/Antlr4/FailedPredicateException.swift
+++ b/runtime/Swift/Sources/Antlr4/FailedPredicateException.swift
@@ -38,15 +38,15 @@ public class FailedPredicateException: RecognitionException {
 	}
 
 	public func getRuleIndex() -> Int {
-		return ruleIndex
+        ruleIndex
 	}
 
 	public func getPredIndex() -> Int {
-		return predicateIndex
+        predicateIndex
 	}
 
 	public func getPredicate() -> String? {
-		return predicate
+        predicate
 	}
 
 

--- a/runtime/Swift/Sources/Antlr4/InterpreterRuleContext.swift
+++ b/runtime/Swift/Sources/Antlr4/InterpreterRuleContext.swift
@@ -46,7 +46,7 @@ public class InterpreterRuleContext: ParserRuleContext {
 
     override
     public func getRuleIndex() -> Int {
-        return ruleIndex
+        ruleIndex
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/Lexer.swift
+++ b/runtime/Swift/Sources/Antlr4/Lexer.swift
@@ -229,7 +229,7 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
 
 
     open override func getTokenFactory() -> TokenFactory {
-        return _factory
+        _factory
     }
 
     /// 
@@ -246,12 +246,12 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
 
 
     open func getSourceName() -> String {
-        return _input!.getSourceName()
+        _input!.getSourceName()
     }
 
 
     open func getInputStream() -> CharStream? {
-        return _input
+        _input
     }
 
     /// 
@@ -299,12 +299,12 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
 
 
     open func getLine() -> Int {
-        return getInterpreter().getLine()
+        getInterpreter().getLine()
     }
 
 
     open func getCharPositionInLine() -> Int {
-        return getInterpreter().getCharPositionInLine()
+        getInterpreter().getCharPositionInLine()
     }
 
     open func setLine(_ line: Int) {
@@ -319,7 +319,7 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
     /// What is the index of the current character of lookahead?
     /// 
     open func getCharIndex() -> Int {
-        return _input!.index()
+        _input!.index()
     }
 
     /// 
@@ -345,7 +345,7 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
     /// Override if emitting multiple tokens.
     /// 
     open func getToken() -> Token {
-        return _token!
+        _token!
     }
 
     open func setToken(_ _token: Token) {
@@ -357,7 +357,7 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
     }
 
     open func getType() -> Int {
-        return _type
+        _type
     }
 
     open func setChannel(_ channel: Int) {
@@ -365,15 +365,15 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
     }
 
     open func getChannel() -> Int {
-        return _channel
+        _channel
     }
 
     open func getChannelNames() -> [String]? {
-        return nil
+        nil
     }
 
     open func getModeNames() -> [String]? {
-        return nil
+        nil
     }
 
     /// 
@@ -453,6 +453,6 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
     }
 
     internal func makeTokenSourceAndStream() -> TokenSourceAndStream {
-        return TokenSourceAndStream(self, _input)
+        TokenSourceAndStream(self, _input)
     }
 }

--- a/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerInterpreter.swift
@@ -46,27 +46,27 @@ public class LexerInterpreter: Lexer {
 
     override
     public func getATN() -> ATN {
-        return atn
+        atn
     }
 
     override
     public func getGrammarFileName() -> String {
-        return grammarFileName
+        grammarFileName
     }
 
     override
     public func getRuleNames() -> [String] {
-        return ruleNames
+        ruleNames
     }
 
     override
     public func getChannelNames() -> [String] {
-        return channelNames
+        channelNames
     }
 
     override
     public func getModeNames() -> [String] {
-        return modeNames
+        modeNames
     }
 
     override

--- a/runtime/Swift/Sources/Antlr4/LexerNoViableAltException.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerNoViableAltException.swift
@@ -28,11 +28,11 @@ public class LexerNoViableAltException: RecognitionException, CustomStringConver
     }
 
     public func getStartIndex() -> Int {
-        return startIndex
+        startIndex
     }
 
     public func getDeadEndConfigs() -> ATNConfigSet {
-        return deadEndConfigs
+        deadEndConfigs
     }
 
     public var description: String {

--- a/runtime/Swift/Sources/Antlr4/ListTokenSource.swift
+++ b/runtime/Swift/Sources/Antlr4/ListTokenSource.swift
@@ -191,6 +191,6 @@ public class ListTokenSource: TokenSource {
     }
 
     public func getTokenFactory() -> TokenFactory {
-        return _factory
+        _factory
     }
 }

--- a/runtime/Swift/Sources/Antlr4/NoViableAltException.swift
+++ b/runtime/Swift/Sources/Antlr4/NoViableAltException.swift
@@ -51,12 +51,12 @@ public class NoViableAltException: RecognitionException {
 
 
     public func getStartToken() -> Token {
-        return startToken
+        startToken
     }
 
 
     public func getDeadEndConfigs() -> ATNConfigSet? {
-        return deadEndConfigs
+        deadEndConfigs
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/Parser.swift
+++ b/runtime/Swift/Sources/Antlr4/Parser.swift
@@ -257,7 +257,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// parsing, otherwise `false`
     /// 
     public func getBuildParseTree() -> Bool {
-        return _buildParseTrees
+        _buildParseTrees
     }
 
     /// 
@@ -283,11 +283,11 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// using the default _org.antlr.v4.runtime.Parser.TrimToSizeListener_ during the parse process.
     /// 
     public func getTrimParseTree() -> Bool {
-        return !getParseListeners().filter({ $0 === TrimToSizeListener.INSTANCE }).isEmpty
+        !getParseListeners().filter({ $0 === TrimToSizeListener.INSTANCE }).isEmpty
     }
 
     public func getParseListeners() -> [ParseTreeListener] {
-        return _parseListeners ?? [ParseTreeListener]()
+        _parseListeners ?? [ParseTreeListener]()
     }
 
     /// 
@@ -395,12 +395,12 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// - SeeAlso: #notifyErrorListeners
     /// 
     public func getNumberOfSyntaxErrors() -> Int {
-        return _syntaxErrors
+        _syntaxErrors
     }
 
     override
     open func getTokenFactory() -> TokenFactory {
-        return _input.getTokenSource().getTokenFactory()
+        _input.getTokenSource().getTokenFactory()
     }
 
     /// Tell our token source and error strategy about a new way to create tokens.
@@ -462,7 +462,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
 
     public func getErrorHandler() -> ANTLRErrorStrategy {
-        return _errHandler
+        _errHandler
     }
 
     public func setErrorHandler(_ handler: ANTLRErrorStrategy) {
@@ -471,7 +471,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
     override
     open func getInputStream() -> IntStream? {
-        return getTokenStream()
+        getTokenStream()
     }
 
     override
@@ -480,7 +480,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     }
 
     public func getTokenStream() -> TokenStream? {
-        return _input
+        _input
     }
 
     /// Set the token stream and reset the parser.
@@ -496,7 +496,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// 
 
     public func getCurrentToken() throws -> Token {
-        return try _input.LT(1)!
+        try _input.LT(1)!
     }
 
     public final func notifyErrorListeners(_ msg: String) {
@@ -577,7 +577,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// - Since: 4.7
     /// 
     public func createTerminalNode(parent: ParserRuleContext, t: Token) -> TerminalNode {
-        return TerminalNodeImpl(t)
+        TerminalNodeImpl(t)
     }
 
     /// How to create an error node, given a token, associated with a parent.
@@ -586,7 +586,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// - Since: 4.7
     /// 
     public func createErrorNode(parent: ParserRuleContext, t: Token) -> ErrorNode {
-        return ErrorNode(t)
+        ErrorNode(t)
     }
 
     internal func addContextToParseTree() {
@@ -730,7 +730,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     }
 
     public func getContext() -> ParserRuleContext? {
-        return _ctx
+        _ctx
     }
 
     public func setContext(_ ctx: ParserRuleContext) {
@@ -739,12 +739,12 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
     override
     open func precpred(_ localctx: RuleContext?, _ precedence: Int) -> Bool {
-        return precedence >= _precedenceStack.peek()!
+        precedence >= _precedenceStack.peek()!
     }
 
     public func inContext(_ context: String) -> Bool {
         // TODO: useful in parser?
-        return false
+        false
     }
 
     /// Given an AmbiguityInfo object that contains information about an
@@ -909,7 +909,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// - SeeAlso: org.antlr.v4.runtime.atn.ATN#getExpectedTokens(int, org.antlr.v4.runtime.RuleContext)
     /// 
     public func getExpectedTokens() throws -> IntervalSet {
-        return try getATN().getExpectedTokens(getState(), getContext()!)
+        try getATN().getExpectedTokens(getState(), getContext()!)
     }
 
 
@@ -921,11 +921,11 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
     /// Get a rule's index (i.e., `RULE_ruleName` field) or -1 if not found.
     public func getRuleIndex(_ ruleName: String) -> Int {
-        return getRuleIndexMap()[ruleName] ?? -1
+        getRuleIndexMap()[ruleName] ?? -1
     }
 
     public func getRuleContext() -> ParserRuleContext? {
-        return _ctx
+        _ctx
     }
 
     /// Return List&lt;String&gt; of the rule names in your parser instance
@@ -936,7 +936,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// This is very useful for error messages.
     /// 
     public func getRuleInvocationStack() -> [String] {
-        return getRuleInvocationStack(_ctx)
+        getRuleInvocationStack(_ctx)
     }
 
     public func getRuleInvocationStack(_ p: RuleContext?) -> [String] {
@@ -987,7 +987,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
     }
 
     public func getSourceName() -> String {
-        return _input.getSourceName()
+        _input.getSourceName()
     }
 
     override
@@ -1041,6 +1041,6 @@ open class Parser: Recognizer<ParserATNSimulator> {
     /// - SeeAlso: #setTrace(boolean)
     /// 
     public func isTrace() -> Bool {
-        return _tracer != nil
+        _tracer != nil
     }
 }

--- a/runtime/Swift/Sources/Antlr4/ParserInterpreter.swift
+++ b/runtime/Swift/Sources/Antlr4/ParserInterpreter.swift
@@ -98,22 +98,22 @@ public class ParserInterpreter: Parser {
 
     override
     public func getATN() -> ATN {
-        return atn
+        atn
     }
 
     override
     public func getVocabulary() -> Vocabulary {
-        return vocabulary
+        vocabulary
     }
 
     override
     public func getRuleNames() -> [String] {
-        return ruleNames
+        ruleNames
     }
 
     override
     public func getGrammarFileName() -> String {
-        return grammarFileName
+        grammarFileName
     }
 
     /// Begin parsing at startRuleIndex
@@ -171,7 +171,7 @@ public class ParserInterpreter: Parser {
     }
 
     internal func getATNState() -> ATNState? {
-        return atn.states[getState()]
+        atn.states[getState()]
     }
 
     internal func visitState(_ p: ATNState) throws {

--- a/runtime/Swift/Sources/Antlr4/ParserRuleContext.swift
+++ b/runtime/Swift/Sources/Antlr4/ParserRuleContext.swift
@@ -213,7 +213,7 @@ open class ParserRuleContext: RuleContext {
     }
 
     open func getRuleContext<T: ParserRuleContext>(_ ctxType: T.Type, _ i: Int) -> T? {
-        return getChild(ctxType, i: i)
+        getChild(ctxType, i: i)
     }
 
     open func getRuleContexts<T: ParserRuleContext>(_ ctxType: T.Type) -> [T] {
@@ -225,12 +225,12 @@ open class ParserRuleContext: RuleContext {
 
     override
     open func getChildCount() -> Int {
-        return children?.count ?? 0
+        children?.count ?? 0
     }
 
     override
     open subscript(index: Int) -> ParseTree {
-        return children![index]
+        children![index]
     }
 
     override
@@ -247,7 +247,7 @@ open class ParserRuleContext: RuleContext {
     /// (for example, zero length or error productions) this token may exceed stop.
     /// 
     open func getStart() -> Token? {
-        return start
+        start
     }
     /// 
     /// Get the final token in this context.
@@ -255,7 +255,7 @@ open class ParserRuleContext: RuleContext {
     /// (for example, zero length or error productions) this token may precede start.
     /// 
     open func getStop() -> Token? {
-        return stop
+        stop
     }
 
     /// Used for rule context info debugging during parse-time, not so much for ATN debugging

--- a/runtime/Swift/Sources/Antlr4/RecognitionException.swift
+++ b/runtime/Swift/Sources/Antlr4/RecognitionException.swift
@@ -55,7 +55,7 @@ public class RecognitionException {
     /// If the state number is not known, this method returns -1.
     /// 
     public func getOffendingState() -> Int {
-        return offendingState
+        offendingState
     }
 
     internal final func setOffendingState(_ offendingState: Int) {
@@ -88,7 +88,7 @@ public class RecognitionException {
     /// If the context is not available, this method returns `null`.
     /// 
     public func getCtx() -> RuleContext? {
-        return ctx
+        ctx
     }
 
     /// 
@@ -102,7 +102,7 @@ public class RecognitionException {
     /// available.
     /// 
     public func getInputStream() -> IntStream? {
-        return input
+        input
     }
 
     public func clearInputStream() {
@@ -110,7 +110,7 @@ public class RecognitionException {
     }
 
     public func getOffendingToken() -> Token {
-        return offendingToken
+        offendingToken
     }
 
     internal final func setOffendingToken(_ offendingToken: Token) {
@@ -126,7 +126,7 @@ public class RecognitionException {
     /// the recognizer is not available.
     /// 
     public func getRecognizer() -> RecognizerProtocol? {
-        return recognizer
+        recognizer
     }
 
     public func clearRecognizer() {

--- a/runtime/Swift/Sources/Antlr4/Recognizer.swift
+++ b/runtime/Swift/Sources/Antlr4/Recognizer.swift
@@ -45,7 +45,7 @@ open class Recognizer<ATNInterpreter: ATNSimulator>: RecognizerProtocol {
     /// Used for XPath and tree pattern compilation.
     /// 
     public func getTokenTypeMap() -> [String: Int] {
-        return tokenTypeMap
+        tokenTypeMap
     }
 
     public lazy var tokenTypeMap: [String: Int] = {
@@ -75,7 +75,7 @@ open class Recognizer<ATNInterpreter: ATNSimulator>: RecognizerProtocol {
     /// Used for XPath and tree pattern compilation.
     /// 
     public func getRuleIndexMap() -> [String : Int] {
-        return ruleIndexMap
+        ruleIndexMap
     }
 
     public lazy var ruleIndexMap: [String: Int] = {
@@ -85,7 +85,7 @@ open class Recognizer<ATNInterpreter: ATNSimulator>: RecognizerProtocol {
 
 
     public func getTokenType(_ tokenName: String) -> Int {
-        return getTokenTypeMap()[tokenName] ?? CommonToken.INVALID_TYPE
+        getTokenTypeMap()[tokenName] ?? CommonToken.INVALID_TYPE
     }
 
     /// 
@@ -121,7 +121,7 @@ open class Recognizer<ATNInterpreter: ATNSimulator>: RecognizerProtocol {
     /// - Returns: The ATN interpreter used by the recognizer for prediction.
     /// 
     open func getInterpreter() -> ATNInterpreter {
-        return _interp
+        _interp
     }
 
     /// If profiling during the parse/lex, this will return DecisionInfo records
@@ -130,7 +130,7 @@ open class Recognizer<ATNInterpreter: ATNSimulator>: RecognizerProtocol {
     /// - Since: 4.3
     /// 
     open func getParseInfo() -> ParseInfo? {
-        return nil
+        nil
     }
 
     /// 
@@ -168,28 +168,28 @@ open class Recognizer<ATNInterpreter: ATNSimulator>: RecognizerProtocol {
     }
 
     open func getErrorListeners() -> [ANTLRErrorListener] {
-        return _listeners
+        _listeners
     }
 
     open func getErrorListenerDispatch() -> ANTLRErrorListener {
-        return ProxyErrorListener(getErrorListeners())
+        ProxyErrorListener(getErrorListeners())
     }
 
     // subclass needs to override these if there are sempreds or actions
     // that the ATN interp needs to execute
     open func sempred(_ _localctx: RuleContext?, _ ruleIndex: Int, _ actionIndex: Int) throws -> Bool {
-        return true
+        true
     }
 
     open func precpred(_ localctx: RuleContext?, _ precedence: Int) -> Bool {
-        return true
+        true
     }
 
     open func action(_ _localctx: RuleContext?, _ ruleIndex: Int, _ actionIndex: Int) throws {
     }
 
     public final func getState() -> Int {
-        return _stateNumber
+        _stateNumber
     }
 
     /// Indicate that the recognizer has changed internal state that is

--- a/runtime/Swift/Sources/Antlr4/RuleContext.swift
+++ b/runtime/Swift/Sources/Antlr4/RuleContext.swift
@@ -91,21 +91,21 @@ open class RuleContext: RuleNode {
     /// current context.
     /// 
     open func isEmpty() -> Bool {
-        return invokingState == -1
+        invokingState == -1
     }
 
     // satisfy the ParseTree / SyntaxTree interface
 
     open func getSourceInterval() -> Interval {
-        return Interval.INVALID
+        Interval.INVALID
     }
 
     open func getRuleContext() -> RuleContext {
-        return self
+        self
     }
 
     open func getParent() -> Tree? {
-        return parent
+        parent
     }
 
     open func setParent(_ parent: RuleContext) {
@@ -113,7 +113,7 @@ open class RuleContext: RuleNode {
     }
 
     open func getPayload() -> AnyObject {
-        return self
+        self
     }
 
     /// Return the combined text of all child nodes. This method only considers
@@ -139,19 +139,21 @@ open class RuleContext: RuleNode {
     }
 
     open func getRuleIndex() -> Int {
-        return -1
+        -1
     }
 
-    open func getAltNumber() -> Int { return ATN.INVALID_ALT_NUMBER }
+    open func getAltNumber() -> Int {
+        ATN.INVALID_ALT_NUMBER
+    }
     open func setAltNumber(_ altNumber: Int) { }
 
     open func getChild(_ i: Int) -> Tree? {
-        return nil
+        nil
     }
 
 
     open func getChildCount() -> Int {
-        return 0
+        0
     }
 
 
@@ -161,7 +163,7 @@ open class RuleContext: RuleNode {
 
 
     open func accept<T>(_ visitor: ParseTreeVisitor<T>) -> T? {
-        return visitor.visitChildren(self)
+        visitor.visitChildren(self)
     }
 
     /// Print out a whole tree, not just a node, in LISP format
@@ -169,34 +171,34 @@ open class RuleContext: RuleNode {
     /// We have to know the recognizer so we can get rule names.
     ///
     open func toStringTree(_ recog: Parser) -> String {
-        return Trees.toStringTree(self, recog)
+        Trees.toStringTree(self, recog)
     }
 
     /// Print out a whole tree, not just a node, in LISP format
     /// (root child1 .. childN). Print just a node if this is a leaf.
     /// 
     public func toStringTree(_ ruleNames: [String]?) -> String {
-        return Trees.toStringTree(self, ruleNames)
+        Trees.toStringTree(self, ruleNames)
     }
 
     open func toStringTree() -> String {
-        return toStringTree(nil)
+        toStringTree(nil)
     }
 
     open var description: String {
-        return toString(nil, nil)
+        toString(nil, nil)
     }
 
      open var debugDescription: String {
-         return description
+         description
     }
 
     public final func toString<T>(_ recog: Recognizer<T>) -> String {
-        return toString(recog, ParserRuleContext.EMPTY)
+        toString(recog, ParserRuleContext.EMPTY)
     }
 
     public final func toString(_ ruleNames: [String]) -> String {
-        return toString(ruleNames, nil)
+        toString(ruleNames, nil)
     }
 
     // recog null unless ParserRuleContext, in which case we use subclass toString(...)
@@ -234,7 +236,7 @@ open class RuleContext: RuleNode {
     }
 
     open func castdown<T>(_ subType: T.Type) -> T {
-        return self as! T
+        self as! T
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/RuntimeMetaData.swift
+++ b/runtime/Swift/Sources/Antlr4/RuntimeMetaData.swift
@@ -76,7 +76,7 @@ public class RuntimeMetaData {
     /// 
 
     public static func getRuntimeVersion() -> String {
-        return RuntimeMetaData.VERSION
+        RuntimeMetaData.VERSION
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/TokenStreamRewriter.swift
+++ b/runtime/Swift/Sources/Antlr4/TokenStreamRewriter.swift
@@ -113,7 +113,7 @@ public class TokenStreamRewriter {
         /// Return the index of the next token to operate on.
         /// 
         public func execute(_ buf: inout String) throws -> Int {
-            return index
+            index
         }
 
         public var description: String {
@@ -188,11 +188,11 @@ public class TokenStreamRewriter {
         }
 
         final var count: Int {
-            return rewrites.count
+            rewrites.count
         }
 
         final var isEmpty: Bool {
-            return rewrites.isEmpty
+            rewrites.isEmpty
         }
 
         /// We need to combine operations and report invalid operations (like
@@ -396,7 +396,7 @@ public class TokenStreamRewriter {
     }
 
     public final func getTokenStream() -> TokenStream {
-        return tokens
+        tokens
     }
 
     public func rollback(_ instructionIndex: Int) {
@@ -516,11 +516,11 @@ public class TokenStreamRewriter {
     }
 
     public func getLastRewriteTokenIndex() -> Int {
-        return getLastRewriteTokenIndex(DEFAULT_PROGRAM_NAME)
+        getLastRewriteTokenIndex(DEFAULT_PROGRAM_NAME)
     }
 
     internal func getLastRewriteTokenIndex(_ programName: String) -> Int {
-        return lastRewriteTokenIndexes[programName] ?? -1
+        lastRewriteTokenIndexes[programName] ?? -1
     }
 
     internal func setLastRewriteTokenIndex(_ programName: String, _ i: Int) {
@@ -546,14 +546,14 @@ public class TokenStreamRewriter {
     /// instructions given to this rewriter.
     /// 
     public func getText() throws -> String {
-        return try getText(DEFAULT_PROGRAM_NAME, Interval.of(0, tokens.size() - 1))
+        try getText(DEFAULT_PROGRAM_NAME, Interval.of(0, tokens.size() - 1))
     }
 
     /// Return the text from the original tokens altered per the
     /// instructions given to this rewriter in programName.
     /// 
     public func getText(_ programName: String) throws -> String {
-        return try getText(programName, Interval.of(0, tokens.size() - 1))
+        try getText(programName, Interval.of(0, tokens.size() - 1))
     }
 
     /// Return the text associated with the tokens in the interval from the
@@ -566,7 +566,7 @@ public class TokenStreamRewriter {
     /// The same is true if you do an insertAfter the stop token.
     /// 
     public func getText(_ interval: Interval) throws -> String {
-        return try getText(DEFAULT_PROGRAM_NAME, interval)
+        try getText(DEFAULT_PROGRAM_NAME, interval)
     }
 
     public func getText(_ programName: String, _ interval: Interval) throws -> String {

--- a/runtime/Swift/Sources/Antlr4/UnbufferedCharStream.swift
+++ b/runtime/Swift/Sources/Antlr4/UnbufferedCharStream.swift
@@ -224,7 +224,7 @@ open class UnbufferedCharStream: CharStream {
     }
 
     public func index() -> Int {
-        return currentCharIndex
+        currentCharIndex
     }
 
     /** Seek to absolute character index, which might not be in the current
@@ -269,7 +269,7 @@ open class UnbufferedCharStream: CharStream {
     }
 
     public func getSourceName() -> String {
-        return name
+        name
     }
 
     public func getText(_ interval: Interval) throws -> String {
@@ -304,7 +304,7 @@ open class UnbufferedCharStream: CharStream {
     }
 
     internal func getBufferStartIndex() -> Int {
-        return currentCharIndex - p
+        currentCharIndex - p
     }
 }
 

--- a/runtime/Swift/Sources/Antlr4/UnbufferedTokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/UnbufferedTokenStream.swift
@@ -97,27 +97,27 @@ public class UnbufferedTokenStream: TokenStream {
 
 
     public func LA(_ i: Int) throws -> Int {
-        return try LT(i)!.getType()
+        try LT(i)!.getType()
     }
 
 
     public func getTokenSource() -> TokenSource {
-        return tokenSource
+        tokenSource
     }
 
 
     public func getText() -> String {
-        return ""
+        ""
     }
 
 
     public func getText(_ ctx: RuleContext) throws -> String {
-        return try getText(ctx.getSourceInterval())
+        try getText(ctx.getSourceInterval())
     }
 
 
     public func getText(_ start: Token?, _ stop: Token?) throws -> String {
-        return try getText(Interval.of(start!.getTokenIndex(), stop!.getTokenIndex()))
+        try getText(Interval.of(start!.getTokenIndex(), stop!.getTokenIndex()))
     }
 
 
@@ -228,7 +228,7 @@ public class UnbufferedTokenStream: TokenStream {
 
 
     public func index() -> Int {
-        return currentTokenIndex
+        currentTokenIndex
     }
 
 
@@ -270,7 +270,7 @@ public class UnbufferedTokenStream: TokenStream {
 
 
     public func getSourceName() -> String {
-        return tokenSource.getSourceName()
+        tokenSource.getSourceName()
     }
 
 
@@ -295,6 +295,6 @@ public class UnbufferedTokenStream: TokenStream {
     }
 
     internal final func getBufferStartIndex() -> Int {
-        return currentTokenIndex - p
+        currentTokenIndex - p
     }
 }

--- a/runtime/Swift/Sources/Antlr4/VocabularySingle.swift
+++ b/runtime/Swift/Sources/Antlr4/VocabularySingle.swift
@@ -161,5 +161,5 @@ public class Vocabulary: Hashable {
 }
 
 public func ==(lhs: Vocabulary, rhs: Vocabulary) -> Bool {
-    return lhs === rhs
+    lhs === rhs
 }

--- a/runtime/Swift/Sources/Antlr4/atn/ATN.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATN.swift
@@ -116,7 +116,7 @@ public class ATN {
     }
 
     public func getNumberOfDecisions() -> Int {
-        return decisionToState.count
+        decisionToState.count
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/atn/ATNConfig.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNConfig.swift
@@ -111,11 +111,11 @@ public class ATNConfig: Hashable, CustomStringConvertible {
     /// _#isPrecedenceFilterSuppressed_ method.
     /// 
     public final func getOuterContextDepth() -> Int {
-        return reachesIntoOuterContext & ~SUPPRESS_PRECEDENCE_FILTER
+        reachesIntoOuterContext & ~SUPPRESS_PRECEDENCE_FILTER
     }
 
     public final func isPrecedenceFilterSuppressed() -> Bool {
-        return (reachesIntoOuterContext & SUPPRESS_PRECEDENCE_FILTER) != 0
+        (reachesIntoOuterContext & SUPPRESS_PRECEDENCE_FILTER) != 0
     }
 
     public final func setPrecedenceFilterSuppressed(_ value: Bool) {
@@ -135,7 +135,7 @@ public class ATNConfig: Hashable, CustomStringConvertible {
 
     public var description: String {
         //return "MyClass \(string)"
-        return toString(nil, true)
+        toString(nil, true)
     }
     public func toString<T>(_ recog: Recognizer<T>?, _ showAlt: Bool) -> String {
         var buf = "(\(state)"

--- a/runtime/Swift/Sources/Antlr4/atn/ATNConfigSet.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNConfigSet.swift
@@ -133,7 +133,7 @@ public final class ATNConfigSet: Hashable, CustomStringConvertible {
 
     public func getOrAdd(_ config: ATNConfig) -> ATNConfig {
 
-        return configLookup.getOrAdd(config)
+        configLookup.getOrAdd(config)
     }
 
 
@@ -141,7 +141,7 @@ public final class ATNConfigSet: Hashable, CustomStringConvertible {
     /// Return a List holding list of configs
     /// 
     public func elements() -> [ATNConfig] {
-        return configs
+        configs
     }
 
     public func getStates() -> Set<ATNState> {
@@ -179,7 +179,7 @@ public final class ATNConfigSet: Hashable, CustomStringConvertible {
     }
 
     public func get(_ i: Int) -> ATNConfig {
-        return configs[i]
+        configs[i]
     }
 
     public func optimizeConfigs(_ interpreter: ATNSimulator) throws {
@@ -224,21 +224,21 @@ public final class ATNConfigSet: Hashable, CustomStringConvertible {
     }
 
     public var count: Int {
-        return configs.count
+        configs.count
     }
 
     public func size() -> Int {
-        return configs.count
+        configs.count
     }
 
 
     public func isEmpty() -> Bool {
-        return configs.isEmpty
+        configs.isEmpty
     }
 
 
     public func contains(_ o: ATNConfig) -> Bool {
-        return configLookup.contains(o)
+        configLookup.contains(o)
     }
 
 
@@ -252,7 +252,7 @@ public final class ATNConfigSet: Hashable, CustomStringConvertible {
     }
 
     public func isReadonly() -> Bool {
-        return readonly
+        readonly
     }
 
     public func setReadonly(_ readonly: Bool) {
@@ -529,11 +529,11 @@ public final class ATNConfigSet: Hashable, CustomStringConvertible {
     }
 
     public var hasConfigInRuleStopState: Bool {
-        return configs.contains(where: { $0.state is RuleStopState })
+        configs.contains(where: { $0.state is RuleStopState })
     }
 
     public var allConfigsInRuleStopStates: Bool {
-        return !configs.contains(where: { !($0.state is RuleStopState) })
+        !configs.contains(where: { !($0.state is RuleStopState) })
     }
 }
 

--- a/runtime/Swift/Sources/Antlr4/atn/ATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNSimulator.swift
@@ -69,7 +69,7 @@ open class ATNSimulator {
     }
 
     open func getSharedContextCache() -> PredictionContextCache {
-        return sharedContextCache
+        sharedContextCache
     }
 
     open func getCachedContext(_ context: PredictionContext) -> PredictionContext {
@@ -85,6 +85,6 @@ open class ATNSimulator {
                                   _ type: Int, _ src: Int, _ trg: Int,
                                   _ arg1: Int, _ arg2: Int, _ arg3: Int,
                                   _ sets: Array<IntervalSet>) throws -> Transition {
-        return try ATNDeserializer().edgeFactory(atn, type, src, trg, arg1, arg2, arg3, sets)
+        try ATNDeserializer().edgeFactory(atn, type, src, trg, arg1, arg2, arg3, sets)
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/ATNState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNState.swift
@@ -128,20 +128,20 @@ public class ATNState: Hashable, CustomStringConvertible {
     }
 
     public func isNonGreedyExitState() -> Bool {
-        return false
+        false
     }
 
 
     public var description: String {
         //return "MyClass \(string)"
-        return String(stateNumber)
+        String(stateNumber)
     }
     public final func getTransitions() -> [Transition] {
-        return transitions
+        transitions
     }
 
     public final func getNumberOfTransitions() -> Int {
-        return transitions.count
+        transitions.count
     }
 
     public final func addTransition(_ e: Transition) {
@@ -175,7 +175,7 @@ public class ATNState: Hashable, CustomStringConvertible {
     }
 
     public final func transition(_ i: Int) -> Transition {
-        return transitions[i]
+        transitions[i]
     }
 
     public final func setTransition(_ i: Int, _ e: Transition) {
@@ -184,7 +184,7 @@ public class ATNState: Hashable, CustomStringConvertible {
 
     public final func removeTransition(_ index: Int) -> Transition {
 
-        return transitions.remove(at: index)
+        transitions.remove(at: index)
     }
 
     public func getStateType() -> Int {
@@ -192,7 +192,7 @@ public class ATNState: Hashable, CustomStringConvertible {
     }
 
     public final func onlyHasEpsilonTransitions() -> Bool {
-        return epsilonOnlyTransitions
+        epsilonOnlyTransitions
     }
 
     public final func setRuleIndex(_ ruleIndex: Int) {

--- a/runtime/Swift/Sources/Antlr4/atn/ActionTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ActionTransition.swift
@@ -26,21 +26,21 @@ public final class ActionTransition: Transition, CustomStringConvertible {
 
     override
     public func getSerializationType() -> Int {
-        return Transition.ACTION
+        Transition.ACTION
     }
 
     override
     public func isEpsilon() -> Bool {
-        return true // we are to be ignored by analysis 'cept for predicates
+        true // we are to be ignored by analysis 'cept for predicates
     }
 
     override
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        return false
+        false
     }
 
     public var description: String {
-        return "action_\(ruleIndex):\(actionIndex)"
+        "action_\(ruleIndex):\(actionIndex)"
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/atn/ArrayPredictionContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ArrayPredictionContext.swift
@@ -35,22 +35,22 @@ public class ArrayPredictionContext: PredictionContext {
     final public func isEmpty() -> Bool {
         // since EMPTY_RETURN_STATE can only appear in the last position, we
         // don't need to verify that size==1
-        return returnStates[0] == PredictionContext.EMPTY_RETURN_STATE
+        returnStates[0] == PredictionContext.EMPTY_RETURN_STATE
     }
 
     override
     final public func size() -> Int {
-        return returnStates.count
+        returnStates.count
     }
 
     override
     final public func getParent(_ index: Int) -> PredictionContext? {
-        return parents[index]
+        parents[index]
     }
 
     override
     final public func getReturnState(_ index: Int) -> Int {
-        return returnStates[index]
+        returnStates[index]
     }
 
     override

--- a/runtime/Swift/Sources/Antlr4/atn/AtomTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/AtomTransition.swift
@@ -23,21 +23,21 @@ public final class AtomTransition: Transition, CustomStringConvertible {
 
     override
     public func getSerializationType() -> Int {
-        return Transition.ATOM
+        Transition.ATOM
     }
 
     override
     public func labelIntervalSet() -> IntervalSet? {
-        return IntervalSet(label)
+        IntervalSet(label)
     }
 
     override
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        return label == symbol
+        label == symbol
     }
 
 
     public var description: String {
-        return String(label)
+        String(label)
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/BasicBlockStartState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/BasicBlockStartState.swift
@@ -14,6 +14,6 @@
 public final class BasicBlockStartState: BlockStartState {
     override
     public func getStateType() -> Int {
-        return BlockStartState.BLOCK_START
+        BlockStartState.BLOCK_START
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/BasicState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/BasicState.swift
@@ -15,7 +15,7 @@ public final class BasicState: ATNState {
 
     override
     public func getStateType() -> Int {
-        return ATNState.BASIC
+        ATNState.BASIC
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/atn/BlockEndState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/BlockEndState.swift
@@ -15,6 +15,6 @@ public final class BlockEndState: ATNState {
 
     override
     public func getStateType() -> Int {
-        return ATNState.BLOCK_END
+        ATNState.BLOCK_END
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/EmptyPredictionContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/EmptyPredictionContext.swift
@@ -12,28 +12,28 @@ public class EmptyPredictionContext: SingletonPredictionContext {
 
     override
     public func isEmpty() -> Bool {
-        return true
+        true
     }
 
     override
     public func size() -> Int {
-        return 1
+        1
     }
 
     override
     public func getParent(_ index: Int) -> PredictionContext? {
-        return nil
+        nil
     }
 
     override
     public func getReturnState(_ index: Int) -> Int {
-        return returnState
+        returnState
     }
 
 
     override
     public var description: String {
-        return "$"
+        "$"
     }
 }
 

--- a/runtime/Swift/Sources/Antlr4/atn/EpsilonTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/EpsilonTransition.swift
@@ -28,26 +28,26 @@ public final class EpsilonTransition: Transition, CustomStringConvertible {
     /// -  4.4.1
     /// 
     public func outermostPrecedenceReturn() -> Int {
-        return outermostPrecedenceReturnInside
+        outermostPrecedenceReturnInside
     }
 
     override
     public func getSerializationType() -> Int {
-        return Transition.EPSILON
+        Transition.EPSILON
     }
 
     override
     public func isEpsilon() -> Bool {
-        return true
+        true
     }
 
     override
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        return false
+        false
     }
 
 
     public var description: String {
-        return "epsilon"
+        "epsilon"
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LL1Analyzer.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LL1Analyzer.swift
@@ -67,7 +67,7 @@ public class LL1Analyzer {
     /// specified `ctx`.
     /// 
     public func LOOK(_ s: ATNState, _ ctx: RuleContext?) -> IntervalSet {
-        return LOOK(s, nil, ctx)
+        LOOK(s, nil, ctx)
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNConfig.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNConfig.swift
@@ -57,7 +57,7 @@ public class LexerATNConfig: ATNConfig {
     }
 
     private static func checkNonGreedyDecision(_ source: LexerATNConfig, _ target: ATNState) -> Bool {
-        return source.passedThroughNonGreedyDecision
+        source.passedThroughNonGreedyDecision
                 || target is DecisionState && (target as! DecisionState).nonGreedy
     }
     /// 
@@ -65,11 +65,11 @@ public class LexerATNConfig: ATNConfig {
     /// action(s) for the current configuration.
     /// 
     public final func getLexerActionExecutor() -> LexerActionExecutor? {
-        return lexerActionExecutor
+        lexerActionExecutor
     }
 
     public final func hasPassedThroughNonGreedyDecision() -> Bool {
-        return passedThroughNonGreedyDecision
+        passedThroughNonGreedyDecision
     }
 
     public override func hash(into hasher: inout Hasher) {

--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
@@ -725,7 +725,7 @@ open class LexerATNSimulator: ATNSimulator {
 
 
     public final func getDFA(_ mode: Int) -> DFA {
-        return decisionToDFA[mode]
+        decisionToDFA[mode]
     }
 
     /// 
@@ -734,11 +734,11 @@ open class LexerATNSimulator: ATNSimulator {
 
     public func getText(_ input: CharStream) -> String {
         // index is first lookahead char, don't include.
-        return try! input.getText(Interval.of(startIndex, input.index() - 1))
+        try! input.getText(Interval.of(startIndex, input.index() - 1))
     }
 
     public func getLine() -> Int {
-        return line
+        line
     }
 
     public func setLine(_ line: Int) {
@@ -746,7 +746,7 @@ open class LexerATNSimulator: ATNSimulator {
     }
 
     public func getCharPositionInLine() -> Int {
-        return charPositionInLine
+        charPositionInLine
     }
 
     public func setCharPositionInLine(_ charPositionInLine: Int) {

--- a/runtime/Swift/Sources/Antlr4/atn/LexerActionExecutor.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerActionExecutor.swift
@@ -125,7 +125,7 @@ public class LexerActionExecutor: Hashable {
     /// - returns: The lexer actions to be executed by this executor.
     /// 
     public func getLexerActions() -> [LexerAction] {
-        return lexerActions
+        lexerActions
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/atn/LexerChannelAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerChannelAction.swift
@@ -30,7 +30,7 @@ public final class LexerChannelAction: LexerAction, CustomStringConvertible {
     /// - returns: The channel to use for the _org.antlr.v4.runtime.Token_ created by the lexer.
     /// 
     public func getChannel() -> Int {
-        return channel
+        channel
     }
 
     /// 
@@ -39,7 +39,7 @@ public final class LexerChannelAction: LexerAction, CustomStringConvertible {
     /// 
 
     public override func getActionType() -> LexerActionType {
-        return LexerActionType.channel
+        LexerActionType.channel
     }
 
     /// 
@@ -48,7 +48,7 @@ public final class LexerChannelAction: LexerAction, CustomStringConvertible {
     /// 
 
     public override func isPositionDependent() -> Bool {
-        return false
+        false
     }
 
     /// 
@@ -69,7 +69,7 @@ public final class LexerChannelAction: LexerAction, CustomStringConvertible {
     }
 
     public var description: String {
-        return "channel\(channel)"
+        "channel\(channel)"
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LexerCustomAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerCustomAction.swift
@@ -43,7 +43,7 @@ public final class LexerCustomAction: LexerAction {
     /// - returns: The rule index for the custom action.
     /// 
     public func getRuleIndex() -> Int {
-        return ruleIndex
+        ruleIndex
     }
 
     /// 
@@ -52,7 +52,7 @@ public final class LexerCustomAction: LexerAction {
     /// - returns: The action index for the custom action.
     /// 
     public func getActionIndex() -> Int {
-        return actionIndex
+        actionIndex
     }
 
     /// 
@@ -62,7 +62,7 @@ public final class LexerCustomAction: LexerAction {
     /// 
 
     public override func getActionType() -> LexerActionType {
-        return LexerActionType.custom
+        LexerActionType.custom
     }
 
     /// 
@@ -78,7 +78,7 @@ public final class LexerCustomAction: LexerAction {
     /// 
     override
     public func isPositionDependent() -> Bool {
-        return true
+        true
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/atn/LexerIndexedCustomAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerIndexedCustomAction.swift
@@ -51,7 +51,7 @@ public final class LexerIndexedCustomAction: LexerAction {
     /// action should be executed.
     /// 
     public func getOffset() -> Int {
-        return offset
+        offset
     }
 
     /// 
@@ -60,7 +60,7 @@ public final class LexerIndexedCustomAction: LexerAction {
     /// - returns: A _org.antlr.v4.runtime.atn.LexerAction_ object which executes the lexer action.
     /// 
     public func getAction() -> LexerAction {
-        return action
+        action
     }
 
     /// 
@@ -71,7 +71,7 @@ public final class LexerIndexedCustomAction: LexerAction {
     /// 
 
     public override func getActionType() -> LexerActionType {
-        return action.getActionType()
+        action.getActionType()
     }
 
     /// 
@@ -80,7 +80,7 @@ public final class LexerIndexedCustomAction: LexerAction {
     /// 
 
     public override func isPositionDependent() -> Bool {
-        return true
+        true
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/atn/LexerModeAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerModeAction.swift
@@ -31,7 +31,7 @@ public final class LexerModeAction: LexerAction, CustomStringConvertible {
     /// - returns: The lexer mode for this `mode` command.
     /// 
     public func getMode() -> Int {
-        return mode
+        mode
     }
 
     /// 
@@ -40,7 +40,7 @@ public final class LexerModeAction: LexerAction, CustomStringConvertible {
     /// 
 
     public override func getActionType() -> LexerActionType {
-        return LexerActionType.mode
+        LexerActionType.mode
     }
 
     /// 
@@ -49,7 +49,7 @@ public final class LexerModeAction: LexerAction, CustomStringConvertible {
     /// 
 
     public override func isPositionDependent() -> Bool {
-        return false
+        false
     }
 
     /// 
@@ -68,7 +68,7 @@ public final class LexerModeAction: LexerAction, CustomStringConvertible {
     }
 
     public var description: String {
-        return "mode(\(mode))"
+        "mode(\(mode))"
     }
 }
 

--- a/runtime/Swift/Sources/Antlr4/atn/LexerMoreAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerMoreAction.swift
@@ -33,7 +33,7 @@ public final class LexerMoreAction: LexerAction, CustomStringConvertible {
     /// 
     override
     public func getActionType() -> LexerActionType {
-        return LexerActionType.more
+        LexerActionType.more
     }
 
     /// 
@@ -42,7 +42,7 @@ public final class LexerMoreAction: LexerAction, CustomStringConvertible {
     /// 
     override
     public func isPositionDependent() -> Bool {
-        return false
+        false
     }
 
     /// 
@@ -61,10 +61,10 @@ public final class LexerMoreAction: LexerAction, CustomStringConvertible {
     }
 
     public var description: String {
-        return "more"
+        "more"
     }
 }
 
 public func ==(lhs: LexerMoreAction, rhs: LexerMoreAction) -> Bool {
-    return lhs === rhs
+    lhs === rhs
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LexerPopModeAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerPopModeAction.swift
@@ -34,7 +34,7 @@ public final class LexerPopModeAction: LexerAction, CustomStringConvertible {
     /// 
     override
     public func getActionType() -> LexerActionType {
-        return LexerActionType.popMode
+        LexerActionType.popMode
     }
 
     /// 
@@ -43,7 +43,7 @@ public final class LexerPopModeAction: LexerAction, CustomStringConvertible {
     /// 
 
     public override func isPositionDependent() -> Bool {
-        return false
+        false
     }
 
     /// 
@@ -62,10 +62,10 @@ public final class LexerPopModeAction: LexerAction, CustomStringConvertible {
     }
 
     public var description: String {
-        return "popMode"
+        "popMode"
     }
 }
 
 public func ==(lhs: LexerPopModeAction, rhs: LexerPopModeAction) -> Bool {
-    return lhs === rhs
+    lhs === rhs
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LexerPushModeAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerPushModeAction.swift
@@ -31,7 +31,7 @@ public final class LexerPushModeAction: LexerAction, CustomStringConvertible {
     /// - returns: The lexer mode for this `pushMode` command.
     /// 
     public func getMode() -> Int {
-        return mode
+        mode
     }
 
     /// 
@@ -40,7 +40,7 @@ public final class LexerPushModeAction: LexerAction, CustomStringConvertible {
     /// 
 
     public override func getActionType() -> LexerActionType {
-        return LexerActionType.pushMode
+        LexerActionType.pushMode
     }
 
     /// 
@@ -49,7 +49,7 @@ public final class LexerPushModeAction: LexerAction, CustomStringConvertible {
     /// 
 
     public override func isPositionDependent() -> Bool {
-        return false
+        false
     }
 
     /// 
@@ -68,7 +68,7 @@ public final class LexerPushModeAction: LexerAction, CustomStringConvertible {
     }
 
     public var description: String {
-        return "pushMode(\(mode))"
+        "pushMode(\(mode))"
     }
 }
 

--- a/runtime/Swift/Sources/Antlr4/atn/LexerSkipAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerSkipAction.swift
@@ -33,7 +33,7 @@ public final class LexerSkipAction: LexerAction, CustomStringConvertible {
     /// 
     override
     public func getActionType() -> LexerActionType {
-        return LexerActionType.skip
+        LexerActionType.skip
     }
 
     /// 
@@ -42,7 +42,7 @@ public final class LexerSkipAction: LexerAction, CustomStringConvertible {
     /// 
     override
     public func isPositionDependent() -> Bool {
-        return false
+        false
     }
 
     /// 
@@ -61,10 +61,10 @@ public final class LexerSkipAction: LexerAction, CustomStringConvertible {
     }
 
     public var description: String {
-        return "skip"
+        "skip"
     }
 }
 
 public func ==(lhs: LexerSkipAction, rhs: LexerSkipAction) -> Bool {
-    return lhs === rhs
+    lhs === rhs
 }

--- a/runtime/Swift/Sources/Antlr4/atn/LexerTypeAction.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerTypeAction.swift
@@ -29,7 +29,7 @@ public class LexerTypeAction: LexerAction, CustomStringConvertible {
     /// - returns: The type to assign to a token created by the lexer.
     /// 
     public func getType() -> Int {
-        return type
+        type
     }
 
     /// 
@@ -38,7 +38,7 @@ public class LexerTypeAction: LexerAction, CustomStringConvertible {
     /// 
 
     public override func getActionType() -> LexerActionType {
-        return LexerActionType.type
+        LexerActionType.type
     }
 
     /// 
@@ -47,7 +47,7 @@ public class LexerTypeAction: LexerAction, CustomStringConvertible {
     /// 
     override
     public func isPositionDependent() -> Bool {
-        return false
+        false
     }
 
     /// 
@@ -67,7 +67,7 @@ public class LexerTypeAction: LexerAction, CustomStringConvertible {
     }
 
     public var description: String {
-        return "type(\(type))"
+        "type(\(type))"
     }
 }
 

--- a/runtime/Swift/Sources/Antlr4/atn/LookupDictionary.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LookupDictionary.swift
@@ -86,7 +86,7 @@ public struct LookupDictionary {
     }
 
     public var isEmpty: Bool {
-        return cache.isEmpty
+        cache.isEmpty
     }
 
     public func contains(_ config: ATNConfig) -> Bool {

--- a/runtime/Swift/Sources/Antlr4/atn/LoopEndState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LoopEndState.swift
@@ -15,6 +15,6 @@ public final class LoopEndState: ATNState {
 
     override
     public func getStateType() -> Int {
-        return ATNState.LOOP_END
+        ATNState.LOOP_END
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/NotSetTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/NotSetTransition.swift
@@ -12,18 +12,18 @@ public final class NotSetTransition: SetTransition {
 
     override
     public func getSerializationType() -> Int {
-        return Transition.NOT_SET
+        Transition.NOT_SET
     }
 
     override
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        return symbol >= minVocabSymbol
+        symbol >= minVocabSymbol
                 && symbol <= maxVocabSymbol
                 && !super.matches(symbol, minVocabSymbol, maxVocabSymbol)
     }
 
     override
     public var description: String {
-        return "~" + super.description
+        "~" + super.description
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/ParseInfo.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParseInfo.swift
@@ -28,7 +28,7 @@ public class ParseInfo {
     /// number.
     /// 
     public func getDecisionInfo() -> [DecisionInfo] {
-        return atnSimulator.getDecisionInfo()
+        atnSimulator.getDecisionInfo()
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
@@ -926,7 +926,7 @@ open class ParserATNSimulator: ATNSimulator {
     /// the configurations from `configs` which are in a rule stop state
     /// 
     final func removeAllConfigsNotInRuleStopState(_ configs: ATNConfigSet, _ lookToEndOfRule: Bool) -> ATNConfigSet {
-        return configs.removeAllConfigsNotInRuleStopState(&mergeCache,lookToEndOfRule,atn)
+        configs.removeAllConfigsNotInRuleStopState(&mergeCache, lookToEndOfRule, atn)
     }
 
 
@@ -1103,7 +1103,7 @@ open class ParserATNSimulator: ATNSimulator {
     /// calling _org.antlr.v4.runtime.Parser#getPrecedence_).
     /// 
     final internal func applyPrecedenceFilter(_ configs: ATNConfigSet) throws -> ATNConfigSet {
-        return try configs.applyPrecedenceFilter(&mergeCache,parser,_outerContext)
+        try configs.applyPrecedenceFilter(&mergeCache, parser, _outerContext)
     }
 
     final internal func getReachableTarget(_ trans: Transition, _ ttype: Int) -> ATNState? {
@@ -1225,7 +1225,7 @@ open class ParserATNSimulator: ATNSimulator {
 
     final internal func getAltThatFinishedDecisionEntryRule(_ configs: ATNConfigSet) -> Int {
 
-        return configs.getAltThatFinishedDecisionEntryRule()
+        configs.getAltThatFinishedDecisionEntryRule()
     }
 
     /// 
@@ -1242,7 +1242,7 @@ open class ParserATNSimulator: ATNSimulator {
         _ configs: ATNConfigSet,
         _ outerContext: ParserRuleContext) throws -> (ATNConfigSet, ATNConfigSet) {
 
-            return try configs.splitAccordingToSemanticValidity(outerContext, evalSemanticContext)
+        try configs.splitAccordingToSemanticValidity(outerContext, evalSemanticContext)
     }
 
     /// 
@@ -1313,7 +1313,7 @@ open class ParserATNSimulator: ATNSimulator {
     /// - since: 4.3
     /// 
     internal func evalSemanticContext(_ pred: SemanticContext, _ parserCallStack: ParserRuleContext, _ alt: Int, _ fullCtx: Bool) throws -> Bool {
-        return try pred.eval(parser, parserCallStack)
+        try pred.eval(parser, parserCallStack)
     }
 
     /// 
@@ -1887,7 +1887,7 @@ open class ParserATNSimulator: ATNSimulator {
     }
 
     public final func getLookaheadName(_ input: TokenStream) throws -> String {
-        return try getTokenName(input.LA(1))
+        try getTokenName(input.LA(1))
     }
 
     /// 
@@ -2073,10 +2073,10 @@ open class ParserATNSimulator: ATNSimulator {
 
 
     public final func getPredictionMode() -> PredictionMode {
-        return mode
+        mode
     }
 
     public final func getParser() -> Parser {
-        return parser
+        parser
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/PlusBlockStartState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PlusBlockStartState.swift
@@ -18,6 +18,6 @@ public final class PlusBlockStartState: BlockStartState {
 
     override
     public func getStateType() -> Int {
-        return ATNState.PLUS_BLOCK_START
+        ATNState.PLUS_BLOCK_START
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/PlusLoopbackState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PlusLoopbackState.swift
@@ -15,6 +15,6 @@ public final class PlusLoopbackState: DecisionState {
 
     override
     public func getStateType() -> Int {
-        return ATNState.PLUS_LOOP_BACK
+        ATNState.PLUS_LOOP_BACK
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/PrecedencePredicateTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PrecedencePredicateTransition.swift
@@ -22,24 +22,24 @@ public final class PrecedencePredicateTransition: AbstractPredicateTransition, C
 
     override
     public func getSerializationType() -> Int {
-        return Transition.PRECEDENCE
+        Transition.PRECEDENCE
     }
 
     override
     public func isEpsilon() -> Bool {
-        return true
+        true
     }
 
     override
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        return false
+        false
     }
 
     public func getPredicate() -> SemanticContext.PrecedencePredicate {
-        return SemanticContext.PrecedencePredicate(precedence)
+        SemanticContext.PrecedencePredicate(precedence)
     }
 
     public var description: String {
-        return "\(precedence)  >= _p"
+        "\(precedence)  >= _p"
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/PredicateTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PredicateTransition.swift
@@ -30,24 +30,24 @@ public final class PredicateTransition: AbstractPredicateTransition, CustomStrin
 
     override
     public func getSerializationType() -> Int {
-        return PredicateTransition.PREDICATE
+        PredicateTransition.PREDICATE
     }
 
     override
     public func isEpsilon() -> Bool {
-        return true
+        true
     }
 
     override
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        return false
+        false
     }
 
     public func getPredicate() -> SemanticContext.Predicate {
-        return SemanticContext.Predicate(ruleIndex, predIndex, isCtxDependent)
+        SemanticContext.Predicate(ruleIndex, predIndex, isCtxDependent)
     }
 
     public var description: String {
-        return "pred_\(ruleIndex):\(predIndex)"
+        "pred_\(ruleIndex):\(predIndex)"
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/PredictionContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PredictionContext.swift
@@ -98,11 +98,11 @@ public class PredictionContext: Hashable, CustomStringConvertible {
     /// This means only the _#EMPTY_ context is in set.
     /// 
     public func isEmpty() -> Bool {
-        return self === PredictionContext.EMPTY
+        self === PredictionContext.EMPTY
     }
 
     public func hasEmptyPath() -> Bool {
-        return getReturnState(size() - 1) == PredictionContext.EMPTY_RETURN_STATE
+        getReturnState(size() - 1) == PredictionContext.EMPTY_RETURN_STATE
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -668,12 +668,12 @@ public class PredictionContext: Hashable, CustomStringConvertible {
     }
 
     public func toString<T>(_ recog: Recognizer<T>) -> String {
-        return String(describing: PredictionContext.self)
+        String(describing: PredictionContext.self)
         //		return toString(recog, ParserRuleContext.EMPTY);
     }
 
     public func toStrings<T>(_ recognizer: Recognizer<T>, _ currentState: Int) -> [String] {
-        return toStrings(recognizer, PredictionContext.EMPTY, currentState)
+        toStrings(recognizer, PredictionContext.EMPTY, currentState)
     }
 
     // FROM SAM
@@ -745,7 +745,7 @@ public class PredictionContext: Hashable, CustomStringConvertible {
     }
 
     public var description: String {
-        return String(describing: PredictionContext.self) + "@" + String(Unmanaged.passUnretained(self).toOpaque().hashValue)
+        String(describing: PredictionContext.self) + "@" + String(Unmanaged.passUnretained(self).toOpaque().hashValue)
     }
 }
 
@@ -780,21 +780,21 @@ public func ==(lhs: PredictionContext, rhs: PredictionContext) -> Bool {
 }
 
 public func ==(lhs: ArrayPredictionContext, rhs: SingletonPredictionContext) -> Bool {
-    return false
+    false
 }
 
 public func ==(lhs: SingletonPredictionContext, rhs: ArrayPredictionContext) -> Bool {
-    return false
+    false
 }
 
 public func ==(lhs: SingletonPredictionContext, rhs: EmptyPredictionContext) -> Bool {
-    return false
+    false
 }
 
 public func ==(lhs: EmptyPredictionContext, rhs: ArrayPredictionContext) -> Bool {
-    return lhs === rhs
+    lhs === rhs
 }
 
 public func ==(lhs: EmptyPredictionContext, rhs: SingletonPredictionContext) -> Bool {
-    return lhs === rhs
+    lhs === rhs
 }

--- a/runtime/Swift/Sources/Antlr4/atn/PredictionContextCache.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PredictionContextCache.swift
@@ -36,10 +36,10 @@ public final class PredictionContextCache {
     }
 
     public func get(_ ctx: PredictionContext) -> PredictionContext? {
-        return cache[ctx]
+        cache[ctx]
     }
 
     public func size() -> Int {
-        return cache.count
+        cache.count
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/PredictionMode.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/PredictionMode.swift
@@ -208,7 +208,7 @@ public enum PredictionMode {
     /// 
     public static func hasConfigInRuleStopState(_ configs: ATNConfigSet) -> Bool {
 
-        return  configs.hasConfigInRuleStopState
+        configs.hasConfigInRuleStopState
     }
 
     /// 
@@ -223,7 +223,7 @@ public enum PredictionMode {
     /// 
     public static func allConfigsInRuleStopStates(_ configs: ATNConfigSet) -> Bool {
 
-        return configs.allConfigsInRuleStopStates
+        configs.allConfigsInRuleStopStates
     }
 
     /// 
@@ -364,7 +364,7 @@ public enum PredictionMode {
     /// `A={{1,2`}} or `{{1,2`,{1,2}}}, etc...
     /// 
     public static func resolvesToJustOneViableAlt(_ altsets: [BitSet]) -> Int {
-        return getSingleViableAlt(altsets)
+        getSingleViableAlt(altsets)
     }
 
     /// 
@@ -376,7 +376,7 @@ public enum PredictionMode {
     /// _java.util.BitSet#cardinality cardinality_ &gt; 1, otherwise `false`
     /// 
     public static func allSubsetsConflict(_ altsets: [BitSet]) -> Bool {
-        return !hasNonConflictingAltSet(altsets)
+        !hasNonConflictingAltSet(altsets)
     }
 
     /// 
@@ -467,7 +467,7 @@ public enum PredictionMode {
     /// Get union of all alts from configs. - Since: 4.5.1
     /// 
     public static func getAlts(_ configs: ATNConfigSet) -> BitSet {
-        return configs.getAltBitSet()
+        configs.getAltBitSet()
 
     }
 
@@ -482,7 +482,7 @@ public enum PredictionMode {
     /// 
 
     public static func getConflictingAltSubsets(_ configs: ATNConfigSet) -> [BitSet] {
-        return configs.getConflictingAltSubsets()
+        configs.getConflictingAltSubsets()
     }
 
     public static func hasStateAssociatedWithOneAlt(_ configs: ATNConfigSet) -> Bool {

--- a/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
@@ -215,6 +215,6 @@ public class ProfilingATNSimulator: ParserATNSimulator {
 
 
     public func getDecisionInfo() -> [DecisionInfo] {
-        return decisions
+        decisions
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/RangeTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/RangeTransition.swift
@@ -18,21 +18,21 @@ public final class RangeTransition: Transition, CustomStringConvertible {
 
     override
     public func getSerializationType() -> Int {
-        return Transition.RANGE
+        Transition.RANGE
     }
 
     override
     public func labelIntervalSet() -> IntervalSet? {
-        return IntervalSet.of(from, to)
+        IntervalSet.of(from, to)
     }
 
     override
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        return symbol >= from && symbol <= to
+        symbol >= from && symbol <= to
     }
 
     public var description: String {
-        return "'" + String(from) + "'..'" + String(to) + "'"
+        "'" + String(from) + "'..'" + String(to) + "'"
 
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/RuleStartState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/RuleStartState.swift
@@ -12,6 +12,6 @@ public final class RuleStartState: ATNState {
 
     override
     public func getStateType() -> Int {
-        return ATNState.RULE_START
+        ATNState.RULE_START
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/RuleStopState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/RuleStopState.swift
@@ -17,7 +17,7 @@ public final class RuleStopState: ATNState {
 
     override
     public func getStateType() -> Int {
-        return ATNState.RULE_STOP
+        ATNState.RULE_STOP
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/atn/RuleTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/RuleTransition.swift
@@ -36,16 +36,16 @@ public final class RuleTransition: Transition {
 
     override
     public func getSerializationType() -> Int {
-        return Transition.RULE
+        Transition.RULE
     }
 
     override
     public func isEpsilon() -> Bool {
-        return true
+        true
     }
 
     override
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        return false
+        false
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/SemanticContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/SemanticContext.swift
@@ -58,7 +58,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
     /// semantic context after precedence predicates are evaluated.
     /// 
     public func evalPrecedence<T>(_ parser: Recognizer<T>, _ parserCallStack: RuleContext) throws -> SemanticContext? {
-        return self
+        self
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -102,7 +102,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
 
         override
         public var description: String {
-            return "{\(ruleIndex):\(predIndex)}?"
+            "{\(ruleIndex):\(predIndex)}?"
         }
 
     }
@@ -121,7 +121,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
 
         override
         public func eval<T>(_ parser: Recognizer<T>, _ parserCallStack: RuleContext) throws -> Bool {
-            return parser.precpred(parserCallStack, precedence)
+            parser.precpred(parserCallStack, precedence)
         }
 
         override
@@ -140,7 +140,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
 
         override
         public var description: String {
-            return "{" + String(precedence) + ">=prec}?"
+            "{" + String(precedence) + ">=prec}?"
 
         }
     }
@@ -203,7 +203,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
 
         override
         public func getOperands() -> [SemanticContext] {
-            return opnds
+            opnds
         }
 
 
@@ -268,7 +268,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
 
         override
         public var description: String {
-            return opnds.map({ $0.description }).joined(separator: "&&")
+            opnds.map({ $0.description }).joined(separator: "&&")
 
         }
     }
@@ -309,7 +309,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
 
         override
         public func getOperands() -> [SemanticContext] {
-            return opnds
+            opnds
         }
 
         public override func hash(into hasher: inout Hasher) {
@@ -370,7 +370,7 @@ public class SemanticContext: Hashable, CustomStringConvertible {
 
         override
         public var description: String {
-            return opnds.map({ $0.description }).joined(separator: "||")
+            opnds.map({ $0.description }).joined(separator: "||")
 
         }
     }

--- a/runtime/Swift/Sources/Antlr4/atn/SetTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/SetTransition.swift
@@ -15,24 +15,23 @@ public class SetTransition: Transition, CustomStringConvertible {
 
     // TODO (sam): should we really allow null here?
     public init(_ target: ATNState, _ set: IntervalSet) {
-
         self.set = set
         super.init(target)
     }
 
     override
     public func getSerializationType() -> Int {
-        return Transition.SET
+        Transition.SET
     }
 
     override
     public func labelIntervalSet() -> IntervalSet? {
-        return set
+        set
     }
 
     override
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        return set.contains(symbol)
+        set.contains(symbol)
     }
 
     public var description: String {

--- a/runtime/Swift/Sources/Antlr4/atn/SingletonPredictionContext.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/SingletonPredictionContext.swift
@@ -31,7 +31,7 @@ public class SingletonPredictionContext: PredictionContext {
 
     override
     public func size() -> Int {
-        return 1
+        1
     }
 
     override

--- a/runtime/Swift/Sources/Antlr4/atn/StarBlockStartState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/StarBlockStartState.swift
@@ -14,6 +14,6 @@ public final class StarBlockStartState: BlockStartState {
 
     override
     public func getStateType() -> Int {
-        return ATNState.STAR_BLOCK_START
+        ATNState.STAR_BLOCK_START
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/StarLoopEntryState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/StarLoopEntryState.swift
@@ -22,6 +22,6 @@ public final class StarLoopEntryState: DecisionState {
 
     override
     public func getStateType() -> Int {
-        return ATNState.STAR_LOOP_ENTRY
+        ATNState.STAR_LOOP_ENTRY
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/StarLoopbackState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/StarLoopbackState.swift
@@ -7,11 +7,11 @@
 
 public final class StarLoopbackState: ATNState {
     public func getLoopEntryState() -> StarLoopEntryState {
-        return transition(0).target as! StarLoopEntryState
+        transition(0).target as! StarLoopEntryState
     }
 
     override
     public func getStateType() -> Int {
-        return ATNState.STAR_LOOP_BACK
+        ATNState.STAR_LOOP_BACK
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/TokensStartState.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/TokensStartState.swift
@@ -13,6 +13,6 @@ public final class TokensStartState: DecisionState {
 
     override
     public func getStateType() -> Int {
-        return ATNState.TOKEN_START
+        ATNState.TOKEN_START
     }
 }

--- a/runtime/Swift/Sources/Antlr4/atn/Transition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/Transition.swift
@@ -95,12 +95,12 @@ public class Transition {
     /// transition consumes (matches) an input symbol.
     /// 
     public func isEpsilon() -> Bool {
-        return false
+        false
     }
 
 
     public func labelIntervalSet() -> IntervalSet? {
-        return nil
+        nil
     }
 
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {

--- a/runtime/Swift/Sources/Antlr4/atn/WildcardTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/WildcardTransition.swift
@@ -12,17 +12,17 @@ final public class WildcardTransition: Transition, CustomStringConvertible {
 
     override
     public func getSerializationType() -> Int {
-        return Transition.WILDCARD
+        Transition.WILDCARD
     }
 
     override
     public func matches(_ symbol: Int, _ minVocabSymbol: Int, _ maxVocabSymbol: Int) -> Bool {
-        return symbol >= minVocabSymbol && symbol <= maxVocabSymbol
+        symbol >= minVocabSymbol && symbol <= maxVocabSymbol
     }
 
     public var description: String {
 
-        return "."
+        "."
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFA.swift
@@ -66,7 +66,7 @@ public class DFA: CustomStringConvertible {
     /// - seealso: org.antlr.v4.runtime.Parser#getPrecedence()
     /// 
     public final func isPrecedenceDfa() -> Bool {
-        return precedenceDfa
+        precedenceDfa
     }
 
     /// 
@@ -138,7 +138,7 @@ public class DFA: CustomStringConvertible {
     }
 
     public var description: String {
-        return toString(Vocabulary.EMPTY_VOCABULARY)
+        toString(Vocabulary.EMPTY_VOCABULARY)
     }
 
     public func toString(_ vocabulary: Vocabulary) -> String {

--- a/runtime/Swift/Sources/Antlr4/dfa/DFASerializer.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFASerializer.swift
@@ -44,7 +44,7 @@ public class DFASerializer: CustomStringConvertible {
     }
 
     internal func getEdgeLabel(_ i: Int) -> String {
-        return vocabulary.getDisplayName(i - 1)
+        vocabulary.getDisplayName(i - 1)
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
@@ -92,7 +92,7 @@ public final class DFAState: Hashable, CustomStringConvertible {
         }
 
         public var description: String {
-            return "(\(pred),\(alt))"
+            "(\(pred),\(alt))"
         }
     }
 
@@ -105,7 +105,7 @@ public final class DFAState: Hashable, CustomStringConvertible {
     /// DFA state.
     /// 
     public func getAltSet() -> Set<Int>? {
-        return configs.getAltSet()
+        configs.getAltSet()
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/dfa/LexerDFASerializer.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/LexerDFASerializer.swift
@@ -13,6 +13,6 @@ public class LexerDFASerializer: DFASerializer {
     override
 
     internal func getEdgeLabel(_ i: Int) -> String {
-        return "'\(Character(integerLiteral: i))'"
+        "'\(Character(integerLiteral: i))'"
     }
 }

--- a/runtime/Swift/Sources/Antlr4/misc/BitSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/BitSet.swift
@@ -95,7 +95,7 @@ public class BitSet: Hashable, CustomStringConvertible {
     /// Given a bit index, return word index containing it.
     /// 
     private static func wordIndex(_ bitIndex: Int) -> Int {
-        return bitIndex >> ADDRESS_BITS_PER_WORD
+        bitIndex >> ADDRESS_BITS_PER_WORD
     }
 
     /// 
@@ -187,7 +187,7 @@ public class BitSet: Hashable, CustomStringConvertible {
     /// of all the bits in this bit set
     /// 
     public func toLongArray() -> [Int64] {
-        return copyOf(words, wordsInUse)
+        copyOf(words, wordsInUse)
     }
 
     private func copyOf(_ words: [Int64], _ newLength: Int) -> [Int64] {
@@ -596,7 +596,7 @@ public class BitSet: Hashable, CustomStringConvertible {
     /// Equivalent to nextSetBit(0), but guaranteed not to throw an exception.
     ///
     public func firstSetBit() -> Int {
-        return try! nextSetBit(0)
+        try! nextSetBit(0)
     }
 
     ///
@@ -867,7 +867,7 @@ public class BitSet: Hashable, CustomStringConvertible {
     /// - returns: boolean indicating whether this `BitSet` is empty
     /// 
     public func isEmpty() -> Bool {
-        return wordsInUse == 0
+        wordsInUse == 0
     }
 
     /// 
@@ -1077,7 +1077,7 @@ public class BitSet: Hashable, CustomStringConvertible {
     /// - returns: the number of bits currently in this bit set
     /// 
     public func size() -> Int {
-        return words.count * BitSet.BITS_PER_WORD
+        words.count * BitSet.BITS_PER_WORD
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/misc/DoubleKeyMap.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/DoubleKeyMap.swift
@@ -41,6 +41,6 @@ public struct DoubleKeyMap<Key1: Hashable, Key2: Hashable, Value> {
     }
 
     public func get(_ k1: Key1) -> [Key2: Value]? {
-        return data[k1]
+        data[k1]
     }
 }

--- a/runtime/Swift/Sources/Antlr4/misc/Interval.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/Interval.swift
@@ -71,67 +71,67 @@ public class Interval: Hashable {
     /// Does this start completely before other? Disjoint
     /// 
     public func startsBeforeDisjoint(_ other: Interval) -> Bool {
-        return self.a < other.a && self.b < other.a
+        self.a < other.a && self.b < other.a
     }
 
     /// 
     /// Does this start at or before other? Nondisjoint
     /// 
     public func startsBeforeNonDisjoint(_ other: Interval) -> Bool {
-        return self.a <= other.a && self.b >= other.a
+        self.a <= other.a && self.b >= other.a
     }
 
     /// 
     /// Does this.a start after other.b? May or may not be disjoint
     /// 
     public func startsAfter(_ other: Interval) -> Bool {
-        return self.a > other.a
+        self.a > other.a
     }
 
     /// 
     /// Does this start completely after other? Disjoint
     /// 
     public func startsAfterDisjoint(_ other: Interval) -> Bool {
-        return self.a > other.b
+        self.a > other.b
     }
 
     /// 
     /// Does this start after other? NonDisjoint
     /// 
     public func startsAfterNonDisjoint(_ other: Interval) -> Bool {
-        return self.a > other.a && self.a <= other.b // this.b>=other.b implied
+        self.a > other.a && self.a <= other.b // this.b>=other.b implied
     }
 
     /// 
     /// Are both ranges disjoint? I.e., no overlap?
     /// 
     public func disjoint(_ other: Interval) -> Bool {
-        return startsBeforeDisjoint(other) || startsAfterDisjoint(other)
+        startsBeforeDisjoint(other) || startsAfterDisjoint(other)
     }
 
     /// 
     /// Are two intervals adjacent such as 0..41 and 42..42?
     /// 
     public func adjacent(_ other: Interval) -> Bool {
-        return self.a == other.b + 1 || self.b == other.a - 1
+        self.a == other.b + 1 || self.b == other.a - 1
     }
 
     public func properlyContains(_ other: Interval) -> Bool {
-        return other.a >= self.a && other.b <= self.b
+        other.a >= self.a && other.b <= self.b
     }
 
     /// 
     /// Return the interval computed from combining this and other
     /// 
     public func union(_ other: Interval) -> Interval {
-        return Interval.of(min(a, other.a), max(b, other.b))
+        Interval.of(min(a, other.a), max(b, other.b))
     }
 
     /// 
     /// Return the interval in common between this and o
     /// 
     public func intersection(_ other: Interval) -> Interval {
-        return Interval.of(max(a, other.a), min(b, other.b))
+        Interval.of(max(a, other.a), min(b, other.b))
     }
 
     /// 
@@ -159,10 +159,10 @@ public class Interval: Hashable {
 
 
    public var description: String {
-        return "\(a)..\(b)"
+       "\(a)..\(b)"
     }
 }
 
 public func ==(lhs: Interval, rhs: Interval) -> Bool {
-    return lhs.a == rhs.a && lhs.b == rhs.b
+    lhs.a == rhs.a && lhs.b == rhs.b
 }

--- a/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
@@ -192,7 +192,7 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
     }
 
     public func complement(_ minElement: Int, _ maxElement: Int) -> IntSet? {
-        return complement(IntervalSet.of(minElement, maxElement))
+        complement(IntervalSet.of(minElement, maxElement))
     }
 
     ///
@@ -418,7 +418,7 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
     /// 
 
     public func isNil() -> Bool {
-        return intervals.isEmpty
+        intervals.isEmpty
     }
 
     /// 
@@ -467,7 +467,7 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
     /// Return a list of Interval objects.
     /// 
     public func getIntervals() -> [Interval] {
-        return intervals
+        intervals
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -494,7 +494,7 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
     /// 
 
     public var description: String {
-        return toString(false)
+        toString(false)
     }
 
     public func toString(_ elemAreChar: Bool) -> String {
@@ -689,7 +689,7 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
     }
 
     public func isReadonly() -> Bool {
-        return readonly
+        readonly
     }
 
     public func makeReadonly() {
@@ -698,5 +698,5 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
 }
 
 public func ==(lhs: IntervalSet, rhs: IntervalSet) -> Bool {
-    return lhs.intervals == rhs.intervals
+    lhs.intervals == rhs.intervals
 }

--- a/runtime/Swift/Sources/Antlr4/misc/MultiMap.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/MultiMap.swift
@@ -25,11 +25,11 @@ public class MultiMap<K:Hashable, V> {
     }
 
     public func get(_ key: K) -> Array<(V)>? {
-        return mapping[key]
+        mapping[key]
     }
 
     public func size() -> Int {
-        return mapping.count
+        mapping.count
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/misc/MurmurHash.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/MurmurHash.swift
@@ -28,7 +28,7 @@ public final class MurmurHash {
     /// - Returns: the intermediate hash value
     /// 
     public static func initialize() -> UInt32 {
-        return initialize(DEFAULT_SEED)
+        initialize(DEFAULT_SEED)
     }
 
     /// 
@@ -38,7 +38,7 @@ public final class MurmurHash {
     /// - Returns: the intermediate hash value
     /// 
     public static func initialize(_ seed: UInt32) -> UInt32 {
-        return seed
+        seed
     }
 
     private static func calcK(_ value: UInt32) -> UInt32 {
@@ -57,7 +57,7 @@ public final class MurmurHash {
     /// - Returns: the updated intermediate hash value
     /// 
     public static func update2(_ hashIn: UInt32, _ value: Int) -> UInt32 {
-        return updateInternal(hashIn, UInt32(truncatingIfNeeded: value))
+        updateInternal(hashIn, UInt32(truncatingIfNeeded: value))
     }
 
 
@@ -79,7 +79,7 @@ public final class MurmurHash {
     /// - Returns: the updated intermediate hash value
     /// 
     public static func update<T:Hashable>(_ hash: UInt32, _ value: T?) -> UInt32 {
-        return update2(hash, value != nil ? value!.hashValue : 0)
+        update2(hash, value != nil ? value!.hashValue : 0)
     }
 
     /// 
@@ -91,7 +91,7 @@ public final class MurmurHash {
     /// - Returns: the final hash result
     /// 
     public static func finish(_ hashin: UInt32, _ numberOfWords: Int) -> Int {
-        return Int(finish(hashin, byteCount: (numberOfWords &* 4)))
+        Int(finish(hashin, byteCount: (numberOfWords &* 4)))
     }
 
     private static func finish(_ hashin: UInt32, byteCount byteCountInt: Int) -> UInt32 {

--- a/runtime/Swift/Sources/Antlr4/misc/Utils.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/Utils.swift
@@ -41,7 +41,7 @@ public class Utils {
     }
 
     public static func bitLeftShift(_ n: Int) -> Int64 {
-       return (Int64(1) << Int64(n % 64))
+        (Int64(1) << Int64(n % 64))
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/misc/extension/ArrayExtension.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/extension/ArrayExtension.swift
@@ -10,7 +10,7 @@ import Foundation
 extension Array {
    @discardableResult
     mutating func concat(_ addArray: [Element]) -> [Element] {
-        return self + addArray
+       self + addArray
     }
 
     mutating func removeObject<T:Equatable>(_ object: T) {
@@ -37,7 +37,7 @@ extension Array {
     /// :returns: The removed element
     /// 
     mutating func pop() -> Element {
-        return removeLast()
+        removeLast()
     }
     /// 
     /// Same as append.
@@ -104,7 +104,7 @@ extension Array {
     func slice(startIndex: Int, endIndex: Int) -> ArraySlice<Element> {
 
 
-        return self[startIndex ... endIndex]
+        self[startIndex...endIndex]
 
     }
     // func slice(index:Int,isClose:Bool = false) ->(first:Slice<Element> ,second:Slice<Element>){

--- a/runtime/Swift/Sources/Antlr4/misc/extension/CharacterExtension.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/extension/CharacterExtension.swift
@@ -17,7 +17,7 @@ extension Character {
 
     //"1" -> 1 "2"  -> 2
     var integerValue: Int {
-        return Int(String(self)) ?? 0
+        Int(String(self)) ?? 0
     }
     public init(integerLiteral value: IntegerLiteralType) {
         self = Character(UnicodeScalar(value)!)
@@ -38,7 +38,7 @@ extension Character {
 
     //char ->  int
     var unicodeValue: Int {
-        return Int(String(self).unicodeScalars.first?.value ?? 0)
+        Int(String(self).unicodeScalars.first?.value ?? 0)
     }
 
     public static var MAX_VALUE: Int {

--- a/runtime/Swift/Sources/Antlr4/misc/extension/IntStreamExtension.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/extension/IntStreamExtension.swift
@@ -20,7 +20,7 @@ extension IntStream {
     /// reached.
     /// 
     public static var EOF: Int {
-        return -1
+        -1
     }
 
     /// 
@@ -28,7 +28,7 @@ extension IntStream {
     /// underlying source is not known.
     /// 
     public static var UNKNOWN_SOURCE_NAME: String {
-        return "<unknown>"
+        "<unknown>"
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/misc/extension/StringExtension.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/extension/StringExtension.swift
@@ -37,7 +37,7 @@ extension String {
 #if os(Linux)
 extension Substring {
     func hasPrefix(_ prefix: String) -> Bool {
-        return String(self).hasPrefix(prefix)
+        String(self).hasPrefix(prefix)
     }
 }
 #endif

--- a/runtime/Swift/Sources/Antlr4/misc/extension/TokenExtension.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/extension/TokenExtension.swift
@@ -16,7 +16,7 @@ import Foundation
 extension Token {
 
     static public var INVALID_TYPE: Int {
-        return 0
+        0
     }
 
     /// 
@@ -24,16 +24,16 @@ extension Token {
     /// and did not follow it despite needing to.
     /// 
     static public var EPSILON: Int {
-        return -2
+        -2
     }
 
 
     static public var MIN_USER_TOKEN_TYPE: Int {
-        return 1
+        1
     }
 
     static public var EOF: Int {
-        return -1
+        -1
     }
     
     ///
@@ -42,7 +42,7 @@ extension Token {
     /// so that whitespace etc... can go to the parser on a "hidden" channel.
     ///
     static public var DEFAULT_CHANNEL: Int {
-        return 0
+        0
     }
     
     /// 
@@ -50,7 +50,7 @@ extension Token {
     /// by parser.
     ///
     static public var HIDDEN_CHANNEL: Int {
-        return 1
+        1
     }
     
     /// 
@@ -65,6 +65,6 @@ extension Token {
     /// - seealso: org.antlr.v4.runtime.Token#getChannel()
     /// 
     static public var MIN_USER_CHANNEL_VALUE: Int {
-        return 2
+        2
     }
 }

--- a/runtime/Swift/Sources/Antlr4/misc/utils/CommonUtil.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/utils/CommonUtil.swift
@@ -17,19 +17,19 @@ func errPrint(_ msg: String) {
 }
 
 public func +(lhs: String, rhs: Int) -> String {
-    return lhs + String(rhs)
+    lhs + String(rhs)
 }
 
 public func +(lhs: Int, rhs: String) -> String {
-    return String(lhs) + rhs
+    String(lhs) + rhs
 }
 
 public func +(lhs: String, rhs: Token) -> String {
-    return lhs + rhs.description
+    lhs + rhs.description
 }
 
 public func +(lhs: Token, rhs: String) -> String {
-    return lhs.description + rhs
+    lhs.description + rhs
 }
 
 infix operator >>> : BitwiseShiftPrecedence
@@ -58,7 +58,7 @@ func >>>(lhs: Int, rhs: Int) -> Int {
 }
 
 func intChar2String(_ i: Int) -> String {
-    return String(Character(integerLiteral: i))
+    String(Character(integerLiteral: i))
 }
 
 func log(_ message: String = "", file: String = #file, function: String = #function, lineNum: Int = #line) {
@@ -71,11 +71,11 @@ func log(_ message: String = "", file: String = #file, function: String = #funct
 }
 
 func toInt(_ c: Character) -> Int {
-    return c.unicodeValue
+    c.unicodeValue
 }
 
 func toInt32(_ data: [Character], _ offset: Int) -> Int {
-    return data[offset].unicodeValue | (data[offset + 1].unicodeValue << 16)
+    data[offset].unicodeValue | (data[offset + 1].unicodeValue << 16)
 }
 
 func toLong(_ data: [Character], _ offset: Int) -> Int64 {

--- a/runtime/Swift/Sources/Antlr4/misc/utils/Stack.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/utils/Stack.swift
@@ -19,7 +19,7 @@ public struct Stack<T> {
     }
     @discardableResult
     public mutating func pop() -> T {
-        return items.removeLast()
+        items.removeLast()
     }
 
     public mutating func clear() {
@@ -27,10 +27,10 @@ public struct Stack<T> {
     }
 
     public func peek() -> T? {
-        return items.last
+        items.last
     }
     public var isEmpty: Bool {
-        return items.isEmpty
+        items.isEmpty
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/tree/AbstractParseTreeVisitor.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/AbstractParseTreeVisitor.swift
@@ -14,7 +14,7 @@ open class AbstractParseTreeVisitor<T>: ParseTreeVisitor<T> {
     /// specified tree.
     /// 
     open override func visit(_ tree: ParseTree) -> T? {
-        return tree.accept(self)
+        tree.accept(self)
     }
 
     ///
@@ -52,7 +52,7 @@ open class AbstractParseTreeVisitor<T>: ParseTreeVisitor<T> {
     /// _#defaultResult defaultResult_.
     /// 
     open override func visitTerminal(_ node: TerminalNode) -> T? {
-        return defaultResult()
+        defaultResult()
     }
 
     ///
@@ -61,7 +61,7 @@ open class AbstractParseTreeVisitor<T>: ParseTreeVisitor<T> {
     /// 
     override
     open func visitErrorNode(_ node: ErrorNode) -> T? {
-        return defaultResult()
+        defaultResult()
     }
 
     /// 
@@ -76,7 +76,7 @@ open class AbstractParseTreeVisitor<T>: ParseTreeVisitor<T> {
     /// - Returns: The default value returned by visitor methods.
     /// 
     open func defaultResult() -> T? {
-        return nil
+        nil
     }
 
     /// 
@@ -99,7 +99,7 @@ open class AbstractParseTreeVisitor<T>: ParseTreeVisitor<T> {
     /// - Returns: The updated aggregate result.
     /// 
     open func aggregateResult(_ aggregate: T?, _ nextResult: T?) -> T? {
-        return nextResult
+        nextResult
     }
 
     /// 
@@ -127,7 +127,7 @@ open class AbstractParseTreeVisitor<T>: ParseTreeVisitor<T> {
     /// current aggregate result from _#visitChildren_.
     /// 
     open func shouldVisitNextChild(_ node: RuleNode, _ currentResult: T?) -> Bool {
-        return true
+        true
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/tree/ErrorNode.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/ErrorNode.swift
@@ -18,7 +18,7 @@ public class ErrorNode: TerminalNodeImpl {
 
     override
     public func accept<T>(_ visitor: ParseTreeVisitor<T>) -> T? {
-        return visitor.visitErrorNode(self)
+        visitor.visitErrorNode(self)
     }
 
 }

--- a/runtime/Swift/Sources/Antlr4/tree/ParseTreeProperty.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/ParseTreeProperty.swift
@@ -9,7 +9,9 @@ public class ParseTreeProperty<V> {
   
   public init() {}
   
-  open func get(_ node: ParseTree) -> V? { return annotations[ObjectIdentifier(node)] }
+  open func get(_ node: ParseTree) -> V? {
+      annotations[ObjectIdentifier(node)]
+  }
   open func put(_ node: ParseTree, _ value: V) { annotations[ObjectIdentifier(node)] = value }
   open func removeFrom(_ node: ParseTree) { annotations.removeValue(forKey: ObjectIdentifier(node)) }
 }

--- a/runtime/Swift/Sources/Antlr4/tree/TerminalNodeImpl.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/TerminalNodeImpl.swift
@@ -14,7 +14,7 @@ public class TerminalNodeImpl: TerminalNode {
 
 
     public func getChild(_ i: Int) -> Tree? {
-        return nil
+        nil
     }
 
     open subscript(index: Int) -> ParseTree {
@@ -22,11 +22,11 @@ public class TerminalNodeImpl: TerminalNode {
     }
 
     public func getSymbol() -> Token? {
-        return symbol
+        symbol
     }
 
     public func getParent() -> Tree? {
-        return parent
+        parent
     }
 
     public func setParent(_ parent: RuleContext) {
@@ -34,7 +34,7 @@ public class TerminalNodeImpl: TerminalNode {
     }
 
     public func getPayload() -> AnyObject {
-        return symbol
+        symbol
     }
 
     public func getSourceInterval() -> Interval {
@@ -45,20 +45,20 @@ public class TerminalNodeImpl: TerminalNode {
     }
 
     public func getChildCount() -> Int {
-        return 0
+        0
     }
 
 
     public func accept<T>(_ visitor: ParseTreeVisitor<T>) -> T? {
-        return visitor.visitTerminal(self)
+        visitor.visitTerminal(self)
     }
 
     public func getText() -> String {
-        return (symbol.getText())!
+        (symbol.getText())!
     }
 
     public func toStringTree(_ parser: Parser) -> String {
-        return description
+        description
     }
 
     public var description: String {
@@ -71,10 +71,10 @@ public class TerminalNodeImpl: TerminalNode {
     }
 
     public var debugDescription: String {
-        return description
+        description
     }
 
     public func toStringTree() -> String {
-        return description
+        description
     }
 }

--- a/runtime/Swift/Sources/Antlr4/tree/Trees.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/Trees.swift
@@ -149,11 +149,11 @@ public class Trees {
     }
 
     public static func findAllTokenNodes(_ t: ParseTree, _ ttype: Int) -> Array<ParseTree> {
-        return findAllNodes(t, ttype, true)
+        findAllNodes(t, ttype, true)
     }
 
     public static func findAllRuleNodes(_ t: ParseTree, _ ruleIndex: Int) -> Array<ParseTree> {
-        return findAllNodes(t, ruleIndex, false)
+        findAllNodes(t, ruleIndex, false)
     }
 
     public static func findAllNodes(_ t: ParseTree, _ index: Int, _ findTokens: Bool) -> Array<ParseTree> {

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/Chunk.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/Chunk.swift
@@ -19,10 +19,10 @@
 
 public class Chunk: Equatable {
     public static func ==(lhs: Chunk, rhs: Chunk) -> Bool {
-        return lhs.isEqual(rhs)
+        lhs.isEqual(rhs)
     }
 
     public func isEqual(_ other: Chunk) -> Bool {
-        return false
+        false
     }
 }

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/ParseTreeMatch.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/ParseTreeMatch.swift
@@ -119,7 +119,7 @@ public class ParseTreeMatch: CustomStringConvertible {
     /// pattern did not contain any rule or token tags, this map will be empty.
     /// 
     public func getLabels() -> MultiMap<String, ParseTree> {
-        return labels
+        labels
     }
 
     /// 
@@ -129,7 +129,7 @@ public class ParseTreeMatch: CustomStringConvertible {
     /// if the match was successful.
     /// 
     public func getMismatchedNode() -> ParseTree? {
-        return mismatchedNode
+        mismatchedNode
     }
 
     /// 
@@ -139,7 +139,7 @@ public class ParseTreeMatch: CustomStringConvertible {
     /// `false`.
     /// 
     public func succeeded() -> Bool {
-        return mismatchedNode == nil
+        mismatchedNode == nil
     }
 
     /// 
@@ -148,7 +148,7 @@ public class ParseTreeMatch: CustomStringConvertible {
     /// - Returns: The tree pattern we are matching against.
     /// 
     public func getPattern() -> ParseTreePattern {
-        return pattern
+        pattern
     }
 
     /// 
@@ -157,7 +157,7 @@ public class ParseTreeMatch: CustomStringConvertible {
     /// - Returns: The _org.antlr.v4.runtime.tree.ParseTree_ we are trying to match to a pattern.
     /// 
     public func getTree() -> ParseTree {
-        return tree
+        tree
     }
 
     public var description: String {

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/ParseTreePattern.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/ParseTreePattern.swift
@@ -61,7 +61,7 @@ public class ParseTreePattern {
     /// 
 
     public func match(_ tree: ParseTree) throws -> ParseTreeMatch {
-        return try matcher.match(tree, self)
+        try matcher.match(tree, self)
     }
 
     /// 
@@ -72,7 +72,7 @@ public class ParseTreePattern {
     /// pattern; otherwise, `false`.
     /// 
     public func matches(_ tree: ParseTree) throws -> Bool {
-        return try matcher.match(tree, self).succeeded()
+        try matcher.match(tree, self).succeeded()
     }
 
     /// 
@@ -107,7 +107,7 @@ public class ParseTreePattern {
     /// 
 
     public func getMatcher() -> ParseTreePatternMatcher {
-        return matcher
+        matcher
     }
 
     /// 
@@ -117,7 +117,7 @@ public class ParseTreePattern {
     /// 
 
     public func getPattern() -> String {
-        return pattern
+        pattern
     }
 
     /// 
@@ -128,7 +128,7 @@ public class ParseTreePattern {
     /// pattern.
     /// 
     public func getPatternRuleIndex() -> Int {
-        return patternRuleIndex
+        patternRuleIndex
     }
 
     /// 
@@ -140,6 +140,6 @@ public class ParseTreePattern {
     /// 
 
     public func getPatternTree() -> ParseTree {
-        return patternTree
+        patternTree
     }
 }

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/ParseTreePatternMatcher.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/ParseTreePatternMatcher.swift
@@ -185,7 +185,7 @@ public class ParseTreePatternMatcher {
     /// input stream is reset.
     /// 
     public func getLexer() -> Lexer {
-        return lexer
+        lexer
     }
 
     /// 
@@ -193,7 +193,7 @@ public class ParseTreePatternMatcher {
     /// used to parse the pattern into a parse tree.
     /// 
     public func getParser() -> Parser {
-        return parser
+        parser
     }
 
     // ---- SUPPORT CODE ----

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/RuleTagToken.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/RuleTagToken.swift
@@ -66,7 +66,7 @@ public class RuleTagToken: Token, CustomStringConvertible {
     /// - Returns: The name of the parser rule associated with this rule tag.
     /// 
     public final func getRuleName() -> String {
-        return ruleName
+        ruleName
     }
 
     /// 
@@ -76,14 +76,14 @@ public class RuleTagToken: Token, CustomStringConvertible {
     /// `null` if this is an unlabeled rule tag.
     /// 
     public final func getLabel() -> String? {
-        return label
+        label
     }
 
     /// 
     /// Rule tag tokens are always placed on the _#DEFAULT_CHANNEL_.
     /// 
     public func getChannel() -> Int {
-        return RuleTagToken.DEFAULT_CHANNEL
+        RuleTagToken.DEFAULT_CHANNEL
     }
 
     /// 
@@ -102,21 +102,21 @@ public class RuleTagToken: Token, CustomStringConvertible {
     /// transitions created during ATN deserialization.
     /// 
     public func getType() -> Int {
-        return bypassTokenType
+        bypassTokenType
     }
 
     /// 
     /// The implementation for _org.antlr.v4.runtime.tree.pattern.RuleTagToken_ always returns 0.
     /// 
     public func getLine() -> Int {
-        return 0
+        0
     }
 
     /// 
     /// The implementation for _org.antlr.v4.runtime.tree.pattern.RuleTagToken_ always returns -1.
     /// 
     public func getCharPositionInLine() -> Int {
-        return -1
+        -1
     }
 
     /// 
@@ -125,39 +125,39 @@ public class RuleTagToken: Token, CustomStringConvertible {
     /// The implementation for _org.antlr.v4.runtime.tree.pattern.RuleTagToken_ always returns -1.
     /// 
     public func getTokenIndex() -> Int {
-        return -1
+        -1
     }
 
     /// 
     /// The implementation for _org.antlr.v4.runtime.tree.pattern.RuleTagToken_ always returns -1.
     /// 
     public func getStartIndex() -> Int {
-        return -1
+        -1
     }
 
     /// 
     /// The implementation for _org.antlr.v4.runtime.tree.pattern.RuleTagToken_ always returns -1.
     /// 
     public func getStopIndex() -> Int {
-        return -1
+        -1
     }
 
     /// 
     /// The implementation for _org.antlr.v4.runtime.tree.pattern.RuleTagToken_ always returns `null`.
     /// 
     public func getTokenSource() -> TokenSource? {
-        return nil
+        nil
     }
 
     ///
     /// The implementation for _org.antlr.v4.runtime.tree.pattern.RuleTagToken_ always returns `null`.
     /// 
     public func getInputStream() -> CharStream? {
-        return nil
+        nil
     }
 
     public func getTokenSourceAndStream() -> TokenSourceAndStream {
-        return TokenSourceAndStream.EMPTY
+        TokenSourceAndStream.EMPTY
     }
 
     ///
@@ -165,7 +165,7 @@ public class RuleTagToken: Token, CustomStringConvertible {
     /// `ruleName:bypassTokenType`.
     /// 
     public var description: String {
-        return ruleName + ":" + String(bypassTokenType)
+        ruleName + ":" + String(bypassTokenType)
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/TagChunk.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/TagChunk.swift
@@ -68,7 +68,7 @@ public class TagChunk: Chunk, CustomStringConvertible {
     /// - Returns: The tag for the chunk.
     /// 
     public final func getTag() -> String {
-        return tag
+        tag
     }
 
     /// 
@@ -78,7 +78,7 @@ public class TagChunk: Chunk, CustomStringConvertible {
     /// assigned to the chunk.
     /// 
     public final func getLabel() -> String? {
-        return label
+        label
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/TextChunk.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/TextChunk.swift
@@ -33,7 +33,7 @@ public class TextChunk: Chunk, CustomStringConvertible {
     /// 
 
     public final func getText() -> String {
-        return text
+        text
     }
 
     ///
@@ -41,7 +41,7 @@ public class TextChunk: Chunk, CustomStringConvertible {
     /// _#getText()_ in single quotes.
     ///
     public var description: String {
-        return "'\(text)'"
+        "'\(text)'"
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/tree/pattern/TokenTagToken.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/pattern/TokenTagToken.swift
@@ -56,7 +56,7 @@ public class TokenTagToken: CommonToken {
     /// 
 
     public final func getTokenName() -> String {
-        return tokenName
+        tokenName
     }
 
     /// 
@@ -67,7 +67,7 @@ public class TokenTagToken: CommonToken {
     /// 
 
     public final func getLabel() -> String? {
-        return label
+        label
     }
 
     /// 
@@ -94,6 +94,6 @@ public class TokenTagToken: CommonToken {
 
     override
     public var description: String {
-        return tokenName + ":" + String(type)
+        tokenName + ":" + String(type)
     }
 }

--- a/runtime/Swift/Tests/Antlr4Tests/StringExtensionTests.swift
+++ b/runtime/Swift/Tests/Antlr4Tests/StringExtensionTests.swift
@@ -23,8 +23,7 @@ private func doLastIndexTest(_ str: String, _ target: String, _ expectedOffset: 
     let expectedIdx: String.Index?
     if let expectedOffset = expectedOffset {
         expectedIdx = str.index(str.startIndex, offsetBy: expectedOffset)
-    }
-    else {
+    } else {
         expectedIdx = nil
     }
     XCTAssertEqual(str.lastIndex(of: target), expectedIdx)

--- a/runtime/Swift/Tests/Antlr4Tests/VisitorTests.swift
+++ b/runtime/Swift/Tests/Antlr4Tests/VisitorTests.swift
@@ -27,15 +27,15 @@ class VisitorTests: XCTestCase {
 
         class Visitor: VisitorBasicBaseVisitor<String> {
             override func visitTerminal(_ node: TerminalNode) -> String? {
-                return "\(node.getSymbol()!)\n"
+                "\(node.getSymbol()!)\n"
             }
 
             override func defaultResult() -> String? {
-                return ""
+                ""
             }
 
             override func aggregateResult(_ aggregate: String?, _ nextResult: String?) -> String? {
-                return aggregate! + nextResult!
+                aggregate! + nextResult!
             }
         }
 
@@ -82,15 +82,15 @@ class VisitorTests: XCTestCase {
 
         class Visitor: VisitorBasicBaseVisitor<String> {
             override func visitErrorNode(_ node: ErrorNode) -> String? {
-                return "Error encountered: \(node.getSymbol()!)"
+                "Error encountered: \(node.getSymbol()!)"
             }
 
             override func defaultResult() -> String? {
-                return ""
+                ""
             }
 
             override func aggregateResult(_ aggregate: String?, _ nextResult: String?) -> String? {
-                return aggregate! + nextResult!
+                aggregate! + nextResult!
             }
         }
 
@@ -115,11 +115,11 @@ class VisitorTests: XCTestCase {
 
         class Visitor: VisitorBasicBaseVisitor<String> {
             override func visitTerminal(_ node: TerminalNode) -> String? {
-                return "\(node.getSymbol()!)\n"
+                "\(node.getSymbol()!)\n"
             }
 
             override func shouldVisitNextChild(_ node: RuleNode, _ currentResult: String?) -> Bool {
-                return currentResult == nil || currentResult!.isEmpty
+                currentResult == nil || currentResult!.isEmpty
             }
         }
 
@@ -149,11 +149,11 @@ class VisitorTests: XCTestCase {
             }
 
             override func defaultResult() -> String? {
-                return "default result"
+                "default result"
             }
 
             override func shouldVisitNextChild(_ node: RuleNode, _ currentResult: String?) -> Bool {
-                return false
+                false
             }
         }
 
@@ -176,11 +176,11 @@ class VisitorTests: XCTestCase {
 
         class Visitor: VisitorCalcBaseVisitor<Int> {
             override func visitS(_ ctx: VisitorCalcParser.SContext) -> Int? {
-                return visit(ctx.expr()!)
+                visit(ctx.expr()!)
             }
 
             override func visitNumber(_ ctx: VisitorCalcParser.NumberContext) -> Int? {
-                return Int((ctx.INT()?.getText())!)
+                Int((ctx.INT()?.getText())!)
             }
 
             override func visitMultiply(_ ctx: VisitorCalcParser.MultiplyContext) -> Int? {

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -219,7 +219,7 @@ import Antlr4
  * \<p>The default implementation returns the result of calling
  * {@link #visitChildren\} on {@code ctx\}.\</p>
  */
-<accessLevelOpenOK(file)> func visit<lname; format="cap">(_ ctx: <file.parserName>.<lname; format="cap">Context) -> T? { return visitChildren(ctx) \}}; separator="\n">
+<accessLevelOpenOK(file)> func visit<lname; format="cap">(_ ctx: <file.parserName>.<lname; format="cap">Context) -> T? { visitChildren(ctx) \}}; separator="\n">
 }
 >>
 
@@ -268,16 +268,16 @@ Parser_(parser, funcs, atn, sempredFuncs, ctor, superClass) ::= <<
                     accessLevelNotOpen(parser))>
 
 	override <accessLevelOpenOK(parser)>
-	func getGrammarFileName() -> String { return "<parser.grammarFileName; format="java-escape">" }
+	func getGrammarFileName() -> String { "<parser.grammarFileName; format="java-escape">" }
 
 	override <accessLevelOpenOK(parser)>
-	func getRuleNames() -> [String] { return <parser.name>.ruleNames }
+	func getRuleNames() -> [String] { <parser.name>.ruleNames }
 
 	override <accessLevelOpenOK(parser)>
-	func getSerializedATN() -> String { return <parser.name>._serializedATN }
+	func getSerializedATN() -> String { <parser.name>._serializedATN }
 
 	override <accessLevelOpenOK(parser)>
-	func getATN() -> ATN { return <parser.name>._ATN }
+	func getATN() -> ATN { <parser.name>._ATN }
 
 	<namedActions.members>
 	<parser:(ctor)()>
@@ -351,7 +351,7 @@ parser_ctor(p) ::= <<
 
 override <accessLevelOpenOK(parser)>
 func getVocabulary() -> Vocabulary {
-    return <p.name>.VOCABULARY
+    <p.name>.VOCABULARY
 }
 
 override <accessLevelNotOpen(parser)>
@@ -789,31 +789,31 @@ ContextTokenGetterDecl(t) ::= <<
 ContextTokenListGetterDecl(t) ::= <<
 	<accessLevelOpenOK(parser)>
 	func <t.name>() -> [TerminalNode] {
-		return getTokens(<parser.name>.Tokens.<t.name>.rawValue)
+		getTokens(<parser.name>.Tokens.<t.name>.rawValue)
 	}
 >>
 ContextTokenListIndexedGetterDecl(t) ::= <<
 	<accessLevelOpenOK(parser)>
 	func <t.name>(_ i:Int) -> TerminalNode? {
-		return getToken(<parser.name>.Tokens.<t.name>.rawValue, i)
+		getToken(<parser.name>.Tokens.<t.name>.rawValue, i)
 	}
 >>
 ContextRuleGetterDecl(r) ::= <<
 	<accessLevelOpenOK(parser)>
 	func <r.name>() -> <r.ctxName>? {
-		return getRuleContext(<r.ctxName>.self, 0)
+		getRuleContext(<r.ctxName>.self, 0)
 	}
 >>
 ContextRuleListGetterDecl(r) ::= <<
 	<accessLevelOpenOK(parser)>
 	func <r.name>() -> [<r.ctxName>] {
-		return getRuleContexts(<r.ctxName>.self)
+		getRuleContexts(<r.ctxName>.self)
 	}
 >>
 ContextRuleListIndexedGetterDecl(r)   ::= <<
 	<accessLevelOpenOK(parser)>
 	func <r.name>(_ i: Int) -> <r.ctxName>? {
-		return getRuleContext(<r.ctxName>.self, i)
+		getRuleContext(<r.ctxName>.self, i)
 	}
 >>
 
@@ -848,7 +848,7 @@ StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMe
 
 	override <accessLevelOpenOK(parser)>
 	func getRuleIndex() -> Int {
-		return <parser.name>.RULE_<struct.derivedFromName>
+		<parser.name>.RULE_<struct.derivedFromName>
 	}
 <if(struct.provideCopyFrom && struct.attrs)> <! don't need copy unless we have subclasses !>
 	<accessLevelOpenOK(parser)>
@@ -1024,22 +1024,22 @@ Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 	}
 
 	override <accessLevelOpenOK(lexer)>
-	func getGrammarFileName() -> String { return "<lexer.grammarFileName>" }
+	func getGrammarFileName() -> String { "<lexer.grammarFileName>" }
 
 	override <accessLevelOpenOK(lexer)>
-	func getRuleNames() -> [String] { return <lexer.name>.ruleNames }
+	func getRuleNames() -> [String] { <lexer.name>.ruleNames }
 
 	override <accessLevelOpenOK(lexer)>
-	func getSerializedATN() -> String { return <lexer.name>._serializedATN }
+	func getSerializedATN() -> String { <lexer.name>._serializedATN }
 
 	override <accessLevelOpenOK(lexer)>
-	func getChannelNames() -> [String] { return <lexer.name>.channelNames }
+	func getChannelNames() -> [String] { <lexer.name>.channelNames }
 
 	override <accessLevelOpenOK(lexer)>
-	func getModeNames() -> [String] { return <lexer.name>.modeNames }
+	func getModeNames() -> [String] { <lexer.name>.modeNames }
 
 	override <accessLevelOpenOK(lexer)>
-	func getATN() -> ATN { return <lexer.name>._ATN }
+	func getATN() -> ATN { <lexer.name>._ATN }
 
 	<dumpActions(lexer, "", actionFuncs, sempredFuncs)>
 	<atn>


### PR DESCRIPTION
Removed usages of return where it can be omitted, i.e., in all single-expression closures, getters, and functions.

Applied by AppCode

`Swift.stg` was processed manually