### PR TITLE
[C++] Partially undo commit a8d828016e54adfc403326d8e56d93e7c75c27fc

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -456,7 +456,11 @@ RuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs, namedAction
   <namedActions.init>
   <locals; separator = "\n">
 
+#if __cplusplus > 201703L
   auto onExit = finally([=, this] {
+#else
+  auto onExit = finally([=] {
+#endif
   <finallyAction>
     exitRule();
   });
@@ -509,7 +513,11 @@ LeftRecursiveRuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs
     <namedActions.init>
 <! TODO: untested !>    <locals; separator = "\n">
 
+#if __cplusplus > 201703L
   auto onExit = finally([=, this] {
+#else
+  auto onExit = finally([=] {
+#endif
   <if (finallyAction)><finallyAction><endif>
     unrollRecursionContexts(parentContext);
   });


### PR DESCRIPTION
Partially undo a previous commit. I misread the original preprocessor condition. It is actually testing for C++ 20, not C++ 17. So it needs to stay otherwise compilers conformant to C++ 17 without any extensions will fail.