### PR TITLE
fix warnings in C# CI

### DIFF
--- a/runtime/CSharp/src/Antlr4.csproj
+++ b/runtime/CSharp/src/Antlr4.csproj
@@ -5,7 +5,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <TargetFramework Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFramework>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;netstandard2.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS1591;CS1574;CS1580</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS1574;CS1580;CS1570;NU5048</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Antlr4.Runtime.Standard</AssemblyName>
     <AssemblyOriginatorKeyFile>Antlr4.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->