### PR TITLE
[C++] Use faster alternative to dynamic_cast when not testing inherit…

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -315,3 +315,5 @@ YYYY/MM/DD, github id, Full name, email
 2021/08/08, ansiemens, Yi-Hong Lin, ansiemens@gmail.com
 2021/09/08, jmcken8, Joel McKenzie, joel.b.mckenzie@gmail.com
 2021/10/10, tools4origins, Erwan Guyomarc'h, contact@erwan-guyomarch.fr
+2021/10/25, jcking, Justin King, jcking@google.com
+

--- a/runtime/Cpp/runtime/src/Recognizer.h
+++ b/runtime/Cpp/runtime/src/Recognizer.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "ProxyErrorListener.h"
+#include "support/Casts.h"
 
 namespace antlr4 {
 
@@ -79,7 +80,7 @@ namespace antlr4 {
     /// @returns The ATN interpreter used by the recognizer for prediction.
     template <class T>
     T* getInterpreter() const {
-      return dynamic_cast<T *>(_interpreter);
+      return antlrcpp::downCast<T *>(_interpreter);
     }
 
     /**

--- a/runtime/Cpp/runtime/src/antlr4-runtime.h
+++ b/runtime/Cpp/runtime/src/antlr4-runtime.h
@@ -131,6 +131,7 @@
 #include "support/Any.h"
 #include "support/Arrays.h"
 #include "support/BitSet.h"
+#include "support/Casts.h"
 #include "support/CPPUtils.h"
 #include "support/StringUtils.h"
 #include "support/guid.h"

--- a/runtime/Cpp/runtime/src/support/Casts.h
+++ b/runtime/Cpp/runtime/src/support/Casts.h
@@ -1,0 +1,33 @@
+/* Copyright (c) 2012-2021 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <type_traits>
+
+namespace antlrcpp {
+
+template <typename To, typename From>
+To downCast(From* from) {
+  static_assert(std::is_pointer<To>::value, "Target type not a pointer.");
+  static_assert((std::is_base_of<From, typename std::remove_pointer<To>::type>::value), "Target type not derived from source type.");
+#if !defined(__GNUC__) || defined(__GXX_RTTI)
+  assert(from == nullptr || dynamic_cast<To>(from) != nullptr);
+#endif
+  return static_cast<To>(from);
+}
+
+template <typename To, typename From>
+To downCast(From& from) {
+  static_assert(std::is_lvalue_reference<To>::value, "Target type not a lvalue reference.");
+  static_assert((std::is_base_of<From, typename std::remove_reference<To>::type>::value), "Target type not derived from source type.");
+#if !defined(__GNUC__) || defined(__GXX_RTTI)
+  assert(dynamic_cast<typename std::add_pointer<typename std::remove_reference<To>::type>::type>(&from) != nullptr);
+#endif
+  return static_cast<To>(from);
+}
+
+}

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -159,7 +159,7 @@ const atn::ATN& <lexer.name>::getATN() const {
 <if (actionFuncs)>
 void <lexer.name>::action(RuleContext *context, size_t ruleIndex, size_t actionIndex) {
   switch (ruleIndex) {
-    <lexer.actionFuncs.values: {f | case <f.ruleIndex>: <f.name>Action(dynamic_cast\<<f.ctxType> *>(context), actionIndex); break;}; separator="\n">
+    <lexer.actionFuncs.values: {f | case <f.ruleIndex>: <f.name>Action(antlrcpp::downCast\<<f.ctxType> *>(context), actionIndex); break;}; separator="\n">
 
   default:
     break;
@@ -170,7 +170,7 @@ void <lexer.name>::action(RuleContext *context, size_t ruleIndex, size_t actionI
 <if (sempredFuncs)>
 bool <lexer.name>::sempred(RuleContext *context, size_t ruleIndex, size_t predicateIndex) {
   switch (ruleIndex) {
-    <lexer.sempredFuncs.values: {f | case <f.ruleIndex>: return <f.name>Sempred(dynamic_cast\<<f.ctxType> *>(context), predicateIndex);}; separator="\n">
+    <lexer.sempredFuncs.values: {f | case <f.ruleIndex>: return <f.name>Sempred(antlrcpp::downCast\<<f.ctxType> *>(context), predicateIndex);}; separator="\n">
 
   default:
     break;
@@ -361,7 +361,7 @@ dfa::Vocabulary& <parser.name>::getVocabulary() const {
 bool <parser.name>::sempred(RuleContext *context, size_t ruleIndex, size_t predicateIndex) {
   switch (ruleIndex) {
   <parser.sempredFuncs.values: {f |
-  case <f.ruleIndex>: return <f.name>Sempred(dynamic_cast\<<f.ctxType> *>(context), predicateIndex);}; separator="\n">
+  case <f.ruleIndex>: return <f.name>Sempred(antlrcpp::downCast\<<f.ctxType> *>(context), predicateIndex);}; separator="\n">
 
   default:
     break;
@@ -614,7 +614,7 @@ AltLabelStructDecl(struct, attrs, getters, dispatchMethods) ::= <<
 CodeBlockForOuterMostAltHeader(currentOuterMostAltCodeBlock, locals, preamble, ops) ::= "<! Required to exist, but unused. !>"
 CodeBlockForOuterMostAlt(currentOuterMostAltCodeBlock, locals, preamble, ops) ::= <<
 <if (currentOuterMostAltCodeBlock.altLabel)>
-_localctx = dynamic_cast\<<currentRule.ctxType> *>(_tracker.createInstance\<<parser.name>::<currentOuterMostAltCodeBlock.altLabel; format = "cap">Context>(_localctx));
+_localctx = _tracker.createInstance\<<parser.name>::<currentOuterMostAltCodeBlock.altLabel; format = "cap">Context>(_localctx);
 <endif>
 enterOuterAlt(_localctx, <currentOuterMostAltCodeBlock.alt.altNum>);
 <CodeBlockForAlt(currentAltCodeBlock = currentOuterMostAltCodeBlock, ...)>
@@ -1076,10 +1076,10 @@ AttributeDeclHeader(d) ::= "<d.type> <d.name><if(d.initValue)> = <d.initValue><e
 AttributeDecl(d) ::= "<d.type> <d.name>"
 
 /** If we don't know location of label def x, use this template */
-labelref(x) ::= "<if (!x.isLocal)>dynamic_cast\<<x.ctx.name> *>(_localctx)-><endif><x.name>"
+labelref(x) ::= "<if (!x.isLocal)>antlrcpp::downCast\<<x.ctx.name> *>(_localctx)-><endif><x.name>"
 
 /** For any action chunk, what is correctly-typed context struct ptr? */
-ctx(actionChunk) ::= "dynamic_cast\<<actionChunk.ctx.name> *>(_localctx)"
+ctx(actionChunk) ::= "antlrcpp::downCast\<<actionChunk.ctx.name> *>(_localctx)"
 
 // used for left-recursive rules
 recRuleAltPredicate(ruleName,opPrec) ::= "precpred(_ctx, <opPrec>)"


### PR DESCRIPTION
By default the generated lexer/parsers use `dynamic_cast` everywhere. This is not necessary when casting from a base class to a derived class and not inspecting the result of `dynamic_cast`. In those cases we can use `static_cast`. This patch introduces `antlrcpp:downCast` which uses `dynamic_cast` in debug builds and `static_cast` in release builds. This should result in faster generated code in release-like builds.