### PR TITLE
[C++] Improve whitespace escaping

### DIFF
--- a/runtime/Cpp/runtime/src/ANTLRFileStream.cpp
+++ b/runtime/Cpp/runtime/src/ANTLRFileStream.cpp
@@ -3,8 +3,6 @@
  * can be found in the LICENSE.txt file in the project root.
  */
 
-#include "support/StringUtils.h"
-
 #include "ANTLRFileStream.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/CommonToken.cpp
+++ b/runtime/Cpp/runtime/src/CommonToken.cpp
@@ -10,8 +10,8 @@
 
 #include "misc/Interval.h"
 
-#include "support/StringUtils.h"
 #include "support/CPPUtils.h"
+#include "support/StringUtils.h"
 
 #include "CommonToken.h"
 
@@ -165,9 +165,7 @@ std::string CommonToken::toString(Recognizer *r) const {
   }
   std::string txt = getText();
   if (!txt.empty()) {
-    antlrcpp::replaceAll(txt, "\n", "\\n");
-    antlrcpp::replaceAll(txt, "\r", "\\r");
-    antlrcpp::replaceAll(txt, "\t", "\\t");
+    txt = antlrcpp::escapeWhitespace(txt);
   } else {
     txt = "<no text>";
   }

--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
@@ -12,10 +12,10 @@
 #include "atn/RuleTransition.h"
 #include "atn/ATN.h"
 #include "atn/ATNState.h"
+#include "support/StringUtils.h"
 #include "Parser.h"
 #include "CommonToken.h"
 #include "Vocabulary.h"
-#include "support/StringUtils.h"
 
 #include "DefaultErrorStrategy.h"
 
@@ -292,11 +292,13 @@ size_t DefaultErrorStrategy::getSymbolType(Token *symbol) {
 }
 
 std::string DefaultErrorStrategy::escapeWSAndQuote(const std::string &s) const {
-  std::string result = s;
-  antlrcpp::replaceAll(result, "\n", "\\n");
-  antlrcpp::replaceAll(result, "\r","\\r");
-  antlrcpp::replaceAll(result, "\t","\\t");
-  return "'" + result + "'";
+  std::string result;
+  result.reserve(s.size() + 2);
+  result.push_back('\'');
+  antlrcpp::escapeWhitespace(result, s);
+  result.push_back('\'');
+  result.shrink_to_fit();
+  return result;
 }
 
 misc::IntervalSet DefaultErrorStrategy::getErrorRecoverySet(Parser *recognizer) {

--- a/runtime/Cpp/runtime/src/Lexer.cpp
+++ b/runtime/Cpp/runtime/src/Lexer.cpp
@@ -11,7 +11,6 @@
 #include "ANTLRErrorListener.h"
 #include "support/CPPUtils.h"
 #include "CommonToken.h"
-#include "support/StringUtils.h"
 
 #include "Lexer.h"
 

--- a/runtime/Cpp/runtime/src/RecognitionException.cpp
+++ b/runtime/Cpp/runtime/src/RecognitionException.cpp
@@ -5,7 +5,6 @@
 
 #include "atn/ATN.h"
 #include "Recognizer.h"
-#include "support/StringUtils.h"
 #include "ParserRuleContext.h"
 #include "misc/IntervalSet.h"
 

--- a/runtime/Cpp/runtime/src/Recognizer.cpp
+++ b/runtime/Cpp/runtime/src/Recognizer.cpp
@@ -6,11 +6,11 @@
 #include "ConsoleErrorListener.h"
 #include "RecognitionException.h"
 #include "support/CPPUtils.h"
-#include "support/StringUtils.h"
 #include "Token.h"
 #include "atn/ATN.h"
 #include "atn/ATNSimulator.h"
 #include "support/CPPUtils.h"
+#include "support/StringUtils.h"
 
 #include "Vocabulary.h"
 
@@ -113,11 +113,13 @@ std::string Recognizer::getTokenErrorDisplay(Token *t) {
     }
   }
 
-  antlrcpp::replaceAll(s, "\n", "\\n");
-  antlrcpp::replaceAll(s, "\r","\\r");
-  antlrcpp::replaceAll(s, "\t", "\\t");
-
-  return "'" + s + "'";
+  std::string result;
+  result.reserve(s.size() + 2);
+  result.push_back('\'');
+  antlrcpp::escapeWhitespace(result, s);
+  result.push_back('\'');
+  result.shrink_to_fit();
+  return result;
 }
 
 void Recognizer::addErrorListener(ANTLRErrorListener *listener) {

--- a/runtime/Cpp/runtime/src/antlr4-runtime.h
+++ b/runtime/Cpp/runtime/src/antlr4-runtime.h
@@ -133,7 +133,6 @@
 #include "support/BitSet.h"
 #include "support/Casts.h"
 #include "support/CPPUtils.h"
-#include "support/StringUtils.h"
 #include "support/Guid.h"
 #include "tree/AbstractParseTreeVisitor.h"
 #include "tree/ErrorNode.h"

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
@@ -38,7 +38,6 @@
 #include "misc/IntervalSet.h"
 #include "Exceptions.h"
 #include "support/CPPUtils.h"
-#include "support/StringUtils.h"
 #include "support/Casts.h"
 
 #include "atn/LexerCustomAction.h"

--- a/runtime/Cpp/runtime/src/support/StringUtils.cpp
+++ b/runtime/Cpp/runtime/src/support/StringUtils.cpp
@@ -7,15 +7,32 @@
 
 namespace antlrcpp {
 
-  void replaceAll(std::string& str, std::string_view from, std::string_view to) {
-    if (from.empty())
-      return;
+  std::string escapeWhitespace(std::string_view in) {
+    std::string out;
+    escapeWhitespace(out, in);
+    out.shrink_to_fit();
+    return out;
+  }
 
-    size_t start_pos = 0;
-    while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
-      str.replace(start_pos, from.length(), to);
-      start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'.
+  std::string& escapeWhitespace(std::string& out, std::string_view in) {
+    out.reserve(in.size());  // Best case, no escaping.
+    for (const auto &c : in) {
+      switch (c) {
+        case '\t':
+          out.append("\\t");
+          break;
+        case '\r':
+          out.append("\\r");
+          break;
+        case '\n':
+          out.append("\\n");
+          break;
+        default:
+          out.push_back(c);
+          break;
+      }
     }
+    return out;
   }
 
 } // namespace antrlcpp

--- a/runtime/Cpp/runtime/src/support/StringUtils.h
+++ b/runtime/Cpp/runtime/src/support/StringUtils.h
@@ -9,6 +9,8 @@
 
 namespace antlrcpp {
 
-  void replaceAll(std::string &str, std::string_view from, std::string_view to);
+  std::string escapeWhitespace(std::string_view in);
+
+  std::string& escapeWhitespace(std::string& out, std::string_view in);
 
 }

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
@@ -21,7 +21,6 @@
 #include "ANTLRInputStream.h"
 #include "support/Arrays.h"
 #include "Exceptions.h"
-#include "support/StringUtils.h"
 #include "support/CPPUtils.h"
 
 #include "tree/pattern/ParseTreePatternMatcher.h"


### PR DESCRIPTION
`replaceAll` is the only function left and its usage is inefficient as its only use case is escaping whitespace. The current usage involves scanning the string 3 times. If any whitespace is actually encountered it updates the string in place, which is terribly slow as std::string is effectively just std::vector with an additional bookkeeping for the null terminator. So updating in place can involve may may memory moves and re-allocations. If there its lots of whitespace to escape, its performance is unacceptable.

Instead an optimal implementation which has a bounded worse case is written inline at its 3 call locations and StringUtils has been removed.