### PR TITLE
[C++] Switch from NOEXCEPT to noexcept

### DIFF
--- a/runtime/Cpp/runtime/src/Exceptions.cpp
+++ b/runtime/Cpp/runtime/src/Exceptions.cpp
@@ -10,7 +10,7 @@ using namespace antlr4;
 RuntimeException::RuntimeException(const std::string &msg) : std::exception(), _message(msg) {
 }
 
-const char* RuntimeException::what() const NOEXCEPT {
+const char* RuntimeException::what() const noexcept {
   return _message.c_str();
 }
 
@@ -19,7 +19,7 @@ const char* RuntimeException::what() const NOEXCEPT {
 IOException::IOException(const std::string &msg) : std::exception(), _message(msg) {
 }
 
-const char* IOException::what() const NOEXCEPT {
+const char* IOException::what() const noexcept {
   return _message.c_str();
 }
 

--- a/runtime/Cpp/runtime/src/Exceptions.h
+++ b/runtime/Cpp/runtime/src/Exceptions.h
@@ -16,7 +16,7 @@ namespace antlr4 {
   public:
     RuntimeException(const std::string &msg = "");
 
-    virtual const char* what() const NOEXCEPT override;
+    virtual const char* what() const noexcept override;
   };
 
   class ANTLR4CPP_PUBLIC IllegalStateException : public RuntimeException {
@@ -77,7 +77,7 @@ namespace antlr4 {
   public:
     IOException(const std::string &msg = "");
 
-    virtual const char* what() const NOEXCEPT override;
+    virtual const char* what() const noexcept override;
   };
 
   class ANTLR4CPP_PUBLIC CancellationException : public IllegalStateException {

--- a/runtime/Cpp/runtime/src/antlr4-common.h
+++ b/runtime/Cpp/runtime/src/antlr4-common.h
@@ -110,25 +110,6 @@
 #include "support/Guid.h"
 #include "support/Declarations.h"
 
-#if !defined(HAS_NOEXCEPT)
-  #if defined(__clang__)
-    #if __has_feature(cxx_noexcept)
-      #define HAS_NOEXCEPT
-    #endif
-  #else
-    #if defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC__ * 10 + __GNUC_MINOR__ >= 46 || \
-      defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026
-      #define HAS_NOEXCEPT
-    #endif
-  #endif
-
-  #ifdef HAS_NOEXCEPT
-    #define NOEXCEPT noexcept
-  #else
-    #define NOEXCEPT
-  #endif
-#endif
-
 // We have to undefine this symbol as ANTLR will use this name for own members and even
 // generated functions. Because EOF is a global macro we cannot use e.g. a namespace scope to disambiguate.
 #ifdef EOF

--- a/runtime/Cpp/runtime/src/atn/ATN.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATN.cpp
@@ -48,7 +48,7 @@ ATN::~ATN() {
 /**
  * Required to be defined (even though not used) as we have an explicit move assignment operator.
  */
-ATN& ATN::operator = (ATN &other) NOEXCEPT {
+ATN& ATN::operator = (ATN &other) noexcept {
   states = other.states;
   decisionToState = other.decisionToState;
   ruleToStartState = other.ruleToStartState;
@@ -66,7 +66,7 @@ ATN& ATN::operator = (ATN &other) NOEXCEPT {
  * Explicit move assignment operator to make this the preferred assignment. With implicit copy/move assignment
  * operators it seems the copy operator is preferred causing trouble when releasing the allocated ATNState instances.
  */
-ATN& ATN::operator = (ATN &&other) NOEXCEPT {
+ATN& ATN::operator = (ATN &&other) noexcept {
   // All source vectors are implicitly cleared by the moves.
   states = std::move(other.states);
   decisionToState = std::move(other.decisionToState);

--- a/runtime/Cpp/runtime/src/atn/ATN.h
+++ b/runtime/Cpp/runtime/src/atn/ATN.h
@@ -60,8 +60,8 @@ namespace atn {
 
     std::vector<TokensStartState *> modeToStartState;
 
-    ATN& operator = (ATN &other) NOEXCEPT;
-    ATN& operator = (ATN &&other) NOEXCEPT;
+    ATN& operator = (ATN &other) noexcept;
+    ATN& operator = (ATN &&other) noexcept;
 
     /// <summary>
     /// Compute the set of valid tokens that can occur starting in state {@code s}.


### PR DESCRIPTION
Get rid of `NOEXCEPT` macro as we are on C++17 and `noexcept` is available.