### PR TITLE
Fix for Issue #3441 -- export Reset() function.

### DIFF
--- a/runtime/Go/antlr/lexer.go
+++ b/runtime/Go/antlr/lexer.go
@@ -118,7 +118,7 @@ const (
 	LexerMaxCharValue        = 0x10FFFF
 )
 
-func (b *BaseLexer) reset() {
+func (b *BaseLexer) Reset() {
 	// wack Lexer state variables
 	if b.input != nil {
 		b.input.Seek(0) // rewind the input
@@ -282,7 +282,7 @@ func (b *BaseLexer) inputStream() CharStream {
 func (b *BaseLexer) SetInputStream(input CharStream) {
 	b.input = nil
 	b.tokenFactorySourcePair = &TokenSourceCharStreamPair{b, b.input}
-	b.reset()
+	b.Reset()
 	b.input = input
 	b.tokenFactorySourcePair = &TokenSourceCharStreamPair{b, b.input}
 }


### PR DESCRIPTION
This is a change to the Go runtime API. "reset()" is a function to rewind the lexer state for a subsequent parse. It is a public method for [CSharp](https://github.com/antlr/antlr4/blob/667631bb651a2e625f39988f193d08eddccd1c4e/runtime/CSharp/src/Lexer.cs#L112), [Cpp](https://github.com/antlr/antlr4/blob/667631bb651a2e625f39988f193d08eddccd1c4e/runtime/Cpp/runtime/src/Lexer.h#L82), [Dart](https://github.com/antlr/antlr4/blob/33122ac442fdfd5884a5182dac559889de60c218/runtime/Dart/lib/src/lexer.dart#L79), [Java](https://github.com/antlr/antlr4/blob/33122ac442fdfd5884a5182dac559889de60c218/runtime/Java/src/org/antlr/v4/runtime/Lexer.java#L88), [JavaScript](https://github.com/antlr/antlr4/blob/33122ac442fdfd5884a5182dac559889de60c218/runtime/JavaScript/src/antlr4/Lexer.js#L72), and [Python3](https://github.com/antlr/antlr4/blob/33122ac442fdfd5884a5182dac559889de60c218/runtime/Python3/src/antlr4/Lexer.py#L94), which is used in a generated driver for all the mentioned targets in [grammars-v4](https://github.com/antlr/grammars-v4) CI testing by [trgen](https://github.com/kaby76/Domemtech.Trash/tree/main/trgen). But, for the Go target, [reset()  is not publicly available](https://github.com/antlr/antlr4/blob/33122ac442fdfd5884a5182dac559889de60c218/runtime/Go/antlr/lexer.go#L121) because Go has no explicit language modifiers to export the function--it must begin with an uppercase letter. The fix is just a rename from "reset" to "Reset".