### PR TITLE
[C++] Optimize ATN deserialization

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
@@ -39,6 +39,7 @@
 #include "Exceptions.h"
 #include "support/CPPUtils.h"
 #include "support/StringUtils.h"
+#include "support/Casts.h"
 
 #include "atn/LexerCustomAction.h"
 #include "atn/LexerChannelAction.h"
@@ -90,15 +91,28 @@ void initializeWellKnownUuids() {
   wellKnownUuids->supported.shrink_to_fit();
 }
 
-uint32_t deserializeInt32(const std::vector<uint16_t>& data, size_t offset) {
+// Specialized view of the serialized ATN that performs the value shift on each element as it is accessed.
+class SerializedATNView final {
+public:
+  explicit SerializedATNView(const std::vector<uint16_t>& input) : _input(&input) {}
+
+  SerializedATNView(const SerializedATNView&) = default;
+
+  uint16_t operator[](size_t index) const { return (*_input)[index] - 2; }
+
+private:
+  const std::vector<uint16_t>* _input;
+};
+
+uint32_t deserializeInt32(SerializedATNView data, size_t offset) {
   return static_cast<uint32_t>(data[offset]) | (static_cast<uint32_t>(data[offset + 1]) << 16);
 }
 
-ssize_t readUnicodeInt(const std::vector<uint16_t>& data, int& p) {
+ssize_t readUnicodeInt(SerializedATNView data, int& p) {
   return static_cast<ssize_t>(data[p++]);
 }
 
-ssize_t readUnicodeInt32(const std::vector<uint16_t>& data, int& p) {
+ssize_t readUnicodeInt32(SerializedATNView data, int& p) {
   auto result = deserializeInt32(data, p);
   p += 2;
   return static_cast<ssize_t>(result);
@@ -108,13 +122,14 @@ ssize_t readUnicodeInt32(const std::vector<uint16_t>& data, int& p) {
 // the 16- or 32-bit readUnicodeInt/readUnicodeInt32 as needed.
 template <typename F>
 void deserializeSets(
-  const std::vector<uint16_t>& data,
+  SerializedATNView data,
   int& p,
   std::vector<misc::IntervalSet>& sets,
   F readUnicode) {
-  int nsets = data[p++];
-  for (int i = 0; i < nsets; i++) {
-    int nintervals = data[p++];
+  size_t nsets = data[p++];
+  sets.reserve(sets.size() + nsets);
+  for (size_t i = 0; i < nsets; i++) {
+    size_t nintervals = data[p++];
     misc::IntervalSet set;
 
     bool containsEof = data[p++] != 0;
@@ -122,7 +137,7 @@ void deserializeSets(
       set.add(-1);
     }
 
-    for (int j = 0; j < nintervals; j++) {
+    for (size_t j = 0; j < nintervals; j++) {
       auto a = readUnicode(data, p);
       auto b = readUnicode(data, p);
       set.add(a, b);
@@ -190,22 +205,23 @@ bool ATNDeserializer::isFeatureSupported(const antlrcpp::Guid &feature, const an
 
 ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
   // Don't adjust the first value since that's the version number.
-  std::vector<uint16_t> data(input.size());
-  data[0] = input[0];
-  for (size_t i = 1; i < input.size(); ++i) {
-    data[i] = input[i] - 2;
-  }
-
+  SerializedATNView data(input);
   int p = 0;
-  int version = data[p++];
+  int version = input[p++];
   if (version != SERIALIZED_VERSION) {
     std::string reason = "Could not deserialize ATN with version" + std::to_string(version) + "(expected " + std::to_string(SERIALIZED_VERSION) + ").";
 
     throw UnsupportedOperationException(reason);
   }
 
-  antlrcpp::Guid uuid = toUUID(data.data(), p);
-  p += 8;
+  antlrcpp::Guid uuid;
+  {
+    uint16_t bytes[8];
+    for (size_t i = 0; i < 8; i++) {
+      bytes[i] = data[p++];
+    }
+    uuid = toUUID(bytes, 0);
+  }
   auto uuidIterator = std::find(SUPPORTED_UUIDS().begin(), SUPPORTED_UUIDS().end(), uuid);
   if (uuidIterator == SUPPORTED_UUIDS().end()) {
     std::string reason = "Could not deserialize ATN with UUID " + uuid.toString() + " (expected " +
@@ -224,40 +240,45 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
   //
   // STATES
   //
-  std::vector<std::pair<LoopEndState*, size_t>> loopBackStateNumbers;
-  std::vector<std::pair<BlockStartState*, size_t>> endStateNumbers;
-  size_t nstates = data[p++];
-  for (size_t i = 0; i < nstates; i++) {
-    size_t stype = data[p++];
-    // ignore bad type of states
-    if (stype == ATNState::ATN_INVALID_TYPE) {
-      atn.addState(nullptr);
-      continue;
+  {
+    std::vector<std::pair<LoopEndState*, size_t>> loopBackStateNumbers;
+    std::vector<std::pair<BlockStartState*, size_t>> endStateNumbers;
+    size_t nstates = data[p++];
+    atn.states.reserve(nstates);
+    loopBackStateNumbers.reserve(nstates);  // Reserve worst case size, its short lived.
+    endStateNumbers.reserve(nstates);  // Reserve worst case size, its short lived.
+    for (size_t i = 0; i < nstates; i++) {
+      size_t stype = data[p++];
+      // ignore bad type of states
+      if (stype == ATNState::ATN_INVALID_TYPE) {
+        atn.addState(nullptr);
+        continue;
+      }
+
+      size_t ruleIndex = data[p++];
+      if (ruleIndex == 0xFFFF) {
+        ruleIndex = INVALID_INDEX;
+      }
+
+      ATNState *s = stateFactory(stype, ruleIndex);
+      if (stype == ATNState::LOOP_END) { // special case
+        int loopBackStateNumber = data[p++];
+        loopBackStateNumbers.push_back({ downCast<LoopEndState*>(s),  loopBackStateNumber });
+      } else if (is<BlockStartState*>(s)) {
+        int endStateNumber = data[p++];
+        endStateNumbers.push_back({ downCast<BlockStartState*>(s), endStateNumber });
+      }
+      atn.addState(s);
     }
 
-    size_t ruleIndex = data[p++];
-    if (ruleIndex == 0xFFFF) {
-      ruleIndex = INVALID_INDEX;
+    // delay the assignment of loop back and end states until we know all the state instances have been initialized
+    for (auto &pair : loopBackStateNumbers) {
+      pair.first->loopBackState = atn.states[pair.second];
     }
 
-    ATNState *s = stateFactory(stype, ruleIndex);
-    if (stype == ATNState::LOOP_END) { // special case
-      int loopBackStateNumber = data[p++];
-      loopBackStateNumbers.push_back({ (LoopEndState*)s,  loopBackStateNumber });
-    } else if (is<BlockStartState*>(s)) {
-      int endStateNumber = data[p++];
-      endStateNumbers.push_back({ (BlockStartState*)s, endStateNumber });
+    for (auto &pair : endStateNumbers) {
+      pair.first->endState = downCast<BlockEndState*>(atn.states[pair.second]);
     }
-    atn.addState(s);
-  }
-
-  // delay the assignment of loop back and end states until we know all the state instances have been initialized
-  for (auto &pair : loopBackStateNumbers) {
-    pair.first->loopBackState = atn.states[pair.second];
-  }
-
-  for (auto &pair : endStateNumbers) {
-    pair.first->endState = (BlockEndState*)atn.states[pair.second];
   }
 
   size_t numNonGreedyStates = data[p++];
@@ -265,14 +286,14 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
     size_t stateNumber = data[p++];
     // The serialized ATN must be specifying the right states, so that the
     // cast below is correct.
-    ((DecisionState *)atn.states[stateNumber])->nonGreedy = true;
+    downCast<DecisionState*>(atn.states[stateNumber])->nonGreedy = true;
   }
 
   if (supportsPrecedencePredicates) {
     size_t numPrecedenceStates = data[p++];
     for (size_t i = 0; i < numPrecedenceStates; i++) {
       size_t stateNumber = data[p++];
-      ((RuleStartState *)atn.states[stateNumber])->isLeftRecursiveRule = true;
+      downCast<RuleStartState*>(atn.states[stateNumber])->isLeftRecursiveRule = true;
     }
   }
 
@@ -280,10 +301,11 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
   // RULES
   //
   size_t nrules = data[p++];
+  atn.ruleToStartState.reserve(nrules);
   for (size_t i = 0; i < nrules; i++) {
     size_t s = data[p++];
     // Also here, the serialized atn must ensure to point to the correct class type.
-    RuleStartState *startState = (RuleStartState*)atn.states[s];
+    RuleStartState *startState = downCast<RuleStartState*>(atn.states[s]);
     atn.ruleToStartState.push_back(startState);
     if (atn.grammarType == ATNType::LEXER) {
       size_t tokenType = data[p++];
@@ -308,7 +330,7 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
       continue;
     }
 
-    RuleStopState *stopState = static_cast<RuleStopState*>(state);
+    RuleStopState *stopState = downCast<RuleStopState*>(state);
     atn.ruleToStopState[state->ruleIndex] = stopState;
     atn.ruleToStartState[state->ruleIndex]->stopState = stopState;
   }
@@ -317,42 +339,46 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
   // MODES
   //
   size_t nmodes = data[p++];
+  atn.modeToStartState.reserve(nmodes);
   for (size_t i = 0; i < nmodes; i++) {
     size_t s = data[p++];
-    atn.modeToStartState.push_back(static_cast<TokensStartState*>(atn.states[s]));
+    atn.modeToStartState.push_back(downCast<TokensStartState*>(atn.states[s]));
   }
 
   //
   // SETS
   //
-  std::vector<misc::IntervalSet> sets;
+  {
+    std::vector<misc::IntervalSet> sets;
 
-  // First, deserialize sets with 16-bit arguments <= U+FFFF.
-  deserializeSets(data, p, sets, readUnicodeInt);
+    // First, deserialize sets with 16-bit arguments <= U+FFFF.
+    deserializeSets(data, p, sets, readUnicodeInt);
 
-  // Next, if the ATN was serialized with the Unicode SMP feature,
-  // deserialize sets with 32-bit arguments <= U+10FFFF.
-  if (isFeatureSupported(ADDED_UNICODE_SMP(), uuid)) {
-    deserializeSets(data, p, sets, readUnicodeInt32);
+    // Next, if the ATN was serialized with the Unicode SMP feature,
+    // deserialize sets with 32-bit arguments <= U+10FFFF.
+    if (isFeatureSupported(ADDED_UNICODE_SMP(), uuid)) {
+      deserializeSets(data, p, sets, readUnicodeInt32);
+    }
+
+    sets.shrink_to_fit();
+
+    //
+    // EDGES
+    //
+    int nedges = data[p++];
+    for (int i = 0; i < nedges; i++) {
+      size_t src = data[p];
+      size_t trg = data[p + 1];
+      size_t ttype = data[p + 2];
+      size_t arg1 = data[p + 3];
+      size_t arg2 = data[p + 4];
+      size_t arg3 = data[p + 5];
+      Transition *trans = edgeFactory(atn, ttype, src, trg, arg1, arg2, arg3, sets);
+      ATNState *srcState = atn.states[src];
+      srcState->addTransition(trans);
+      p += 6;
+    }
   }
-
-  //
-  // EDGES
-  //
-  int nedges = data[p++];
-  for (int i = 0; i < nedges; i++) {
-    size_t src = data[p];
-    size_t trg = data[p + 1];
-    size_t ttype = data[p + 2];
-    size_t arg1 = data[p + 3];
-    size_t arg2 = data[p + 4];
-    size_t arg3 = data[p + 5];
-    Transition *trans = edgeFactory(atn, ttype, src, trg, arg1, arg2, arg3, sets);
-    ATNState *srcState = atn.states[src];
-    srcState->addTransition(trans);
-    p += 6;
-  }
-
   // edges for rule stop states can be derived, so they aren't serialized
   for (ATNState *state : atn.states) {
     for (size_t i = 0; i < state->transitions.size(); i++) {
@@ -361,7 +387,7 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
         continue;
       }
 
-      RuleTransition *ruleTransition = static_cast<RuleTransition*>(t);
+      RuleTransition *ruleTransition = downCast<RuleTransition*>(t);
       size_t outermostPrecedenceReturn = INVALID_INDEX;
       if (atn.ruleToStartState[ruleTransition->target->ruleIndex]->isLeftRecursiveRule) {
         if (ruleTransition->precedence == 0) {
@@ -375,8 +401,8 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
   }
 
   for (ATNState *state : atn.states) {
-    if (is<BlockStartState *>(state)) {
-      BlockStartState *startState = static_cast<BlockStartState *>(state);
+    if (is<BlockStartState*>(state)) {
+      BlockStartState *startState = downCast<BlockStartState*>(state);
 
       // we need to know the end state to set its start state
       if (startState->endState == nullptr) {
@@ -388,23 +414,23 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
         throw IllegalStateException();
       }
 
-      startState->endState->startState = static_cast<BlockStartState*>(state);
+      startState->endState->startState = downCast<BlockStartState*>(state);
     }
 
     if (is<PlusLoopbackState*>(state)) {
-      PlusLoopbackState *loopbackState = static_cast<PlusLoopbackState *>(state);
+      PlusLoopbackState *loopbackState = downCast<PlusLoopbackState*>(state);
       for (size_t i = 0; i < loopbackState->transitions.size(); i++) {
         ATNState *target = loopbackState->transitions[i]->target;
-        if (is<PlusBlockStartState *>(target)) {
-          (static_cast<PlusBlockStartState *>(target))->loopBackState = loopbackState;
+        if (is<PlusBlockStartState*>(target)) {
+          (downCast<PlusBlockStartState*>(target))->loopBackState = loopbackState;
         }
       }
-    } else if (is<StarLoopbackState *>(state)) {
-      StarLoopbackState *loopbackState = static_cast<StarLoopbackState *>(state);
+    } else if (is<StarLoopbackState*>(state)) {
+      StarLoopbackState *loopbackState = downCast<StarLoopbackState*>(state);
       for (size_t i = 0; i < loopbackState->transitions.size(); i++) {
         ATNState *target = loopbackState->transitions[i]->target;
         if (is<StarLoopEntryState *>(target)) {
-          (static_cast<StarLoopEntryState*>(target))->loopBackState = loopbackState;
+          downCast<StarLoopEntryState*>(target)->loopBackState = loopbackState;
         }
       }
     }
@@ -414,14 +440,15 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
   // DECISIONS
   //
   size_t ndecisions = data[p++];
-  for (size_t i = 1; i <= ndecisions; i++) {
+  atn.decisionToState.reserve(ndecisions);
+  for (size_t i = 0; i < ndecisions; i++) {
     size_t s = data[p++];
-    DecisionState *decState = dynamic_cast<DecisionState*>(atn.states[s]);
+    DecisionState *decState = downCast<DecisionState*>(atn.states[s]);
     if (decState == nullptr)
       throw IllegalStateException();
 
     atn.decisionToState.push_back(decState);
-    decState->decision = (int)i - 1;
+    decState->decision = static_cast<int>(i);
   }
 
   //
@@ -431,7 +458,7 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
     if (supportsLexerActions) {
       atn.lexerActions.resize(data[p++]);
       for (size_t i = 0; i < atn.lexerActions.size(); i++) {
-        LexerActionType actionType = (LexerActionType)data[p++];
+        LexerActionType actionType = static_cast<LexerActionType>(data[p++]);
         int data1 = data[p++];
         if (data1 == 0xFFFF) {
           data1 = -1;
@@ -451,7 +478,7 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
       for (ATNState *state : atn.states) {
         for (size_t i = 0; i < state->transitions.size(); i++) {
           Transition *transition = state->transitions[i];
-          if (!is<ActionTransition *>(transition)) {
+          if (!is<ActionTransition*>(transition)) {
             continue;
           }
 
@@ -475,16 +502,16 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
   if (_deserializationOptions.isGenerateRuleBypassTransitions() && atn.grammarType == ATNType::PARSER) {
     atn.ruleToTokenType.resize(atn.ruleToStartState.size());
     for (size_t i = 0; i < atn.ruleToStartState.size(); i++) {
-      atn.ruleToTokenType[i] = int(atn.maxTokenType + i + 1);
+      atn.ruleToTokenType[i] = static_cast<int>(atn.maxTokenType + i + 1);
     }
 
     for (std::vector<RuleStartState*>::size_type i = 0; i < atn.ruleToStartState.size(); i++) {
       BasicBlockStartState *bypassStart = new BasicBlockStartState(); /* mem check: freed in ATN d-tor */
-      bypassStart->ruleIndex = (int)i;
+      bypassStart->ruleIndex = static_cast<int>(i);
       atn.addState(bypassStart);
 
       BlockEndState *bypassStop = new BlockEndState(); /* mem check: freed in ATN d-tor */
-      bypassStop->ruleIndex = (int)i;
+      bypassStop->ruleIndex = static_cast<int>(i);
       atn.addState(bypassStop);
 
       bypassStart->endState = bypassStop;
@@ -574,7 +601,7 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
  */
 void ATNDeserializer::markPrecedenceDecisions(const ATN &atn) const {
   for (ATNState *state : atn.states) {
-    if (!is<StarLoopEntryState *>(state)) {
+    if (!is<StarLoopEntryState*>(state)) {
       continue;
     }
 
@@ -585,8 +612,8 @@ void ATNDeserializer::markPrecedenceDecisions(const ATN &atn) const {
     if (atn.ruleToStartState[state->ruleIndex]->isLeftRecursiveRule) {
       ATNState *maybeLoopEndState = state->transitions[state->transitions.size() - 1]->target;
       if (is<LoopEndState *>(maybeLoopEndState)) {
-        if (maybeLoopEndState->epsilonOnlyTransitions && is<RuleStopState *>(maybeLoopEndState->transitions[0]->target)) {
-          static_cast<StarLoopEntryState *>(state)->isPrecedenceDecision = true;
+        if (maybeLoopEndState->epsilonOnlyTransitions && is<RuleStopState*>(maybeLoopEndState->transitions[0]->target)) {
+          downCast<StarLoopEntryState*>(state)->isPrecedenceDecision = true;
         }
       }
     }
@@ -602,53 +629,52 @@ void ATNDeserializer::verifyATN(const ATN &atn) {
 
     checkCondition(state->epsilonOnlyTransitions || state->transitions.size() <= 1);
 
-    if (is<PlusBlockStartState *>(state)) {
-      checkCondition((static_cast<PlusBlockStartState *>(state))->loopBackState != nullptr);
+    if (is<PlusBlockStartState*>(state)) {
+      checkCondition((downCast<PlusBlockStartState*>(state))->loopBackState != nullptr);
     }
 
-    if (is<StarLoopEntryState *>(state)) {
-      StarLoopEntryState *starLoopEntryState = static_cast<StarLoopEntryState*>(state);
+    if (is<StarLoopEntryState*>(state)) {
+      StarLoopEntryState *starLoopEntryState = downCast<StarLoopEntryState*>(state);
       checkCondition(starLoopEntryState->loopBackState != nullptr);
       checkCondition(starLoopEntryState->transitions.size() == 2);
 
-      if (is<StarBlockStartState *>(starLoopEntryState->transitions[0]->target)) {
-        checkCondition(static_cast<LoopEndState *>(starLoopEntryState->transitions[1]->target) != nullptr);
+      if (is<StarBlockStartState*>(starLoopEntryState->transitions[0]->target)) {
+        checkCondition(downCast<LoopEndState*>(starLoopEntryState->transitions[1]->target) != nullptr);
         checkCondition(!starLoopEntryState->nonGreedy);
-      } else if (is<LoopEndState *>(starLoopEntryState->transitions[0]->target)) {
-        checkCondition(is<StarBlockStartState *>(starLoopEntryState->transitions[1]->target));
+      } else if (is<LoopEndState*>(starLoopEntryState->transitions[0]->target)) {
+        checkCondition(is<StarBlockStartState*>(starLoopEntryState->transitions[1]->target));
         checkCondition(starLoopEntryState->nonGreedy);
       } else {
         throw IllegalStateException();
-
       }
     }
 
-    if (is<StarLoopbackState *>(state)) {
+    if (is<StarLoopbackState*>(state)) {
       checkCondition(state->transitions.size() == 1);
-      checkCondition(is<StarLoopEntryState *>(state->transitions[0]->target));
+      checkCondition(is<StarLoopEntryState*>(state->transitions[0]->target));
     }
 
-    if (is<LoopEndState *>(state)) {
-      checkCondition((static_cast<LoopEndState *>(state))->loopBackState != nullptr);
+    if (is<LoopEndState*>(state)) {
+      checkCondition((downCast<LoopEndState*>(state))->loopBackState != nullptr);
     }
 
-    if (is<RuleStartState *>(state)) {
-      checkCondition((static_cast<RuleStartState *>(state))->stopState != nullptr);
+    if (is<RuleStartState*>(state)) {
+      checkCondition((downCast<RuleStartState*>(state))->stopState != nullptr);
     }
 
-    if (is<BlockStartState *>(state)) {
-      checkCondition((static_cast<BlockStartState *>(state))->endState != nullptr);
+    if (is<BlockStartState*>(state)) {
+      checkCondition((downCast<BlockStartState*>(state))->endState != nullptr);
     }
 
-    if (is<BlockEndState *>(state)) {
-      checkCondition((static_cast<BlockEndState *>(state))->startState != nullptr);
+    if (is<BlockEndState*>(state)) {
+      checkCondition((downCast<BlockEndState*>(state))->startState != nullptr);
     }
 
-    if (is<DecisionState *>(state)) {
-      DecisionState *decisionState = static_cast<DecisionState *>(state);
+    if (is<DecisionState*>(state)) {
+      DecisionState *decisionState = downCast<DecisionState*>(state);
       checkCondition(decisionState->transitions.size() <= 1 || decisionState->decision >= 0);
     } else {
-      checkCondition(state->transitions.size() <= 1 || is<RuleStopState *>(state));
+      checkCondition(state->transitions.size() <= 1 || is<RuleStopState*>(state));
     }
   }
 }
@@ -683,7 +709,7 @@ Transition *ATNDeserializer::edgeFactory(const ATN &atn, size_t type, size_t /*s
         return new RangeTransition(target, arg1, arg2);
       }
     case Transition::RULE:
-      return new RuleTransition(static_cast<RuleStartState*>(atn.states[arg1]), arg2, (int)arg3, target);
+      return new RuleTransition(downCast<RuleStartState*>(atn.states[arg1]), arg2, (int)arg3, target);
     case Transition::PREDICATE:
       return new PredicateTransition(target, arg1, arg2, arg3 != 0);
     case Transition::PRECEDENCE:


### PR DESCRIPTION
Improve ATN deserialization by avoiding unnecessary copies and right-sizing `std::vector` when the size is known ahead of time.