### PR TITLE
Fix case insensitive option with unicode, RANGE_PROBABLY_CONTAINS_NOT_IMPLIED_CHARACTERS fixes

### DIFF
--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestSymbolIssues.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestSymbolIssues.java
@@ -394,7 +394,7 @@ public class TestSymbolIssues extends BaseJavaToolTest {
 
 				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4:2:18: chars a-f used multiple times in set [aa-f]\n" +
 				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4:3:18: chars D-J used multiple times in set [A-FD-J]\n" +
-				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4:4:13: chars O-V used multiple times in set 'Z' | 'K'..'R' | 'O'..'V'\n" +
+				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4:4:38: chars O-V used multiple times in set 'Z' | 'K'..'R' | 'O'..'V'\n" +
 				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4::: chars 'g' used multiple times in set 'g'..'l'\n" +
 				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4::: chars '\\n' used multiple times in set '\\n'..'\\r'\n"
 		};
@@ -411,9 +411,7 @@ public class TestSymbolIssues extends BaseJavaToolTest {
 				"TOKEN_RANGE_3:    'm'..'q' | [M-Q];\n",
 
 				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4:3:18: chars a-f used multiple times in set [a-fA-F0-9]\n" +
-				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4:3:18: chars A-F used multiple times in set [a-fA-F0-9]\n" +
-				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4:4:13: chars g-l used multiple times in set 'g'..'l' | 'G'..'L'\n" +
-				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4:4:13: chars G-L used multiple times in set 'g'..'l' | 'G'..'L'\n" +
+				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4:4:32: chars g-l used multiple times in set 'g'..'l' | 'G'..'L'\n" +
 				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4::: chars 'M' used multiple times in set 'M'..'Q' | 'm'..'q'\n" +
 				"warning(" + ErrorType.CHARACTERS_COLLISION_IN_SET.code + "): L.g4::: chars 'm' used multiple times in set 'M'..'Q' | 'm'..'q'\n"
 		};

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestSymbolIssues.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestSymbolIssues.java
@@ -498,4 +498,16 @@ public class TestSymbolIssues extends BaseJavaToolTest {
 
 		testErrors(test, false);
 	}
+
+	@Test public void testNotImpliedCharactersWithCaseInsensitiveOption() {
+		String[] test = {
+				"lexer grammar Test;\n" +
+				"options { caseInsensitive=true; }\n" +
+				"TOKEN: [A-z];",
+
+				"warning(" + ErrorType.RANGE_PROBABLY_CONTAINS_NOT_IMPLIED_CHARACTERS.code + "): Test.g4:3:7: Range A..z probably contains not implied characters [\\]^_`. Both bounds should be defined in lower or UPPER case\n"
+		};
+
+		testErrors(test, false);
+	}
 }

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestSymbolIssues.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestSymbolIssues.java
@@ -489,7 +489,8 @@ public class TestSymbolIssues extends BaseJavaToolTest {
 				"lexer grammar Test;\n" +
 				"TOKEN1: 'A'..'g';\n" +
 				"TOKEN2: [C-m];\n" +
-				"TOKEN3: [А-я]; // OK since range does not contain intermediate characters",
+				"TOKEN3: [А-я]; // OK since range does not contain intermediate characters\n" +
+				"TOKEN4: '\\u0100'..'\\u1fff'; // OK since range borders are unicode characters",
 
 				"warning(" + ErrorType.RANGE_PROBABLY_CONTAINS_NOT_IMPLIED_CHARACTERS.code + "): Test.g4:2:8: Range A..g probably contains not implied characters [\\]^_`. Both bounds should be defined in lower or UPPER case\n" +
 				"warning(" + ErrorType.RANGE_PROBABLY_CONTAINS_NOT_IMPLIED_CHARACTERS.code + "): Test.g4:3:8: Range C..m probably contains not implied characters [\\]^_`. Both bounds should be defined in lower or UPPER case\n"

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestSymbolIssues.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestSymbolIssues.java
@@ -419,6 +419,24 @@ public class TestSymbolIssues extends BaseJavaToolTest {
 		testErrors(test, false);
 	}
 
+	@Test public void testCaseInsensitiveWithUnicodeRanges() {
+		String[] test = {
+				"lexer grammar L;\n" +
+				"options { caseInsensitive=true; }\n" +
+				"FullWidthLetter\n" +
+				"    : '\\u00c0'..'\\u00d6' // ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ\n" +
+				"    | '\\u00f8'..'\\u00ff' // øùúûüýþÿ\n" +
+				"    ;",
+
+				""
+		};
+
+		// Don't transform øùúûüýþÿ to uppercase
+		// ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸ
+		// because of different length of lower and UPPER range
+		testErrors(test, false);
+	}
+
 	@Test public void testUnreachableTokens() {
 		String[] test = {
 				"lexer grammar Test;\n" +

--- a/tool/src/org/antlr/v4/automata/CharactersDataCheckStatus.java
+++ b/tool/src/org/antlr/v4/automata/CharactersDataCheckStatus.java
@@ -1,0 +1,11 @@
+package org.antlr.v4.automata;
+
+public class CharactersDataCheckStatus {
+	public final boolean collision;
+	public final boolean notImpliedCharacters;
+
+	public CharactersDataCheckStatus(boolean collision, boolean notImpliedCharacters) {
+		this.collision = collision;
+		this.notImpliedCharacters = notImpliedCharacters;
+	}
+}

--- a/tool/src/org/antlr/v4/automata/RangeBorderCharactersData.java
+++ b/tool/src/org/antlr/v4/automata/RangeBorderCharactersData.java
@@ -5,11 +5,11 @@ import org.antlr.v4.tool.ErrorType;
 import org.antlr.v4.tool.Grammar;
 
 public class RangeBorderCharactersData {
-	public int lowerFrom;
-	public int upperFrom;
-	public int lowerTo;
-	public int upperTo;
-	public boolean mixOfLowerAndUpperCharCase;
+	public final int lowerFrom;
+	public final int upperFrom;
+	public final int lowerTo;
+	public final int upperTo;
+	public final boolean mixOfLowerAndUpperCharCase;
 
 	public RangeBorderCharactersData(int lowerFrom, int upperFrom, int lowerTo, int upperTo, boolean mixOfLowerAndUpperCharCase) {
 		this.lowerFrom = lowerFrom;
@@ -24,6 +24,7 @@ public class RangeBorderCharactersData {
 		int upperFrom = Character.toUpperCase(from);
 		int lowerTo = Character.toLowerCase(to);
 		int upperTo = Character.toUpperCase(to);
+
 		boolean isLowerFrom = lowerFrom == from;
 		boolean isLowerTo = lowerTo == to;
 		boolean mixOfLowerAndUpperCharCase = isLowerFrom && !isLowerTo || !isLowerFrom && isLowerTo;
@@ -40,5 +41,9 @@ public class RangeBorderCharactersData {
 			}
 		}
 		return new RangeBorderCharactersData(lowerFrom, upperFrom, lowerTo, upperTo, mixOfLowerAndUpperCharCase);
+	}
+
+	public boolean isSingleRange() {
+		return lowerFrom == upperFrom && lowerTo == upperTo || mixOfLowerAndUpperCharCase;
 	}
 }

--- a/tool/src/org/antlr/v4/automata/RangeBorderCharactersData.java
+++ b/tool/src/org/antlr/v4/automata/RangeBorderCharactersData.java
@@ -19,7 +19,9 @@ public class RangeBorderCharactersData {
 		this.mixOfLowerAndUpperCharCase = mixOfLowerAndUpperCharCase;
 	}
 
-	public static RangeBorderCharactersData getAndCheckCharactersData(int from, int to, Grammar grammar, CommonTree tree) {
+	public static RangeBorderCharactersData getAndCheckCharactersData(int from, int to, Grammar grammar, CommonTree tree,
+																	  boolean reportRangeContainsNotImpliedCharacters
+	) {
 		int lowerFrom = Character.toLowerCase(from);
 		int upperFrom = Character.toUpperCase(from);
 		int lowerTo = Character.toLowerCase(to);
@@ -28,7 +30,7 @@ public class RangeBorderCharactersData {
 		boolean isLowerFrom = lowerFrom == from;
 		boolean isLowerTo = lowerTo == to;
 		boolean mixOfLowerAndUpperCharCase = isLowerFrom && !isLowerTo || !isLowerFrom && isLowerTo;
-		if (mixOfLowerAndUpperCharCase && from <= 0x7F && to <= 0x7F) {
+		if (reportRangeContainsNotImpliedCharacters && mixOfLowerAndUpperCharCase && from <= 0x7F && to <= 0x7F) {
 			StringBuilder notImpliedCharacters = new StringBuilder();
 			for (int i = from; i < to; i++) {
 				if (!Character.isAlphabetic(i)) {

--- a/tool/src/org/antlr/v4/automata/RangeBorderCharactersData.java
+++ b/tool/src/org/antlr/v4/automata/RangeBorderCharactersData.java
@@ -44,6 +44,8 @@ public class RangeBorderCharactersData {
 	}
 
 	public boolean isSingleRange() {
-		return lowerFrom == upperFrom && lowerTo == upperTo || mixOfLowerAndUpperCharCase;
+		return lowerFrom == upperFrom && lowerTo == upperTo ||
+				mixOfLowerAndUpperCharCase ||
+				lowerTo - lowerFrom != upperTo - upperFrom;
 	}
 }

--- a/tool/src/org/antlr/v4/automata/RangeBorderCharactersData.java
+++ b/tool/src/org/antlr/v4/automata/RangeBorderCharactersData.java
@@ -28,10 +28,10 @@ public class RangeBorderCharactersData {
 		boolean isLowerFrom = lowerFrom == from;
 		boolean isLowerTo = lowerTo == to;
 		boolean mixOfLowerAndUpperCharCase = isLowerFrom && !isLowerTo || !isLowerFrom && isLowerTo;
-		if (mixOfLowerAndUpperCharCase) {
+		if (mixOfLowerAndUpperCharCase && from <= 0x7F && to <= 0x7F) {
 			StringBuilder notImpliedCharacters = new StringBuilder();
 			for (int i = from; i < to; i++) {
-				if (Character.toLowerCase(i) == Character.toUpperCase(i)) {
+				if (!Character.isAlphabetic(i)) {
 					notImpliedCharacters.append((char)i);
 				}
 			}


### PR DESCRIPTION
I've tested our case insensitive grammars-v4 repository with enabled new option and have found some errors that are fixed by the current PR:

* Enable `RANGE_PROBABLY_CONTAINS_NOT_IMPLIED_CHARACTERS` only for ASCII characters because there is probably not fully correct behavior with Unicode ranges. Anyway, I still think it's a useful warning, there are even questions on StackOverflow about `[A-z]` range: [Difference between regex [A-z] and [a-zA-Z]](https://stackoverflow.com/q/4923380/1046374), [[A-z0-9]+ regexp matching square brackets [duplicate]](https://stackoverflow.com/q/28449927/1046374)
* Convert range with `caseInsensitive` option if only UPPER range length equals to lower range length
* Improve location for warnings
* Remove some duplicated warnings