### PR TITLE
[C++] Clean up antlr4::misc::Interval and antlr4::dfa

### DIFF
--- a/runtime/Cpp/runtime/src/dfa/DFA.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFA.cpp
@@ -107,7 +107,7 @@ std::string DFA::toString(const Vocabulary &vocabulary) const {
   return serializer.toString();
 }
 
-std::string DFA::toLexerString() {
+std::string DFA::toLexerString() const {
   if (s0 == nullptr) {
     return "";
   }

--- a/runtime/Cpp/runtime/src/dfa/DFA.h
+++ b/runtime/Cpp/runtime/src/dfa/DFA.h
@@ -10,7 +10,7 @@
 namespace antlr4 {
 namespace dfa {
 
-  class ANTLR4CPP_PUBLIC DFA {
+  class ANTLR4CPP_PUBLIC DFA final {
   public:
     /// A set of all DFA states. Use a map so we can get old state back.
     /// Set only allows you to see if it's there.
@@ -21,11 +21,11 @@ namespace dfa {
     DFAState *s0;
     size_t decision;
 
-    DFA(atn::DecisionState *atnStartState);
+    explicit DFA(atn::DecisionState *atnStartState);
     DFA(atn::DecisionState *atnStartState, size_t decision);
     DFA(const DFA &other) = delete;
     DFA(DFA &&other);
-    virtual ~DFA();
+    ~DFA();
 
     /**
      * Gets whether this DFA is a precedence DFA. Precedence DFAs use a special
@@ -65,11 +65,11 @@ namespace dfa {
     void setPrecedenceStartState(int precedence, DFAState *startState, std::shared_mutex &lock);
 
     /// Return a list of all states in this DFA, ordered by state number.
-    virtual std::vector<DFAState *> getStates() const;
+    std::vector<DFAState *> getStates() const;
 
     std::string toString(const Vocabulary &vocabulary) const;
 
-    virtual std::string toLexerString();
+    std::string toLexerString() const;
 
   private:
     /**

--- a/runtime/Cpp/runtime/src/dfa/DFASerializer.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFASerializer.cpp
@@ -13,9 +13,6 @@ using namespace antlr4::dfa;
 DFASerializer::DFASerializer(const DFA *dfa, const Vocabulary &vocabulary) : _dfa(dfa), _vocabulary(vocabulary) {
 }
 
-DFASerializer::~DFASerializer() {
-}
-
 std::string DFASerializer::toString() const {
   if (_dfa->s0 == nullptr) {
     return "";

--- a/runtime/Cpp/runtime/src/dfa/DFASerializer.h
+++ b/runtime/Cpp/runtime/src/dfa/DFASerializer.h
@@ -14,13 +14,14 @@ namespace dfa {
   class ANTLR4CPP_PUBLIC DFASerializer {
   public:
     DFASerializer(const DFA *dfa, const Vocabulary &vocabulary);
-    virtual ~DFASerializer();
 
-    virtual std::string toString() const;
+    virtual ~DFASerializer() = default;
+
+    std::string toString() const;
 
   protected:
     virtual std::string getEdgeLabel(size_t i) const;
-    virtual std::string getStateString(DFAState *s) const;
+    std::string getStateString(DFAState *s) const;
 
   private:
     const DFA *_dfa;

--- a/runtime/Cpp/runtime/src/dfa/DFAState.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.cpp
@@ -13,20 +13,10 @@
 using namespace antlr4::dfa;
 using namespace antlr4::atn;
 
-DFAState::PredPrediction::PredPrediction(const Ref<SemanticContext> &pred, int alt) : pred(pred) {
-  InitializeInstanceFields();
-  this->alt = alt;
-}
+DFAState::PredPrediction::PredPrediction(Ref<SemanticContext> pred, int alt) : pred(std::move(pred)), alt(alt) {}
 
-DFAState::PredPrediction::~PredPrediction() {
-}
-
-std::string DFAState::PredPrediction::toString() {
+std::string DFAState::PredPrediction::toString() const {
   return std::string("(") + pred->toString() + ", " + std::to_string(alt) + ")";
-}
-
-void DFAState::PredPrediction::InitializeInstanceFields() {
-  alt = 0;
 }
 
 DFAState::DFAState() {
@@ -47,7 +37,7 @@ DFAState::~DFAState() {
   }
 }
 
-std::set<size_t> DFAState::getAltSet() {
+std::set<size_t> DFAState::getAltSet() const {
   std::set<size_t> alts;
   if (configs != nullptr) {
     for (size_t i = 0; i < configs->size(); i++) {
@@ -73,7 +63,7 @@ bool DFAState::operator == (const DFAState &o) const {
   return *configs == *o.configs;
 }
 
-std::string DFAState::toString() {
+std::string DFAState::toString() const {
   std::stringstream ss;
   ss << stateNumber;
   if (configs) {

--- a/runtime/Cpp/runtime/src/dfa/DFAState.h
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.h
@@ -35,20 +35,16 @@ namespace dfa {
   ///  but with different ATN contexts (with same or different alts)
   ///  meaning that state was reached via a different set of rule invocations.
   /// </summary>
-  class ANTLR4CPP_PUBLIC DFAState {
+  class ANTLR4CPP_PUBLIC DFAState final {
   public:
-    class PredPrediction {
+    class PredPrediction final {
     public:
       Ref<atn::SemanticContext> pred; // never null; at least SemanticContext.NONE
       int alt;
 
-      PredPrediction(const Ref<atn::SemanticContext> &pred, int alt);
-      virtual ~PredPrediction();
+      PredPrediction(Ref<atn::SemanticContext> pred, int alt);
 
-      virtual std::string toString();
-
-    private:
-      void InitializeInstanceFields();
+      std::string toString() const;
     };
 
     int stateNumber;
@@ -95,17 +91,17 @@ namespace dfa {
 
     /// Map a predicate to a predicted alternative.
     DFAState();
-    DFAState(int state);
-    DFAState(std::unique_ptr<atn::ATNConfigSet> configs);
-    virtual ~DFAState();
+    explicit DFAState(int state);
+    explicit DFAState(std::unique_ptr<atn::ATNConfigSet> configs);
+    ~DFAState();
 
     /// <summary>
     /// Get the set of all alts mentioned by all ATN configurations in this
     ///  DFA state.
     /// </summary>
-    virtual std::set<size_t> getAltSet();
+    std::set<size_t> getAltSet() const;
 
-    virtual size_t hashCode() const;
+    size_t hashCode() const;
 
     /// Two DFAState instances are equal if their ATN configuration sets
     /// are the same. This method is used to see if a state already exists.
@@ -118,19 +114,19 @@ namespace dfa {
     /// ParserATNSimulator#addDFAState we need to know if any other state
     /// exists that has this exact set of ATN configurations. The
     /// stateNumber is irrelevant.
-    bool operator == (const DFAState &o) const;
+    bool operator==(const DFAState &o) const;
 
-    virtual std::string toString();
+    std::string toString() const;
 
     struct Hasher
     {
-      size_t operator()(DFAState *k) const {
+      size_t operator()(const DFAState *k) const {
         return k->hashCode();
       }
     };
 
     struct Comparer {
-      bool operator()(DFAState *lhs, DFAState *rhs) const
+      bool operator()(const DFAState *lhs, const DFAState *rhs) const
       {
         return *lhs == *rhs;
       }

--- a/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.cpp
+++ b/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.cpp
@@ -9,10 +9,7 @@
 
 using namespace antlr4::dfa;
 
-LexerDFASerializer::LexerDFASerializer(DFA *dfa) : DFASerializer(dfa, Vocabulary()) {
-}
-
-LexerDFASerializer::~LexerDFASerializer() {
+LexerDFASerializer::LexerDFASerializer(const DFA *dfa) : DFASerializer(dfa, Vocabulary()) {
 }
 
 std::string LexerDFASerializer::getEdgeLabel(size_t i) const {

--- a/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.h
+++ b/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.h
@@ -10,13 +10,12 @@
 namespace antlr4 {
 namespace dfa {
 
-  class ANTLR4CPP_PUBLIC LexerDFASerializer : public DFASerializer {
+  class ANTLR4CPP_PUBLIC LexerDFASerializer final : public DFASerializer {
   public:
-    LexerDFASerializer(DFA *dfa);
-    virtual ~LexerDFASerializer();
+    explicit LexerDFASerializer(const DFA *dfa);
 
   protected:
-    virtual std::string getEdgeLabel(size_t i) const override;
+    std::string getEdgeLabel(size_t i) const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/misc/Interval.cpp
+++ b/runtime/Cpp/runtime/src/misc/Interval.cpp
@@ -7,35 +7,7 @@
 
 using namespace antlr4::misc;
 
-size_t antlr4::misc::numericToSymbol(ssize_t v) {
-  return static_cast<size_t>(v);
-}
-
-ssize_t antlr4::misc::symbolToNumeric(size_t v) {
-  return static_cast<ssize_t>(v);
-}
-
-Interval const Interval::INVALID;
-
-Interval::Interval() : Interval(static_cast<ssize_t>(-1), -2) { // Need an explicit cast here for VS.
-}
-
-Interval::Interval(size_t a_, size_t b_) : Interval(symbolToNumeric(a_), symbolToNumeric(b_)) {
-}
-
-Interval::Interval(ssize_t a_, ssize_t b_) : a(a_), b(b_) {
-}
-
-size_t Interval::length() const {
-  if (b < a) {
-    return 0;
-  }
-  return size_t(b - a + 1);
-}
-
-bool Interval::operator == (const Interval &other) const {
-  return a == other.a && b == other.b;
-}
+const Interval Interval::INVALID;
 
 size_t Interval::hashCode() const {
   size_t hash = 23;

--- a/runtime/Cpp/runtime/src/misc/Interval.h
+++ b/runtime/Cpp/runtime/src/misc/Interval.h
@@ -13,11 +13,11 @@ namespace misc {
   // Helpers to convert certain unsigned symbols (e.g. Token::EOF) to their original numeric value (e.g. -1)
   // and vice versa. This is needed mostly for intervals to keep their original order and for toString()
   // methods to print the original numeric value (e.g. for tests).
-  size_t numericToSymbol(ssize_t v);
-  ssize_t symbolToNumeric(size_t v);
+  constexpr size_t numericToSymbol(ssize_t v) { return static_cast<size_t>(v); }
+  constexpr ssize_t symbolToNumeric(size_t v) { return static_cast<ssize_t>(v); }
 
   /// An immutable inclusive interval a..b
-  class ANTLR4CPP_PUBLIC Interval {
+  class ANTLR4CPP_PUBLIC Interval final {
   public:
     static const Interval INVALID;
 
@@ -25,15 +25,17 @@ namespace misc {
     ssize_t a;
     ssize_t b;
 
-    Interval();
-    explicit Interval(size_t a_, size_t b_); // For unsigned -> signed mappings.
-    Interval(ssize_t a_, ssize_t b_);
+    constexpr Interval() : Interval(static_cast<ssize_t>(-1), static_cast<ssize_t>(-2)) {}
+
+    constexpr explicit Interval(size_t a_, size_t b_) : Interval(symbolToNumeric(a_), symbolToNumeric(b_)) {}
+
+    constexpr Interval(ssize_t a_, ssize_t b_) : a(a_), b(b_) {}
 
     /// return number of elements between a and b inclusively. x..x is length 1.
     ///  if b < a, then length is 0.  9..10 has length 2.
-    size_t length() const;
+    constexpr size_t length() const { return b >= a ? static_cast<size_t>(b - a + 1) : 0; }
 
-    bool operator == (const Interval &other) const;
+    constexpr bool operator==(const Interval &other) const { return a == other.a && b == other.b; }
 
     size_t hashCode() const;
 
@@ -76,8 +78,6 @@ namespace misc {
     Interval intersection(const Interval &other) const;
 
     std::string toString() const;
-
-  private:
   };
 
 } // namespace atn


### PR DESCRIPTION
Fix const correctness, remove virtual where it makes sense (class is instantiated directly by antlr4 and there is no way for users to override), and make things constexpr where it is feasible.