### PR TITLE
C#, JavaScript, Go runtime tests performance improvements

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTestSupport.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTestSupport.java
@@ -16,9 +16,7 @@ import org.junit.runner.Description;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
-import java.util.Locale;
+import java.util.*;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
@@ -41,6 +39,12 @@ public abstract class BaseRuntimeTestSupport implements RuntimeTestSupport {
 
 	/** Errors found while running antlr */
 	private StringBuilder antlrToolErrors;
+
+	public static String cachingDirectory;
+
+	static {
+		cachingDirectory = new File(System.getProperty("java.io.tmpdir"), "ANTLR-runtime-testsuite-cache").getAbsolutePath();
+	}
 
 	@org.junit.Rule
 	public final TestRule testWatcher = new TestWatcher() {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/Antlr4.Test.csproj
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/Antlr4.Test.csproj
@@ -15,4 +15,10 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Reference Include="Antlr4.Runtime">
+      <HintPath>Antlr4.Runtime.Standard.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/BaseCSharpTest.java
@@ -317,20 +317,10 @@ public class BaseCSharpTest extends BaseRuntimeTestSupport implements RuntimeTes
 			process.waitFor();
 			stdoutVacuum.join();
 			stderrVacuum.join();
-			int exitValue = process.exitValue();
+			process.exitValue();
 			String stdoutString = stdoutVacuum.toString();
 			String stderrString = stderrVacuum.toString();
 			setParseErrors(stderrString);
-			if (exitValue != 0) {
-				System.err.println("execTest command: " + Utils.join(args, " "));
-				System.err.println("execTest exitValue: " + exitValue);
-			}
-			if (!stdoutString.isEmpty()) {
-				System.err.println("execTest stdoutVacuum: " + stdoutString);
-			}
-			if (!stderrString.isEmpty()) {
-				System.err.println("execTest stderrVacuum: " + stderrString);
-			}
 			return stdoutString;
 		} catch (Exception e) {
 			System.err.println("can't exec recognizer");


### PR DESCRIPTION
I've added compilation of C# runtime project before the test session. After that, each test use compiled assembly instead of referencing to `.csproj` and extra compilation.

For Node I've removed npm packaging and implemented referencing right on runtime files.

For Go I've added GOROOT redirecting and removed extra copying of runtime files on every test.

There is the table with optimization results:

| Language | [Before](https://ci.appveyor.com/project/parrt/antlr4/builds/41692715) | [After](https://ci.appveyor.com/project/parrt/antlr4/builds/41693296) | Ratio |
|-                 | -          | -        | -    |
| C#             | 21 min | 15 min | 0.7 |
| JavaScript | 22 min | 6 min | 0.3 |
| Go            | 20 min | 8 min | 0.4 |
| **All**       | 88 min | 55 min | 0.63 |

Now runtime tests work much faster and use much less IO operations.