### PR TITLE
[C++] Upstream various performance, build, and best practice fixes

### DIFF
--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
@@ -93,7 +93,7 @@ TokenStreamRewriter::TokenStreamRewriter(TokenStream *tokens_) : tokens(tokens_)
 }
 
 TokenStreamRewriter::~TokenStreamRewriter() {
-  for (auto program : _programs) {
+  for (const auto &program : _programs) {
     for (auto *operation : program.second) {
       delete operation;
     }

--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.h
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "antlr4-common.h"
+
 namespace antlr4 {
 
   /**

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "antlr4-common.h"
+
 namespace antlr4 {
 namespace atn {
 

--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.cpp
@@ -74,7 +74,7 @@ bool ATNConfigSet::add(const Ref<ATNConfig> &config, PredictionContextMergeCache
 }
 
 bool ATNConfigSet::addAll(const Ref<ATNConfigSet> &other) {
-  for (auto &c : other->configs) {
+  for (const auto &c : other->configs) {
     add(c);
   }
   return false;
@@ -82,7 +82,7 @@ bool ATNConfigSet::addAll(const Ref<ATNConfigSet> &other) {
 
 std::vector<ATNState*> ATNConfigSet::getStates() {
   std::vector<ATNState*> states;
-  for (auto c : configs) {
+  for (const auto &c : configs) {
     states.push_back(c->state);
   }
   return states;
@@ -99,7 +99,7 @@ std::vector<ATNState*> ATNConfigSet::getStates() {
 
 BitSet ATNConfigSet::getAlts() {
   BitSet alts;
-  for (ATNConfig config : configs) {
+  for (const ATNConfig &config : configs) {
     alts.set(config.alt);
   }
   return alts;
@@ -107,7 +107,7 @@ BitSet ATNConfigSet::getAlts() {
 
 std::vector<Ref<SemanticContext>> ATNConfigSet::getPredicates() {
   std::vector<Ref<SemanticContext>> preds;
-  for (auto c : configs) {
+  for (const auto &c : configs) {
     if (c->semanticContext != SemanticContext::NONE) {
       preds.push_back(c->semanticContext);
     }
@@ -126,7 +126,7 @@ void ATNConfigSet::optimizeConfigs(ATNSimulator *interpreter) {
   if (_configLookup.empty())
     return;
 
-  for (auto &config : configs) {
+  for (const auto &config : configs) {
     config->context = interpreter->getCachedContext(config->context);
   }
 }
@@ -150,7 +150,7 @@ bool ATNConfigSet::operator == (const ATNConfigSet &other) {
 size_t ATNConfigSet::hashCode() {
   if (!isReadonly() || _cachedHashCode == 0) {
     _cachedHashCode = 1;
-    for (auto &i : configs) {
+    for (const auto &i : configs) {
       _cachedHashCode = 31 * _cachedHashCode + i->hashCode(); // Same as Java's list hashCode impl.
     }
   }

--- a/runtime/Cpp/runtime/src/atn/ATNSerializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNSerializer.cpp
@@ -156,7 +156,7 @@ std::vector<size_t> ATNSerializer::serialize() {
 
   size_t nsets = sets.size();
   data.push_back(nsets);
-  for (auto set : sets) {
+  for (const auto &set : sets) {
     bool containsEof = set.contains(Token::EOF);
     if (containsEof && set.getIntervals().at(0).b == -1) {
       data.push_back(set.getIntervals().size() - 1);
@@ -287,7 +287,7 @@ std::vector<size_t> ATNSerializer::serialize() {
   // LEXER ACTIONS
   if (atn->grammarType == ATNType::LEXER) {
     data.push_back(atn->lexerActions.size());
-    for (Ref<LexerAction> &action : atn->lexerActions) {
+    for (const auto &action : atn->lexerActions) {
       data.push_back(static_cast<size_t>(action->getActionType()));
       switch (action->getActionType()) {
         case LexerActionType::CHANNEL:

--- a/runtime/Cpp/runtime/src/atn/ATNSerializer.h
+++ b/runtime/Cpp/runtime/src/atn/ATNSerializer.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "antlr4-common.h"
+
 namespace antlr4 {
 namespace atn {
 

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -241,7 +241,7 @@ void LexerATNSimulator::getReachableConfigSet(CharStream *input, ATNConfigSet *c
   // than a config that already reached an accept state for the same rule
   size_t skipAlt = ATN::INVALID_ALT_NUMBER;
 
-  for (auto c : closure_->configs) {
+  for (const auto &c : closure_->configs) {
     bool currentAltReachedAcceptState = c->alt == skipAlt;
     if (currentAltReachedAcceptState && (std::static_pointer_cast<LexerATNConfig>(c))->hasPassedThroughNonGreedyDecision()) {
       continue;
@@ -543,7 +543,7 @@ dfa::DFAState *LexerATNSimulator::addDFAState(ATNConfigSet *configs) {
 
   dfa::DFAState *proposed = new dfa::DFAState(std::unique_ptr<ATNConfigSet>(configs)); /* mem-check: managed by the DFA or deleted below */
   Ref<ATNConfig> firstConfigWithRuleStopState = nullptr;
-  for (auto &c : configs->configs) {
+  for (const auto &c : configs->configs) {
     if (is<RuleStopState *>(c->state)) {
       firstConfigWithRuleStopState = c;
       break;

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
@@ -98,7 +98,7 @@ bool LexerActionExecutor::operator != (const LexerActionExecutor &obj) const {
 
 size_t LexerActionExecutor::generateHashCode() const {
   size_t hash = MurmurHash::initialize();
-  for (auto lexerAction : _lexerActions) {
+  for (const auto &lexerAction : _lexerActions) {
     hash = MurmurHash::update(hash, lexerAction);
   }
   hash = MurmurHash::finish(hash, _lexerActions.size());

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -452,7 +452,7 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *
   std::vector<Ref<ATNConfig>> skippedStopStates;
 
   // First figure out where we can reach on input t
-  for (auto &c : closure_->configs) {
+  for (const auto &c : closure_->configs) {
     if (is<RuleStopState *>(c->state)) {
       assert(c->context->isEmpty());
 
@@ -507,7 +507,7 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *
     ATNConfig::Set closureBusy;
 
     bool treatEofAsEpsilon = t == Token::EOF;
-    for (auto c : intermediate->configs) {
+    for (const auto &c : intermediate->configs) {
       closure(c, reach.get(), closureBusy, false, fullCtx, treatEofAsEpsilon);
     }
   }
@@ -546,7 +546,7 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeReachSet(ATNConfigSet *
   if (skippedStopStates.size() > 0 && (!fullCtx || !PredictionModeClass::hasConfigInRuleStopState(reach.get()))) {
     assert(!skippedStopStates.empty());
 
-    for (auto c : skippedStopStates) {
+    for (const auto &c : skippedStopStates) {
       reach->add(c, &mergeCache);
     }
   }
@@ -565,7 +565,7 @@ ATNConfigSet* ParserATNSimulator::removeAllConfigsNotInRuleStopState(ATNConfigSe
 
   ATNConfigSet *result = new ATNConfigSet(configs->fullCtx); /* mem-check: released by caller */
 
-  for (auto &config : configs->configs) {
+  for (const auto &config : configs->configs) {
     if (is<RuleStopState*>(config->state)) {
       result->add(config, &mergeCache);
       continue;
@@ -601,7 +601,7 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::computeStartState(ATNState *p,
 std::unique_ptr<ATNConfigSet> ParserATNSimulator::applyPrecedenceFilter(ATNConfigSet *configs) {
   std::map<size_t, Ref<PredictionContext>> statesFromAlt1;
   std::unique_ptr<ATNConfigSet> configSet(new ATNConfigSet(configs->fullCtx));
-  for (Ref<ATNConfig> &config : configs->configs) {
+  for (const auto &config : configs->configs) {
     // handle alt 1 first
     if (config->alt != 1) {
       continue;
@@ -622,7 +622,7 @@ std::unique_ptr<ATNConfigSet> ParserATNSimulator::applyPrecedenceFilter(ATNConfi
     }
   }
 
-  for (Ref<ATNConfig> &config : configs->configs) {
+  for (const auto &config : configs->configs) {
     if (config->alt == 1) {
       // already handled
       continue;
@@ -671,7 +671,7 @@ std::vector<Ref<SemanticContext>> ParserATNSimulator::getPredsForAmbigAlts(const
    */
   std::vector<Ref<SemanticContext>> altToPred(nalts + 1);
 
-  for (auto &c : configs->configs) {
+  for (const auto &c : configs->configs) {
     if (ambigAlts.test(c->alt)) {
       altToPred[c->alt] = SemanticContext::Or(altToPred[c->alt], c->semanticContext);
     }
@@ -739,7 +739,7 @@ size_t ParserATNSimulator::getSynValidOrSemInvalidAltThatFinishedDecisionEntryRu
 
 size_t ParserATNSimulator::getAltThatFinishedDecisionEntryRule(ATNConfigSet *configs) {
   misc::IntervalSet alts;
-  for (auto &c : configs->configs) {
+  for (const auto &c : configs->configs) {
     if (c->getOuterContextDepth() > 0 || (is<RuleStopState *>(c->state) && c->context->hasEmptyPath())) {
       alts.add(c->alt);
     }
@@ -756,7 +756,7 @@ std::pair<ATNConfigSet *, ATNConfigSet *> ParserATNSimulator::splitAccordingToSe
   // mem-check: both pointers must be freed by the caller.
   ATNConfigSet *succeeded(new ATNConfigSet(configs->fullCtx));
   ATNConfigSet *failed(new ATNConfigSet(configs->fullCtx));
-  for (Ref<ATNConfig> &c : configs->configs) {
+  for (const auto &c : configs->configs) {
     if (c->semanticContext != SemanticContext::NONE) {
       bool predicateEvaluationResult = evalSemanticContext(c->semanticContext, outerContext, c->alt, configs->fullCtx);
       if (predicateEvaluationResult) {
@@ -1204,7 +1204,7 @@ std::string ParserATNSimulator::getLookaheadName(TokenStream *input) {
 
 void ParserATNSimulator::dumpDeadEndConfigs(NoViableAltException &nvae) {
   std::cerr << "dead end configs: ";
-  for (auto c : nvae.getDeadEndConfigs()->configs) {
+  for (const auto &c : nvae.getDeadEndConfigs()->configs) {
     std::string trans = "no edges";
     if (c->state->transitions.size() > 0) {
       Transition *t = c->state->transitions[0];
@@ -1230,7 +1230,7 @@ NoViableAltException ParserATNSimulator::noViableAlt(TokenStream *input, ParserR
 
 size_t ParserATNSimulator::getUniqueAlt(ATNConfigSet *configs) {
   size_t alt = ATN::INVALID_ALT_NUMBER;
-  for (auto &c : configs->configs) {
+  for (const auto &c : configs->configs) {
     if (alt == ATN::INVALID_ALT_NUMBER) {
       alt = c->alt; // found first alt
     } else if (c->alt != alt) {

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
@@ -81,11 +81,11 @@ size_t PredictionContext::calculateHashCode(const std::vector<Ref<PredictionCont
                                             const std::vector<size_t> &returnStates) {
   size_t hash = MurmurHash::initialize(INITIAL_HASH);
 
-  for (auto parent : parents) {
+  for (const auto &parent : parents) {
     hash = MurmurHash::update(hash, parent);
   }
 
-  for (auto returnState : returnStates) {
+  for (const auto &returnState : returnStates) {
     hash = MurmurHash::update(hash, returnState);
   }
 
@@ -391,7 +391,7 @@ std::string PredictionContext::toDOTString(const Ref<PredictionContext> &context
     return o1->id - o2->id;
   });
 
-  for (auto current : nodes) {
+  for (const auto &current : nodes) {
     if (is<SingletonPredictionContext>(current)) {
       std::string s = std::to_string(current->id);
       ss << "  s" << s;
@@ -420,7 +420,7 @@ std::string PredictionContext::toDOTString(const Ref<PredictionContext> &context
     ss << "\"];\n";
   }
 
-  for (auto current : nodes) {
+  for (const auto &current : nodes) {
     if (current == EMPTY) {
       continue;
     }
@@ -646,8 +646,8 @@ void PredictionContextMergeCache::clear() {
 
 std::string PredictionContextMergeCache::toString() const {
   std::string result;
-  for (auto pair : _data)
-    for (auto pair2 : pair.second)
+  for (const auto &pair : _data)
+    for (const auto &pair2 : pair.second)
       result += pair2.second->toString() + "\n";
 
   return result;
@@ -655,7 +655,7 @@ std::string PredictionContextMergeCache::toString() const {
 
 size_t PredictionContextMergeCache::count() const {
   size_t result = 0;
-  for (auto entry : _data)
+  for (const auto &entry : _data)
     result += entry.second.size();
   return result;
 }

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
@@ -107,7 +107,7 @@ SemanticContext::AND::AND(Ref<SemanticContext> const& a, Ref<SemanticContext> co
   Set operands;
 
   if (is<AND>(a)) {
-    for (auto operand : std::dynamic_pointer_cast<AND>(a)->opnds) {
+    for (const auto &operand : std::dynamic_pointer_cast<AND>(a)->opnds) {
       operands.insert(operand);
     }
   } else {
@@ -115,7 +115,7 @@ SemanticContext::AND::AND(Ref<SemanticContext> const& a, Ref<SemanticContext> co
   }
 
   if (is<AND>(b)) {
-    for (auto operand : std::dynamic_pointer_cast<AND>(b)->opnds) {
+    for (const auto &operand : std::dynamic_pointer_cast<AND>(b)->opnds) {
       operands.insert(operand);
     }
   } else {
@@ -157,7 +157,7 @@ size_t SemanticContext::AND::hashCode() const {
 }
 
 bool SemanticContext::AND::eval(Recognizer *parser, RuleContext *parserCallStack) {
-  for (auto opnd : opnds) {
+  for (const auto &opnd : opnds) {
     if (!opnd->eval(parser, parserCallStack)) {
       return false;
     }
@@ -168,7 +168,7 @@ bool SemanticContext::AND::eval(Recognizer *parser, RuleContext *parserCallStack
 Ref<SemanticContext> SemanticContext::AND::evalPrecedence(Recognizer *parser, RuleContext *parserCallStack) {
   bool differs = false;
   std::vector<Ref<SemanticContext>> operands;
-  for (auto context : opnds) {
+  for (const auto &context : opnds) {
     Ref<SemanticContext> evaluated = context->evalPrecedence(parser, parserCallStack);
     differs |= (evaluated != context);
     if (evaluated == nullptr) {
@@ -199,7 +199,7 @@ Ref<SemanticContext> SemanticContext::AND::evalPrecedence(Recognizer *parser, Ru
 
 std::string SemanticContext::AND::toString() const {
   std::string tmp;
-  for (auto var : opnds) {
+  for (const auto &var : opnds) {
     tmp += var->toString() + " && ";
   }
   return tmp;
@@ -211,7 +211,7 @@ SemanticContext::OR::OR(Ref<SemanticContext> const& a, Ref<SemanticContext> cons
   Set operands;
 
   if (is<OR>(a)) {
-    for (auto operand : std::dynamic_pointer_cast<OR>(a)->opnds) {
+    for (const auto &operand : std::dynamic_pointer_cast<OR>(a)->opnds) {
       operands.insert(operand);
     }
   } else {
@@ -219,7 +219,7 @@ SemanticContext::OR::OR(Ref<SemanticContext> const& a, Ref<SemanticContext> cons
   }
 
   if (is<OR>(b)) {
-    for (auto operand : std::dynamic_pointer_cast<OR>(b)->opnds) {
+    for (const auto &operand : std::dynamic_pointer_cast<OR>(b)->opnds) {
       operands.insert(operand);
     }
   } else {
@@ -259,7 +259,7 @@ size_t SemanticContext::OR::hashCode() const {
 }
 
 bool SemanticContext::OR::eval(Recognizer *parser, RuleContext *parserCallStack) {
-  for (auto opnd : opnds) {
+  for (const auto &opnd : opnds) {
     if (opnd->eval(parser, parserCallStack)) {
       return true;
     }
@@ -270,7 +270,7 @@ bool SemanticContext::OR::eval(Recognizer *parser, RuleContext *parserCallStack)
 Ref<SemanticContext> SemanticContext::OR::evalPrecedence(Recognizer *parser, RuleContext *parserCallStack) {
   bool differs = false;
   std::vector<Ref<SemanticContext>> operands;
-  for (auto context : opnds) {
+  for (const auto &context : opnds) {
     Ref<SemanticContext> evaluated = context->evalPrecedence(parser, parserCallStack);
     differs |= (evaluated != context);
     if (evaluated == NONE) {
@@ -301,7 +301,7 @@ Ref<SemanticContext> SemanticContext::OR::evalPrecedence(Recognizer *parser, Rul
 
 std::string SemanticContext::OR::toString() const {
   std::string tmp;
-  for(auto var : opnds) {
+  for(const auto &var : opnds) {
     tmp += var->toString() + " || ";
   }
   return tmp;
@@ -361,7 +361,7 @@ Ref<SemanticContext> SemanticContext::Or(Ref<SemanticContext> const& a, Ref<Sema
 
 std::vector<Ref<SemanticContext::PrecedencePredicate>> SemanticContext::filterPrecedencePredicates(const Set &collection) {
   std::vector<Ref<SemanticContext::PrecedencePredicate>> result;
-  for (auto context : collection) {
+  for (const auto &context : collection) {
     if (antlrcpp::is<PrecedencePredicate>(context)) {
       result.push_back(std::dynamic_pointer_cast<PrecedencePredicate>(context));
     }

--- a/runtime/Cpp/runtime/src/misc/InterpreterDataReader.h
+++ b/runtime/Cpp/runtime/src/misc/InterpreterDataReader.h
@@ -6,6 +6,8 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATN.h"
+#include "Vocabulary.h"
 
 namespace antlr4 {
 namespace misc {

--- a/runtime/Cpp/runtime/src/support/CPPUtils.cpp
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.cpp
@@ -7,10 +7,10 @@
 
 namespace antlrcpp {
 
-  std::string join(std::vector<std::string> strings, const std::string &separator) {
+  std::string join(const std::vector<std::string> &strings, const std::string &separator) {
     std::string str;
     bool firstItem = true;
-    for (std::string s : strings) {
+    for (const std::string &s : strings) {
       if (!firstItem) {
         str.append(separator);
       }
@@ -72,8 +72,13 @@ namespace antlrcpp {
 
   std::string arrayToString(const std::vector<std::string> &data) {
     std::string answer;
-    for (auto sub: data) {
-      answer += sub;
+    size_t toReserve = 0;
+    for (const auto &sub : data) {
+      toReserve += sub.size();
+    }
+    answer.reserve(toReserve);
+    for (const auto &sub: data) {
+      answer.append(sub);
     }
     return answer;
   }

--- a/runtime/Cpp/runtime/src/support/CPPUtils.h
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.h
@@ -9,7 +9,7 @@
 
 namespace antlrcpp {
 
-  std::string join(std::vector<std::string> strings, const std::string &separator);
+  std::string join(const std::vector<std::string> &strings, const std::string &separator);
   std::map<std::string, size_t> toMap(const std::vector<std::string> &keys);
   std::string escapeWhitespace(std::string str, bool escapeSpaces);
   std::string toHexString(const int t);

--- a/runtime/Cpp/runtime/src/tree/AbstractParseTreeVisitor.h
+++ b/runtime/Cpp/runtime/src/tree/AbstractParseTreeVisitor.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tree/ParseTree.h"
 #include "tree/ParseTreeVisitor.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
@@ -109,7 +109,7 @@ ParseTreePattern ParseTreePatternMatcher::compile(const std::string &pattern, in
     throw e;
 #else
   } catch (std::exception & /*e*/) {
-    std::throw_with_nested((const char*)"Cannot invoke start rule"); // Wrap any other exception. We should however probably use one of the ANTLR exceptions here.
+    std::throw_with_nested(RuntimeException("Cannot invoke start rule")); // Wrap any other exception.
 #endif
   }
 


### PR DESCRIPTION
Pushing upstream a bunch of performance, build, and best practice fixes.

Most of the performance fixes are related to incorrect/misused auto. Lots of places simply use `auto` which causes values to be copied. They have been switched to `const auto&` which avoids copying-by-value. The best practice fix is switching to throw `RuntimeException` instead of a string literal.