### PR TITLE
cpp: support/CPPUtils.cpp: replace clang attribute [[clang::fallthrou…

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -319,3 +319,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/10/10, tools4origins, Erwan Guyomarc'h, contact@erwan-guyomarch.fr
 2021/10/19, jcking, Justin King, jcking@google.com
 2021/10/31, skef, Skef Iterum, github@skef.org
+2021/12/03, enedil, Michał Radwański, enedil@outlook.com

--- a/runtime/Cpp/runtime/src/support/CPPUtils.cpp
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.cpp
@@ -50,11 +50,7 @@ namespace antlrcpp {
             break;
           }
           // else fall through
-#ifndef _MSC_VER
-#if __has_cpp_attribute(clang::fallthrough)
-          [[clang::fallthrough]];
-#endif
-#endif
+          [[fallthrough]];
 
         default:
           result += c;


### PR DESCRIPTION
…gh]]

[[clang::fallthrough]] has been used to mark a switch branch target to
be falling through, however just if `clang` has been used.
Since C++17, [[fallthrough]] is a part of the standard:
https://en.cppreference.com/w/cpp/language/attributes/fallthrough

It's recoginzed by MSVC, clang, GCC and respected when using all the C++
versions at least from C++11 upwards.

This change also removes warning in the switch, which would happen when
compiling with GCC.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->