### PR TITLE
[Swift] Use proper constants

### DIFF
--- a/runtime/Swift/Sources/Antlr4/Lexer.swift
+++ b/runtime/Swift/Sources/Antlr4/Lexer.swift
@@ -75,7 +75,7 @@ open class Lexer: Recognizer<LexerATNSimulator>, TokenSource {
     /// 
     /// The token type for the current token
     /// 
-    public var _type = 0
+    public var _type = CommonToken.INVALID_TYPE
 
     public final var _modeStack = Stack<Int>()
     public var _mode = Lexer.DEFAULT_MODE

--- a/runtime/Swift/Sources/Antlr4/RecognitionException.swift
+++ b/runtime/Swift/Sources/Antlr4/RecognitionException.swift
@@ -28,7 +28,7 @@ public class RecognitionException {
     /// 
     private var offendingToken: Token!
 
-    private var offendingState = -1
+    private var offendingState = ATNState.INVALID_STATE_NUMBER
 
     public var message: String?
 

--- a/runtime/Swift/Sources/Antlr4/Recognizer.swift
+++ b/runtime/Swift/Sources/Antlr4/Recognizer.swift
@@ -23,7 +23,7 @@ open class Recognizer<ATNInterpreter: ATNSimulator>: RecognizerProtocol {
 
     public var _interp: ATNInterpreter!
 
-    private var _stateNumber = -1
+    private var _stateNumber = ATNState.INVALID_STATE_NUMBER
 
     open func getRuleNames() -> [String] {
         fatalError(#function + " must be overridden")

--- a/runtime/Swift/Sources/Antlr4/RuleContext.swift
+++ b/runtime/Swift/Sources/Antlr4/RuleContext.swift
@@ -12,7 +12,7 @@
 /// as a children list so that we can turn this data structure into a
 /// tree.
 /// 
-/// The root node always has a null pointer and invokingState of -1.
+/// The root node always has a null pointer and invokingState of ATNState.INVALID_STATE_NUMBER.
 /// 
 /// Upon entry to parsing, the first invoked rule function creates a
 /// context object (asubclass specialized for that rule such as
@@ -63,10 +63,10 @@ open class RuleContext: RuleNode {
 
     /// What state invoked the rule associated with this context?
     /// The "return address" is the followState of invokingState
-    /// If parent is null, this should be -1 this context object represents
-    /// the start rule.
+    /// If parent is null, this should be ATNState.INVALID_STATE_NUMBER
+    /// this context object represents the start rule.
     /// 
-    public var invokingState = -1
+    public var invokingState = ATNState.INVALID_STATE_NUMBER
 
     public init() {
     }
@@ -91,7 +91,7 @@ open class RuleContext: RuleNode {
     /// current context.
     /// 
     open func isEmpty() -> Bool {
-        return invokingState == -1
+        return invokingState == ATNState.INVALID_STATE_NUMBER
     }
 
     // satisfy the ParseTree / SyntaxTree interface

--- a/runtime/Swift/Sources/Antlr4/atn/ATNConfig.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNConfig.swift
@@ -20,7 +20,7 @@ public class ATNConfig: Hashable, CustomStringConvertible {
     /// _#isPrecedenceFilterSuppressed_ property as a bit within the
     /// existing _#reachesIntoOuterContext_ field.
     /// 
-    private final let SUPPRESS_PRECEDENCE_FILTER: Int = 0x40000000
+    private static let SUPPRESS_PRECEDENCE_FILTER: Int = 0x40000000
 
     /// 
     /// The ATN state associated with this configuration
@@ -111,18 +111,18 @@ public class ATNConfig: Hashable, CustomStringConvertible {
     /// _#isPrecedenceFilterSuppressed_ method.
     /// 
     public final func getOuterContextDepth() -> Int {
-        return reachesIntoOuterContext & ~SUPPRESS_PRECEDENCE_FILTER
+        return reachesIntoOuterContext & ~Self.SUPPRESS_PRECEDENCE_FILTER
     }
 
     public final func isPrecedenceFilterSuppressed() -> Bool {
-        return (reachesIntoOuterContext & SUPPRESS_PRECEDENCE_FILTER) != 0
+        return (reachesIntoOuterContext & Self.SUPPRESS_PRECEDENCE_FILTER) != 0
     }
 
     public final func setPrecedenceFilterSuppressed(_ value: Bool) {
         if value {
-            self.reachesIntoOuterContext |= 0x40000000
+            self.reachesIntoOuterContext |= Self.SUPPRESS_PRECEDENCE_FILTER
         } else {
-            self.reachesIntoOuterContext &= ~SUPPRESS_PRECEDENCE_FILTER
+            self.reachesIntoOuterContext &= ~Self.SUPPRESS_PRECEDENCE_FILTER
         }
     }
 

--- a/runtime/Swift/Sources/Antlr4/atn/ATNConfigSet.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNConfigSet.swift
@@ -42,7 +42,7 @@ public final class ATNConfigSet: Hashable, CustomStringConvertible {
 
     // TODO: these fields make me pretty uncomfortable but nice to pack up info together, saves recomputation
     // TODO: can we track conflicts as they are added to save scanning configs later?
-    public internal(set) var uniqueAlt = 0
+    public internal(set) var uniqueAlt = ATN.INVALID_ALT_NUMBER
     //TODO no default
     /// 
     /// Currently this is only used when we detect SLL conflict; this does

--- a/runtime/Swift/Sources/Antlr4/atn/LL1Analyzer.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LL1Analyzer.swift
@@ -137,7 +137,7 @@ public class LL1Analyzer {
                         _ seeThruPreds: Bool,
                         _ addEOF: Bool) {
         // print ("_LOOK(\(s.stateNumber), ctx=\(ctx)");
-        let c = ATNConfig(s, 0, ctx)
+        let c = ATNConfig(s, ATN.INVALID_ALT_NUMBER, ctx)
         if lookBusy.contains(c) {
             return
         } else {

--- a/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
@@ -646,7 +646,7 @@ open class ParserATNSimulator: ATNSimulator {
         var previous = s0
         try input.seek(startIndex)
         var t = try input.LA(1)
-        var predictedAlt = 0
+        var predictedAlt = ATN.INVALID_ALT_NUMBER
         while true {
             // while more work
             if let computeReach = try computeReachSet(previous, t, fullCtx) {

--- a/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
@@ -49,7 +49,7 @@ public final class DFAState: Hashable, CustomStringConvertible {
     /// This is set to _org.antlr.v4.runtime.atn.ATN#INVALID_ALT_NUMBER_ when _#predicates_`!=null` or
     /// _#requiresFullContext_.
     /// 
-    public internal(set) var prediction = 0
+    public internal(set) var prediction = ATN.INVALID_ALT_NUMBER
 
     public internal(set) var lexerActionExecutor: LexerActionExecutor?
 

--- a/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
+++ b/runtime/Swift/Sources/Antlr4/dfa/DFAState.swift
@@ -32,7 +32,7 @@
 /// 
 
 public final class DFAState: Hashable, CustomStringConvertible {
-    public internal(set) var stateNumber = -1
+    public internal(set) var stateNumber = ATNState.INVALID_STATE_NUMBER
 
     public internal(set) var configs: ATNConfigSet
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->
changes SUPPRESS_PRECEDENCE_FILTER to be a static (type) variable, not an instance variable.