### PR TITLE
Add .clang-format file to ensure consistent style of C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,20 @@
+---
+# This section defines defaults for all languages. Currently we derive ANTLR style from LLVM.
+BasedOnStyle: LLVM
+# Only use clang-format for C++ for now.
+DisableFormat: true
+
+---
+# This section configures C++ formatting.
+Language: Cpp
+DisableFormat: false
+Standard: c++17
+# Prevent clang-format from attempting to pick the alignment and always use right alignment.
+DerivePointerAlignment: false
+# ANTLR existing style is to right align pointers and references.
+PointerAlignment: Right
+ReferenceAlignment: Right
+# Some of ANTLR existing code is longer than the default 80, so use 100 for now.
+ColumnLimit: 100
+# Historically ANTLR has used indentation within namespaces, so replicate it.
+NamespaceIndentation: Inner


### PR DESCRIPTION
This change adds a `.clang-format` file to the root directory to enable consistent styling of C++. It disables all languages except C++ for now (unless we decide to use clang-format for other languages as well). I based it off of LLVM and forced right alignment for pointers and references. It seems to be pretty close, however we can always tweak it going forward as it is very configurable. https://clang.llvm.org/docs/ClangFormatStyleOptions.html