### PR TITLE
Fix stack overflow exception when using Lexer.type in JavaScript

### DIFF
--- a/runtime/JavaScript/src/antlr4/Lexer.js
+++ b/runtime/JavaScript/src/antlr4/Lexer.js
@@ -320,7 +320,7 @@ class Lexer extends Recognizer {
 	}
 
 	get type(){
-		return this.type;
+		return this._type;
 	}
 
 	set type(type) {


### PR DESCRIPTION
fixes #3328