### PR TITLE
normalize targets to 80 char strings for ATN serialization segments.

### DIFF
--- a/.circleci/scripts/run-tests-cpp.sh
+++ b/.circleci/scripts/run-tests-cpp.sh
@@ -9,15 +9,15 @@ popd
 pushd runtime-testsuite
   echo "running maven tests..."
   if [ $GROUP == "LEXER" ]; then
-      mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
+      mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
   elif [ $GROUP == "PARSER1" ]; then
-      mvn -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
+      mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
   elif [ $GROUP == "PARSER2" ]; then
-      mvn -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
+      mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
   elif [ $GROUP == "RECURSION" ]; then
-      mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
+      mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
   else
-      mvn -q -Dtest=cpp.** test
+      mvn -Dtest=cpp.** test
   fi
 popd
 

--- a/.circleci/scripts/run-tests-dart.sh
+++ b/.circleci/scripts/run-tests-dart.sh
@@ -7,5 +7,5 @@ dart --version
 pushd runtime-testsuite
   echo "running maven tests..."
 #  mvn -q -Dparallel=classes -DthreadCount=4 -Dtest=dart.** test
-  mvn -q -Dtest=dart.** test
+  mvn -Dtest=dart.** test
 popd

--- a/.circleci/scripts/run-tests-swift.sh
+++ b/.circleci/scripts/run-tests-swift.sh
@@ -15,15 +15,15 @@ if [ $rc == 0 ]; then
   pushd runtime-testsuite
     echo "running maven tests..."
     if [ $GROUP == "LEXER" ]; then
-        mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=swift.** test
+        mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=swift.** test
     elif [ $GROUP == "PARSER1" ]; then
-        mvn -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=swift.** test
+        mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=swift.** test
     elif [ $GROUP == "PARSER2" ]; then
-        mvn -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=swift.** test
+        mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=swift.** test
     elif [ $GROUP == "RECURSION" ]; then
-        mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=swift.** test
+        mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=swift.** test
     else
-        mvn -q -Dtest=swift.** test
+        mvn -Dtest=swift.** test
     fi
   popd
 fi

--- a/tool/src/org/antlr/v4/codegen/Target.java
+++ b/tool/src/org/antlr/v4/codegen/Target.java
@@ -457,7 +457,10 @@ public abstract class Target {
 	 * @return the serialized ATN segment limit
 	 */
 	public int getSerializedATNSegmentLimit() {
-		return Integer.MAX_VALUE;
+		// Make strings encoding ATN fit on a single line conveniently so
+		// we can march through generated code more easily.  Only Java has
+		// an actual string len limit (16 bits).
+		return 80;
 	}
 
 	/** How many bits should be used to do inline token type tests? Java assumes

--- a/tool/src/org/antlr/v4/codegen/target/CppTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/CppTarget.java
@@ -88,13 +88,6 @@ public class CppTarget extends Target {
 	}
 
 	@Override
-	public int getSerializedATNSegmentLimit() {
-		// 65535 is the class file format byte limit for a UTF-8 encoded string literal
-		// 3 is the maximum number of bytes it takes to encode a value in the range 0-0xFFFF
-		return 65535 / 3;
-	}
-
-	@Override
 	public String getRecognizerFileName(boolean header) {
 		ST extST = getTemplates().getInstanceOf(header ? "headerFileExtension" : "codeFileExtension");
 		String recognizerName = gen.g.getRecognizerName();

--- a/tool/src/org/antlr/v4/codegen/target/DartTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/DartTarget.java
@@ -77,13 +77,6 @@ public class DartTarget extends Target {
 	}
 
 	@Override
-	public int getSerializedATNSegmentLimit() {
-		// 65535 is the class file format byte limit for a UTF-8 encoded string literal
-		// 3 is the maximum number of bytes it takes to encode a value in the range 0-0xFFFF
-		return 65535 / 3;
-	}
-
-	@Override
 	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
 		return getBadWords().contains(idNode.getText());
 	}

--- a/tool/src/org/antlr/v4/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/GoTarget.java
@@ -133,14 +133,6 @@ public class GoTarget extends Target {
 	}
 
 	@Override
-	public int getSerializedATNSegmentLimit() {
-		// 65535 is the class file format byte limit for a UTF-8 encoded string literal
-		// 3 is the maximum number of bytes it takes to encode a value in the range 0-0xFFFF
-		// (Mimicking Java here; not sure of true limit)
-		return 65535 / 3;
-	}
-
-	@Override
 	public int getInlineTestSetWordSize() {
 		return 32;
 	}

--- a/tool/src/org/antlr/v4/codegen/target/JavaScriptTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/JavaScriptTarget.java
@@ -87,14 +87,6 @@ public class JavaScriptTarget extends Target {
 	}
 
 	@Override
-	public int getSerializedATNSegmentLimit() {
-		// 65535 is the class file format byte limit for a UTF-8 encoded string literal
-		// 3 is the maximum number of bytes it takes to encode a value in the range 0-0xFFFF
-		// (Mimicking Java here; not sure of true limit)
-		return 65535 / 3;
-	}
-
-	@Override
 	public int getInlineTestSetWordSize() {
 		return 32;
 	}

--- a/tool/src/org/antlr/v4/codegen/target/Python3Target.java
+++ b/tool/src/org/antlr/v4/codegen/target/Python3Target.java
@@ -55,12 +55,6 @@ public class Python3Target extends Target {
 	}
 
 	@Override
-	public int getSerializedATNSegmentLimit() {
-		// set to something stupid to avoid segmentation
-		return Integer.MAX_VALUE;
-	}
-
-	@Override
 	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
 		return getBadWords().contains(idNode.getText());
 	}

--- a/tool/src/org/antlr/v4/codegen/target/SwiftTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/SwiftTarget.java
@@ -105,13 +105,6 @@ public class SwiftTarget extends Target {
     }
 
     @Override
-    public int getSerializedATNSegmentLimit() {
-        // 65535 is the class file format byte limit for a UTF-8 encoded string literal
-        // 3 is the maximum number of bytes it takes to encode a value in the range 0-0xFFFF
-        return 65535 / 3;
-    }
-
-    @Override
     protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
         return getBadWords().contains(idNode.getText());
     }


### PR DESCRIPTION
@ericvergnaud @KvanTTT How does this look? Tests appear to pass locally.