### PR TITLE
Fix missing accessors in JavaScript

### DIFF
--- a/runtime/JavaScript/src/antlr4/Recognizer.js
+++ b/runtime/JavaScript/src/antlr4/Recognizer.js
@@ -29,6 +29,27 @@ class Recognizer {
         this._listeners = [];
     }
 
+    getLiteralNames() {
+        return Object.getPrototypeOf(this).constructor.literalNames || [];
+    }
+
+    getSymbolicNames() {
+        return Object.getPrototypeOf(this).constructor.symbolicNames || [];
+    }
+
+    getTokenNames() {
+        if(!this.tokenNames) {
+            const literalNames = this.getLiteralNames();
+            const symbolicNames = this.getSymbolicNames();
+            const length = literalNames.length > symbolicNames.length ? literalNames.length : symbolicNames.length;
+            this.tokenNames = [];
+            for(let i=0; i<length; i++) {
+                this.tokenNames[i] = literalNames[i] || symbolicNames[i] || "<INVALID";
+            }
+        }
+        return this.tokenNames;
+    }
+
     getTokenTypeMap() {
         const tokenNames = this.getTokenNames();
         if (tokenNames===null) {


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->