### PR TITLE
Update javadoc to 8 and 11

### DIFF
--- a/doc/java-target.md
+++ b/doc/java-target.md
@@ -150,8 +150,8 @@ Edit the pom.xml file. Now we need to extensively modify the pom.xml file. The f
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <!-- Plugin to compile the g4 files ahead of the java files

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
@@ -133,7 +133,7 @@ public class BaseJavaTest extends BaseRuntimeTestSupport implements RuntimeTestS
 			fileManager.getJavaFileObjectsFromFiles(files);
 
 		Iterable<String> compileOptions =
-			Arrays.asList("-g", "-source", "1.7", "-target", "1.7", "-implicit:class", "-Xlint:-options", "-d", getTempDirPath(), "-cp", getTempDirPath() + PATH_SEP + CLASSPATH);
+			Arrays.asList("-g", "-source", "1.8", "-target", "1.8", "-implicit:class", "-Xlint:-options", "-d", getTempDirPath(), "-cp", getTempDirPath() + PATH_SEP + CLASSPATH);
 
 		JavaCompiler.CompilationTask task =
 			compiler.getTask(null, fileManager, null, compileOptions, null,

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -46,7 +46,6 @@
 				<version>1.0</version>
 				<executions>
 					<execution>
-						<phase>deploy</phase>
 						<goals>
 							<goal>dot</goal>
 						</goals>
@@ -63,29 +62,13 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.3.1</version>
 				<configuration>
-					<javadocVersion>1.7</javadocVersion>
+					<javadocVersion>1.8</javadocVersion>
 					<failOnError>false</failOnError>
 				</configuration>
 				<executions>
 					<execution>
 						<goals>
 							<goal>javadoc</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.antlr</groupId>
-				<artifactId>antlr4-maven-plugin</artifactId>
-				<version>4.5.3</version> <!-- use older version to process XPathLexer.g4, avoiding cyclic build dependency -->
-				<executions>
-					<execution>
-						<id>antlr</id>
-						<configuration>
-							<sourceDirectory>src</sourceDirectory>
-						</configuration>
-						<goals>
-							<goal>antlr4</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -77,7 +77,7 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.3.1</version>
 				<configuration>
-					<javadocVersion>1.7</javadocVersion>
+					<javadocVersion>11</javadocVersion>
 					<failOnError>false</failOnError>
 				</configuration>
 				<executions>
@@ -180,8 +180,8 @@
 							<target>${basedir}/target/generated-sources/tool/src/org/antlr/v4/unicode/UnicodeData.java</target>
 							<controller>
 								<className>org.antlr.v4.unicode.UnicodeDataTemplateController</className>
-								<sourceVersion>1.7</sourceVersion>
-								<targetVersion>1.7</targetVersion>
+								<sourceVersion>11</sourceVersion>
+								<targetVersion>11</targetVersion>
 								<method>getProperties</method>
 							</controller>
 						</template>


### PR DESCRIPTION
* tweak doc for 1.8 runtime.  Test rig should gen 1.8 not 1.7
* no need for plugin in runtime, always gen svg from dot for javadoc, gen 1.8 not 1.7 doc for runtime. Gen 11 for tool.