### PR TITLE
Simplify test rig related to timeouts

### DIFF
--- a/.appveyor/workflow.yml
+++ b/.appveyor/workflow.yml
@@ -32,24 +32,24 @@ for:
       only:
         - job_name: java-tool-and-runtime
     build_script:
-      - mvn -q -DskipTests install --batch-mode
+      - mvn -DskipTests install --batch-mode
     test_script:
       - cd tool-testsuite
-      - mvn -q test
+      - mvn test
       - cd ..\runtime-testsuite
-      - mvn -q -Dtest=java.** test
+      - mvn -Dtest=java.** test
 
   - matrix:
       only:
         - job_name: csharp-runtime
     build_script:
-      - mvn -q -DskipTests install --batch-mode
+      - mvn -DskipTests install --batch-mode
       - dotnet build runtime/CSharp/src/Antlr4.csproj -c Release
     after_build:
       - dotnet pack runtime/CSharp/src/Antlr4.csproj -c Release
     test_script:
       - cd runtime-testsuite
-      - mvn -q -Dtest=csharp.** test
+      - mvn -Dtest=csharp.** test
     artifacts:
       - path: 'runtime\**\*.nupkg'
         name: NuGet
@@ -60,19 +60,19 @@ for:
     install:
       - cinst -y dart-sdk --version=2.12.1
     build_script:
-      - mvn -q -DskipTests install --batch-mode
+      - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime-testsuite
-      - mvn -q -Dtest=dart.** test -Dantlr-dart-dart="C:\tools\dart-sdk\bin\dart.exe" -Dantlr-dart-pub="C:\tools\dart-sdk\bin\pub.bat" -Dantlr-dart-dart2native="C:\tools\dart-sdk\bin\dart2native.bat"
+      - mvn -Dtest=dart.** test -Dantlr-dart-dart="C:\tools\dart-sdk\bin\dart.exe" -Dantlr-dart-pub="C:\tools\dart-sdk\bin\pub.bat" -Dantlr-dart-dart2native="C:\tools\dart-sdk\bin\dart2native.bat"
 
   - matrix:
       only:
         - job_name: go-runtime
     build_script:
-      - mvn -q -DskipTests install --batch-mode
+      - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime-testsuite
-      - mvn -q -Dtest=go.** test
+      - mvn -Dtest=go.** test
 
   - matrix:
       only:
@@ -87,13 +87,13 @@ for:
       - npm install
       - npm link
       - cd ..\..
-      - mvn -q -DskipTests install --batch-mode
+      - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime\JavaScript\
       - yarn test
       - cd ..\..
       - cd runtime-testsuite
-      - mvn -q -Dtest=javascript.** test -Dantlr-javascript-npm="C:\Program Files\nodejs\npm.cmd" -Dantlr-javascript-nodejs="C:\Program Files\nodejs\node.exe"
+      - mvn -Dtest=javascript.** test -Dantlr-javascript-npm="C:\Program Files\nodejs\npm.cmd" -Dantlr-javascript-nodejs="C:\Program Files\nodejs\node.exe"
 
   - matrix:
       only:
@@ -104,25 +104,25 @@ for:
       - cinst -y php --params "/InstallDir:C:\tools\php"
       - cinst -y composer
     build_script:
-      - mvn -q -DskipTests install --batch-mode
+      - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime-testsuite
-      - mvn -q -Dtest=php.** test -Dantlr-php-php="C:\tools\php\php.exe"
+      - mvn -Dtest=php.** test -Dantlr-php-php="C:\tools\php\php.exe"
 
   - matrix:
       only:
         - job_name: python2-runtime
     build_script:
-      - mvn -q -DskipTests install --batch-mode
+      - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime-testsuite
-      - mvn -q -Dtest=python2.** test -Dantlr-python2-python="C:\Python27\python.exe"
+      - mvn -Dtest=python2.** test -Dantlr-python2-python="C:\Python27\python.exe"
 
   - matrix:
       only:
         - job_name: python3-runtime
     build_script:
-      - mvn -q -DskipTests install --batch-mode
+      - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime-testsuite
-      - mvn -q -Dtest=python3.** test -Dantlr-python3-python="C:\Python35\python.exe"
+      - mvn -Dtest=python3.** test -Dantlr-python3-python="C:\Python35\python.exe"

--- a/.appveyor/workflow.yml
+++ b/.appveyor/workflow.yml
@@ -37,7 +37,7 @@ for:
       - cd tool-testsuite
       - mvn test
       - cd ..\runtime-testsuite
-      - mvn -Dtest=java.** test
+      - mvn -Dparallel=classes -DthreadCount=4 -Dtest=java.** test
 
   - matrix:
       only:
@@ -49,7 +49,7 @@ for:
       - dotnet pack runtime/CSharp/src/Antlr4.csproj -c Release
     test_script:
       - cd runtime-testsuite
-      - mvn -Dtest=csharp.** test
+      - mvn -Dparallel=classes -DthreadCount=4 -Dtest=csharp.** test
     artifacts:
       - path: 'runtime\**\*.nupkg'
         name: NuGet
@@ -63,7 +63,7 @@ for:
       - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime-testsuite
-      - mvn -Dtest=dart.** test -Dantlr-dart-dart="C:\tools\dart-sdk\bin\dart.exe" -Dantlr-dart-pub="C:\tools\dart-sdk\bin\pub.bat" -Dantlr-dart-dart2native="C:\tools\dart-sdk\bin\dart2native.bat"
+      - mvn -Dparallel=classes -DthreadCount=4 -Dtest=dart.** test -Dantlr-dart-dart="C:\tools\dart-sdk\bin\dart.exe" -Dantlr-dart-pub="C:\tools\dart-sdk\bin\pub.bat" -Dantlr-dart-dart2native="C:\tools\dart-sdk\bin\dart2native.bat"
 
   - matrix:
       only:
@@ -72,7 +72,7 @@ for:
       - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime-testsuite
-      - mvn -Dtest=go.** test
+      - mvn -Dparallel=classes -DthreadCount=4 -Dtest=go.** test
 
   - matrix:
       only:
@@ -93,7 +93,7 @@ for:
       - yarn test
       - cd ..\..
       - cd runtime-testsuite
-      - mvn -Dtest=javascript.** test -Dantlr-javascript-npm="C:\Program Files\nodejs\npm.cmd" -Dantlr-javascript-nodejs="C:\Program Files\nodejs\node.exe"
+      - mvn -Dparallel=classes -DthreadCount=4 -Dtest=javascript.** test -Dantlr-javascript-npm="C:\Program Files\nodejs\npm.cmd" -Dantlr-javascript-nodejs="C:\Program Files\nodejs\node.exe"
 
   - matrix:
       only:
@@ -107,7 +107,7 @@ for:
       - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime-testsuite
-      - mvn -Dtest=php.** test -Dantlr-php-php="C:\tools\php\php.exe"
+      - mvn -Dparallel=classes -DthreadCount=4 -Dtest=php.** test -Dantlr-php-php="C:\tools\php\php.exe"
 
   - matrix:
       only:
@@ -116,7 +116,7 @@ for:
       - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime-testsuite
-      - mvn -Dtest=python2.** test -Dantlr-python2-python="C:\Python27\python.exe"
+      - mvn -Dparallel=classes -DthreadCount=4 -Dtest=python2.** test -Dantlr-python2-python="C:\Python27\python.exe"
 
   - matrix:
       only:
@@ -125,4 +125,4 @@ for:
       - mvn -DskipTests install --batch-mode
     test_script:
       - cd runtime-testsuite
-      - mvn -Dtest=python3.** test -Dantlr-python3-python="C:\Python35\python.exe"
+      - mvn -Dparallel=classes -DthreadCount=4 -Dtest=python3.** test -Dantlr-python3-python="C:\Python35\python.exe"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ jobs:
         default: java
     docker:
       - image: cimg/openjdk:8.0
+        environment:
+          MAVEN_OPTS: -Xmx512m
+    resource_class: large
     environment:
       TARGET: << parameters.target >>
       GROUP: << parameters.test-group >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,13 @@ jobs:
           name: test runtime
           command: |
             cd runtime-testsuite
-            mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=java.** test
+            mvn -Dparallel=methods -DthreadCount=4 -Dtest=java.** test
             cd ..
       - run:
           name: test tool
           command: |
             cd tool-testsuite
-            mvn -q -Dparallel=methods -DthreadCount=4 test
+            mvn -Dparallel=methods -DthreadCount=4 test
             cd ..
   test_runtime:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,10 @@ workflows:
       - test_runtime:
           matrix:
             parameters:
-              target: [ dart, go, python2, python3, javascript, php ]
-      - test_runtime:
-          matrix:
-            parameters:
-              target: [ cpp, dotnet ]
-              test-group: [ LEXER, PARSER1, PARSER2, RECURSION ]
+#              target: [ dart, go, python2, python3, javascript, php ]
+              target: [ dart, go, python2, python3, javascript, php, cpp, dotnet ]
+#      - test_runtime:
+#          matrix:
+#            parameters:
+#              target: [ cpp, dotnet ]
+#              test-group: [ LEXER, PARSER1, PARSER2, RECURSION ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,13 @@ jobs:
           name: test runtime
           command: |
             cd runtime-testsuite
-            mvn -Dparallel=methods -DthreadCount=4 -Dtest=java.** test
+            mvn -Dparallel=classes -DthreadCount=4 -Dtest=java.** test
             cd ..
       - run:
           name: test tool
           command: |
             cd tool-testsuite
-            mvn -Dparallel=methods -DthreadCount=4 test
+            mvn -Dparallel=classes -DthreadCount=4 test
             cd ..
   test_runtime:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,4 @@ workflows:
       - test_runtime:
           matrix:
             parameters:
-#              target: [ dart, go, python2, python3, javascript, php ]
               target: [ dart, go, python2, python3, javascript, php, cpp, dotnet ]
-#      - test_runtime:
-#          matrix:
-#            parameters:
-#              target: [ cpp, dotnet ]
-#              test-group: [ LEXER, PARSER1, PARSER2, RECURSION ]

--- a/.circleci/scripts/run-tests-cpp.sh
+++ b/.circleci/scripts/run-tests-cpp.sh
@@ -9,15 +9,15 @@ popd
 pushd runtime-testsuite
   echo "running maven tests..."
   if [ $GROUP == "LEXER" ]; then
-      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
   elif [ $GROUP == "PARSER1" ]; then
-      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
   elif [ $GROUP == "PARSER2" ]; then
-      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
   elif [ $GROUP == "RECURSION" ]; then
-      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
   else
-      mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=1 -Dtest=cpp.** test
   fi
 popd
 

--- a/.circleci/scripts/run-tests-cpp.sh
+++ b/.circleci/scripts/run-tests-cpp.sh
@@ -17,7 +17,7 @@ pushd runtime-testsuite
   elif [ $GROUP == "RECURSION" ]; then
       mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
   else
-      mvn -Dparallel=classes -DthreadCount=1 -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.** test
   fi
 popd
 

--- a/.circleci/scripts/run-tests-cpp.sh
+++ b/.circleci/scripts/run-tests-cpp.sh
@@ -2,22 +2,6 @@
 
 set -euo pipefail
 
-pushd runtime/Cpp
-ctest
-popd
-
 pushd runtime-testsuite
-  echo "running maven tests..."
-  if [ $GROUP == "LEXER" ]; then
-      mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
-  elif [ $GROUP == "PARSER1" ]; then
-      mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
-  elif [ $GROUP == "PARSER2" ]; then
-      mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
-  elif [ $GROUP == "RECURSION" ]; then
-      mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
-  else
-      mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.** test
-  fi
+mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.** test
 popd
-

--- a/.circleci/scripts/run-tests-cpp.sh
+++ b/.circleci/scripts/run-tests-cpp.sh
@@ -9,15 +9,15 @@ popd
 pushd runtime-testsuite
   echo "running maven tests..."
   if [ $GROUP == "LEXER" ]; then
-      mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
   elif [ $GROUP == "PARSER1" ]; then
-      mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
   elif [ $GROUP == "PARSER2" ]; then
-      mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
   elif [ $GROUP == "RECURSION" ]; then
-      mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
   else
-      mvn -Dtest=cpp.** test
+      mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.** test
   fi
 popd
 

--- a/.circleci/scripts/run-tests-dart.sh
+++ b/.circleci/scripts/run-tests-dart.sh
@@ -6,6 +6,5 @@ dart --version
 
 pushd runtime-testsuite
   echo "running maven tests..."
-#  mvn -q -Dparallel=classes -DthreadCount=4 -Dtest=dart.** test
-  mvn -Dtest=dart.** test
+  mvn -Dparallel=classes -DthreadCount=4 -Dtest=dart.** test
 popd

--- a/.circleci/scripts/run-tests-dotnet.sh
+++ b/.circleci/scripts/run-tests-dotnet.sh
@@ -2,15 +2,6 @@
 
 set -euo pipefail
 
-pushd runtime-testsuite/
-  echo "running maven tests..."
-  if [ $GROUP == "LEXER" ]; then
-      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=csharp.** test
-  elif [ $GROUP == "PARSER1" ]; then
-      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=csharp.** test
-  elif [ $GROUP == "RECURSION" ]; then
-      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=csharp.** test
-  else
-      mvn -Dparallel=classes -DthreadCount=4 -Dtest=csharp.** test
-  fi
+pushd runtime-testsuite
+mvn -Dparallel=classes -DthreadCount=4 -Dtest=csharp.** test
 popd

--- a/.circleci/scripts/run-tests-dotnet.sh
+++ b/.circleci/scripts/run-tests-dotnet.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 pushd runtime-testsuite/
   echo "running maven tests..."
   if [ $GROUP == "LEXER" ]; then
-      mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=csharp.** test
+      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=csharp.** test
   elif [ $GROUP == "PARSER1" ]; then
-      mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=csharp.** test
+      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=csharp.** test
   elif [ $GROUP == "RECURSION" ]; then
-      mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=csharp.** test
+      mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=csharp.** test
   else
-      mvn -Dtest=csharp.** test
+      mvn -Dparallel=classes -DthreadCount=4 -Dtest=csharp.** test
   fi
 popd

--- a/.circleci/scripts/run-tests-go.sh
+++ b/.circleci/scripts/run-tests-go.sh
@@ -6,5 +6,5 @@ go version
 
 pushd runtime-testsuite
     echo "running maven tests..."
-    mvn -Dparallel=methods -DthreadCount=4 -Dtest=go.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dtest=go.** test
 popd

--- a/.circleci/scripts/run-tests-php.sh
+++ b/.circleci/scripts/run-tests-php.sh
@@ -7,5 +7,5 @@ php -v
 php_path=$(which php)
 pushd runtime-testsuite
   echo "running maven tests..."
-  mvn -q -DPHP_PATH="${php_path}" -Dparallel=methods -DthreadCount=4 -Dtest=php.** test
+  mvn -DPHP_PATH="${php_path}" -Dparallel=methods -DthreadCount=4 -Dtest=php.** test
 popd

--- a/.circleci/scripts/run-tests-php.sh
+++ b/.circleci/scripts/run-tests-php.sh
@@ -7,5 +7,5 @@ php -v
 php_path=$(which php)
 pushd runtime-testsuite
   echo "running maven tests..."
-  mvn -DPHP_PATH="${php_path}" -Dparallel=methods -DthreadCount=4 -Dtest=php.** test
+  mvn -DPHP_PATH="${php_path}" -Dparallel=classes -DthreadCount=4 -Dtest=php.** test
 popd

--- a/.circleci/scripts/run-tests-python2.sh
+++ b/.circleci/scripts/run-tests-python2.sh
@@ -16,7 +16,7 @@ popd
 if [ $rc == 0 ]; then
   pushd runtime-testsuite
     echo "running maven tests..."
-    mvn -Dtest=python2.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dtest=python2.** test
     rc=$?
   popd
 fi

--- a/.circleci/scripts/run-tests-python2.sh
+++ b/.circleci/scripts/run-tests-python2.sh
@@ -16,7 +16,7 @@ popd
 if [ $rc == 0 ]; then
   pushd runtime-testsuite
     echo "running maven tests..."
-    mvn -q -Dtest=python2.** test
+    mvn -Dtest=python2.** test
     rc=$?
   popd
 fi

--- a/.circleci/scripts/run-tests-python3.sh
+++ b/.circleci/scripts/run-tests-python3.sh
@@ -16,7 +16,7 @@ popd
 if [ $rc == 0 ]; then
   pushd runtime-testsuite
     echo "running maven tests..."
-    mvn -Dtest=python3.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dtest=python3.** test
     rc=$?
   popd
 fi

--- a/.circleci/scripts/run-tests-python3.sh
+++ b/.circleci/scripts/run-tests-python3.sh
@@ -16,7 +16,7 @@ popd
 if [ $rc == 0 ]; then
   pushd runtime-testsuite
     echo "running maven tests..."
-    mvn -q -Dtest=python3.** test
+    mvn -Dtest=python3.** test
     rc=$?
   popd
 fi

--- a/.circleci/scripts/run-tests-swift.sh
+++ b/.circleci/scripts/run-tests-swift.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Appears to be unused
+
 set -euo pipefail
 
 pushd runtime/Swift

--- a/.circleci/scripts/run-tests-swift.sh
+++ b/.circleci/scripts/run-tests-swift.sh
@@ -15,15 +15,15 @@ if [ $rc == 0 ]; then
   pushd runtime-testsuite
     echo "running maven tests..."
     if [ $GROUP == "LEXER" ]; then
-        mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=swift.** test
+        mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=swift.** test
     elif [ $GROUP == "PARSER1" ]; then
-        mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=swift.** test
+        mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=swift.** test
     elif [ $GROUP == "PARSER2" ]; then
-        mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=swift.** test
+        mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=swift.** test
     elif [ $GROUP == "RECURSION" ]; then
-        mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=swift.** test
+        mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=swift.** test
     else
-        mvn -Dtest=swift.** test
+        mvn -Dparallel=classes -DthreadCount=4 -Dtest=swift.** test
     fi
   popd
 fi

--- a/.github/scripts/run-tests-cpp.sh
+++ b/.github/scripts/run-tests-cpp.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 pushd runtime-testsuite
-mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.* test
+mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.** test
 popd
 
 #pushd runtime/Cpp
@@ -20,6 +20,6 @@ popd
 #elif [ $GROUP == "RECURSION" ]; then
 #    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
 #else
-#    mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.* test
+#    mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.** test
 #fi
 #popd

--- a/.github/scripts/run-tests-cpp.sh
+++ b/.github/scripts/run-tests-cpp.sh
@@ -5,21 +5,3 @@ set -euo pipefail
 pushd runtime-testsuite
 mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.** test
 popd
-
-#pushd runtime/Cpp
-#ctest
-#popd
-#
-#pushd runtime-testsuite
-#if [ $GROUP == "LEXER" ]; then
-#    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
-#elif [ $GROUP == "PARSER1" ]; then
-#    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
-#elif [ $GROUP == "PARSER2" ]; then
-#    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
-#elif [ $GROUP == "RECURSION" ]; then
-#    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
-#else
-#    mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.** test
-#fi
-#popd

--- a/.github/scripts/run-tests-cpp.sh
+++ b/.github/scripts/run-tests-cpp.sh
@@ -16,6 +16,6 @@ elif [ $GROUP == "PARSER2" ]; then
 elif [ $GROUP == "RECURSION" ]; then
     mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
 else
-    mvn -Dparallel=classes -DthreadCount=1 -Dtest=cpp.* test
+    mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.* test
 fi
 popd

--- a/.github/scripts/run-tests-cpp.sh
+++ b/.github/scripts/run-tests-cpp.sh
@@ -2,20 +2,24 @@
 
 set -euo pipefail
 
-pushd runtime/Cpp
-ctest
+pushd runtime-testsuite
+mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.* test
 popd
 
-pushd runtime-testsuite
-if [ $GROUP == "LEXER" ]; then
-    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
-elif [ $GROUP == "PARSER1" ]; then
-    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
-elif [ $GROUP == "PARSER2" ]; then
-    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
-elif [ $GROUP == "RECURSION" ]; then
-    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
-else
-    mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.* test
-fi
-popd
+#pushd runtime/Cpp
+#ctest
+#popd
+#
+#pushd runtime-testsuite
+#if [ $GROUP == "LEXER" ]; then
+#    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
+#elif [ $GROUP == "PARSER1" ]; then
+#    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
+#elif [ $GROUP == "PARSER2" ]; then
+#    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
+#elif [ $GROUP == "RECURSION" ]; then
+#    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
+#else
+#    mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.* test
+#fi
+#popd

--- a/.github/scripts/run-tests-cpp.sh
+++ b/.github/scripts/run-tests-cpp.sh
@@ -8,14 +8,14 @@ popd
 
 pushd runtime-testsuite
 if [ $GROUP == "LEXER" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
 elif [ $GROUP == "PARSER1" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
 elif [ $GROUP == "PARSER2" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
 elif [ $GROUP == "RECURSION" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
 else
-    mvn -q -Dtest=cpp.* test
+    mvn -Dtest=cpp.* test
 fi
 popd

--- a/.github/scripts/run-tests-cpp.sh
+++ b/.github/scripts/run-tests-cpp.sh
@@ -8,14 +8,14 @@ popd
 
 pushd runtime-testsuite
 if [ $GROUP == "LEXER" ]; then
-    mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
 elif [ $GROUP == "PARSER1" ]; then
-    mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
 elif [ $GROUP == "PARSER2" ]; then
-    mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
 elif [ $GROUP == "RECURSION" ]; then
-    mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
 else
-    mvn -Dtest=cpp.* test
+    mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.* test
 fi
 popd

--- a/.github/scripts/run-tests-cpp.sh
+++ b/.github/scripts/run-tests-cpp.sh
@@ -8,14 +8,14 @@ popd
 
 pushd runtime-testsuite
 if [ $GROUP == "LEXER" ]; then
-    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
+    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.** test
 elif [ $GROUP == "PARSER1" ]; then
-    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
+    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=cpp.** test
 elif [ $GROUP == "PARSER2" ]; then
-    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
+    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest=cpp.** test
 elif [ $GROUP == "RECURSION" ]; then
-    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
+    mvn -Dparallel=classes -DthreadCount=1 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.** test
 else
-    mvn -Dparallel=classes -DthreadCount=4 -Dtest=cpp.* test
+    mvn -Dparallel=classes -DthreadCount=1 -Dtest=cpp.* test
 fi
 popd

--- a/.github/scripts/run-tests-dotnet.sh
+++ b/.github/scripts/run-tests-dotnet.sh
@@ -12,14 +12,6 @@ export PATH=$PATH:~/.dotnet
 dotnet build -c Release -f netstandard2.0 runtime/CSharp/Antlr4.csproj
 
 # run tests
-cd runtime-testsuite/
-
-if [ $GROUP == "LEXER" ]; then
-    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=csharp.** test
-elif [ $GROUP == "PARSER1" ]; then
-    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=csharp.** test
-elif [ $GROUP == "RECURSION" ]; then
-    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=csharp.** test
-else
-    mvn -Dparallel=classes -DthreadCount=4 -Dtest=csharp.** test
-fi
+pushd runtime-testsuite/
+mvn -Dparallel=classes -DthreadCount=4 -Dtest=csharp.** test
+popd

--- a/.github/scripts/run-tests-dotnet.sh
+++ b/.github/scripts/run-tests-dotnet.sh
@@ -13,11 +13,11 @@ dotnet build -c Release -f netstandard2.0 runtime/CSharp/Antlr4.csproj
 cd runtime-testsuite/
 
 if [ $GROUP == "LEXER" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=csharp.** test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=csharp.** test
 elif [ $GROUP == "PARSER1" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=csharp.** test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=csharp.** test
 elif [ $GROUP == "RECURSION" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=csharp.** test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=csharp.** test
 else
-    mvn -q -Dtest=csharp.** test
+    mvn -Dtest=csharp.** test
 fi

--- a/.github/scripts/run-tests-dotnet.sh
+++ b/.github/scripts/run-tests-dotnet.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Appears not to be used at moment
+
 set -euo pipefail
 
 export PATH=$PATH:~/.dotnet

--- a/.github/scripts/run-tests-dotnet.sh
+++ b/.github/scripts/run-tests-dotnet.sh
@@ -13,11 +13,11 @@ dotnet build -c Release -f netstandard2.0 runtime/CSharp/Antlr4.csproj
 cd runtime-testsuite/
 
 if [ $GROUP == "LEXER" ]; then
-    mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=csharp.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=csharp.** test
 elif [ $GROUP == "PARSER1" ]; then
-    mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=csharp.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest=csharp.** test
 elif [ $GROUP == "RECURSION" ]; then
-    mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=csharp.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=csharp.** test
 else
-    mvn -Dtest=csharp.** test
+    mvn -Dparallel=classes -DthreadCount=4 -Dtest=csharp.** test
 fi

--- a/.github/scripts/run-tests-swift.sh
+++ b/.github/scripts/run-tests-swift.sh
@@ -36,15 +36,15 @@ if [ $rc == 0 ]; then
   # run java tests
   cd runtime-testsuite/
   if [ $GROUP == "LEXER" ]; then
-      mvn -e -q -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest="swift.**" test
+      mvn -e -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest="swift.**" test
   elif [ $GROUP == "PARSER1" ]; then
-      mvn -e -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest="swift.**" test
+      mvn -e -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest="swift.**" test
   elif [ $GROUP == "PARSER2" ]; then
-      mvn -e -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest="swift.**" test
+      mvn -e -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest="swift.**" test
   elif [ $GROUP == "RECURSION" ]; then
-      mvn -e -q -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest="swift.**" test
+      mvn -e -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest="swift.**" test
   else
-      mvn -e -q -Dtest=swift.** test
+      mvn -e -Dtest=swift.** test
   fi
   rc=$?
   cat target/surefire-reports/*.dumpstream || true

--- a/.github/scripts/run-tests-swift.sh
+++ b/.github/scripts/run-tests-swift.sh
@@ -35,7 +35,9 @@ popd
 if [ $rc == 0 ]; then
   # run java tests
   cd runtime-testsuite/
-  mvn -e -Dparallel=classes -DthreadCount=4 -Dtest=swift.** test
+#  mvn -e -Dparallel=classes -DthreadCount=4 -Dtest=swift.** test
+# I don't know swift enough to make it parallel. revert to single threaded
+  mvn -e -Dtest=swift.** test
   rc=$?
   cat target/surefire-reports/*.dumpstream || true
 fi

--- a/.github/scripts/run-tests-swift.sh
+++ b/.github/scripts/run-tests-swift.sh
@@ -35,17 +35,7 @@ popd
 if [ $rc == 0 ]; then
   # run java tests
   cd runtime-testsuite/
-  if [ $GROUP == "LEXER" ]; then
-      mvn -e -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest="swift.**" test
-  elif [ $GROUP == "PARSER1" ]; then
-      mvn -e -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup1" -Dtest="swift.**" test
-  elif [ $GROUP == "PARSER2" ]; then
-      mvn -e -Dgroups="org.antlr.v4.test.runtime.category.ParserTestsGroup2" -Dtest="swift.**" test
-  elif [ $GROUP == "RECURSION" ]; then
-      mvn -e -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest="swift.**" test
-  else
-      mvn -e -Dtest=swift.** test
-  fi
+  mvn -e -Dparallel=classes -DthreadCount=4 -Dtest=swift.** test
   rc=$?
   cat target/surefire-reports/*.dumpstream || true
 fi

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -12,10 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        TARGET: [swift, cpp, dotnet] disabling dotnet which is unstable on M1
         TARGET: [swift, cpp]
-        GROUP: [ALL] # temporary
-#        GROUP: [LEXER, PARSER1, PARSER2, RECURSION]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
@@ -29,8 +26,6 @@ jobs:
     - name: Build tool with Maven
       run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
     - name: Test with Maven
-#      run: arch -x86_64 .github/scripts/run-tests-${{ matrix.TARGET }}.sh
       run: .github/scripts/run-tests-${{ matrix.TARGET }}.sh
       env:
         TARGET: ${{ matrix.TARGET }}
-        GROUP: ${{ matrix.GROUP }}

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
 #        TARGET: [swift, cpp, dotnet] disabling dotnet which is unstable on M1
         TARGET: [swift, cpp]
-        GROUP: ALL # temporary
+        GROUP: [ALL] # temporary
 #        GROUP: [LEXER, PARSER1, PARSER2, RECURSION]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
 #        TARGET: [swift, cpp, dotnet] disabling dotnet which is unstable on M1
         TARGET: [swift, cpp]
+        GROUP: ALL # temporary
 #        GROUP: [LEXER, PARSER1, PARSER2, RECURSION]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
 #        TARGET: [swift, cpp, dotnet] disabling dotnet which is unstable on M1
         TARGET: [swift, cpp]
-        GROUP: [LEXER, PARSER1, PARSER2, RECURSION]
+#        GROUP: [LEXER, PARSER1, PARSER2, RECURSION]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -29,7 +29,8 @@ jobs:
     - name: Build tool with Maven
       run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
     - name: Test with Maven
-      run: arch -x86_64 .github/scripts/run-tests-${{ matrix.TARGET }}.sh
+#      run: arch -x86_64 .github/scripts/run-tests-${{ matrix.TARGET }}.sh
+      run: .github/scripts/run-tests-${{ matrix.TARGET }}.sh
       env:
         TARGET: ${{ matrix.TARGET }}
         GROUP: ${{ matrix.GROUP }}

--- a/.travis/run-tests-cpp.sh
+++ b/.travis/run-tests-cpp.sh
@@ -8,12 +8,12 @@ popd
 
 pushd runtime-testsuite
 if [ $GROUP == "LEXER" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.* test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=cpp.* test
 elif [ $GROUP == "PARSER" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTests" -Dtest=cpp.* test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTests" -Dtest=cpp.* test
 elif [ $GROUP == "RECURSION" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.* test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=cpp.* test
 else
-    mvn -q -Dtest=cpp.* test
+    mvn -Dtest=cpp.* test
 fi
 popd

--- a/.travis/run-tests-dart.sh
+++ b/.travis/run-tests-dart.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 set -euo pipefail
-mvn -q -Dparallel=classes -DthreadCount=4 -Dtest=dart.* test
+mvn -Dparallel=classes -DthreadCount=4 -Dtest=dart.* test

--- a/.travis/run-tests-dotnet.sh
+++ b/.travis/run-tests-dotnet.sh
@@ -12,11 +12,11 @@ dotnet build -c Release -f netstandard2.0 ../runtime/CSharp/src/Antlr4.csproj
 # call test
 
 if [ $GROUP == "LEXER" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dparallel=classes -DthreadCount=4 -Dtest=csharp.* test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dparallel=classes -DthreadCount=4 -Dtest=csharp.* test
 elif [ $GROUP == "PARSER" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTests" -Dparallel=classes -DthreadCount=4 -Dtest=csharp.* test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTests" -Dparallel=classes -DthreadCount=4 -Dtest=csharp.* test
 elif [ $GROUP == "RECURSION" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dparallel=classes -DthreadCount=4 -Dtest=csharp.* test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dparallel=classes -DthreadCount=4 -Dtest=csharp.* test
 else
-    mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=csharp.* test
+    mvn -Dparallel=methods -DthreadCount=4 -Dtest=csharp.* test
 fi

--- a/.travis/run-tests-dotnet.sh
+++ b/.travis/run-tests-dotnet.sh
@@ -18,5 +18,5 @@ elif [ $GROUP == "PARSER" ]; then
 elif [ $GROUP == "RECURSION" ]; then
     mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dparallel=classes -DthreadCount=4 -Dtest=csharp.* test
 else
-    mvn -Dparallel=methods -DthreadCount=4 -Dtest=csharp.* test
+    mvn -Dparallel=classes -DthreadCount=4 -Dtest=csharp.* test
 fi

--- a/.travis/run-tests-go.sh
+++ b/.travis/run-tests-go.sh
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=go.* test
+mvn -Dparallel=methods -DthreadCount=4 -Dtest=go.* test

--- a/.travis/run-tests-go.sh
+++ b/.travis/run-tests-go.sh
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-mvn -Dparallel=methods -DthreadCount=4 -Dtest=go.* test
+mvn -Dparallel=classes -DthreadCount=4 -Dtest=go.* test

--- a/.travis/run-tests-java.sh
+++ b/.travis/run-tests-java.sh
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-mvn -Dparallel=methods -DthreadCount=4 -Dtest=java.* test
+mvn -Dparallel=classes -DthreadCount=4 -Dtest=java.* test
 cd ../tool-testsuite
 mvn test

--- a/.travis/run-tests-java.sh
+++ b/.travis/run-tests-java.sh
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=java.* test
+mvn -Dparallel=methods -DthreadCount=4 -Dtest=java.* test
 cd ../tool-testsuite
 mvn test

--- a/.travis/run-tests-javascript.sh
+++ b/.travis/run-tests-javascript.sh
@@ -6,4 +6,4 @@ cd ../runtime/JavaScript
 npm install
 npm link
 cd ../../runtime-testsuite
-mvn -q -Dparallel=methods -DthreadCount=1 -Dtest=javascript.* test
+mvn -Dparallel=methods -DthreadCount=1 -Dtest=javascript.* test

--- a/.travis/run-tests-javascript.sh
+++ b/.travis/run-tests-javascript.sh
@@ -6,4 +6,4 @@ cd ../runtime/JavaScript
 npm install
 npm link
 cd ../../runtime-testsuite
-mvn -Dparallel=methods -DthreadCount=1 -Dtest=javascript.* test
+mvn -Dparallel=classes -DthreadCount=1 -Dtest=javascript.* test

--- a/.travis/run-tests-php.sh
+++ b/.travis/run-tests-php.sh
@@ -6,4 +6,4 @@ php_path=$(which php)
 
 composer install -d ../runtime/PHP
 
-mvn -DPHP_PATH="${php_path}" -Dparallel=methods -DthreadCount=4 -Dtest=php.* test
+mvn -DPHP_PATH="${php_path}" -Dparallel=classes -DthreadCount=4 -Dtest=php.* test

--- a/.travis/run-tests-php.sh
+++ b/.travis/run-tests-php.sh
@@ -6,4 +6,4 @@ php_path=$(which php)
 
 composer install -d ../runtime/PHP
 
-mvn -q -DPHP_PATH="${php_path}" -Dparallel=methods -DthreadCount=4 -Dtest=php.* test
+mvn -DPHP_PATH="${php_path}" -Dparallel=methods -DthreadCount=4 -Dtest=php.* test

--- a/.travis/run-tests-python2.sh
+++ b/.travis/run-tests-python2.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 python --version
 
-mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=python2.* test
+mvn -Dparallel=methods -DthreadCount=4 -Dtest=python2.* test
 
 cd ../runtime/Python2/tests
 

--- a/.travis/run-tests-python2.sh
+++ b/.travis/run-tests-python2.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 python --version
 
-mvn -Dparallel=methods -DthreadCount=4 -Dtest=python2.* test
+mvn -Dparallel=classes -DthreadCount=4 -Dtest=python2.* test
 
 cd ../runtime/Python2/tests
 

--- a/.travis/run-tests-python3.sh
+++ b/.travis/run-tests-python3.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 python3 --version
 
-mvn -Dparallel=methods -DthreadCount=4 -Dtest=python3.* test
+mvn -Dparallel=classes -DthreadCount=4 -Dtest=python3.* test
 
 cd ../runtime/Python3/test
 

--- a/.travis/run-tests-python3.sh
+++ b/.travis/run-tests-python3.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 python3 --version
 
-mvn -q -Dparallel=methods -DthreadCount=4 -Dtest=python3.* test
+mvn -Dparallel=methods -DthreadCount=4 -Dtest=python3.* test
 
 cd ../runtime/Python3/test
 

--- a/.travis/run-tests-swift.sh
+++ b/.travis/run-tests-swift.sh
@@ -31,11 +31,11 @@ pushd ../runtime/Swift
 popd
 
 if [ $GROUP == "LEXER" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=swift.* test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.LexerTests" -Dtest=swift.* test
 elif [ $GROUP == "PARSER" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.ParserTests" -Dtest=swift.* test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.ParserTests" -Dtest=swift.* test
 elif [ $GROUP == "RECURSION" ]; then
-    mvn -q -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=swift.* test
+    mvn -Dgroups="org.antlr.v4.test.runtime.category.LeftRecursionTests" -Dtest=swift.* test
 else
-    mvn -q -Dtest=swift.* test
+    mvn -Dtest=swift.* test
 fi

--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -95,7 +95,8 @@
                         <include>**/dart/Test*.java</include>
                         <include>${antlr.tests.swift}</include>
                     </includes>
-				</configuration>
+                    <forkCount>0</forkCount>
+                </configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -95,7 +95,6 @@
                         <include>**/dart/Test*.java</include>
                         <include>${antlr.tests.swift}</include>
                     </includes>
-                    <forkCount>0</forkCount>
                 </configuration>
 			</plugin>
 			<plugin>

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
@@ -57,8 +57,9 @@ public abstract class BaseRuntimeTest {
 
 	@BeforeClass
 	public static void startHeartbeatToAvoidTimeout() {
-		if(requiresHeartbeat())
+		if(requiresHeartbeat()) {
 			startHeartbeat();
+		}
 	}
 
 	private static boolean requiresHeartbeat() {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/category/LeftRecursionTests.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/category/LeftRecursionTests.java
@@ -1,7 +1,0 @@
-package org.antlr.v4.test.runtime.category;
-
-/**
- * Created by ericvergnaud on 27/06/2017.
- */
-public class LeftRecursionTests {
-}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/category/LexerTests.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/category/LexerTests.java
@@ -1,7 +1,0 @@
-package org.antlr.v4.test.runtime.category;
-
-/**
- * Created by ericvergnaud on 27/06/2017.
- */
-public class LexerTests {
-}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/category/ParserTestsGroup1.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/category/ParserTestsGroup1.java
@@ -1,7 +1,0 @@
-package org.antlr.v4.test.runtime.category;
-
-/**
- * Created by ericvergnaud on 27/06/2017.
- */
-public class ParserTestsGroup1 {
-}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/category/ParserTestsGroup2.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/category/ParserTestsGroup2.java
@@ -1,4 +1,0 @@
-package org.antlr.v4.test.runtime.category;
-
-public class ParserTestsGroup2 {
-}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/BaseCppTest.java
@@ -264,8 +264,8 @@ public class BaseCppTest extends BaseRuntimeTestSupport implements RuntimeTestSu
 		String binPath = new File(getTempTestDir(), "a.out").getAbsolutePath();
 		String inputPath = new File(getTempTestDir(), "input").getAbsolutePath();
 
-		// Build runtime using cmake once.
-		synchronized (runtimeBuiltOnce) {
+		// Build runtime using cmake once per VM.
+		synchronized (BaseCppTest.class) {
 			if ( !runtimeBuiltOnce ) {
 				try {
 					String[] command = {"clang++", "--version"};

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestCompositeLexers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestCompositeLexers.java
@@ -7,13 +7,8 @@
 package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
-import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.antlr.v4.test.runtime.RuntimeTestDescriptor;import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestCompositeLexers extends BaseRuntimeTest {
 	public TestCompositeLexers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestCompositeParsers.java
@@ -7,13 +7,9 @@
 package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
-import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.antlr.v4.test.runtime.RuntimeTestDescriptor;import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestCompositeParsers extends BaseRuntimeTest {
 	public TestCompositeParsers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestFullContextParsing.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestFullContextParsing extends BaseRuntimeTest {
 	public TestFullContextParsing(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestLeftRecursion.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LeftRecursionTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LeftRecursionTests.class)
 @RunWith(Parameterized.class)
 public class TestLeftRecursion extends BaseRuntimeTest {
 	public TestLeftRecursion(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestLexerErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestLexerErrors.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestLexerErrors extends BaseRuntimeTest {
 	public TestLexerErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestLexerExec.java
@@ -7,13 +7,8 @@
 package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
-import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.antlr.v4.test.runtime.RuntimeTestDescriptor;import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestLexerExec extends BaseRuntimeTest {
 	public TestLexerExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestListeners.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestListeners extends BaseRuntimeTest {
 	public TestListeners(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestParseTrees.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestParseTrees extends BaseRuntimeTest {
 	public TestParseTrees(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestParserErrors.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestParserErrors extends BaseRuntimeTest {
 	public TestParserErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestParserExec.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestParserExec extends BaseRuntimeTest {
 	public TestParserExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestPerformance.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestPerformance.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestPerformance extends BaseRuntimeTest {
 	public TestPerformance(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestSemPredEvalLexer.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestSemPredEvalLexer.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestSemPredEvalLexer extends BaseRuntimeTest {
 	public TestSemPredEvalLexer(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestSemPredEvalParser.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestSemPredEvalParser extends BaseRuntimeTest {
 	public TestSemPredEvalParser(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestSets.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/TestSets.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.cpp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestSets extends BaseRuntimeTest {
 	public TestSets(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestCompositeLexers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestCompositeLexers.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestCompositeLexers extends BaseRuntimeTest {
 	public TestCompositeLexers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestCompositeParsers.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestCompositeParsers extends BaseRuntimeTest {
 	public TestCompositeParsers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestFullContextParsing.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestFullContextParsing extends BaseRuntimeTest {
 	public TestFullContextParsing(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestLeftRecursion.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LeftRecursionTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LeftRecursionTests.class)
 @RunWith(Parameterized.class)
 public class TestLeftRecursion extends BaseRuntimeTest {
 	public TestLeftRecursion(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestLexerErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestLexerErrors.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestLexerErrors extends BaseRuntimeTest {
 	public TestLexerErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestLexerExec.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestLexerExec extends BaseRuntimeTest {
 	public TestLexerExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestListeners.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestListeners extends BaseRuntimeTest {
 	public TestListeners(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestParseTrees.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestParseTrees extends BaseRuntimeTest {
 	public TestParseTrees(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestParserErrors.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestParserErrors extends BaseRuntimeTest {
 	public TestParserErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestParserExec.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestParserExec extends BaseRuntimeTest {
 	public TestParserExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestPerformance.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestPerformance.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestPerformance extends BaseRuntimeTest {
 	public TestPerformance(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestSemPredEvalLexer.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestSemPredEvalLexer.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestSemPredEvalLexer extends BaseRuntimeTest {
 	public TestSemPredEvalLexer(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestSemPredEvalParser.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestSemPredEvalParser extends BaseRuntimeTest {
 	public TestSemPredEvalParser(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestSets.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/csharp/TestSets.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.csharp;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestSets extends BaseRuntimeTest {
 	public TestSets(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestCompositeLexers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestCompositeLexers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeLexers extends BaseRuntimeTest {
 	public TestCompositeLexers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestCompositeParsers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeParsers extends BaseRuntimeTest {
 	public TestCompositeParsers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestFullContextParsing.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestFullContextParsing extends BaseRuntimeTest {
 	public TestFullContextParsing(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestLeftRecursion.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLeftRecursion extends BaseRuntimeTest {
 	public TestLeftRecursion(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestLexerErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestLexerErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerErrors extends BaseRuntimeTest {
 	public TestLexerErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestLexerExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerExec extends BaseRuntimeTest {
 	public TestLexerExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestListeners.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestListeners extends BaseRuntimeTest {
 	public TestListeners(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestParseTrees.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParseTrees extends BaseRuntimeTest {
 	public TestParseTrees(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestParserErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserErrors extends BaseRuntimeTest {
 	public TestParserErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestParserExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserExec extends BaseRuntimeTest {
 	public TestParserExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestPerformance.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestPerformance.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestPerformance extends BaseRuntimeTest {
 	public TestPerformance(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestSemPredEvalLexer.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestSemPredEvalLexer.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalLexer extends BaseRuntimeTest {
 	public TestSemPredEvalLexer(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestSemPredEvalParser.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalParser extends BaseRuntimeTest {
 	public TestSemPredEvalParser(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestSets.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/dart/TestSets.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSets extends BaseRuntimeTest {
 	public TestSets(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestCompositeLexers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestCompositeLexers.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeLexers extends BaseRuntimeTest {
 	public TestCompositeLexers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestCompositeParsers.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeParsers extends BaseRuntimeTest {
 	public TestCompositeParsers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestFullContextParsing.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestFullContextParsing extends BaseRuntimeTest {
 	public TestFullContextParsing(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestLeftRecursion.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLeftRecursion extends BaseRuntimeTest {
 	public TestLeftRecursion(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestLexerErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestLexerErrors.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerErrors extends BaseRuntimeTest {
 	public TestLexerErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestLexerExec.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerExec extends BaseRuntimeTest {
 	public TestLexerExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestListeners extends BaseRuntimeTest {
 	public TestListeners(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParseTrees.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParseTrees extends BaseRuntimeTest {
 	public TestParseTrees(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParserErrors.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserErrors extends BaseRuntimeTest {
 	public TestParserErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParserExec.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserExec extends BaseRuntimeTest {
 	public TestParserExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestPerformance.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestPerformance.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestPerformance extends BaseRuntimeTest {
 	public TestPerformance(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestSemPredEvalLexer.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestSemPredEvalLexer.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalLexer extends BaseRuntimeTest {
 	public TestSemPredEvalLexer(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestSemPredEvalParser.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalParser extends BaseRuntimeTest {
 	public TestSemPredEvalParser(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestSets.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestSets.java
@@ -12,7 +12,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSets extends BaseRuntimeTest {
 	public TestSets(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestCompositeLexers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestCompositeLexers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeLexers extends BaseRuntimeTest {
 	public TestCompositeLexers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestCompositeParsers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeParsers extends BaseRuntimeTest {
 	public TestCompositeParsers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestFullContextParsing.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestFullContextParsing extends BaseRuntimeTest {
 	public TestFullContextParsing(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestLeftRecursion.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLeftRecursion extends BaseRuntimeTest {
 	public TestLeftRecursion(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestLexerErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestLexerErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerErrors extends BaseRuntimeTest {
 	public TestLexerErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestLexerExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerExec extends BaseRuntimeTest {
 	public TestLexerExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestListeners.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestListeners extends BaseRuntimeTest {
 	public TestListeners(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestParseTrees.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParseTrees extends BaseRuntimeTest {
 	public TestParseTrees(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestParserErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserErrors extends BaseRuntimeTest {
 	public TestParserErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestParserExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserExec extends BaseRuntimeTest {
 	public TestParserExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestPerformance.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestPerformance.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestPerformance extends BaseRuntimeTest {
 	public TestPerformance(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestSemPredEvalLexer.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestSemPredEvalLexer.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalLexer extends BaseRuntimeTest {
 	public TestSemPredEvalLexer(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestSemPredEvalParser.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalParser extends BaseRuntimeTest {
 	public TestSemPredEvalParser(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestSets.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/TestSets.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSets extends BaseRuntimeTest {
 	public TestSets(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestCompositeLexers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestCompositeLexers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeLexers extends BaseRuntimeTest {
 	public TestCompositeLexers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestCompositeParsers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeParsers extends BaseRuntimeTest {
 	public TestCompositeParsers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestFullContextParsing.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestFullContextParsing extends BaseRuntimeTest {
 	public TestFullContextParsing(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestLeftRecursion.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLeftRecursion extends BaseRuntimeTest {
 	public TestLeftRecursion(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestLexerErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestLexerErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerErrors extends BaseRuntimeTest {
 	public TestLexerErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestLexerExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerExec extends BaseRuntimeTest {
 	public TestLexerExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestListeners.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestListeners extends BaseRuntimeTest {
 	public TestListeners(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestParseTrees.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParseTrees extends BaseRuntimeTest {
 	public TestParseTrees(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestParserErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserErrors extends BaseRuntimeTest {
 	public TestParserErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestParserExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserExec extends BaseRuntimeTest {
 	public TestParserExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestPerformance.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestPerformance.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestPerformance extends BaseRuntimeTest {
 	public TestPerformance(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestSemPredEvalLexer.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestSemPredEvalLexer.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalLexer extends BaseRuntimeTest {
 	public TestSemPredEvalLexer(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestSemPredEvalParser.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalParser extends BaseRuntimeTest {
 	public TestSemPredEvalParser(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestSets.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/javascript/TestSets.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSets extends BaseRuntimeTest {
 	public TestSets(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestCompositeLexers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestCompositeLexers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeLexers extends BaseRuntimeTest {
 	public TestCompositeLexers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestCompositeParsers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeParsers extends BaseRuntimeTest {
 	public TestCompositeParsers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestFullContextParsing.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestFullContextParsing extends BaseRuntimeTest {
 	public TestFullContextParsing(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestLeftRecursion.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLeftRecursion extends BaseRuntimeTest {
 	public TestLeftRecursion(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestLexerErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestLexerErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerErrors extends BaseRuntimeTest {
 	public TestLexerErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestLexerExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerExec extends BaseRuntimeTest {
 	public TestLexerExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestListeners.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestListeners extends BaseRuntimeTest {
 	public TestListeners(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestParseTrees.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParseTrees extends BaseRuntimeTest {
 	public TestParseTrees(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestParserErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserErrors extends BaseRuntimeTest {
 	public TestParserErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestParserExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserExec extends BaseRuntimeTest {
 	public TestParserExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestPerformance.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestPerformance.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestPerformance extends BaseRuntimeTest {
 	public TestPerformance(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestSemPredEvalLexer.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestSemPredEvalLexer.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalLexer extends BaseRuntimeTest {
 	public TestSemPredEvalLexer(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestSemPredEvalParser.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalParser extends BaseRuntimeTest {
 	public TestSemPredEvalParser(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestSets.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/php/TestSets.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSets extends BaseRuntimeTest {
 	public TestSets(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestCompositeLexers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestCompositeLexers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeLexers extends BaseRuntimeTest {
 	public TestCompositeLexers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestCompositeParsers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeParsers extends BaseRuntimeTest {
 	public TestCompositeParsers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestFullContextParsing.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestFullContextParsing extends BaseRuntimeTest {
 	public TestFullContextParsing(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestLeftRecursion.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLeftRecursion extends BaseRuntimeTest {
 	public TestLeftRecursion(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestLexerErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestLexerErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerErrors extends BaseRuntimeTest {
 	public TestLexerErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestLexerExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerExec extends BaseRuntimeTest {
 	public TestLexerExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestListeners.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestListeners extends BaseRuntimeTest {
 	public TestListeners(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestParseTrees.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParseTrees extends BaseRuntimeTest {
 	public TestParseTrees(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestParserErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserErrors extends BaseRuntimeTest {
 	public TestParserErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestParserExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserExec extends BaseRuntimeTest {
 	public TestParserExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestPerformance.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestPerformance.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestPerformance extends BaseRuntimeTest {
 	public TestPerformance(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestSemPredEvalLexer.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestSemPredEvalLexer.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalLexer extends BaseRuntimeTest {
 	public TestSemPredEvalLexer(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestSemPredEvalParser.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalParser extends BaseRuntimeTest {
 	public TestSemPredEvalParser(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestSets.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python2/TestSets.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSets extends BaseRuntimeTest {
 	public TestSets(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestCompositeLexers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestCompositeLexers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeLexers extends BaseRuntimeTest {
 	public TestCompositeLexers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestCompositeParsers.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestCompositeParsers extends BaseRuntimeTest {
 	public TestCompositeParsers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestFullContextParsing.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestFullContextParsing extends BaseRuntimeTest {
 	public TestFullContextParsing(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestLeftRecursion.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLeftRecursion extends BaseRuntimeTest {
 	public TestLeftRecursion(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestLexerErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestLexerErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerErrors extends BaseRuntimeTest {
 	public TestLexerErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestLexerExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestLexerExec extends BaseRuntimeTest {
 	public TestLexerExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestListeners.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestListeners extends BaseRuntimeTest {
 	public TestListeners(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestParseTrees.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParseTrees extends BaseRuntimeTest {
 	public TestParseTrees(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestParserErrors.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserErrors extends BaseRuntimeTest {
 	public TestParserErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestParserExec.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestParserExec extends BaseRuntimeTest {
 	public TestParserExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestPerformance.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestPerformance.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestPerformance extends BaseRuntimeTest {
 	public TestPerformance(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestSemPredEvalLexer.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestSemPredEvalLexer.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalLexer extends BaseRuntimeTest {
 	public TestSemPredEvalLexer(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestSemPredEvalParser.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSemPredEvalParser extends BaseRuntimeTest {
 	public TestSemPredEvalParser(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestSets.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/python3/TestSets.java
@@ -10,7 +10,6 @@ import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 @RunWith(Parameterized.class)
 public class TestSets extends BaseRuntimeTest {
 	public TestSets(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestCompositeLexers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestCompositeLexers.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestCompositeLexers extends BaseRuntimeTest {
 	public TestCompositeLexers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestCompositeParsers.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestCompositeParsers extends BaseRuntimeTest {
 	public TestCompositeParsers(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestFullContextParsing.java
@@ -7,13 +7,9 @@
 package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
-import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.antlr.v4.test.runtime.RuntimeTestDescriptor;import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestFullContextParsing extends BaseRuntimeTest {
 	public TestFullContextParsing(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestLeftRecursion.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LeftRecursionTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LeftRecursionTests.class)
 @RunWith(Parameterized.class)
 public class TestLeftRecursion extends BaseRuntimeTest {
 	public TestLeftRecursion(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestLexerErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestLexerErrors.java
@@ -7,13 +7,8 @@
 package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
-import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.antlr.v4.test.runtime.RuntimeTestDescriptor;import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestLexerErrors extends BaseRuntimeTest {
 	public TestLexerErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestLexerExec.java
@@ -7,13 +7,9 @@
 package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
-import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.antlr.v4.test.runtime.RuntimeTestDescriptor;import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestLexerExec extends BaseRuntimeTest {
 	public TestLexerExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestListeners.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestListeners extends BaseRuntimeTest {
 	public TestListeners(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestParseTrees.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestParseTrees extends BaseRuntimeTest {
 	public TestParseTrees(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestParserErrors.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup1;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup1.class)
 @RunWith(Parameterized.class)
 public class TestParserErrors extends BaseRuntimeTest {
 	public TestParserErrors(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestParserExec.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestParserExec extends BaseRuntimeTest {
 	public TestParserExec(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestPerformance.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestPerformance.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestPerformance extends BaseRuntimeTest {
 	public TestPerformance(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestSemPredEvalLexer.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestSemPredEvalLexer.java
@@ -9,12 +9,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestSemPredEvalLexer extends BaseRuntimeTest {
 	public TestSemPredEvalLexer(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestSemPredEvalParser.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.ParserTestsGroup2;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(ParserTestsGroup2.class)
 @RunWith(Parameterized.class)
 public class TestSemPredEvalParser extends BaseRuntimeTest {
 	public TestSemPredEvalParser(RuntimeTestDescriptor descriptor) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestSets.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/TestSets.java
@@ -8,12 +8,9 @@ package org.antlr.v4.test.runtime.swift;
 
 import org.antlr.v4.test.runtime.BaseRuntimeTest;
 import org.antlr.v4.test.runtime.RuntimeTestDescriptor;
-import org.antlr.v4.test.runtime.category.LexerTests;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@Category(LexerTests.class)
 @RunWith(Parameterized.class)
 public class TestSets extends BaseRuntimeTest {
 	public TestSets(RuntimeTestDescriptor descriptor) {

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestScopeParsing.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestScopeParsing.java
@@ -21,7 +21,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-
 @RunWith(Parameterized.class)
 public class TestScopeParsing extends BaseJavaToolTest {
     static String[] argPairs = {


### PR DESCRIPTION
The test rig has a bit of complexity related to making sure that our continuous integration servers don't timeout.  I'm trying an experiment where I turn off the quiet option so that we are always getting output.  I think as long as all TestX.java finish within 10 minutes we should be okay because he will generates an output.  Also, I have turned on `-Dparallel=classes -DthreadCount=4` so that 4 TestX will run the same time.  This seems a decent level of granularity rather than creating a new thread for possibly 100 tests within a TestX.java file.  If this works then I can try taking out the heartbeat mechanism which spits out `.` every once in a while to let the integration server know that we are still running.