### PR TITLE
Report LexerEmptyModeStackException instead of throwing empty stack exception

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LexerErrors/EmptyModeStack.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LexerErrors/EmptyModeStack.txt
@@ -1,0 +1,21 @@
+[type]
+Lexer
+
+[grammar]
+lexer grammar T;
+A: 'aa';
+B: 'bb' -> popMode;
+C: 'cc';
+
+[input]
+aabbcc
+
+[output]
+[@0,0:1='aa',<1>,1:0]
+[@1,2:3='bb',<2>,1:2]
+[@2,4:5='cc',<3>,1:4]
+[@3,6:5='<EOF>',<-1>,1:6]
+
+[errors]
+"""line 1:2 Unable to pop mode because mode stack is empty at: 'bb'
+"""

--- a/runtime/CSharp/src/Atn/LexerATNSimulator.cs
+++ b/runtime/CSharp/src/Atn/LexerATNSimulator.cs
@@ -300,7 +300,7 @@ namespace Antlr4.Runtime.Atn
 					return TokenConstants.EOF;
 				}
 
-				throw new LexerNoViableAltException(recog, input, startIndex, reach);
+				throw new LexerNoViableAltException(recog, input, startIndex, input.Index - startIndex, reach);
 			}
 		}
 

--- a/runtime/CSharp/src/LexerEmptyModeStackException.cs
+++ b/runtime/CSharp/src/LexerEmptyModeStackException.cs
@@ -1,0 +1,15 @@
+﻿namespace Antlr4.Runtime
+{
+    public class LexerEmptyModeStackException : LexerException
+    {
+        public LexerEmptyModeStackException(Lexer lexer, ICharStream input, int startIndex, int length)
+            : base(lexer, input, startIndex, length)
+        {
+        }
+
+        public override string GetErrorMessage(string input)
+        {
+            return "Unable to pop mode because mode stack is empty at: '" + input + "'";
+        }
+    }
+}

--- a/runtime/CSharp/src/LexerException.cs
+++ b/runtime/CSharp/src/LexerException.cs
@@ -1,0 +1,16 @@
+﻿namespace Antlr4.Runtime
+{
+    public abstract class LexerException : RecognitionException
+    {
+        public readonly int StartIndex;
+        public readonly int Length;
+
+        protected LexerException(Lexer lexer, ICharStream input, int startIndex, int length) : base(lexer, input)
+        {
+            StartIndex = startIndex;
+            Length = length;
+        }
+
+        public abstract string GetErrorMessage(string input);
+    }
+}

--- a/runtime/CSharp/src/LexerNoViableAltException.cs
+++ b/runtime/CSharp/src/LexerNoViableAltException.cs
@@ -2,64 +2,47 @@
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
+
+using System;
 using System.Globalization;
-using Antlr4.Runtime;
 using Antlr4.Runtime.Atn;
 using Antlr4.Runtime.Misc;
-using Antlr4.Runtime.Sharpen;
 
 namespace Antlr4.Runtime
 {
-    [System.Serializable]
-    public class LexerNoViableAltException : RecognitionException
+    [Serializable]
+    public class LexerNoViableAltException : LexerException
     {
-        private const long serialVersionUID = -730999203913001726L;
-
-        /// <summary>Matching attempted at what input index?</summary>
-        private readonly int startIndex;
-
         /// <summary>Which configurations did we try at input.index() that couldn't match input.LA(1)?</summary>
         [Nullable]
         private readonly ATNConfigSet deadEndConfigs;
 
+        [Obsolete]
         public LexerNoViableAltException(Lexer lexer, ICharStream input, int startIndex, ATNConfigSet deadEndConfigs)
-            : base(lexer, input)
+            : base(lexer, input, startIndex, 1)
         {
-            this.startIndex = startIndex;
             this.deadEndConfigs = deadEndConfigs;
         }
 
-        public virtual int StartIndex
+        public LexerNoViableAltException(Lexer lexer, ICharStream input, int startIndex, int length, ATNConfigSet deadEndConfigs)
+            : base(lexer, input, startIndex, length)
         {
-            get
-            {
-                return startIndex;
-            }
+            this.deadEndConfigs = deadEndConfigs;
         }
 
         [Nullable]
-        public virtual ATNConfigSet DeadEndConfigs
-        {
-            get
-            {
-                return deadEndConfigs;
-            }
-        }
+        public virtual ATNConfigSet DeadEndConfigs => deadEndConfigs;
 
-        public override IIntStream InputStream
-        {
-            get
-            {
-                return (ICharStream)base.InputStream;
-            }
-        }
+        public override IIntStream InputStream => (ICharStream)base.InputStream;
+
+        public override string GetErrorMessage(string input) => "token recognition error at: '" + input + "'";
 
         public override string ToString()
         {
             string symbol = string.Empty;
-            if (startIndex >= 0 && startIndex < ((ICharStream)InputStream).Size)
+            if (StartIndex >= 0 && StartIndex < ((ICharStream)InputStream).Size)
             {
-                symbol = ((ICharStream)InputStream).GetText(Interval.Of(startIndex, startIndex));
+                symbol = ((ICharStream)InputStream).GetText(Interval.Of(StartIndex, StartIndex));
                 symbol = Utils.EscapeWhitespace(symbol, false);
             }
             return string.Format(CultureInfo.CurrentCulture, "{0}('{1}')", typeof(Antlr4.Runtime.LexerNoViableAltException).Name, symbol);

--- a/runtime/Dart/lib/src/atn/src/lexer_atn_simulator.dart
+++ b/runtime/Dart/lib/src/atn/src/lexer_atn_simulator.dart
@@ -311,7 +311,8 @@ class LexerATNSimulator extends ATNSimulator {
         return Token.EOF;
       }
 
-      throw LexerNoViableAltException(recog, input, startIndex, reach);
+      throw LexerNoViableAltException(recog, input, startIndex,
+          input.index - startIndex, reach);
     }
   }
 

--- a/runtime/Dart/lib/src/error/src/errors.dart
+++ b/runtime/Dart/lib/src/error/src/errors.dart
@@ -87,19 +87,28 @@ class RecognitionException<StreamType extends IntStream> extends StateError {
   }
 }
 
-class LexerNoViableAltException extends RecognitionException<CharStream> {
-  /// Matching attempted at what input index? */
+abstract class LexerException extends RecognitionException<CharStream> {
   final int startIndex;
+  final int length;
 
+  LexerException(Recognizer<ATNSimulator>? recognizer, CharStream inputStream, RuleContext? ctx,
+      this.startIndex, this.length)
+      : super(recognizer, inputStream, ctx);
+
+  String getErrorMessage(String input);
+}
+
+class LexerNoViableAltException extends LexerException {
   /// Which configurations did we try at input.index() that couldn't match input.LA(1)? */
   final ATNConfigSet deadEndConfigs;
 
   LexerNoViableAltException(
     Lexer? lexer,
     CharStream input,
-    this.startIndex,
-    this.deadEndConfigs,
-  ) : super(lexer, input, null);
+    int startIndex,
+    int length,
+    this.deadEndConfigs
+  ) : super(lexer, input, null, startIndex, length);
 
   @override
   String toString() {
@@ -110,6 +119,25 @@ class LexerNoViableAltException extends RecognitionException<CharStream> {
     }
 
     return "$LexerNoViableAltException('$symbol')";
+  }
+
+  @override
+  String getErrorMessage(String input) {
+    return "token recognition error at: '" + input + "'";
+  }
+}
+
+class LexerEmptyModeStackException extends LexerException {
+  LexerEmptyModeStackException(
+      Lexer? lexer,
+      CharStream input,
+      int startIndex,
+      int length,
+      ) : super(lexer, input, null, startIndex, length);
+
+  @override
+  String getErrorMessage(String input) {
+    return "Unable to pop mode because mode stack is empty at: '" + input + "'";
   }
 }
 

--- a/runtime/Go/antlr/errors.go
+++ b/runtime/Go/antlr/errors.go
@@ -96,20 +96,36 @@ func (b *BaseRecognitionException) String() string {
 	return b.message
 }
 
+type LexerException interface {
+	GetErrorMessage(token string) string
+	GetStartIndex() int
+	GetLength() int
+}
+
 type LexerNoViableAltException struct {
 	*BaseRecognitionException
 
-	startIndex     int
+	startIndex int
+	length int
+
 	deadEndConfigs ATNConfigSet
 }
 
-func NewLexerNoViableAltException(lexer Lexer, input CharStream, startIndex int, deadEndConfigs ATNConfigSet) *LexerNoViableAltException {
+type LexerEmptyModeStackException struct {
+	*BaseRecognitionException
+
+	startIndex int
+	length int
+}
+
+func NewLexerNoViableAltException(lexer Lexer, input CharStream, startIndex int, length int, deadEndConfigs ATNConfigSet) *LexerNoViableAltException {
 
 	l := new(LexerNoViableAltException)
 
 	l.BaseRecognitionException = NewBaseRecognitionException("", lexer, input, nil)
 
 	l.startIndex = startIndex
+	l.length = length
 	l.deadEndConfigs = deadEndConfigs
 
 	return l
@@ -121,6 +137,42 @@ func (l *LexerNoViableAltException) String() string {
 		symbol = l.input.(CharStream).GetTextFromInterval(NewInterval(l.startIndex, l.startIndex))
 	}
 	return "LexerNoViableAltException" + symbol
+}
+
+func (l *LexerNoViableAltException) GetErrorMessage(token string) string {
+	return "token recognition error at: '" + token + "'"
+}
+
+func (l *LexerNoViableAltException) GetStartIndex() int {
+	return l.startIndex
+}
+
+func (l *LexerNoViableAltException) GetLength() int {
+	return l.length
+}
+
+func NewLexerEmptyModeStackException(lexer Lexer, input CharStream, startIndex int, length int) *LexerEmptyModeStackException {
+
+	l := new(LexerEmptyModeStackException)
+
+	l.BaseRecognitionException = NewBaseRecognitionException("", lexer, input, nil)
+
+	l.startIndex = startIndex
+	l.length = length
+
+	return l
+}
+
+func (l *LexerEmptyModeStackException) GetErrorMessage(token string) string {
+	return "Unable to pop mode because mode stack is empty at: '" + token + "'"
+}
+
+func (l *LexerEmptyModeStackException) GetStartIndex() int {
+	return l.startIndex
+}
+
+func (l *LexerEmptyModeStackException) GetLength() int {
+	return l.length
 }
 
 type NoViableAltException struct {

--- a/runtime/Go/antlr/lexer_atn_simulator.go
+++ b/runtime/Go/antlr/lexer_atn_simulator.go
@@ -256,7 +256,7 @@ func (l *LexerATNSimulator) failOrAccept(prevAccept *SimState, input CharStream,
 		return TokenEOF
 	}
 
-	panic(NewLexerNoViableAltException(l.recog, input, l.startIndex, reach))
+	panic(NewLexerNoViableAltException(l.recog, input, l.startIndex, input.Index() - l.startIndex, reach))
 }
 
 // Given a starting configuration set, figure out all ATN configurations

--- a/runtime/Java/src/org/antlr/v4/runtime/LexerEmptyModeStackException.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/LexerEmptyModeStackException.java
@@ -1,0 +1,12 @@
+package org.antlr.v4.runtime;
+
+public class LexerEmptyModeStackException extends LexerException {
+	public LexerEmptyModeStackException(Lexer lexer, IntStream input, int startIndex, int length) {
+		super(lexer, input, startIndex, length);
+	}
+
+	@Override
+	public String getErrorMessage(String input) {
+		return "Unable to pop mode because mode stack is empty at: '" + input + "'";
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/LexerException.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/LexerException.java
@@ -1,0 +1,14 @@
+package org.antlr.v4.runtime;
+
+public abstract class LexerException extends RecognitionException {
+	public final int startIndex;
+	public final int length;
+
+	protected LexerException(Lexer lexer, IntStream input, int startIndex, int length) {
+		super(lexer, input, null);
+		this.startIndex = startIndex;
+		this.length = length;
+	}
+
+	public abstract String getErrorMessage(String input);
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/LexerNoViableAltException.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/LexerNoViableAltException.java
@@ -12,26 +12,22 @@ import org.antlr.v4.runtime.misc.Utils;
 
 import java.util.Locale;
 
-public class LexerNoViableAltException extends RecognitionException {
-	/** Matching attempted at what input index? */
-	private final int startIndex;
-
+public class LexerNoViableAltException extends LexerException {
 	/** Which configurations did we try at input.index() that couldn't match input.LA(1)? */
 	private final ATNConfigSet deadEndConfigs;
 
-	public LexerNoViableAltException(Lexer lexer,
-									 CharStream input,
-									 int startIndex,
-									 ATNConfigSet deadEndConfigs) {
-		super(lexer, input, null);
-		this.startIndex = startIndex;
+	@Deprecated
+	public LexerNoViableAltException(Lexer lexer, CharStream input, int startIndex, ATNConfigSet deadEndConfigs) {
+		this(lexer, input, startIndex, 1, deadEndConfigs);
+	}
+
+	public LexerNoViableAltException(Lexer lexer, CharStream input, int startIndex, int length, ATNConfigSet deadEndConfigs) {
+		super(lexer, input, startIndex, length);
 		this.deadEndConfigs = deadEndConfigs;
 	}
 
-	public int getStartIndex() {
-		return startIndex;
-	}
-
+	@Deprecated
+	public int getStartIndex() { return startIndex; }
 
 	public ATNConfigSet getDeadEndConfigs() {
 		return deadEndConfigs;
@@ -40,6 +36,11 @@ public class LexerNoViableAltException extends RecognitionException {
 	@Override
 	public CharStream getInputStream() {
 		return (CharStream)super.getInputStream();
+	}
+
+	@Override
+	public String getErrorMessage(String input) {
+		return "token recognition error at: '" + input + "'";
 	}
 
 	@Override

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -306,7 +306,7 @@ public class LexerATNSimulator extends ATNSimulator {
 				return Token.EOF;
 			}
 
-			throw new LexerNoViableAltException(recog, input, startIndex, reach);
+			throw new LexerNoViableAltException(recog, input, startIndex, input.index() - startIndex, reach);
 		}
 	}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/tree/xpath/XPathLexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/tree/xpath/XPathLexer.java
@@ -126,7 +126,7 @@ public class XPathLexer extends Lexer {
 						else t = new CommonToken(RULE_REF, id);
 					}
 					else {
-						throw new LexerNoViableAltException(this, _input, _tokenStartCharIndex, null);
+						throw new LexerNoViableAltException(this, _input, _tokenStartCharIndex, _input.index() - _tokenStartCharIndex, null);
 					}
 					break;
 			}

--- a/runtime/JavaScript/src/antlr4/atn/LexerATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/LexerATNSimulator.js
@@ -266,7 +266,8 @@ class LexerATNSimulator extends ATNSimulator {
 			if (t === Token.EOF && input.index === this.startIndex) {
 				return Token.EOF;
 			}
-			throw new LexerNoViableAltException(this.recog, input, this.startIndex, reach);
+			throw new LexerNoViableAltException(this.recog, input,
+                this.startIndex, input.index - this.startIndex, reach);
 		}
 	}
 

--- a/runtime/JavaScript/src/antlr4/error/Errors.js
+++ b/runtime/JavaScript/src/antlr4/error/Errors.js
@@ -69,11 +69,22 @@ class RecognitionException extends Error {
     }
 }
 
-class LexerNoViableAltException extends RecognitionException {
-    constructor(lexer, input, startIndex, deadEndConfigs) {
+class LexerException extends RecognitionException {
+    constructor(lexer, input, startIndex, length) {
         super({message: "", recognizer: lexer, input: input, ctx: null});
         this.startIndex = startIndex;
+        this.length = length;
+    }
+}
+
+class LexerNoViableAltException extends LexerException {
+    constructor(lexer, input, startIndex, length, deadEndConfigs) {
+        super(lexer, input, startIndex, length);
         this.deadEndConfigs = deadEndConfigs;
+    }
+
+    getErrorMessage(token) {
+        return "token recognition error at: '" + token + "'";
     }
 
     toString() {
@@ -85,6 +96,15 @@ class LexerNoViableAltException extends RecognitionException {
     }
 }
 
+class LexerEmptyModeStackException extends LexerException {
+    constructor(lexer, input, startIndex, length) {
+        super(lexer, input, startIndex, length);
+    }
+
+    getErrorMessage(token) {
+        return "Unable to pop mode because mode stack is empty at: '" + token + "'";
+    }
+}
 
 /**
  * Indicates that the parser could not decide which of two or more paths
@@ -167,7 +187,9 @@ class ParseCancellationException extends Error{
 module.exports = {
     RecognitionException,
     NoViableAltException,
+    LexerException,
     LexerNoViableAltException,
+    LexerEmptyModeStackException,
     InputMismatchException,
     FailedPredicateException,
     ParseCancellationException

--- a/runtime/Python2/src/antlr4/atn/LexerATNSimulator.py
+++ b/runtime/Python2/src/antlr4/atn/LexerATNSimulator.py
@@ -241,7 +241,7 @@ class LexerATNSimulator(ATNSimulator):
             # if no accept and EOF is first char, return EOF
             if t==Token.EOF and input.index==self.startIndex:
                 return Token.EOF
-            raise LexerNoViableAltException(self.recog, input, self.startIndex, reach)
+            raise LexerNoViableAltException(self.recog, input, self.startIndex, input.index - self.startIndex, reach)
 
     # Given a starting configuration set, figure out all ATN configurations
     #  we can reach upon input {@code t}. Parameter {@code reach} is a return

--- a/runtime/Python2/src/antlr4/error/Errors.py
+++ b/runtime/Python2/src/antlr4/error/Errors.py
@@ -73,12 +73,17 @@ class RecognitionException(Exception):
         return unicode(self)
 
 
-class LexerNoViableAltException(RecognitionException):
-
-    def __init__(self, lexer, input, startIndex, deadEndConfigs):
-        super(LexerNoViableAltException, self).__init__(message=None, recognizer=lexer, input=input, ctx=None)
+class LexerException(RecognitionException):
+    def __init__(self, lexer, input, startIndex, length):
+        super(LexerException, self).__init__(message=None, recognizer=lexer, input=input, ctx=None)
         self.startIndex = startIndex
-        self.deadEndConfigs = deadEndConfigs
+        self.length = length
+
+
+class LexerNoViableAltException(LexerException):
+    def __init__(self, lexer, input, startIndex, length, deadEndConfigs):
+        super(LexerNoViableAltException, self).__init__(lexer=lexer, input=input, startIndex=startIndex, length=length)
+        self.startIndex = startIndex
 
     def __unicode__(self):
         symbol = ""
@@ -86,6 +91,17 @@ class LexerNoViableAltException(RecognitionException):
             symbol = self.input.getText(self.startIndex,self.startIndex)
             # TODO symbol = Utils.escapeWhitespace(symbol, false);
         return u"LexerNoViableAltException" + symbol
+
+    def getErrorMessage(self, token):
+        return u"token recognition error at: '" + token + u"'"
+
+
+class LexerEmptyModeStackException(LexerException):
+    def __init__(self, lexer, input, startIndex, length):
+        super(LexerEmptyModeStackException, self).__init__(lexer=lexer, input=input, startIndex=startIndex, length=length)
+
+    def getErrorMessage(self, token):
+        return "Unable to pop mode because mode stack is empty at: '" + token + "'"
 
 # Indicates that the parser could not decide which of two or more paths
 #  to take based upon the remaining input. It tracks the starting token

--- a/runtime/Python3/src/antlr4/atn/LexerATNSimulator.py
+++ b/runtime/Python3/src/antlr4/atn/LexerATNSimulator.py
@@ -251,7 +251,7 @@ class LexerATNSimulator(ATNSimulator):
             # if no accept and EOF is first char, return EOF
             if t==Token.EOF and input.index==self.startIndex:
                 return Token.EOF
-            raise LexerNoViableAltException(self.recog, input, self.startIndex, reach)
+            raise LexerNoViableAltException(self.recog, input, self.startIndex, input.index - self.startIndex, reach)
 
     # Given a starting configuration set, figure out all ATN configurations
     #  we can reach upon input {@code t}. Parameter {@code reach} is a return

--- a/runtime/Python3/src/antlr4/error/Errors.py
+++ b/runtime/Python3/src/antlr4/error/Errors.py
@@ -79,11 +79,16 @@ class RecognitionException(Exception):
             return None
 
 
-class LexerNoViableAltException(RecognitionException):
-
-    def __init__(self, lexer:Lexer, input:InputStream, startIndex:int, deadEndConfigs:ATNConfigSet):
+class LexerException(RecognitionException):
+    def __init__(self, lexer: Lexer, input: InputStream, startIndex: int, length: int):
         super().__init__(message=None, recognizer=lexer, input=input, ctx=None)
         self.startIndex = startIndex
+        self.length = length
+
+
+class LexerNoViableAltException(LexerException):
+    def __init__(self, lexer: Lexer, input: InputStream, startIndex: int, length: int, deadEndConfigs: ATNConfigSet):
+        super().__init__(lexer=lexer, input=input, startIndex=startIndex, length=length)
         self.deadEndConfigs = deadEndConfigs
 
     def __str__(self):
@@ -92,6 +97,17 @@ class LexerNoViableAltException(RecognitionException):
             symbol = self.input.getText(self.startIndex, self.startIndex)
             # TODO symbol = Utils.escapeWhitespace(symbol, false);
         return "LexerNoViableAltException('" + symbol + "')"
+
+    def getErrorMessage(self, token: str):
+        return "token recognition error at: '" + token + "'"
+
+
+class LexerEmptyModeStackException(LexerException):
+    def __init__(self, lexer: Lexer, input: InputStream, startIndex: int, length: int):
+        super().__init__(lexer=lexer, input=input, startIndex=startIndex, length=length)
+
+    def getErrorMessage(self, token: str):
+        return "Unable to pop mode because mode stack is empty at: '" + token + "'"
 
 # Indicates that the parser could not decide which of two or more paths
 #  to take based upon the remaining input. It tracks the starting token

--- a/runtime/Swift/Sources/Antlr4/LexerEmptyModeStackException.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerEmptyModeStackException.swift
@@ -1,0 +1,12 @@
+///
+/// Copyright (c) 2012-2021 The ANTLR Project. All rights reserved.
+/// Use of this file is governed by the BSD 3-clause license that
+/// can be found in the LICENSE.txt file in the project root.
+///
+
+public class LexerEmptyModeStackException: LexerException {
+    override
+    public func getErrorMessage(_ input: String) -> String {
+        return "Unable to pop mode because mode stack is empty at: '" + input + "'"
+    }
+}

--- a/runtime/Swift/Sources/Antlr4/LexerException.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerException.swift
@@ -1,0 +1,33 @@
+///
+/// Copyright (c) 2012-2021 The ANTLR Project. All rights reserved.
+/// Use of this file is governed by the BSD 3-clause license that
+/// can be found in the LICENSE.txt file in the project root.
+///
+
+
+public class LexerException: RecognitionException {
+    internal let startIndex: Int
+    internal let length: Int
+
+    public init(_ lexer: Lexer?,
+                _ input: CharStream,
+                _ startIndex: Int,
+                _ length: Int) {
+        let ctx: ParserRuleContext? = nil
+        self.startIndex = startIndex
+        self.length = length
+        super.init(lexer, input as IntStream, ctx)
+    }
+
+    public func getStartIndex() -> Int {
+        return startIndex
+    }
+
+    public func getLength() -> Int {
+        return length
+    }
+
+    public func getErrorMessage(_ input: String) -> String {
+        return input
+    }
+}

--- a/runtime/Swift/Sources/Antlr4/LexerNoViableAltException.swift
+++ b/runtime/Swift/Sources/Antlr4/LexerNoViableAltException.swift
@@ -5,13 +5,8 @@
 /// 
 
 
-public class LexerNoViableAltException: RecognitionException, CustomStringConvertible {
-    /// 
-    /// Matching attempted at what input index?
-    /// 
-    private let startIndex: Int
-
-    /// 
+public class LexerNoViableAltException: LexerException, CustomStringConvertible {
+    ///
     /// Which configurations did we try at input.index() that couldn't match input.LA(1)?
     /// 
     private let deadEndConfigs: ATNConfigSet
@@ -19,20 +14,19 @@ public class LexerNoViableAltException: RecognitionException, CustomStringConver
     public init(_ lexer: Lexer?,
                 _ input: CharStream,
                 _ startIndex: Int,
+                _ length: Int,
                 _ deadEndConfigs: ATNConfigSet) {
-        let ctx: ParserRuleContext? = nil
-        self.startIndex = startIndex
         self.deadEndConfigs = deadEndConfigs
-        super.init(lexer, input as IntStream, ctx)
-
-    }
-
-    public func getStartIndex() -> Int {
-        return startIndex
+        super.init(lexer, input, startIndex, length)
     }
 
     public func getDeadEndConfigs() -> ATNConfigSet {
         return deadEndConfigs
+    }
+
+    override
+    public func getErrorMessage(_ input: String) -> String {
+        return "token recognition error at: '" + input + "'"
     }
 
     public var description: String {

--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
@@ -311,7 +311,8 @@ open class LexerATNSimulator: ATNSimulator {
                 if t == BufferedTokenStream.EOF && input.index() == startIndex {
                     return CommonToken.EOF
                 }
-                throw ANTLRException.recognition(e: LexerNoViableAltException(recog, input, startIndex, reach))
+                throw ANTLRException.recognition(e: LexerNoViableAltException(recog, input,
+                    startIndex, input.index() - startIndex, reach))
             }
     }
 

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestATNLexerInterpreter.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestATNLexerInterpreter.java
@@ -525,6 +525,16 @@ public class TestATNLexerInterpreter extends BaseJavaToolTest {
 		assertEquals("line 1:0 token recognition error at: 'n'\n", getParseErrors());
 	}
 
+	@Test public void testEmptyModeStack() {
+		String grammar = "lexer grammar L;\n" +
+				"A: 'aa';\n" +
+				"B: 'bb' -> popMode;\n" +
+				"C: 'cc';";
+
+		execLexer("L.g4", grammar, "L", "aabbcc");
+		assertEquals("line 1:2 Unable to pop mode because mode stack is empty at: 'bb'\n", getParseErrors());
+	}
+
 	protected void checkLexerMatches(LexerGrammar lg, String inputString, String expecting) {
 		ATN atn = createATN(lg, true);
 		CharStream input = CharStreams.fromString(inputString);


### PR DESCRIPTION
fixes #2006

Fixed for Java, C#, Python2/3, JavaScript, Go runtimes
Need to be fixed: C++, Swift, Dart, PHP