### PR TITLE
Remove unused variable from generated code

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
@@ -855,7 +855,6 @@ class <lexer.name> extends <superClass; null="Lexer"> {
 SerializedATN(model) ::= <<
 <if(rest(model.segments))>
 <! requires segmented representation !>
-static const int _serializedATNSegments = <length(model.segments)>;
 <model.segments:{segment|static final String _serializedATNSegment<i0> =
   '<segment; wrap={'<\n><\t>'}>';}; separator="\n">
 static final String _serializedATN = [

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -967,7 +967,6 @@ public class <lexer.name> extends <superClass; null="Lexer"> {
 SerializedATN(model) ::= <<
 <if(rest(model.segments))>
 <! requires segmented representation !>
-private static final int _serializedATNSegments = <length(model.segments)>;
 <model.segments:{segment|private static final String _serializedATNSegment<i0> =
 	"<segment; wrap={"+<\n><\t>"}>";}; separator="\n">
 public static final String _serializedATN = Utils.join(


### PR DESCRIPTION
These variables are unused and can cause static analyzers to complain, specifically Dart when it is opinionated.