### PR TITLE
cpp/cmake: Fix library install directories

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -325,3 +325,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/12/03, eneko, Eneko Alonso, eneko.alonso@gmail.com
 2021/12/16, Ketler13, Oleksandr Martyshchenko, oleksandr.martyshchenko@gmail.com
 2021/12/25, Tinker1024, Tinker1024, tinker@huawei.com
+2021/12/31, Biswa96, Biswapriyo Nath, nathbappai@gmail.com

--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -131,11 +131,16 @@ set_target_properties(antlr4_static
                                  COMPILE_FLAGS "${disabled_compile_warnings} ${extra_static_compile_flags}")
 
 install(TARGETS antlr4_shared
-        DESTINATION lib
-        EXPORT antlr4-targets)
+        EXPORT antlr4-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 install(TARGETS antlr4_static
-        DESTINATION lib
-        EXPORT antlr4-targets)
+        EXPORT antlr4-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/runtime/src/"
         DESTINATION "include/antlr4-runtime"


### PR DESCRIPTION
This installs DLLs in bin directory instead of lib.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->