### PR TITLE
Fix for #3443 -- missing export of String()

### DIFF
--- a/runtime/Go/antlr/token.go
+++ b/runtime/Go/antlr/token.go
@@ -35,6 +35,7 @@ type Token interface {
 
 	GetTokenSource() TokenSource
 	GetInputStream() CharStream
+	String() string
 }
 
 type BaseToken struct {


### PR DESCRIPTION
This is a fix for the missing API method String() on a Token interface. By analogy to [ToStringTree() in ParseTree](https://github.com/antlr/antlr4/blob/345cc17bf36c67d7be8b7775e9f3693334232b28/runtime/Go/antlr/tree.go#L34), String() should be in the interface Token.