### PR TITLE
[C++] Fix ambiguous ANTLRInputStream constructor overload

### DIFF
--- a/runtime/Cpp/runtime/src/ANTLRInputStream.cpp
+++ b/runtime/Cpp/runtime/src/ANTLRInputStream.cpp
@@ -23,12 +23,8 @@ ANTLRInputStream::ANTLRInputStream() {
   InitializeInstanceFields();
 }
 
-ANTLRInputStream::ANTLRInputStream(const std::string_view &input): ANTLRInputStream() {
+ANTLRInputStream::ANTLRInputStream(std::string_view input): ANTLRInputStream() {
   load(input.data(), input.length());
-}
-
-ANTLRInputStream::ANTLRInputStream(const std::string &input): ANTLRInputStream() {
-  load(input.data(), input.size());
 }
 
 ANTLRInputStream::ANTLRInputStream(const char *data, size_t length) {

--- a/runtime/Cpp/runtime/src/ANTLRInputStream.h
+++ b/runtime/Cpp/runtime/src/ANTLRInputStream.h
@@ -29,9 +29,8 @@ namespace antlr4 {
 
     ANTLRInputStream();
 
-    ANTLRInputStream(const std::string_view &input);
+    ANTLRInputStream(std::string_view input);
 
-    ANTLRInputStream(const std::string &input);
     ANTLRInputStream(const char *data, size_t length);
     ANTLRInputStream(std::istream &stream);
 


### PR DESCRIPTION
Not sure when this was added, but std::string is implicitly convertible to std::string_view. So this can cause compilation errors as the compiler does not know which one to select.