### PR TITLE
[Go] Fix (*BitSet).equals

### DIFF
--- a/runtime/Go/antlr/utils.go
+++ b/runtime/Go/antlr/utils.go
@@ -169,12 +169,18 @@ func (b *BitSet) equals(other interface{}) bool {
 		return true
 	}
 
-	if len(b.data) != len(otherBitSet.data) {
+	// We only compare set bits, so we cannot rely on the two slices having the same size. Its
+	// possible for two BitSets to have different slice lengths but the same set bits. So we only
+	// compare the relavent words and ignore the trailing zeros.
+	bLen := b.minLen()
+	otherLen := otherBitSet.minLen()
+
+	if bLen != otherLen {
 		return false
 	}
 
-	for k := range b.data {
-		if b.data[k] != otherBitSet.data[k] {
+	for i := 0; i < bLen; i++ {
+		if b.data[i] != otherBitSet.data[i] {
 			return false
 		}
 	}

--- a/runtime/Go/antlr/utils_test.go
+++ b/runtime/Go/antlr/utils_test.go
@@ -53,4 +53,10 @@ func TestBitSet(t *testing.T) {
 	bs3.add(63)
 	bs1.or(bs3)
 	testBitSet(t, bs1, "{63, 64}", 2, []int{63, 64}, 63, 2)
+	bs1.clear(64)
+	bs4 := NewBitSet()
+	bs4.or(bs1)
+	if got, want := bs4.equals(bs1), true; got != want {
+		t.Errorf("%+v.equals(%+v) = %v, want %v", bs4, bs1, got, want)
+	}
 }


### PR DESCRIPTION
Currently code assumes slices have the same length for equivalence. This is incorrect, as its possible for one BitSet to have trailing zeros and another to have the best fit. So we should only be comparing set bits and ignoring trailing zeros.