### PR TITLE
[Go] Make BaseGoTest::initializeRuntime static

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/BaseGoTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/BaseGoTest.java
@@ -203,7 +203,7 @@ public class BaseGoTest extends BaseRuntimeTestSupport implements RuntimeTestSup
 		return null;
 	}
 
-	private synchronized boolean initializeRuntime() {
+	private static synchronized boolean initializeRuntime() {
 		if (isRuntimeInitialized)
 			return true;
 
@@ -241,7 +241,7 @@ public class BaseGoTest extends BaseRuntimeTestSupport implements RuntimeTestSup
 		return isRuntimeInitialized;
 	}
 
-	private void copyDirectory(final Path source, final Path target, final CopyOption... options)
+	private static void copyDirectory(final Path source, final Path target, final CopyOption... options)
 			throws IOException {
 		Files.walkFileTree(source, EnumSet.of(FileVisitOption.FOLLOW_LINKS), 2147483647, new SimpleFileVisitor<Path>() {
 			@Override
@@ -260,7 +260,7 @@ public class BaseGoTest extends BaseRuntimeTestSupport implements RuntimeTestSup
 		});
 	}
 
-	private void deleteDirectory(File f) throws IOException {
+	private static void deleteDirectory(File f) throws IOException {
 		if (f.isDirectory()) {
 			for (File c : f.listFiles())
 				deleteDirectory(c);


### PR DESCRIPTION
After this its possible to update pom.xml to make the tests parallel, at least for Go. The other test suites may not support that.

```
diff --git a/runtime-testsuite/pom.xml b/runtime-testsuite/pom.xml
index 9c63282cd..c75dc195a 100644
--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -106,6 +106,8 @@
                         <include>**/dart/Test*.java</include>
                         <include>${antlr.tests.swift}</include>
                     </includes>
+          <parallel>all</parallel>
+          <useUnlimitedThreads>true</useUnlimitedThreads>
 				</configuration>
 			</plugin>
 			<plugin>

```