### PR TITLE
[C++] Mark generated classes as final

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -43,7 +43,7 @@ cppTypeInitMap ::= [
 LexerHeader(lexer, atn, actionFuncs, sempredFuncs, superClass = {antlr4::Lexer}) ::= <<
 <namedActions.context>
 
-class <file.exportMacro> <lexer.name> : public <superClass> {
+class <file.exportMacro> <lexer.name> final : public <superClass> {
 public:
 <if (lexer.tokens)>
   enum {
@@ -64,24 +64,24 @@ public:
 <endif>
 
   explicit <lexer.name>(antlr4::CharStream *input);
-  ~<lexer.name>();
+  ~<lexer.name>() override;
 
   <namedActions.members>
-  virtual std::string getGrammarFileName() const override;
-  virtual const std::vector\<std::string>& getRuleNames() const override;
+  std::string getGrammarFileName() const override;
+  const std::vector\<std::string>& getRuleNames() const override;
 
-  virtual const std::vector\<std::string>& getChannelNames() const override;
-  virtual const std::vector\<std::string>& getModeNames() const override;
-  virtual antlr4::dfa::Vocabulary& getVocabulary() const override;
+  const std::vector\<std::string>& getChannelNames() const override;
+  const std::vector\<std::string>& getModeNames() const override;
+  antlr4::dfa::Vocabulary& getVocabulary() const override;
 
-  virtual const std::vector\<uint16_t> getSerializedATN() const override;
-  virtual const antlr4::atn::ATN& getATN() const override;
+  const std::vector\<uint16_t> getSerializedATN() const override;
+  const antlr4::atn::ATN& getATN() const override;
 
   <if (actionFuncs)>
-  virtual void action(antlr4::RuleContext *context, size_t ruleIndex, size_t actionIndex) override;
+  void action(antlr4::RuleContext *context, size_t ruleIndex, size_t actionIndex) override;
   <endif>
   <if (sempredFuncs)>
-  virtual bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
+  bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
   <endif>
 
 private:
@@ -254,7 +254,7 @@ bool <if (r.factory.g.lexer)><lexer.name><else><parser.name><endif>::<r.name>Sem
 ParserHeader(parser, funcs, atn, sempredFuncs, superClass = {antlr4::Parser}) ::= <<
 <namedActions.context>
 
-class <file.exportMacro> <parser.name> : public <superClass> {
+class <file.exportMacro> <parser.name> final : public <superClass> {
 public:
 <if (parser.tokens)>
   enum {
@@ -269,12 +269,12 @@ public:
 <endif>
 
   explicit <parser.name>(antlr4::TokenStream *input);
-  ~<parser.name>();
+  ~<parser.name>() override;
 
-  virtual std::string getGrammarFileName() const override;
-  virtual const antlr4::atn::ATN& getATN() const override { return _atn; };
-  virtual const std::vector\<std::string>& getRuleNames() const override;
-  virtual antlr4::dfa::Vocabulary& getVocabulary() const override;
+  std::string getGrammarFileName() const override;
+  const antlr4::atn::ATN& getATN() const override { return _atn; };
+  const std::vector\<std::string>& getRuleNames() const override;
+  antlr4::dfa::Vocabulary& getVocabulary() const override;
 
   <namedActions.members>
 
@@ -283,7 +283,7 @@ public:
   <funcs; separator = "\n">
 
   <if (sempredFuncs)>
-  virtual bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
+  bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
   <sempredFuncs.values; separator = "\n">
   <endif>
 
@@ -498,7 +498,7 @@ LeftRecursiveRuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs
 >>
 
 StructDeclHeader(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers) ::= <<
-class <file.exportMacro> <struct.name> : public <if (contextSuperClass)><contextSuperClass><else>antlr4::ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
+class <file.exportMacro> <struct.name><if (!struct.provideCopyFrom)> final<endif> : public <if (contextSuperClass)><contextSuperClass><else>antlr4::ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 public:
   <attrs: {a | <a>;}; separator = "\n">
   <if (ctorAttrs)><struct.name>(antlr4::ParserRuleContext *parent, size_t invokingState);<endif>
@@ -509,7 +509,7 @@ public:
   using antlr4::ParserRuleContext::copyFrom;
 <endif>
 
-  virtual size_t getRuleIndex() const override;
+  size_t getRuleIndex() const override;
   <getters: {g | <g>}; separator = "\n">
 
   <dispatchMethods; separator = "\n">
@@ -550,7 +550,7 @@ void <parser.name>::<struct.name>::copyFrom(<struct.name> *ctx) {
 >>
 
 AltLabelStructDeclHeader(struct, attrs, getters, dispatchMethods) ::= <<
-class <file.exportMacro> <struct.name> : public <currentRule.name; format = "cap">Context {
+class <file.exportMacro> <struct.name> final : public <currentRule.name; format = "cap">Context {
 public:
   <struct.name>(<currentRule.name; format = "cap">Context *ctx);
 
@@ -1009,7 +1009,7 @@ CaptureNextTokenTypeHeader(d) ::= "<! Required but unused. !>"
 CaptureNextTokenType(d) ::= "<d.varName> = _input->LA(1);"
 
 ListenerDispatchMethodHeader(method) ::= <<
-virtual void <if (method.isEnter)>enter<else>exit<endif>Rule(antlr4::tree::ParseTreeListener *listener) override;
+void <if (method.isEnter)>enter<else>exit<endif>Rule(antlr4::tree::ParseTreeListener *listener) override;
 >>
 ListenerDispatchMethod(method) ::= <<
 void <parser.name>::<struct.name>::<if (method.isEnter)>enter<else>exit<endif>Rule(tree::ParseTreeListener *listener) {
@@ -1021,7 +1021,7 @@ void <parser.name>::<struct.name>::<if (method.isEnter)>enter<else>exit<endif>Ru
 
 VisitorDispatchMethodHeader(method) ::= <<
 
-virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
 >>
 VisitorDispatchMethod(method) ::=  <<
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Files.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Files.stg
@@ -137,14 +137,14 @@ public:
 <namedActions.baselistenerdeclarations>
 
 <file.listenerNames: {lname |
-  virtual void enter<lname; format="cap">(<file.parserName>::<lname; format = "cap">Context * /*ctx*/) override { \}
-  virtual void exit<lname; format="cap">(<file.parserName>::<lname; format = "cap">Context * /*ctx*/) override { \}
+  void enter<lname; format="cap">(<file.parserName>::<lname; format = "cap">Context * /*ctx*/) override { \}
+  void exit<lname; format="cap">(<file.parserName>::<lname; format = "cap">Context * /*ctx*/) override { \}
 }; separator="\n">
 
-  virtual void enterEveryRule(antlr4::ParserRuleContext * /*ctx*/) override { }
-  virtual void exitEveryRule(antlr4::ParserRuleContext * /*ctx*/) override { }
-  virtual void visitTerminal(antlr4::tree::TerminalNode * /*node*/) override { }
-  virtual void visitErrorNode(antlr4::tree::ErrorNode * /*node*/) override { }
+  void enterEveryRule(antlr4::ParserRuleContext * /*ctx*/) override { }
+  void exitEveryRule(antlr4::ParserRuleContext * /*ctx*/) override { }
+  void visitTerminal(antlr4::tree::TerminalNode * /*node*/) override { }
+  void visitErrorNode(antlr4::tree::ErrorNode * /*node*/) override { }
 
 <if (namedActions.baselistenermembers)>
 private:
@@ -253,7 +253,7 @@ public:
 <namedActions.basevisitordeclarations>
 
 <file.visitorNames: { lname |
-  virtual std::any visit<lname; format = "cap">(<file.parserName>::<lname; format = "cap">Context *ctx) override {
+  std::any visit<lname; format = "cap">(<file.parserName>::<lname; format = "cap">Context *ctx) override {
     return visitChildren(ctx);
   \}
 }; separator="\n">


### PR DESCRIPTION
Mark generated classes final when possible. This allows the compiler to potentially apply optimizations as the class hierarchy will be known within the compilation unit. This change also removes unnecessary `virtual` keyword usage, as `override` implies `virtual`.