### PR TITLE
Use `AnyObject` instead of `class`.

### DIFF
--- a/runtime/Swift/Sources/Antlr4/ANTLRErrorListener.swift
+++ b/runtime/Swift/Sources/Antlr4/ANTLRErrorListener.swift
@@ -5,7 +5,7 @@
 /// How to emit recognition errors.
 /// 
 
-public protocol ANTLRErrorListener: class {
+public protocol ANTLRErrorListener: AnyObject {
     /// 
     /// Upon syntax error, notify any interested parties. This is not how to
     /// recover from errors or compute error messages. _org.antlr.v4.runtime.ANTLRErrorStrategy_

--- a/runtime/Swift/Sources/Antlr4/IntStream.swift
+++ b/runtime/Swift/Sources/Antlr4/IntStream.swift
@@ -20,7 +20,7 @@
 /// * _#consume_
 /// * _#size_
 /// 
-public protocol IntStream: class {
+public protocol IntStream: AnyObject {
 
     /// 
     /// Consumes the current symbol in the stream. This method has the following

--- a/runtime/Swift/Sources/Antlr4/Token.swift
+++ b/runtime/Swift/Sources/Antlr4/Token.swift
@@ -10,7 +10,7 @@
 /// we obtained this token.
 /// 
 
-public protocol Token: class, CustomStringConvertible {
+public protocol Token: AnyObject, CustomStringConvertible {
     //let INVALID_TYPE : Int = 0;
 
     /// During lookahead operations, this "token" signifies we hit rule end ATN state

--- a/runtime/Swift/Sources/Antlr4/TokenSource.swift
+++ b/runtime/Swift/Sources/Antlr4/TokenSource.swift
@@ -20,7 +20,7 @@
 /// going, looking for a valid token.
 /// 
 
-public protocol TokenSource: class {
+public protocol TokenSource: AnyObject {
     /// 
     /// Return a _org.antlr.v4.runtime.Token_ object from your input stream (usually a
     /// _org.antlr.v4.runtime.CharStream_). Do not fail/return upon lexing error; keep chewing

--- a/runtime/Swift/Sources/Antlr4/tree/ParseTreeListener.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/ParseTreeListener.swift
@@ -17,7 +17,7 @@
 /// https://github.com/antlr/antlr4/issues/841
 /// 
 
-public protocol ParseTreeListener: class {
+public protocol ParseTreeListener: AnyObject {
     func visitTerminal(_ node: TerminalNode)
 
     func visitErrorNode(_ node: ErrorNode)

--- a/runtime/Swift/Sources/Antlr4/tree/Tree.swift
+++ b/runtime/Swift/Sources/Antlr4/tree/Tree.swift
@@ -8,7 +8,7 @@
 /// It is the most abstract interface for all the trees used by ANTLR.
 /// 
 
-public protocol Tree: class {
+public protocol Tree: AnyObject {
     /// The parent of this node. If the return value is null, then this
     /// node is the root of the tree.
     /// 


### PR DESCRIPTION
**Problem**

Using the latest Swift to build Swift runtime will emit warnings about `class` keyword
which is deprecated.

```
warning: using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead
```

**Solution**

Use `AnyObject` instead.