### PR TITLE
Escape reserved words during grammar generation (@parrt version)

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LexerExec/ReservedWordsEscaping.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LexerExec/ReservedWordsEscaping.txt
@@ -1,0 +1,23 @@
+[notes]
+https://github.com/antlr/antlr4/issues/1070
+
+[type]
+Lexer
+
+[grammar]
+lexer grammar L;
+
+channels { break }
+
+A: 'a' -> mode(for);
+
+mode for;
+B: 'b' -> channel(break);
+
+[input]
+ab
+
+[output]
+[@0,0:0='a',<1>,1:0]
+[@1,1:1='b',<2>,channel=2,1:1]
+[@2,2:1='<EOF>',<-1>,1:2]

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ReservedWordsEscaping.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ReservedWordsEscaping.txt
@@ -1,0 +1,36 @@
+[notes]
+https://github.com/antlr/antlr4/issues/1070
+
+[type]
+Parser
+
+[grammar]
+grammar if;
+
+root
+    : {0==0}? continue+ {<writeln("$text")>}
+    ;
+
+continue
+    : for for?                      #else
+    | break=BREAK BREAK+ (for | IF) #class
+    | if+=IF if+=IF*                #int
+    | continue CONTINUE             #static
+    ;
+
+for: FOR;
+FOR: 'for_';
+BREAK: 'break_';
+IF: 'if_';
+CONTINUE: 'continue_';
+
+[start]
+root
+
+[input]
+for_for_break_break_for_if_if_for_continue_
+
+[output]
+"""for_for_break_break_for_if_if_for_continue_
+"""
+

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -65,7 +65,7 @@ using IToken = Antlr4.Runtime.IToken;
 
 /// \<summary>
 /// This interface defines a complete listener for a parse tree produced by
-/// \<see cref="<csIdentifier.(file.parserName)>"/>.
+/// \<see cref="<file.parserName>"/>.
 /// \</summary>
 [System.CodeDom.Compiler.GeneratedCode("ANTLR", "<file.ANTLRVersion>")]
 [System.CLSCompliant(false)]
@@ -80,7 +80,7 @@ public interface I<file.grammarName>Listener : IParseTreeListener {
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
-void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lname; format="cap">Context context);
+void Enter<lname; format="cap">([NotNull] <file.parserName>.<lname; format="cap">Context context);
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Exit a parse tree produced by the \<c><lname>\</c>
@@ -90,7 +90,7 @@ void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lnam
 <endif>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
-void Exit<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lname; format="cap">Context context);}; separator="\n">
+void Exit<lname; format="cap">([NotNull] <file.parserName>.<lname; format="cap">Context context);}; separator="\n">
 }
 <if(file.genPackage)>
 } // namespace <file.genPackage>
@@ -130,7 +130,7 @@ public partial class <file.grammarName>BaseListener : I<file.grammarName>Listene
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
-public virtual void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lname; format="cap">Context context) { \}
+public virtual void Enter<lname; format="cap">([NotNull] <file.parserName>.<lname; format="cap">Context context) { \}
 /// \<summary>
 <if(file.listenerLabelRuleNames.(lname))>
 /// Exit a parse tree produced by the \<c><lname>\</c>
@@ -141,7 +141,7 @@ public virtual void Enter<lname; format="cap">([NotNull] <csIdentifier.(file.par
 /// \<para>The default implementation does nothing.\</para>
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
-public virtual void Exit<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lname; format="cap">Context context) { \}}; separator="\n">
+public virtual void Exit<lname; format="cap">([NotNull] <file.parserName>.<lname; format="cap">Context context) { \}}; separator="\n">
 
 	/// \<inheritdoc/>
 	/// \<remarks>The default implementation does nothing.\</remarks>
@@ -173,7 +173,7 @@ using IToken = Antlr4.Runtime.IToken;
 
 /// \<summary>
 /// This interface defines a complete generic visitor for a parse tree produced
-/// by \<see cref="<csIdentifier.(file.parserName)>"/>.
+/// by \<see cref="<file.parserName>"/>.
 /// \</summary>
 /// \<typeparam name="Result">The return type of the visit operation.\</typeparam>
 [System.CodeDom.Compiler.GeneratedCode("ANTLR", "<file.ANTLRVersion>")]
@@ -190,7 +190,7 @@ public interface I<file.grammarName>Visitor\<Result> : IParseTreeVisitor\<Result
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
 /// \<return>The visitor result.\</return>
-Result Visit<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lname; format="cap">Context context);}; separator="\n">
+Result Visit<lname; format="cap">([NotNull] <file.parserName>.<lname; format="cap">Context context);}; separator="\n">
 }
 <if(file.genPackage)>
 } // namespace <file.genPackage>
@@ -233,7 +233,7 @@ public partial class <file.grammarName>BaseVisitor\<Result> : AbstractParseTreeV
 /// \</summary>
 /// \<param name="context">The parse tree.\</param>
 /// \<return>The visitor result.\</return>
-public virtual Result Visit<lname; format="cap">([NotNull] <csIdentifier.(file.parserName)>.<lname; format="cap">Context context) { return VisitChildren(context); \}}; separator="\n">
+public virtual Result Visit<lname; format="cap">([NotNull] <file.parserName>.<lname; format="cap">Context context) { return VisitChildren(context); \}}; separator="\n">
 }
 <if(file.genPackage)>
 } // namespace <file.genPackage>
@@ -271,7 +271,7 @@ Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
 Parser_(parser, funcs, atn, sempredFuncs, ctor, superClass) ::= <<
 [System.CodeDom.Compiler.GeneratedCode("ANTLR", "<file.ANTLRVersion>")]
 [System.CLSCompliant(false)]
-public partial class <csIdentifier.(parser.name)> : <superClass; null="Parser"> {
+public partial class <parser.name> : <superClass; null="Parser"> {
 	protected static DFA[] decisionToDFA;
 	protected static PredictionContextCache sharedContextCache = new PredictionContextCache();
 	<if(parser.tokens)>
@@ -294,7 +294,7 @@ public partial class <csIdentifier.(parser.name)> : <superClass; null="Parser"> 
 
 	public override string SerializedAtn { get { return new string(_serializedATN); } }
 
-	static <csIdentifier.(parser.name)>() {
+	static <parser.name>() {
 		decisionToDFA = new DFA[_ATN.NumberOfDecisions];
 		for (int i = 0; i \< _ATN.NumberOfDecisions; i++) {
 			decisionToDFA[i] = new DFA(_ATN.GetDecisionState(i), i);
@@ -362,9 +362,9 @@ case <f.ruleIndex> : return <f.name>_sempred(<if(!recog.modes)>(<f.ctxType>)<end
 >>
 
 parser_ctor(parser) ::= <<
-	public <csIdentifier.(parser.name)>(ITokenStream input) : this(input, Console.Out, Console.Error) { }
+	public <parser.name>(ITokenStream input) : this(input, Console.Out, Console.Error) { }
 
-	public <csIdentifier.(parser.name)>(ITokenStream input, TextWriter output, TextWriter errorOutput)
+	public <parser.name>(ITokenStream input, TextWriter output, TextWriter errorOutput)
 	: base(input, output, errorOutput)
 {
 	Interpreter = new ParserATNSimulator(this, _ATN, decisionToDFA, sharedContextCache);
@@ -404,9 +404,9 @@ RuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,namedActions,fina
 <altLabelCtxs:{l | <altLabelCtxs.(l)>}; separator="\n">
 
 [RuleVersion(<namedActions.version; null="0">)]
-<if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>public <endif><currentRule.ctxType> <csIdentifier.(currentRule.name)>(<args; separator=", ">) {
-	<currentRule.ctxType> _localctx = new <currentRule.ctxType>(Context, State<currentRule.args:{a | , <csIdentifier.(a.name)>}>);
-	EnterRule(_localctx, <currentRule.startState>, RULE_<currentRule.name>);
+<if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>public <endif><currentRule.ctxType> <currentRule.name>(<args; separator=", ">) {
+	<currentRule.ctxType> _localctx = new <currentRule.ctxType>(Context, State<currentRule.args:{a | , <a.name>}>);
+	EnterRule(_localctx, <currentRule.startState>, RULE_<currentRule.nameForConcat>);
 	<namedActions.init>
 	<locals; separator="\n">
 	try {
@@ -437,8 +437,8 @@ RuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,namedActions,fina
 LeftFactoredRuleFunction(currentRule,args,code,locals,namedActions,finallyAction,postamble) ::=
 <<
 
-<if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>private <endif><currentRule.ctxType> <csIdentifier.(currentRule.name)>(<args; separator=", ">) {
-	<currentRule.ctxType> _localctx = new <currentRule.ctxType>(Context, State<currentRule.args:{a | , <csIdentifier.(a.name)>}>);
+<if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>private <endif><currentRule.ctxType> <currentRule.name>(<args; separator=", ">) {
+	<currentRule.ctxType> _localctx = new <currentRule.ctxType>(Context, State<currentRule.args:{a | , <a.name>}>);
 	EnterLeftFactoredRule(_localctx, <currentRule.startState>, RULE_<currentRule.variantOf>);
 	<namedActions.init>
 	<locals; separator="\n">
@@ -469,8 +469,8 @@ LeftFactoredRuleFunction(currentRule,args,code,locals,namedActions,finallyAction
 LeftUnfactoredRuleFunction(currentRule,args,code,locals,namedActions,finallyAction,postamble) ::=
 <<
 
-<if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>private <endif><currentRule.ctxType> <csIdentifier.(currentRule.name)>(<args; separator=", ">) {
-	<currentRule.ctxType> _localctx = new <currentRule.ctxType>(Context, State<currentRule.args:{a | , <csIdentifier.(a.name)>}>);
+<if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>private <endif><currentRule.ctxType> <currentRule.name>(<args; separator=", ">) {
+	<currentRule.ctxType> _localctx = new <currentRule.ctxType>(Context, State<currentRule.args:{a | , <a.name>}>);
 	EnterRule(_localctx, <currentRule.startState>, RULE_<currentRule.variantOf>);
 	<namedActions.init>
 	<locals; separator="\n">
@@ -503,17 +503,17 @@ LeftRecursiveRuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,
 <altLabelCtxs:{l | <altLabelCtxs.(l)>}; separator="\n">
 
 [RuleVersion(<namedActions.version; null="0">)]
-<if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>public <endif><currentRule.ctxType> <csIdentifier.(currentRule.name)>(<args; separator=", ">) {
-	return <csIdentifier.(currentRule.name)>(0<currentRule.args:{a | , <csIdentifier.(a.name)>}>);
+<if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>public <endif><currentRule.ctxType> <currentRule.name>(<args; separator=", ">) {
+	return <currentRule.name>(0<currentRule.args:{a | , <a.name>}>);
 }
 
-private <currentRule.ctxType> <csIdentifier.(currentRule.name)>(int _p<args:{a | , <a>}>) {
+private <currentRule.ctxType> <currentRule.name>(int _p<args:{a | , <a>}>) {
 	ParserRuleContext _parentctx = Context;
 	int _parentState = State;
-	<currentRule.ctxType> _localctx = new <currentRule.ctxType>(Context, _parentState<currentRule.args:{a | , <csIdentifier.(a.name)>}>);
+	<currentRule.ctxType> _localctx = new <currentRule.ctxType>(Context, _parentState<currentRule.args:{a | , <a.name>}>);
 	<currentRule.ctxType> _prevctx = _localctx;
 	int _startState = <currentRule.startState>;
-	EnterRecursionRule(_localctx, <currentRule.startState>, RULE_<currentRule.name>, _p);
+	EnterRecursionRule(_localctx, <currentRule.startState>, RULE_<currentRule.nameForConcat>, _p);
 	<namedActions.init>
 	<locals; separator="\n">
 	try {
@@ -709,7 +709,7 @@ cases(ttypes) ::= <<
 
 InvokeRule(r, argExprsChunks) ::= <<
 State = <r.stateNumber>;
-<if(r.labels)><r.labels:{l | <labelref(l)> = }><endif><csIdentifier.(r.name)>(<if(r.ast.options.p)><r.ast.options.p><if(argExprsChunks)>,<endif><endif><argExprsChunks>);
+<if(r.labels)><r.labels:{l | <labelref(l)> = }><endif><r.name>(<if(r.ast.options.p)><r.ast.options.p><if(argExprsChunks)>,<endif><endif><argExprsChunks>);
 >>
 
 MatchToken(m) ::= <<
@@ -769,15 +769,15 @@ LexerPushModeCommand(arg, grammar)  ::= "PushMode(<modeName.(arg)>);"
 
 ActionText(t) ::= "<t.text>"
 ActionTemplate(t) ::= "<t.st>"
-ArgRef(a) ::= "_localctx.<csIdentifier.(a.name)>"
-LocalRef(a) ::= "_localctx.<csIdentifier.(a.name)>"
-RetValueRef(a) ::= "_localctx.<csIdentifier.(a.name)>"
-QRetValueRef(a) ::= "<ctx(a)>.<a.dict>.<csIdentifier.(a.name)>"
+ArgRef(a) ::= "_localctx.<a.name>"
+LocalRef(a) ::= "_localctx.<a.name>"
+RetValueRef(a) ::= "_localctx.<a.name>"
+QRetValueRef(a) ::= "<ctx(a)>.<a.dict>.<a.name>"
 /** How to translate $tokenLabel */
-TokenRef(t) ::= "<ctx(t)>.<csIdentifier.(tokenType.(t.name))>"
-LabelRef(t) ::= "<ctx(t)>.<csIdentifier.(t.name)>"
-ListLabelRef(t) ::= "<ctx(t)>.<ListLabelName(csIdentifier.(t.name))>"
-SetAttr(s,rhsChunks) ::= "<ctx(s)>.<csIdentifier.(s.name)> = <rhsChunks>;"
+TokenRef(t) ::= "<ctx(t)>.<tokenType.(t.name)>"
+LabelRef(t) ::= "<ctx(t)>.<t.name>"
+ListLabelRef(t) ::= "<ctx(t)>.<ListLabelName(t.name)>"
+SetAttr(s,rhsChunks) ::= "<ctx(s)>.<s.name> = <rhsChunks>;"
 
 TokenLabelType() ::= "<file.TokenLabelType; null={IToken}>"
 InputSymbolType() ::= "<file.InputSymbolType; null={IToken}>"
@@ -802,44 +802,44 @@ ThisRulePropertyRef_text(r)	 ::= "TokenStream.GetText(_localctx.Start, TokenStre
 ThisRulePropertyRef_ctx(r)	 ::= "_localctx"
 ThisRulePropertyRef_parser(r)	 ::= "this"
 
-NonLocalAttrRef(s)		 ::= <%((<s.ruleName; format="cap">Context)GetInvokingContext(<s.ruleIndex>)).<csIdentifier.(s.name)>%>
+NonLocalAttrRef(s)		 ::= <%((<s.ruleName; format="cap">Context)GetInvokingContext(<s.ruleIndex>)).<s.name>%>
 SetNonLocalAttr(s, rhsChunks)	  ::=
-	<%((<s.ruleName; format="cap">Context)GetInvokingContext(<s.ruleIndex>)).<csIdentifier.(s.name)> = <rhsChunks>;%>
+	<%((<s.ruleName; format="cap">Context)GetInvokingContext(<s.ruleIndex>)).<s.name> = <rhsChunks>;%>
 
 AddToLabelList(a) ::= "<ctx(a.label)>.<a.listName>.Add(<labelref(a.label)>);"
 
-TokenDecl(t) ::= "<TokenLabelType()> <csIdentifier.(tokenType.(t.name))>"
-TokenTypeDecl(t) ::= "int <csIdentifier.(tokenType.(t.name))>;"
-TokenListDecl(t) ::= "IList\<IToken> <csIdentifier.(tokenType.(t.name))> = new List\<IToken>()"
-RuleContextDecl(r) ::= "<r.ctxName> <csIdentifier.(r.name)>"
-RuleContextListDecl(rdecl) ::= "IList\<<rdecl.ctxName>> <csIdentifier.(rdecl.name)> = new List\<<rdecl.ctxName>>()"
+TokenDecl(t) ::= "<TokenLabelType()> <tokenType.(t.name)>"
+TokenTypeDecl(t) ::= "int <tokenType.(t.name)>;"
+TokenListDecl(t) ::= "IList\<IToken> <tokenType.(t.name)> = new List\<IToken>()"
+RuleContextDecl(r) ::= "<r.ctxName> <r.name>"
+RuleContextListDecl(rdecl) ::= "IList\<<rdecl.ctxName>> <rdecl.name> = new List\<<rdecl.ctxName>>()"
 
 contextGetterCollection(elementType) ::= <%
 <elementType>[]
 %>
 
 ContextTokenGetterDecl(t)      ::=
-    "[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode <csIdentifier.(tokenType.(t.name))>() { return GetToken(<csIdentifier.(parser.name)>.<csIdentifier.(tokenType.(t.name))>, 0); }"
+    "[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode <tokenType.(t.name)>() { return GetToken(<parser.name>.<tokenType.(t.name)>, 0); }"
 ContextTokenListGetterDecl(t)  ::= <<
-[System.Diagnostics.DebuggerNonUserCode] public <contextGetterCollection("ITerminalNode")> <csIdentifier.(tokenType.(t.name))>() { return GetTokens(<csIdentifier.(parser.name)>.<csIdentifier.(tokenType.(t.name))>); }
+[System.Diagnostics.DebuggerNonUserCode] public <contextGetterCollection("ITerminalNode")> <tokenType.(t.name)>() { return GetTokens(<parser.name>.<tokenType.(t.name)>); }
 >>
 ContextTokenListIndexedGetterDecl(t)  ::= <<
-[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode <csIdentifier.(tokenType.(t.name))>(int i) {
-	return GetToken(<csIdentifier.(parser.name)>.<csIdentifier.(tokenType.(t.name))>, i);
+[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode <tokenType.(t.name)>(int i) {
+	return GetToken(<parser.name>.<tokenType.(t.name)>, i);
 }
 >>
 ContextRuleGetterDecl(r)       ::= <<
-[System.Diagnostics.DebuggerNonUserCode] public <r.ctxName> <csIdentifier.(r.name)>() {
+[System.Diagnostics.DebuggerNonUserCode] public <r.ctxName> <r.name>() {
 	return GetRuleContext\<<r.ctxName>\>(0);
 }
 >>
 ContextRuleListGetterDecl(r)   ::= <<
-[System.Diagnostics.DebuggerNonUserCode] public <contextGetterCollection({<r.ctxName>})> <csIdentifier.(r.name)>() {
+[System.Diagnostics.DebuggerNonUserCode] public <contextGetterCollection({<r.ctxName>})> <r.name>() {
 	return GetRuleContexts\<<r.ctxName>\>();
 }
 >>
 ContextRuleListIndexedGetterDecl(r)   ::= <<
-[System.Diagnostics.DebuggerNonUserCode] public <r.ctxName> <csIdentifier.(r.name)>(int i) {
+[System.Diagnostics.DebuggerNonUserCode] public <r.ctxName> <r.name>(int i) {
 	return GetRuleContext\<<r.ctxName>\>(i);
 }
 >>
@@ -868,14 +868,14 @@ public partial class <struct.name> : <if(contextSuperClass)><contextSuperClass><
 	public <struct.name>(ParserRuleContext parent, int invokingState<ctorAttrs:{a | , <a>}>)
 		: base(parent, invokingState)
 	{
-		<struct.ctorAttrs:{a | this.<csIdentifier.(a.name)> = <csIdentifier.(a.name)>;}; separator="\n">
+		<struct.ctorAttrs:{a | this.<a.name> = <a.name>;}; separator="\n">
 	}
 	public override int RuleIndex { get { return RULE_<struct.derivedFromName>; } }
 <if(struct.provideCopyFrom)> <! don't need copy unless we have subclasses !>
 	public <struct.name>() { }
 	public virtual void CopyFrom(<struct.name> context) {
 		base.CopyFrom(context);
-		<struct.attrs:{a | this.<csIdentifier.(a.name)> = context.<csIdentifier.(a.name)>;}; separator="\n">
+		<struct.attrs:{a | this.<a.name> = context.<a.name>;}; separator="\n">
 	}
 <endif>
 	<dispatchMethods; separator="\n">
@@ -884,10 +884,10 @@ public partial class <struct.name> : <if(contextSuperClass)><contextSuperClass><
 >>
 
 AltLabelStructDecl(struct,attrs,getters,dispatchMethods) ::= <<
-public partial class <struct.name> : <currentRule.name; format="cap">Context {
+public partial class <struct.name> : <currentRule.nameForConcat; format="cap">Context {
 	<attrs:{a | public <a>;}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
-	public <struct.name>(<currentRule.name; format="cap">Context context) { CopyFrom(context); }
+	public <struct.name>(<currentRule.nameForConcat; format="cap">Context context) { CopyFrom(context); }
 	<dispatchMethods; separator="\n">
 }
 >>
@@ -909,10 +909,10 @@ public override TResult Accept\<TResult>(IParseTreeVisitor\<TResult> visitor) {
 }
 >>
 
-AttributeDecl(d) ::= "<d.type> <csIdentifier.(d.name)><if(d.initValue)> = <d.initValue><endif>"
+AttributeDecl(d) ::= "<d.type> <d.name><if(d.initValue)> = <d.initValue><endif>"
 
 /** If we don't know location of label def x, use this template */
-labelref(x) ::= "<if(!x.isLocal)><typedContext(x.ctx)>.<endif><csIdentifier.(x.name)>"
+labelref(x) ::= "<if(!x.isLocal)><typedContext(x.ctx)>.<endif><x.name>"
 
 /** For any action chunk, what is correctly-typed context struct ptr? */
 ctx(actionChunk) ::= "<typedContext(actionChunk.ctx)>"
@@ -985,7 +985,7 @@ using DFA = Antlr4.Runtime.Dfa.DFA;
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 [System.CodeDom.Compiler.GeneratedCode("ANTLR", "<file.ANTLRVersion>")]
 [System.CLSCompliant(false)]
-public partial class <csIdentifier.(lexer.name)> : <superClass; null="Lexer"> {
+public partial class <lexer.name> : <superClass; null="Lexer"> {
 	protected static DFA[] decisionToDFA;
 	protected static PredictionContextCache sharedContextCache = new PredictionContextCache();
 	<if(lexer.tokens)>
@@ -994,14 +994,14 @@ public partial class <csIdentifier.(lexer.name)> : <superClass; null="Lexer"> {
 	<endif>
 	<if(lexer.channels)>
 	public const int
-		<lexer.channels:{k | <csIdentifier.(k)>=<lexer.channels.(k)>}; separator=", ", wrap, anchor>;
+		<lexer.channels:{k | <k>=<lexer.channels.(k)>}; separator=", ", wrap, anchor>;
 	<endif>
-	<if(rest(lexer.modes))>
+	<if(rest(lexer.runtimeModeNames))>
 	public const int
-		<rest(lexer.modes):{m | <m>=<i>}; separator=", ", wrap, anchor>;
+		<rest(lexer.runtimeModeNames):{m | <m>=<i>}; separator=", ", wrap, anchor>;
 	<endif>
 	public static string[] channelNames = {
-		"DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels:{c| "<c>"}; separator=", ", wrap, anchor><endif>
+		"DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channelNames)>, <lexer.channelNames:{c| "<c>"}; separator=", ", wrap, anchor><endif>
 	};
 
 	public static string[] modeNames = {
@@ -1014,10 +1014,10 @@ public partial class <csIdentifier.(lexer.name)> : <superClass; null="Lexer"> {
 
 	<namedActions.members>
 
-	public <csIdentifier.(lexer.name)>(ICharStream input)
+	public <lexer.name>(ICharStream input)
 	: this(input, Console.Out, Console.Error) { }
 
-	public <csIdentifier.(lexer.name)>(ICharStream input, TextWriter output, TextWriter errorOutput)
+	public <lexer.name>(ICharStream input, TextWriter output, TextWriter errorOutput)
 	: base(input, output, errorOutput)
 	{
 		Interpreter = new LexerATNSimulator(this, _ATN, decisionToDFA, sharedContextCache);
@@ -1035,7 +1035,7 @@ public partial class <csIdentifier.(lexer.name)> : <superClass; null="Lexer"> {
 
 	public override string SerializedAtn { get { return new string(_serializedATN); } }
 
-	static <csIdentifier.(lexer.name)>() {
+	static <lexer.name>() {
 		decisionToDFA = new DFA[_ATN.NumberOfDecisions];
 		for (int i = 0; i \< _ATN.NumberOfDecisions; i++) {
 			decisionToDFA[i] = new DFA(_ATN.GetDecisionState(i), i);
@@ -1077,87 +1077,5 @@ channelName ::= [
 
 tokenType ::= [
 	"EOF" : "Eof",
-	default : key
-]
-
-csIdentifier ::= [
-	"abstract" : "@abstract",
-	"as" : "@as",
-	"base" : "@base",
-	"bool" : "@bool",
-	"break" : "@break",
-	"byte" : "@byte",
-	"case" : "@case",
-	"catch" : "@catch",
-	"char" : "@char",
-	"checked" : "@checked",
-	"class" : "@class",
-	"const" : "@const",
-	"continue" : "@continue",
-	"decimal" : "@decimal",
-	"default" : "@default",
-	"delegate" : "@delegate",
-	"do" : "@do",
-	"double" : "@double",
-	"else" : "@else",
-	"enum" : "@enum",
-	"event" : "@event",
-	"explicit" : "@explicit",
-	"extern" : "@extern",
-	"false" : "@false",
-	"finally" : "@finally",
-	"fixed" : "@fixed",
-	"float" : "@float",
-	"for" : "@for",
-	"foreach" : "@foreach",
-	"goto" : "@goto",
-	"if" : "@if",
-	"implicit" : "@implicit",
-	"in" : "@in",
-	"int" : "@int",
-	"interface" : "@interface",
-	"internal" : "@internal",
-	"is" : "@is",
-	"lock" : "@lock",
-	"long" : "@long",
-	"namespace" : "@namespace",
-	"new" : "@new",
-	"null" : "@null",
-	"object" : "@object",
-	"operator" : "@operator",
-	"out" : "@out",
-	"override" : "@override",
-	"params" : "@params",
-	"private" : "@private",
-	"protected" : "@protected",
-	"public" : "@public",
-	"readonly" : "@readonly",
-	"ref" : "@ref",
-	"return" : "@return",
-	"sbyte" : "@sbyte",
-	"sealed" : "@sealed",
-	"short" : "@short",
-	"sizeof" : "@sizeof",
-	"stackalloc" : "@stackalloc",
-	"static" : "@static",
-	"string" : "@string",
-	"struct" : "@struct",
-	"switch" : "@switch",
-	"this" : "@this",
-	"throw" : "@throw",
-	"true" : "@true",
-	"try" : "@try",
-	"typeof" : "@typeof",
-	"uint" : "@uint",
-	"ulong" : "@ulong",
-	"unchecked" : "@unchecked",
-	"unsafe" : "@unsafe",
-	"ushort" : "@ushort",
-	"using" : "@using",
-	"virtual" : "@virtual",
-	"values" : "@values",
-	"void" : "@void",
-	"volatile" : "@volatile",
-	"while" : "@while",
 	default : key
 ]

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -57,9 +57,9 @@ public:
   };
 <endif>
 
-<if (rest(lexer.modes))>
+<if (rest(lexer.runtimeModeNames))>
   enum {
-    <rest(lexer.modes): {m | <m> = <i>}; separator=", ", wrap, anchor>
+    <rest(lexer.runtimeModeNames): {m | <m> = <i>}; separator=", ", wrap, anchor>
   };
 <endif>
 
@@ -190,7 +190,7 @@ std::vector\<std::string> <lexer.name>::_ruleNames = {
 };
 
 std::vector\<std::string> <lexer.name>::_channelNames = {
-  "DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels: {c | "<c>"}; separator = ", ", wrap, anchor><endif>
+  "DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channelNames)>, <lexer.channelNames: {c | "<c>"}; separator = ", ", wrap, anchor><endif>
 };
 
 std::vector\<std::string> <lexer.name>::_modeNames = {
@@ -264,7 +264,7 @@ public:
 
 <if (parser.rules)>
   enum {
-    <parser.rules: {r | Rule<r.name; format="cap"> = <r.index>}; separator=", ", wrap, anchor>
+    <parser.rules: {r | Rule<r.escapedName; format="cap"> = <r.index>}; separator=", ", wrap, anchor>
   };
 <endif>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
@@ -193,7 +193,7 @@ Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
 Parser_(parser, funcs, atn, sempredFuncs, ctor, superClass) ::= <<
 <if(namedActions.definitions)><namedActions.definitions><endif>
 <if(parser.rules)>
-const int <parser.rules:{r | RULE_<r.name> = <r.index>}; separator=", ", wrap, anchor>;
+const int <parser.rules:{r | RULE_<r.escapedName> = <r.index>}; separator=", ", wrap, anchor>;
 <endif>
 class <parser.name> extends <superClass; null="Parser"> {
   static final checkVersion = () => RuntimeMetaData.checkVersion('<file.ANTLRVersion>', RuntimeMetaData.VERSION);
@@ -810,14 +810,14 @@ class <lexer.name> extends <superClass; null="Lexer"> {
   static const int
     <lexer.channels:{c | <c> = <lexer.channels.(c)>}; separator=", ", wrap, anchor>;
   <endif>
-  <if(rest(lexer.modes))>
+  <if(rest(lexer.runtimeModeNames))>
   static const int
-    <rest(lexer.modes):{m | <m> = <i>}; separator=", ", wrap, anchor>;
+    <rest(lexer.runtimeModeNames):{m | <m> = <i>}; separator=", ", wrap, anchor>;
   <endif>
 
   @override
   final List\<String> channelNames = [
-    'DEFAULT_TOKEN_CHANNEL', 'HIDDEN'<if (lexer.channels)>, <lexer.channels:{c| '<c>'}; separator=", ", wrap, anchor><endif>
+    'DEFAULT_TOKEN_CHANNEL', 'HIDDEN'<if (lexer.channelNames)>, <lexer.channelNames:{c| '<c>'}; separator=", ", wrap, anchor><endif>
   ];
 
   @override

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -225,12 +225,12 @@ const <parser.name>EOF = antlr.TokenEOF
 
 // <parser.name> rules.
 const (
-	<parser.rules:{r | <parser.name>RULE_<r.name> = <r.index>}; separator="\n">
+	<parser.rules:{r | <parser.name>RULE_<r.escapedName> = <r.index>}; separator="\n">
 )
 <elseif(parser.rules)>
 
-// <parser.name>RULE_<first(parser.rules).name> is the <parser.name> rule.
-const <parser.name>RULE_<first(parser.rules).name> = <first(parser.rules).index>
+// <parser.name>RULE_<first(parser.rules).escapedName> is the <parser.name> rule.
+const <parser.name>RULE_<first(parser.rules).escapedName> = <first(parser.rules).index>
 <endif>
 
 <if(funcs)>
@@ -1411,11 +1411,11 @@ var serializedLexerAtn []uint16
 
 
 var lexerChannelNames = []string{
-	"DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels:{c | "<c>"}; separator=", ", wrap><endif>,
+	"DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channelNames)>, <lexer.channelNames:{c | "<c>"}; separator=", ", wrap><endif>,
 }
 
 var lexerModeNames = []string{
-	<lexer.modes:{m | "<m>"}; separator=", ", wrap>,
+	<lexer.runtimeModeNames:{m | "<m>"}; separator=", ", wrap>,
 }
 
 <if(lexer.literalNames)>
@@ -1502,17 +1502,17 @@ const (
 const <lexer.name><first(lexer.channels)> = <lexer.channels.(first(lexer.channels))>
 <endif>
 
-<if(rest(rest(lexer.modes)))>
+<if(rest(rest(lexer.runtimeModeNames)))>
 
 // <lexer.name> modes.
 const (
-	<first(rest(lexer.modes)):{m | <lexer.name><m> = iota + 1}>
-	<rest(rest(lexer.modes)):{m | <lexer.name><m>}; separator="\n">
+	<first(rest(lexer.runtimeModeNames)):{m | <lexer.name><m> = iota + 1}>
+	<rest(rest(lexer.runtimeModeNames)):{m | <lexer.name><m>}; separator="\n">
 )
-<elseif(rest(lexer.modes))>
+<elseif(rest(lexer.runtimeModeNames))>
 
-// <lexer.name><first(rest(lexer.modes))> is the <lexer.name> mode.
-const <lexer.name><first(rest(lexer.modes))> = 1
+// <lexer.name><first(rest(lexer.runtimeModeNames))> is the <lexer.name> mode.
+const <lexer.name><first(rest(lexer.runtimeModeNames))> = 1
 <endif>
 <if(namedActions.members)>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -236,7 +236,7 @@ public class <parser.name> extends <superClass; null="Parser"> {
 	<endif>
 	<if(parser.rules)>
 	public static final int
-		<parser.rules:{r | RULE_<r.name> = <r.index>}; separator=", ", wrap, anchor>;
+		<parser.rules:{r | RULE_<r.escapedName> = <r.index>}; separator=", ", wrap, anchor>;
 	<endif>
 	private static String[] makeRuleNames() {
 		return new String[] {
@@ -913,12 +913,12 @@ public class <lexer.name> extends <superClass; null="Lexer"> {
 	public static final int
 		<lexer.channels:{c | <c>=<lexer.channels.(c)>}; separator=", ", wrap, anchor>;
 	<endif>
-	<if(rest(lexer.modes))>
+	<if(rest(lexer.runtimeModeNames))>
 	public static final int
-		<rest(lexer.modes):{m | <m>=<i>}; separator=", ", wrap, anchor>;
+		<rest(lexer.runtimeModeNames):{m | <m>=<i>}; separator=", ", wrap, anchor>;
 	<endif>
 	public static String[] channelNames = {
-		"DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels:{c| "<c>"}; separator=", ", wrap, anchor><endif>
+		"DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channelNames)>, <lexer.channelNames:{c| "<c>"}; separator=", ", wrap, anchor><endif>
 	};
 
 	public static String[] modeNames = {

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -163,7 +163,7 @@ export default class <parser.name> extends <superClass; null="antlr4.Parser"> {
 <endif>
 
 <if(parser.rules)>
-<parser.rules:{r | <parser.name>.RULE_<r.name> = <r.index>;}; separator="\n", wrap, anchor>
+<parser.rules:{r | <parser.name>.RULE_<r.escapedName> = <r.index>;}; separator="\n", wrap, anchor>
 <endif>
 
 <funcs:{f | <ruleContexts(f)>}; separator="\n">
@@ -800,7 +800,7 @@ const decisionsToDFA = atn.decisionToState.map( (ds, index) => new antlr4.dfa.DF
 export default class <lexer.name> extends <if(superClass)><superClass><else>antlr4.Lexer<endif> {
 
     static grammarFileName = "<lexer.grammarFileName>";
-    static channelNames = [ "DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels:{c| "<c>"}; separator=", ", wrap, anchor><endif> ];
+    static channelNames = [ "DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channelNames)>, <lexer.channelNames:{c| "<c>"}; separator=", ", wrap, anchor><endif> ];
 	static modeNames = [ <lexer.modes:{m| "<m>"}; separator=", ", wrap, anchor> ];
 	static literalNames = [ <lexer.literalNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
 	static symbolicNames = [ <lexer.symbolicNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
@@ -826,8 +826,8 @@ export default class <lexer.name> extends <if(superClass)><superClass><else>antl
 <lexer.channels:{c| <lexer.name>.<c> = <lexer.channels.(c)>;}; separator="\n">
 
 <endif>
-<if(rest(lexer.modes))>
-<rest(lexer.modes):{m| <lexer.name>.<m> = <i>;}; separator="\n">
+<if(rest(lexer.runtimeModeNames))>
+<rest(lexer.runtimeModeNames):{m| <lexer.name>.<m> = <i>;}; separator="\n">
 
 <endif>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
@@ -243,7 +243,7 @@ namespace<if(file.genPackage)> <file.genPackage><endif> {
 		<endif>
 
 		<if(parser.rules)>
-		public const <parser.rules:{r | RULE_<r.name> = <r.index>}; separator=", ", wrap, anchor>;
+		public const <parser.rules:{r | RULE_<r.escapedName> = <r.index>}; separator=", ", wrap, anchor>;
 		<endif>
 
 		/**
@@ -1091,15 +1091,15 @@ namespace<if(lexerFile.genPackage)> <lexerFile.genPackage><endif> {
 		public const <lexer.channels:{c | <c> = <lexer.channels.(c)>}; separator=", ", wrap, anchor>;
 		<endif>
 
-		<if(rest(lexer.modes))>
-		public const <rest(lexer.modes):{m | <m>=<i>}; separator=", ", wrap, anchor>;
+		<if(rest(lexer.runtimeModeNames))>
+		public const <rest(lexer.runtimeModeNames):{m | <m>=<i>}; separator=", ", wrap, anchor>;
 		<endif>
 
 		/**
 		 * @var array\<string>
 		 */
 		public const CHANNEL_NAMES = [
-			'DEFAULT_TOKEN_CHANNEL', 'HIDDEN'<if (lexer.channels)>, <lexer.channels:{c| '<c>'}; separator=", ", wrap, anchor><endif>
+			'DEFAULT_TOKEN_CHANNEL', 'HIDDEN'<if (lexer.channelNames)>, <lexer.channelNames:{c| '<c>'}; separator=", ", wrap, anchor><endif>
 		];
 
 		/**

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -133,7 +133,7 @@ class <parser.name> ( <if(superClass)><superClass><else>Parser<endif> ):
     symbolicNames = [ <parser.symbolicNames:{t | u<t>}; null="u\"\<INVALID>\"", separator=", ", wrap, anchor> ]
 
     <if(parser.rules)>
-    <parser.rules:{r | RULE_<r.name> = <r.index>}; separator="\n", wrap, anchor>
+    <parser.rules:{r | RULE_<r.escapedName> = <r.index>}; separator="\n", wrap, anchor>
     <endif>
 
     ruleNames =  [ <parser.ruleNames:{r | u"<r>"}; separator=", ", wrap, anchor> ]
@@ -773,15 +773,15 @@ class <lexer.name>(<if(superClass)><superClass><else>Lexer<endif>):
     <lexer.channels:{c| <c> = <lexer.channels.(c)>}; separator="\n">
 
 <endif>
-<if(rest(lexer.modes))>
-    <rest(lexer.modes):{m| <m> = <i>}; separator="\n">
+<if(rest(lexer.runtimeModeNames))>
+    <rest(lexer.runtimeModeNames):{m| <m> = <i>}; separator="\n">
 
 <endif>
     <if(lexer.tokens)>
     <lexer.tokens:{k | <k> = <lexer.tokens.(k)>}; separator="\n", wrap, anchor>
     <endif>
 
-    channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN"<if (lexer.channels)>, <lexer.channels:{c| u"<c>"}; separator=", ", wrap, anchor><endif> ]
+    channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN"<if (lexer.channelNames)>, <lexer.channelNames:{c| u"<c>"}; separator=", ", wrap, anchor><endif> ]
 
     modeNames = [ <lexer.modes:{m| u"<m>"}; separator=", ", wrap, anchor> ]
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -146,7 +146,7 @@ class <parser.name> ( <if(superClass)><superClass><else>Parser<endif> ):
     symbolicNames = [ <parser.symbolicNames:{t | <t>}; null="\"\<INVALID>\"", separator=", ", wrap, anchor> ]
 
     <if(parser.rules)>
-    <parser.rules:{r | RULE_<r.name> = <r.index>}; separator="\n", wrap, anchor>
+    <parser.rules:{r | RULE_<r.escapedName> = <r.index>}; separator="\n", wrap, anchor>
     <endif>
 
     ruleNames =  [ <parser.ruleNames:{r | "<r>"}; separator=", ", wrap, anchor> ]
@@ -787,15 +787,15 @@ class <lexer.name>(<if(superClass)><superClass><else>Lexer<endif>):
     <lexer.channels:{c| <c> = <lexer.channels.(c)>}; separator="\n">
 
 <endif>
-<if(rest(lexer.modes))>
-    <rest(lexer.modes):{m| <m> = <i>}; separator="\n">
+<if(rest(lexer.runtimeModeNames))>
+    <rest(lexer.runtimeModeNames):{m| <m> = <i>}; separator="\n">
 
 <endif>
     <if(lexer.tokens)>
     <lexer.tokens:{k | <k> = <lexer.tokens.(k)>}; separator="\n", wrap, anchor>
     <endif>
 
-    channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN"<if (lexer.channels)>, <lexer.channels:{c| u"<c>"}; separator=", ", wrap, anchor><endif> ]
+    channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN"<if (lexer.channelNames)>, <lexer.channelNames:{c| u"<c>"}; separator=", ", wrap, anchor><endif> ]
 
     modeNames = [ <lexer.modes:{m| "<m>"}; separator=", ", wrap, anchor> ]
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -399,7 +399,7 @@ RuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,namedActions,fina
 <if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else> <accessLevelOpenOK(parser)> func <endif><currentRule.name>(<if(first(args))>_ <endif><args; separator=", _">) throws -> <currentRule.ctxType> {
 	var _localctx: <currentRule.ctxType>
 	_localctx = <currentRule.ctxType>(_ctx, getState()<currentRule.args:{a | , <a.name>}>)
-	try enterRule(_localctx, <currentRule.startState>, <parser.name>.RULE_<currentRule.name>)
+	try enterRule(_localctx, <currentRule.startState>, <parser.name>.RULE_<currentRule.nameForConcat>)
 	<namedActions.init>
 	<locals; separator="\n">
 	defer {
@@ -446,7 +446,7 @@ private func <currentRule.name>(_ _p<args:{a | , <a>}>: Int) throws -> <currentR
 	_localctx = <currentRule.ctxType>(_ctx, _parentState<currentRule.args:{a | , <a.name>}>)
 	var _prevctx: <currentRule.ctxType> = _localctx
 	let _startState: Int = <currentRule.startState>
-	try enterRecursionRule(_localctx, <currentRule.startState>, <parser.name>.RULE_<currentRule.name>, _p)
+	try enterRecursionRule(_localctx, <currentRule.startState>, <parser.name>.RULE_<currentRule.nameForConcat>, _p)
 	<namedActions.init>
 	<locals; separator="\n">
 	defer {
@@ -866,12 +866,12 @@ StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMe
 >>
 
 AltLabelStructDecl(struct,attrs,getters,dispatchMethods) ::= <<
-<accessLevelNotOpen(parser)> class <struct.name>: <currentRule.name; format="cap">Context {
+<accessLevelNotOpen(parser)> class <struct.name>: <currentRule.nameForConcat; format="cap">Context {
 	<attrs:{a | <accessLevelNotOpen(parser)> var <a>}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
 
 	<accessLevelNotOpen(parser)>
-	init(_ ctx: <currentRule.name; format="cap">Context) {
+	init(_ ctx: <currentRule.nameForConcat; format="cap">Context) {
 		super.init()
 		copyFrom(ctx)
 	}
@@ -989,13 +989,13 @@ Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 	<accessLevelNotOpen(lexer)>
 	static let <lexer.channels:{k | <k>=<lexer.channels.(k)>}; separator=", ", wrap, anchor>
 	<endif>
-	<if(rest(lexer.modes))>
+	<if(rest(lexer.runtimeModeNames))>
 	<accessLevelNotOpen(lexer)>
-	static let <rest(lexer.modes):{m| <m>=<i>}; separator=", ", wrap, anchor>
+	static let <rest(lexer.runtimeModeNames):{m| <m>=<i>}; separator=", ", wrap, anchor>
 	<endif>
 	<accessLevelNotOpen(lexer)>
 	static let channelNames: [String] = [
-		"DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels:{c| "<c>"}; separator=", ", wrap, anchor><endif>
+		"DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channelNames)>, <lexer.channelNames:{c| "<c>"}; separator=", ", wrap, anchor><endif>
 	]
 
 	<accessLevelNotOpen(lexer)>

--- a/tool/src/org/antlr/v4/codegen/OutputModelController.java
+++ b/tool/src/org/antlr/v4/codegen/OutputModelController.java
@@ -216,12 +216,14 @@ public class OutputModelController {
 			opAltsCode.add((CodeBlockForAlt)opStuff);
 		}
 
+		Target target = delegate.getGenerator().getTarget();
+		String escapedRuleName = target.escapeIfWordEscapingNotSupported(r.name);
 		// Insert code in front of each primary alt to create specialized ctx if there was a label
 		for (int i = 0; i < primaryAltsCode.size(); i++) {
 			LeftRecursiveRuleAltInfo altInfo = r.recPrimaryAlts.get(i);
 			if ( altInfo.altLabel==null ) continue;
 			ST altActionST = codegenTemplates.getInstanceOf("recRuleReplaceContext");
-			altActionST.add("ctxName", Utils.capitalize(altInfo.altLabel));
+			altActionST.add("ctxName", Utils.capitalize(target.escapeIfWordEscapingNotSupported(altInfo.altLabel)));
 			Action altAction =
 				new Action(delegate, function.altLabelCtxs.get(altInfo.altLabel), altActionST);
 			CodeBlockForAlt alt = primaryAltsCode.get(i);
@@ -246,16 +248,16 @@ public class OutputModelController {
 			if ( altInfo.altLabel!=null ) {
 				templateName = "recRuleLabeledAltStartAction";
 				altActionST = codegenTemplates.getInstanceOf(templateName);
-				altActionST.add("currentAltLabel", altInfo.altLabel);
+				altActionST.add("currentAltLabel", target.escapeIfWordEscapingNotSupported(altInfo.altLabel));
 			}
 			else {
 				templateName = "recRuleAltStartAction";
 				altActionST = codegenTemplates.getInstanceOf(templateName);
-				altActionST.add("ctxName", Utils.capitalize(r.name));
+				altActionST.add("ctxName", Utils.capitalize(escapedRuleName));
 			}
-			altActionST.add("ruleName", r.name);
+			altActionST.add("ruleName", escapedRuleName);
 			// add label of any lr ref we deleted
-			altActionST.add("label", altInfo.leftRecursiveRuleRefLabel);
+			altActionST.add("label", target.escapeIfWordEscapingNotSupported(altInfo.leftRecursiveRuleRefLabel));
 			if (altActionST.impl.formalArguments.containsKey("isListLabel")) {
 				altActionST.add("isListLabel", altInfo.isListLabel);
 			}

--- a/tool/src/org/antlr/v4/codegen/model/AddToLabelList.java
+++ b/tool/src/org/antlr/v4/codegen/model/AddToLabelList.java
@@ -11,8 +11,8 @@ import org.antlr.v4.codegen.model.decl.Decl;
 
 /** */
 public class AddToLabelList extends SrcOp {
-	public Decl label;
-	public String listName;
+	public final Decl label;
+	public final String listName;
 
 	public AddToLabelList(OutputModelFactory factory, String listName, Decl label) {
 		super(factory);

--- a/tool/src/org/antlr/v4/codegen/model/CodeBlockForOuterMostAlt.java
+++ b/tool/src/org/antlr/v4/codegen/model/CodeBlockForOuterMostAlt.java
@@ -6,6 +6,7 @@
 package org.antlr.v4.codegen.model;
 
 import org.antlr.v4.codegen.OutputModelFactory;
+import org.antlr.v4.codegen.Target;
 import org.antlr.v4.tool.Alternative;
 
 /** The code associated with the outermost alternative of a rule.
@@ -25,6 +26,7 @@ public class CodeBlockForOuterMostAlt extends CodeBlockForAlt {
 	public CodeBlockForOuterMostAlt(OutputModelFactory factory, Alternative alt) {
 		super(factory);
 		this.alt = alt;
+		Target target = factory.getGenerator().getTarget();
 		altLabel = alt.ast.altLabel!=null ? alt.ast.altLabel.getText() : null;
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/InvokeRule.java
+++ b/tool/src/org/antlr/v4/codegen/model/InvokeRule.java
@@ -9,12 +9,12 @@ package org.antlr.v4.codegen.model;
 import org.antlr.v4.codegen.ActionTranslator;
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.ParserFactory;
+import org.antlr.v4.codegen.Target;
 import org.antlr.v4.codegen.model.chunk.ActionChunk;
 import org.antlr.v4.codegen.model.decl.Decl;
 import org.antlr.v4.codegen.model.decl.RuleContextDecl;
 import org.antlr.v4.codegen.model.decl.RuleContextListDecl;
 import org.antlr.v4.parse.ANTLRParser;
-import org.antlr.v4.runtime.atn.RuleTransition;
 import org.antlr.v4.runtime.misc.OrderedHashSet;
 import org.antlr.v4.tool.Rule;
 import org.antlr.v4.tool.ast.ActionAST;
@@ -24,40 +24,43 @@ import java.util.List;
 
 /** */
 public class InvokeRule extends RuleElement implements LabeledOp {
-	public String name;
-	public OrderedHashSet<Decl> labels = new OrderedHashSet<Decl>(); // TODO: should need just 1
-	public String ctxName;
+	public final String originalName;
+	public final String name;
+	public final OrderedHashSet<Decl> labels = new OrderedHashSet<Decl>(); // TODO: should need just 1
+	public final String ctxName;
 
 	@ModelElement public List<ActionChunk> argExprsChunks;
 
 	public InvokeRule(ParserFactory factory, GrammarAST ast, GrammarAST labelAST) {
 		super(factory, ast);
 		if ( ast.atnState!=null ) {
-			RuleTransition ruleTrans = (RuleTransition)ast.atnState.transition(0);
 			stateNumber = ast.atnState.stateNumber;
 		}
 
-		this.name = ast.getText();
 		CodeGenerator gen = factory.getGenerator();
-		Rule r = factory.getGrammar().getRule(name);
-		ctxName = gen.getTarget().getRuleFunctionContextStructName(r);
+		Target target = gen.getTarget();
+		String identifier = ast.getText();
+		Rule r = factory.getGrammar().getRule(identifier);
+		this.originalName = r.name;
+		this.name = r.escapedName;
+		ctxName = target.getRuleFunctionContextStructName(r);
 
 		// TODO: move to factory
 		RuleFunction rf = factory.getCurrentRuleFunction();
 		if ( labelAST!=null ) {
+			RuleContextDecl decl;
 			// for x=r, define <rule-context-type> x and list_x
 			String label = labelAST.getText();
 			if ( labelAST.parent.getType() == ANTLRParser.PLUS_ASSIGN  ) {
 				factory.defineImplicitLabel(ast, this);
 				String listLabel = gen.getTarget().getListLabel(label);
-				RuleContextListDecl l = new RuleContextListDecl(factory, listLabel, ctxName);
-				rf.addContextDecl(ast.getAltLabel(), l);
+				decl = new RuleContextListDecl(factory, listLabel, ctxName);
 			}
 			else {
-				RuleContextDecl d = new RuleContextDecl(factory,label,ctxName);
-				labels.add(d);
-				rf.addContextDecl(ast.getAltLabel(), d);
+				decl = new RuleContextDecl(factory,label,ctxName);
+				labels.add(decl);
 			}
+			rf.addContextDecl(ast.getAltLabel(), decl);
 		}
 
 		ActionAST arg = (ActionAST)ast.getFirstChildWithType(ANTLRParser.ARG_ACTION);
@@ -66,8 +69,8 @@ public class InvokeRule extends RuleElement implements LabeledOp {
 		}
 
 		// If action refs rule as rulename not label, we need to define implicit label
-		if ( factory.getCurrentOuterMostAlt().ruleRefsInActions.containsKey(ast.getText()) ) {
-			String label = gen.getTarget().getImplicitRuleLabel(ast.getText());
+		if ( factory.getCurrentOuterMostAlt().ruleRefsInActions.containsKey(identifier) ) {
+			String label = gen.getTarget().getImplicitRuleLabel(identifier);
 			RuleContextDecl d = new RuleContextDecl(factory,label,ctxName);
 			labels.add(d);
 			rf.addContextDecl(ast.getAltLabel(), d);

--- a/tool/src/org/antlr/v4/codegen/model/Lexer.java
+++ b/tool/src/org/antlr/v4/codegen/model/Lexer.java
@@ -7,18 +7,20 @@
 package org.antlr.v4.codegen.model;
 
 import org.antlr.v4.codegen.OutputModelFactory;
+import org.antlr.v4.codegen.Target;
+import org.antlr.v4.runtime.misc.MultiMap;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.LexerGrammar;
 import org.antlr.v4.tool.Rule;
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 public class Lexer extends Recognizer {
-	public Map<String,Integer> channels;
-	public LexerFile file;
-	public Collection<String> modes;
+	public final Map<String, Integer> channels;
+	public final Collection<String> channelNames;
+	public final LexerFile file;
+	public final Collection<String> modes;
+	public final Collection<String> runtimeModeNames;
 
 	@ModelElement public LinkedHashMap<Rule, RuleActionFunction> actionFuncs =
 		new LinkedHashMap<Rule, RuleActionFunction>();
@@ -28,7 +30,24 @@ public class Lexer extends Recognizer {
 		this.file = file; // who contains us?
 
 		Grammar g = factory.getGrammar();
-		channels = new LinkedHashMap<String, Integer>(g.channelNameToValueMap);
-		modes = ((LexerGrammar)g).modes.keySet();
+		Target target = factory.getGenerator().getTarget();
+
+		channels = new LinkedHashMap<>();
+		channelNames = new ArrayList<>();
+		for (String key : g.channelNameToValueMap.keySet()) {
+			Integer value = g.channelNameToValueMap.get(key);
+			String escaped = target.escapeIfNeeded(key);
+			channels.put(escaped, value);
+			channelNames.add(target.supportsWordEscaping() ? key : escaped);
+		}
+
+		MultiMap<String, Rule> grammarModes = ((LexerGrammar) g).modes;
+		modes = new ArrayList<>(grammarModes.size());
+		runtimeModeNames = new ArrayList<>(grammarModes.size());
+		for (String mode : grammarModes.keySet()) {
+			String escaped = target.escapeIfNeeded(mode);
+			modes.add(target.supportsWordEscaping() ? mode : escaped);
+			runtimeModeNames.add(escaped);
+		}
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/ListenerFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/ListenerFile.java
@@ -6,6 +6,7 @@
 package org.antlr.v4.codegen.model;
 
 import org.antlr.v4.codegen.OutputModelFactory;
+import org.antlr.v4.codegen.Target;
 import org.antlr.v4.runtime.misc.Pair;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.Rule;
@@ -47,17 +48,19 @@ public class ListenerFile extends OutputFile {
 		parserName = g.getRecognizerName();
 		grammarName = g.name;
 		namedActions = buildNamedActions(factory.getGrammar());
+		Target target = factory.getGenerator().getTarget();
 		for (Rule r : g.rules.values()) {
 			Map<String, List<Pair<Integer,AltAST>>> labels = r.getAltLabels();
 			if ( labels!=null ) {
 				for (Map.Entry<String, List<Pair<Integer, AltAST>>> pair : labels.entrySet()) {
-					listenerNames.add(pair.getKey());
-					listenerLabelRuleNames.put(pair.getKey(), r.name);
+					String key = target.escapeIfWordEscapingNotSupported(pair.getKey());
+					listenerNames.add(key);
+					listenerLabelRuleNames.put(key, r.name);
 				}
 			}
 			else {
 				// only add rule context if no labels
-				listenerNames.add(r.name);
+				listenerNames.add(target.escapeIfWordEscapingNotSupported(r.name));
 			}
 		}
 		ActionAST ast = g.namedActions.get("header");

--- a/tool/src/org/antlr/v4/codegen/model/Recognizer.java
+++ b/tool/src/org/antlr/v4/codegen/model/Recognizer.java
@@ -7,25 +7,21 @@ package org.antlr.v4.codegen.model;
 
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.OutputModelFactory;
+import org.antlr.v4.codegen.Target;
 import org.antlr.v4.codegen.model.chunk.ActionChunk;
 import org.antlr.v4.codegen.model.chunk.ActionText;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.Rule;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public abstract class Recognizer extends OutputModelObject {
-	public String name;
-	public String grammarName;
-	public String grammarFileName;
-	public String accessLevel;
-	public Map<String,Integer> tokens;
+	public final String name;
+	public final String grammarName;
+	public final String grammarFileName;
+	public final String accessLevel;
+	public final Map<String,Integer> tokens;
 
 	/**
 	 * @deprecated This field is provided only for compatibility with code
@@ -35,14 +31,14 @@ public abstract class Recognizer extends OutputModelObject {
 	@Deprecated
 	public List<String> tokenNames;
 
-	public List<String> literalNames;
-	public List<String> symbolicNames;
-	public Set<String> ruleNames;
-	public Collection<Rule> rules;
-	@ModelElement public ActionChunk superClass;
+	public final List<String> literalNames;
+	public final List<String> symbolicNames;
+	public final List<String> ruleNames;
+	public final Collection<Rule> rules;
+	@ModelElement public final ActionChunk superClass;
 
-	@ModelElement public SerializedATN atn;
-	@ModelElement public LinkedHashMap<Rule, RuleSempredFunction> sempredFuncs =
+	@ModelElement public final SerializedATN atn;
+	@ModelElement public final LinkedHashMap<Rule, RuleSempredFunction> sempredFuncs =
 		new LinkedHashMap<Rule, RuleSempredFunction>();
 
 	public Recognizer(OutputModelFactory factory) {
@@ -61,7 +57,11 @@ public abstract class Recognizer extends OutputModelObject {
 			}
 		}
 
-		ruleNames = g.rules.keySet();
+		Target target = factory.getGenerator().getTarget();
+		ruleNames = new ArrayList<>(g.rules.size());
+		for (String ruleKey : g.rules.keySet()) {
+			ruleNames.add(target.escapeIfWordEscapingNotSupported(ruleKey));
+		}
 		rules = g.rules.values();
 		atn = new SerializedATN(factory, g.atn);
 		if (g.getOptionString("superClass") != null) {

--- a/tool/src/org/antlr/v4/codegen/model/RuleActionFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleActionFunction.java
@@ -22,7 +22,7 @@ public class RuleActionFunction extends OutputModelObject {
 
 	public RuleActionFunction(OutputModelFactory factory, Rule r, String ctxType) {
 		super(factory);
-		name = r.name;
+		name = r.escapedName;
 		ruleIndex = r.index;
 		this.ctxType = ctxType;
 	}

--- a/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
@@ -10,6 +10,7 @@ import org.antlr.runtime.RecognitionException;
 import org.antlr.runtime.tree.CommonTree;
 import org.antlr.runtime.tree.CommonTreeNodeStream;
 import org.antlr.v4.codegen.OutputModelFactory;
+import org.antlr.v4.codegen.Target;
 import org.antlr.v4.codegen.model.decl.AltLabelStructDecl;
 import org.antlr.v4.codegen.model.decl.AttributeDecl;
 import org.antlr.v4.codegen.model.decl.ContextRuleGetterDecl;
@@ -51,6 +52,7 @@ import static org.antlr.v4.parse.ANTLRParser.TOKEN_REF;
 /** */
 public class RuleFunction extends OutputModelObject {
 	public String name;
+	public String nameForConcat;
 	public List<String> modifiers;
 	public String ctxType;
 	public Collection<String> ruleLabels;
@@ -73,7 +75,9 @@ public class RuleFunction extends OutputModelObject {
 
 	public RuleFunction(OutputModelFactory factory, Rule r) {
 		super(factory);
-		this.name = r.name;
+		Target target = factory.getGenerator().getTarget();
+		this.name = target.escapeIfNeeded(r.name);
+		this.nameForConcat = target.supportsWordEscaping() ? r.name : this.name;
 		this.rule = r;
 		if ( r.modifiers!=null && !r.modifiers.isEmpty() ) {
 			this.modifiers = new ArrayList<String>();

--- a/tool/src/org/antlr/v4/codegen/model/RuleSempredFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleSempredFunction.java
@@ -12,5 +12,6 @@ import org.antlr.v4.tool.Rule;
 public class RuleSempredFunction extends RuleActionFunction {
 	public RuleSempredFunction(OutputModelFactory factory, Rule r, String ctxType) {
 		super(factory, r, ctxType);
+		name = factory.getGenerator().getTarget().supportsWordEscaping() ? r.name : r.escapedName;
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/VisitorFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/VisitorFile.java
@@ -6,6 +6,7 @@
 package org.antlr.v4.codegen.model;
 
 import org.antlr.v4.codegen.OutputModelFactory;
+import org.antlr.v4.codegen.Target;
 import org.antlr.v4.runtime.misc.Pair;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.Rule;
@@ -44,17 +45,19 @@ public class VisitorFile extends OutputFile {
 		namedActions = buildNamedActions(g);
 		parserName = g.getRecognizerName();
 		grammarName = g.name;
+		Target target = factory.getGenerator().getTarget();
 		for (Rule r : g.rules.values()) {
 			Map<String, List<Pair<Integer, AltAST>>> labels = r.getAltLabels();
 			if ( labels!=null ) {
 				for (Map.Entry<String, List<Pair<Integer, AltAST>>> pair : labels.entrySet()) {
-					visitorNames.add(pair.getKey());
-					visitorLabelRuleNames.put(pair.getKey(), r.name);
+					String key = target.escapeIfWordEscapingNotSupported(pair.getKey());
+					visitorNames.add(key);
+					visitorLabelRuleNames.put(key, r.name);
 				}
 			}
 			else {
 				// if labels, must label all. no need for generic rule visitor then
-				visitorNames.add(r.name);
+				visitorNames.add(target.escapeIfWordEscapingNotSupported(r.name));
 			}
 		}
 		ActionAST ast = g.namedActions.get("header");

--- a/tool/src/org/antlr/v4/codegen/model/chunk/RulePropertyRef.java
+++ b/tool/src/org/antlr/v4/codegen/model/chunk/RulePropertyRef.java
@@ -10,7 +10,7 @@ import org.antlr.v4.codegen.model.decl.StructDecl;
 
 /** */
 public class RulePropertyRef extends ActionChunk {
-	public String label;
+	public final String label;
 
 	public RulePropertyRef(StructDecl ctx, String label) {
 		super(ctx);

--- a/tool/src/org/antlr/v4/codegen/model/chunk/TokenPropertyRef.java
+++ b/tool/src/org/antlr/v4/codegen/model/chunk/TokenPropertyRef.java
@@ -10,7 +10,7 @@ import org.antlr.v4.codegen.model.decl.StructDecl;
 
 /** */
 public class TokenPropertyRef extends ActionChunk {
-	public String label;
+	public final String label;
 
 	public TokenPropertyRef(StructDecl ctx, String label) {
 		super(ctx);

--- a/tool/src/org/antlr/v4/codegen/model/decl/AltLabelStructDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/AltLabelStructDecl.java
@@ -7,6 +7,7 @@
 package org.antlr.v4.codegen.model.decl;
 
 import org.antlr.v4.codegen.OutputModelFactory;
+import org.antlr.v4.codegen.Target;
 import org.antlr.v4.codegen.model.DispatchMethod;
 import org.antlr.v4.codegen.model.ListenerDispatchMethod;
 import org.antlr.v4.codegen.model.VisitorDispatchMethod;
@@ -23,10 +24,10 @@ public class AltLabelStructDecl extends StructDecl {
 	{
 		super(factory, r);
 		this.altNum = altNum;
-		this.name = // override name set in super to the label ctx
-			factory.getGenerator().getTarget().getAltLabelContextStructName(label);
-		this.parentRule = r.name;
-		derivedFromName = label;
+		Target target = factory.getGenerator().getTarget();
+		this.name = target.getAltLabelContextStructName(label);
+		this.parentRule = target.escapeIfWordEscapingNotSupported(r.name);
+		derivedFromName = target.escapeIfWordEscapingNotSupported(label);
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/model/decl/Decl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/Decl.java
@@ -12,18 +12,18 @@ import org.antlr.v4.codegen.model.SrcOp;
 /** */
 public class Decl extends SrcOp {
 	public String name;
-	public String decl; 	// whole thing if copied from action
+	public final String decl; 	// whole thing if copied from action
 	public boolean isLocal; // if local var (not in RuleContext struct)
 	public StructDecl ctx;  // which context contains us? set by addDecl
 
-	public Decl(OutputModelFactory factory, String name, String decl) {
-		this(factory, name);
-		this.decl = decl;
+	public Decl(OutputModelFactory factory, String name) {
+		this(factory, name, null);
 	}
 
-	public Decl(OutputModelFactory factory, String name) {
+	public Decl(OutputModelFactory factory, String name, String decl) {
 		super(factory);
-		this.name = name;
+		this.name = factory.getGenerator().getTarget().escapeIfNeeded(name);
+		this.decl = decl;
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/model/decl/StructDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/StructDecl.java
@@ -46,7 +46,7 @@ public class StructDecl extends Decl {
 	public StructDecl(OutputModelFactory factory, Rule r) {
 		super(factory, factory.getGenerator().getTarget().getRuleFunctionContextStructName(r));
 		addDispatchMethods(r);
-		derivedFromName = r.name;
+		derivedFromName = factory.getGenerator().getTarget().escapeIfWordEscapingNotSupported(r.name);
 		provideCopyFrom = r.hasAltSpecificContexts();
 	}
 

--- a/tool/src/org/antlr/v4/codegen/target/CSharpTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/CSharpTarget.java
@@ -8,7 +8,6 @@ package org.antlr.v4.codegen.target;
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.Target;
 import org.antlr.v4.tool.ErrorType;
-import org.antlr.v4.tool.ast.GrammarAST;
 import org.stringtemplate.v4.NumberRenderer;
 import org.stringtemplate.v4.STErrorListener;
 import org.stringtemplate.v4.STGroup;
@@ -16,13 +15,111 @@ import org.stringtemplate.v4.STGroupFile;
 import org.stringtemplate.v4.StringRenderer;
 import org.stringtemplate.v4.misc.STMessage;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 public class CSharpTarget extends Target {
+	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
+		"abstract",
+		"as",
+		"base",
+		"bool",
+		"break",
+		"byte",
+		"case",
+		"catch",
+		"char",
+		"checked",
+		"class",
+		"const",
+		"continue",
+		"decimal",
+		"default",
+		"delegate",
+		"do",
+		"double",
+		"else",
+		"enum",
+		"event",
+		"explicit",
+		"extern",
+		"false",
+		"finally",
+		"fixed",
+		"float",
+		"for",
+		"foreach",
+		"goto",
+		"if",
+		"implicit",
+		"in",
+		"int",
+		"interface",
+		"internal",
+		"is",
+		"lock",
+		"long",
+		"namespace",
+		"new",
+		"null",
+		"object",
+		"operator",
+		"out",
+		"override",
+		"params",
+		"private",
+		"protected",
+		"public",
+		"readonly",
+		"ref",
+		"return",
+		"sbyte",
+		"sealed",
+		"short",
+		"sizeof",
+		"stackalloc",
+		"static",
+		"string",
+		"struct",
+		"switch",
+		"this",
+		"throw",
+		"true",
+		"try",
+		"typeof",
+		"uint",
+		"ulong",
+		"unchecked",
+		"unsafe",
+		"ushort",
+		"using",
+		"virtual",
+		"values",
+		"void",
+		"volatile",
+		"while"
+	));
+
 	public CSharpTarget(CodeGenerator gen) {
 		super(gen);
 		targetCharValueEscape[0] = "\\0";
 		targetCharValueEscape[0x0007] = "\\a";
 		targetCharValueEscape[0x000B] = "\\v";
 	}
+
+	@Override
+	protected Set<String> getReservedWords() {
+		return reservedWords;
+	}
+
+	@Override
+	protected String escapeWord(String word) {
+		return "@" + word;
+	}
+
+	@Override
+	public boolean supportsWordEscaping() { return true; }
 
 	@Override
 	public String encodeIntAsCharEscape(int v) {
@@ -42,11 +139,6 @@ public class CSharpTarget extends Target {
 		}
 
 		return "'" + formatted + "'";
-	}
-
-	@Override
-	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
-		return false;
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/CppTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/CppTarget.java
@@ -9,7 +9,6 @@ package org.antlr.v4.codegen.target;
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.Target;
 import org.antlr.v4.tool.ErrorType;
-import org.antlr.v4.tool.ast.GrammarAST;
 import org.stringtemplate.v4.NumberRenderer;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STErrorListener;
@@ -22,7 +21,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class CppTarget extends Target {
-	protected static final String[] cppKeywords = {
+	protected static final HashSet<String> reservedWords =  new HashSet<>(Arrays.asList(
 		"alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand",
 		"bitor", "bool", "break", "case", "catch", "char", "char16_t",
 		"char32_t", "class", "compl", "concept", "const", "constexpr",
@@ -37,34 +36,24 @@ public class CppTarget extends Target {
 		"switch", "template", "this", "thread_local", "throw", "true",
 		"try", "typedef", "typeid", "typename", "union", "unsigned",
 		"using", "virtual", "void", "volatile", "wchar_t", "while",
-		"xor", "xor_eq"
-	};
+		"xor", "xor_eq",
 
-	/** Avoid grammar symbols in this set to prevent conflicts in gen'd code. */
-	protected final Set<String> badWords = new HashSet<String>();
+		"rule", "parserRule"
+	));
 
 	public CppTarget(CodeGenerator gen) {
 		super(gen);
 		targetCharValueEscape['?'] = "\\?";
 	}
 
-    public boolean needsHeader() { return true; }
-
-	public Set<String> getBadWords() {
-		if (badWords.isEmpty()) {
-			addBadWords();
-		}
-
-		return badWords;
+	@Override
+	protected Set<String> getReservedWords() {
+		return reservedWords;
 	}
 
-	protected void addBadWords() {
-		badWords.addAll(Arrays.asList(cppKeywords));
-		badWords.add("rule");
-		badWords.add("parserRule");
-	}
+	public boolean needsHeader() { return true; }
 
-  @Override
+    @Override
 	protected boolean shouldUseUnicodeEscapeForCodePointInDoubleQuotedString(int codePoint) {
 		if (codePoint == '?') {
 			// in addition to the default escaped code points, also escape ? to prevent trigraphs
@@ -118,11 +107,6 @@ public class CppTarget extends Target {
 		ST extST = getTemplates().getInstanceOf(header ? "headerFileExtension" : "codeFileExtension");
 		String listenerName = gen.g.name + "BaseVisitor";
 		return listenerName+extST.render();
-	}
-
-	@Override
-	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
-		return getBadWords().contains(idNode.getText());
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/DartTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/DartTarget.java
@@ -17,12 +17,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class DartTarget extends Target {
-	/**
-	 * The Java target can cache the code generation templates.
-	 */
-	private static final ThreadLocal<STGroup> targetTemplates = new ThreadLocal<STGroup>();
-
-	protected static final String[] javaKeywords = {
+	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
 		"abstract", "dynamic", "implements", "show",
 		"as", "else", "import", "static",
 		"assert", "enum", "in", "super",
@@ -38,10 +33,9 @@ public class DartTarget extends Target {
 		"default", "get", "rethrow", "while",
 		"deferred", "hide", "return", "with",
 		"do", "if", "set", "yield",
-	};
 
-	/// Avoid grammar symbols in this set to prevent conflicts in gen'd code.
-	protected final Set<String> badWords = new HashSet<String>();
+		"rule", "parserRule"
+	));
 
 	public DartTarget(CodeGenerator gen) {
 		super(gen);
@@ -55,23 +49,8 @@ public class DartTarget extends Target {
 		return super.getTargetStringLiteralFromANTLRStringLiteral(generator, literal, addQuotes, escapeSpecial).replace("$", "\\$");
 	}
 
-	public Set<String> getBadWords() {
-		if (badWords.isEmpty()) {
-			addBadWords();
-		}
-
-		return badWords;
-	}
-
-	protected void addBadWords() {
-		badWords.addAll(Arrays.asList(javaKeywords));
-		badWords.add("rule");
-		badWords.add("parserRule");
-	}
-
-	@Override
-	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
-		return getBadWords().contains(idNode.getText());
+	public Set<String> getReservedWords() {
+		return reservedWords;
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/GoTarget.java
@@ -23,42 +23,32 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-/**
- *
- * @author Peter Boyer
- *
- * */
 public class GoTarget extends Target {
-	private static final String[] goKeywords = {
-			"break", "default", "func", "interface", "select",
-			"case", "defer", "go", "map", "struct",
-			"chan", "else", "goto", "package", "switch",
-			"const", "fallthrough", "if", "range", "type",
-			"continue", "for", "import", "return", "var"
-	};
+	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
+		// keywords
+		"break", "default", "func", "interface", "select",
+		"case", "defer", "go", "map", "struct",
+		"chan", "else", "goto", "package", "switch",
+		"const", "fallthrough", "if", "range", "type",
+		"continue", "for", "import", "return", "var",
 
-	// predeclared identifiers https://golang.org/ref/spec#Predeclared_identifiers
-	private static final String[] goPredeclaredIdentifiers = {
-			"bool", "byte", "complex64", "complex128", "error", "float32", "float64",
-			"int", "int8", "int16", "int32", "int64", "rune", "string",
-			"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
-			"true", "false", "iota", "nil",
-			"append", "cap", "close", "complex", "copy", "delete", "imag", "len",
-			"make", "new", "panic", "print", "println", "real", "recover"
-	};
+		// predeclared identifiers https://golang.org/ref/spec#Predeclared_identifiers
+		"bool", "byte", "complex64", "complex128", "error", "float32", "float64",
+		"int", "int8", "int16", "int32", "int64", "rune", "string",
+		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+		"true", "false", "iota", "nil",
+		"append", "cap", "close", "complex", "copy", "delete", "imag", "len",
+		"make", "new", "panic", "print", "println", "real", "recover",
 
-	// interface definition of RuleContext from runtime/Go/antlr/rule_context.go
-	private static final String[] goRuleContextInterfaceMethods = {
+		// interface definition of RuleContext from runtime/Go/antlr/rule_context.go
 		"Accept", "GetAltNumber", "GetBaseRuleContext", "GetChild", "GetChildCount",
 		"GetChildren", "GetInvokingState", "GetParent", "GetPayload", "GetRuleContext",
 		"GetRuleIndex", "GetSourceInterval", "GetText", "IsEmpty", "SetAltNumber",
-		"SetInvokingState", "SetParent", "String"
-	};
+		"SetInvokingState", "SetParent", "String",
 
-	/** Avoid grammar symbols in this set to prevent conflicts in gen'd code. */
-	private final Set<String> badWords = new HashSet<String>(
-		goKeywords.length + goPredeclaredIdentifiers.length + goRuleContextInterfaceMethods.length + 3
-	);
+		// misc
+		"rule", "parserRule", "action"
+	));
 
 	private static final boolean DO_GOFMT = !Boolean.parseBoolean(System.getenv("ANTLR_GO_DISABLE_GOFMT"))
 			&& !Boolean.parseBoolean(System.getProperty("antlr.go.disable-gofmt"));
@@ -67,21 +57,9 @@ public class GoTarget extends Target {
 		super(gen);
 	}
 
-	public Set<String> getBadWords() {
-		if (badWords.isEmpty()) {
-			addBadWords();
-		}
-
-		return badWords;
-	}
-
-	protected void addBadWords() {
-		badWords.addAll(Arrays.asList(goKeywords));
-		badWords.addAll(Arrays.asList(goPredeclaredIdentifiers));
-		badWords.addAll(Arrays.asList(goRuleContextInterfaceMethods));
-		badWords.add("rule");
-		badWords.add("parserRule");
-		badWords.add("action");
+	@Override
+	protected Set<String> getReservedWords() {
+		return reservedWords;
 	}
 
 	@Override
@@ -128,11 +106,6 @@ public class GoTarget extends Target {
 	@Override
 	public int getInlineTestSetWordSize() {
 		return 32;
-	}
-
-	@Override
-	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
-		return getBadWords().contains(idNode.getText());
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/JavaScriptTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/JavaScriptTarget.java
@@ -17,48 +17,38 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-/**
- *
- * @author Eric Vergnaud
- */
 public class JavaScriptTarget extends Target {
 	/** Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar */
-	protected static final String[] javaScriptKeywords = {
+	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
 		"break", "case", "class", "catch", "const", "continue", "debugger",
 		"default", "delete", "do", "else", "export", "extends", "finally", "for",
 		"function", "if", "import", "in", "instanceof", "let", "new", "return",
 		"super", "switch", "this", "throw", "try", "typeof", "var", "void",
 		"while", "with", "yield",
+
 		//future reserved
 		"enum", "await", "implements", "package", "protected", "static",
 		"interface", "private", "public",
+
 		//future reserved in older standards
 		"abstract", "boolean", "byte", "char", "double", "final", "float",
 		"goto", "int", "long", "native", "short", "synchronized", "transient",
 		"volatile",
-		//literals
-		"null", "true", "false"
-	};
 
-	/** Avoid grammar symbols in this set to prevent conflicts in gen'd code. */
-	protected final Set<String> badWords = new HashSet<String>();
+		//literals
+		"null", "true", "false",
+
+		// misc
+		"rule", "parserRule"
+	));
 
 	public JavaScriptTarget(CodeGenerator gen) {
 		super(gen);
 	}
 
-    public Set<String> getBadWords() {
-		if (badWords.isEmpty()) {
-			addBadWords();
-		}
-
-		return badWords;
-	}
-
-	protected void addBadWords() {
-		badWords.addAll(Arrays.asList(javaScriptKeywords));
-		badWords.add("rule");
-		badWords.add("parserRule");
+	@Override
+	protected Set<String> getReservedWords() {
+		return reservedWords;
 	}
 
 	@Override
@@ -82,11 +72,6 @@ public class JavaScriptTarget extends Target {
 	@Override
 	public int getInlineTestSetWordSize() {
 		return 32;
-	}
-
-	@Override
-	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
-		return getBadWords().contains(idNode.getText());
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/JavaTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/JavaTarget.java
@@ -6,10 +6,8 @@
 
 package org.antlr.v4.codegen.target;
 
-import org.antlr.v4.Tool;
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.Target;
-import org.antlr.v4.tool.ast.GrammarAST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
@@ -24,7 +22,7 @@ public class JavaTarget extends Target {
 	 */
 	private static final ThreadLocal<STGroup> targetTemplates = new ThreadLocal<STGroup>();
 
-	protected static final String[] javaKeywords = {
+	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
 		"abstract", "assert", "boolean", "break", "byte", "case", "catch",
 		"char", "class", "const", "continue", "default", "do", "double", "else",
 		"enum", "extends", "false", "final", "finally", "float", "for", "goto",
@@ -32,33 +30,19 @@ public class JavaTarget extends Target {
 		"long", "native", "new", "null", "package", "private", "protected",
 		"public", "return", "short", "static", "strictfp", "super", "switch",
 		"synchronized", "this", "throw", "throws", "transient", "true", "try",
-		"void", "volatile", "while"
-	};
+		"void", "volatile", "while",
 
-	/** Avoid grammar symbols in this set to prevent conflicts in gen'd code. */
-	protected final Set<String> badWords = new HashSet<String>();
+		// misc
+		"rule", "parserRule"
+	));
 
 	public JavaTarget(CodeGenerator gen) {
 		super(gen);
 	}
 
-	@Override
-    public String getVersion() {
-        return Tool.VERSION; // Java and tool versions move in lock step
-    }
-
-    public Set<String> getBadWords() {
-		if (badWords.isEmpty()) {
-			addBadWords();
-		}
-
-		return badWords;
-	}
-
-	protected void addBadWords() {
-		badWords.addAll(Arrays.asList(javaKeywords));
-		badWords.add("rule");
-		badWords.add("parserRule");
+    @Override
+    public Set<String> getReservedWords() {
+		return reservedWords;
 	}
 
 	@Override
@@ -66,11 +50,6 @@ public class JavaTarget extends Target {
 		// 65535 is the class file format byte limit for a UTF-8 encoded string literal
 		// 3 is the maximum number of bytes it takes to encode a value in the range 0-0xFFFF
 		return 65535 / 3;
-	}
-
-	@Override
-	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
-		return getBadWords().contains(idNode.getText());
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/PHPTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/PHPTarget.java
@@ -8,7 +8,6 @@ package org.antlr.v4.codegen.target;
 
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.Target;
-import org.antlr.v4.tool.ast.GrammarAST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
@@ -17,7 +16,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class PHPTarget extends Target {
-	private static final String[] phpKeywords = {
+	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
 		"abstract", "and", "array", "as",
 		"break",
 		"callable", "case", "catch", "class", "clone", "const", "continue",
@@ -40,14 +39,20 @@ public class PHPTarget extends Target {
 		"xor",
 		"yield",
 		"__halt_compiler", "__CLASS__", "__DIR__", "__FILE__", "__FUNCTION__",
-		"__LINE__", "__METHOD__", "__NAMESPACE__", "__TRAIT__"
-	};
+		"__LINE__", "__METHOD__", "__NAMESPACE__", "__TRAIT__",
 
-	private final Set<String> badWords = new HashSet<String>();
+		// misc
+		"rule", "parserRule"
+	));
 
 	public PHPTarget(CodeGenerator gen) {
 		super(gen);
 		targetCharValueEscape['$'] = "\\$";
+	}
+
+	@Override
+	protected Set<String> getReservedWords() {
+		return reservedWords;
 	}
 
 	@Override
@@ -57,25 +62,6 @@ public class PHPTarget extends Target {
 		}
 
 		return String.format("\\u{%X}", v & 0xFFFF);
-	}
-
-    public Set<String> getBadWords() {
-		if (badWords.isEmpty()) {
-			addBadWords();
-		}
-
-		return badWords;
-	}
-
-	protected void addBadWords() {
-		badWords.addAll(Arrays.asList(phpKeywords));
-		badWords.add("rule");
-		badWords.add("parserRule");
-	}
-
-	@Override
-	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
-		return getBadWords().contains(idNode.getText());
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/Python2Target.java
+++ b/tool/src/org/antlr/v4/codegen/target/Python2Target.java
@@ -17,12 +17,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-/**
- *
- * @author Eric Vergnaud
- */
 public class Python2Target extends Target {
-	protected static final String[] python2Keywords = {
+	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
 		"abs", "all", "and", "any", "apply", "as", "assert",
 		"bin", "bool", "break", "buffer", "bytearray",
 		"callable", "chr", "class", "classmethod", "coerce", "compile", "complex", "continue",
@@ -47,19 +43,19 @@ public class Python2Target extends Target {
 		"yield",
 		"zip",
 		"__import__",
-		"True", "False", "None"
-	};
+		"True", "False", "None",
 
-	/** Avoid grammar symbols in this set to prevent conflicts in gen'd code. */
-	protected final Set<String> badWords = new HashSet<String>();
+		// misc
+		"rule", "parserRule"
+	));
 
 	public Python2Target(CodeGenerator gen) {
 		super(gen);
 	}
 
 	@Override
-	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
-		return getBadWords().contains(idNode.getText());
+	protected Set<String> getReservedWords() {
+		return reservedWords;
 	}
 
 	@Override
@@ -90,19 +86,5 @@ public class Python2Target extends Target {
 	@Override
 	public boolean supportsOverloadedMethods() {
 		return false;
-	}
-
-	public Set<String> getBadWords() {
-		if (badWords.isEmpty()) {
-			addBadWords();
-		}
-
-		return badWords;
-	}
-
-	protected void addBadWords() {
-		badWords.addAll(Arrays.asList(python2Keywords));
-		badWords.add("rule");
-		badWords.add("parserRule");
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/target/Python3Target.java
+++ b/tool/src/org/antlr/v4/codegen/target/Python3Target.java
@@ -8,7 +8,6 @@ package org.antlr.v4.codegen.target;
 
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.Target;
-import org.antlr.v4.tool.ast.GrammarAST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
@@ -17,12 +16,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-/**
- *
- * @author Eric Vergnaud
- */
 public class Python3Target extends Target {
-	protected static final String[] python3Keywords = {
+	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
 		"abs", "all", "and", "any", "apply", "as", "assert",
 		"bin", "bool", "break", "buffer", "bytearray",
 		"callable", "chr", "class", "classmethod", "coerce", "compile", "complex", "continue",
@@ -46,16 +41,19 @@ public class Python3Target extends Target {
 		"yield",
 		"zip",
 		"__import__",
-		"True", "False", "None"
-	};
+		"True", "False", "None",
+
+		// misc
+		"rule", "parserRule"
+	));
 
 	public Python3Target(CodeGenerator gen) {
 		super(gen);
 	}
 
 	@Override
-	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
-		return getBadWords().contains(idNode.getText());
+	protected Set<String> getReservedWords() {
+		return reservedWords;
 	}
 
 	@Override
@@ -86,22 +84,5 @@ public class Python3Target extends Target {
 	@Override
 	public boolean supportsOverloadedMethods() {
 		return false;
-	}
-
-	/** Avoid grammar symbols in this set to prevent conflicts in gen'd code. */
-	protected final Set<String> badWords = new HashSet<String>();
-
-	public Set<String> getBadWords() {
-		if (badWords.isEmpty()) {
-			addBadWords();
-		}
-
-		return badWords;
-	}
-
-	protected void addBadWords() {
-		badWords.addAll(Arrays.asList(python3Keywords));
-		badWords.add("rule");
-		badWords.add("parserRule");
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/target/SwiftTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/SwiftTarget.java
@@ -62,7 +62,7 @@ public class SwiftTarget extends Target {
      */
     private static final ThreadLocal<STGroup> targetTemplates = new ThreadLocal<STGroup>();
 
-    protected static final String[] swiftKeywords = {
+    protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
             "associatedtype", "class", "deinit", "enum", "extension", "func", "import", "init", "inout", "internal",
             "let", "operator", "private", "protocol", "public", "static", "struct", "subscript", "typealias", "var",
             "break", "case", "continue", "default", "defer", "do", "else", "fallthrough", "for", "guard", "if",
@@ -71,11 +71,10 @@ public class SwiftTarget extends Target {
             "true", "try", "__COLUMN__", "__FILE__", "__FUNCTION__","__LINE__", "#column", "#file", "#function", "#line", "_" , "#available", "#else", "#elseif", "#endif", "#if", "#selector",
             "associativity", "convenience", "dynamic", "didSet", "final", "get", "infix", "indirect", "lazy",
             "left", "mutating", "none", "nonmutating", "optional", "override", "postfix", "precedence",
-            "prefix", "Protocol", "required", "right", "set", "Type", "unowned", "weak", "willSet"
- };
+            "prefix", "Protocol", "required", "right", "set", "Type", "unowned", "weak", "willSet",
 
-    /** Avoid grammar symbols in this set to prevent conflicts in gen'd code. */
-    protected final Set<String> badWords = new HashSet<String>();
+             "rule", "parserRule"
+	));
 
     public String lexerAtnJSON = null;
     public String parserAtnJSON = null;
@@ -84,24 +83,19 @@ public class SwiftTarget extends Target {
         super(gen);
     }
 
-    public Set<String> getBadWords() {
-        if (badWords.isEmpty()) {
-            addBadWords();
-        }
+	@Override
+	protected Set<String> getReservedWords() {
+		return reservedWords;
+	}
 
-        return badWords;
-    }
+	@Override
+	protected String escapeWord(String word) {
+		return "`" + word + "`";
+	}
 
-    protected void addBadWords() {
-        badWords.addAll(Arrays.asList(swiftKeywords));
-        badWords.add("rule");
-        badWords.add("parserRule");
-    }
+	@Override
+	public boolean supportsWordEscaping() { return true; }
 
-    @Override
-    protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
-        return getBadWords().contains(idNode.getText());
-    }
     @Override
     protected void genFile(Grammar g,
                            ST outputFileST,

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -515,20 +515,13 @@ public enum ErrorType {
 	 * <p>
 	 * symbol <em>symbol</em> conflicts with generated code in target language
 	 * or runtime</p>
-	 *
-	 * <p>
-	 * Note: This error has the same number as the unrelated error
-	 * {@link #UNSUPPORTED_REFERENCE_IN_LEXER_SET}.</p>
 	 */
+	@Deprecated
 	USE_OF_BAD_WORD(134, "symbol <arg> conflicts with generated code in target language or runtime", ErrorSeverity.ERROR),
 	/**
 	 * Compiler Error 183.
 	 *
 	 * <p>rule reference <em>rule</em> is not currently supported in a set</p>
-	 *
-	 * <p>
-	 * Note: This error has the same number as the unrelated error
-	 * {@link #USE_OF_BAD_WORD}.</p>
 	 */
 	UNSUPPORTED_REFERENCE_IN_LEXER_SET(183, "rule reference <arg> is not currently supported in a set", ErrorSeverity.ERROR),
 	/**

--- a/tool/src/org/antlr/v4/tool/Rule.java
+++ b/tool/src/org/antlr/v4/tool/Rule.java
@@ -52,7 +52,8 @@ public class Rule implements AttributeResolver {
 		validLexerCommands.add("more");
 	}
 
-	public String name;
+	public final String name;
+	public String escapedName;
 	public List<GrammarAST> modifiers;
 
 	public RuleAST ast;
@@ -61,7 +62,7 @@ public class Rule implements AttributeResolver {
 	public AttributeDict locals;
 
 	/** In which grammar does this rule live? */
-	public Grammar g;
+	public final Grammar g;
 
 	/** If we're in a lexer grammar, we might be in a mode */
 	public final String mode;
@@ -93,7 +94,7 @@ public class Rule implements AttributeResolver {
 
 	public ActionAST finallyAction;
 
-	public int numberOfAlts;
+	public final int numberOfAlts;
 
 	public boolean isStartRule = true; // nobody calls us
 


### PR DESCRIPTION
fixes #1070

Always escape `x` to `x_`, `X` to `X_`, `XContext` to `X_Context` (@parrt version, see https://github.com/antlr/antlr4/issues/1070#issuecomment-1003596172). It does not relate to languages with reserved words escaping (C#, Swift).

Deprecate `USE_OF_BAD_WORD`