### PR TITLE
[C++] Optimizations and cleanups and const correctness, oh my

### DIFF
--- a/runtime/Cpp/runtime/src/Recognizer.cpp
+++ b/runtime/Cpp/runtime/src/Recognizer.cpp
@@ -149,14 +149,6 @@ bool Recognizer::precpred(RuleContext * /*localctx*/, int /*precedence*/) {
 void Recognizer::action(RuleContext * /*localctx*/, size_t /*ruleIndex*/, size_t /*actionIndex*/) {
 }
 
-size_t Recognizer::getState() const {
-  return _stateNumber;
-}
-
-void Recognizer::setState(size_t atnState) {
-  _stateNumber = atnState;
-}
-
 void Recognizer::InitializeInstanceFields() {
   _stateNumber = ATNState::INVALID_STATE_NUMBER;
   _interpreter = nullptr;

--- a/runtime/Cpp/runtime/src/Recognizer.h
+++ b/runtime/Cpp/runtime/src/Recognizer.h
@@ -113,7 +113,7 @@ namespace antlr4 {
 
     virtual void action(RuleContext *localctx, size_t ruleIndex, size_t actionIndex);
 
-    virtual size_t getState() const ;
+    size_t getState() const { return _stateNumber; }
 
     // Get the ATN used by the recognizer for prediction.
     virtual const atn::ATN& getATN() const = 0;
@@ -126,7 +126,7 @@ namespace antlr4 {
     ///  invoking rules. Combine this and we have complete ATN
     ///  configuration information.
     /// </summary>
-    void setState(size_t atnState);
+    void setState(size_t atnState) { _stateNumber = atnState; }
 
     virtual IntStream* getInputStream() = 0;
 

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
@@ -11,12 +11,12 @@
 
 using namespace antlr4::atn;
 
-ATNConfig::ATNConfig(ATNState *state_, size_t alt_, Ref<PredictionContext> const& context_)
-  : ATNConfig(state_, alt_, context_, SemanticContext::NONE) {
+ATNConfig::ATNConfig(ATNState *state_, size_t alt, Ref<PredictionContext> context)
+  : ATNConfig(state_, alt, std::move(context), SemanticContext::NONE) {
 }
 
-ATNConfig::ATNConfig(ATNState *state_, size_t alt_, Ref<PredictionContext> const& context_, Ref<SemanticContext> const& semanticContext_)
-  : state(state_), alt(alt_), context(context_), semanticContext(semanticContext_) {
+ATNConfig::ATNConfig(ATNState *state, size_t alt, Ref<PredictionContext> context, Ref<SemanticContext> semanticContext)
+  : state(state), alt(alt), context(std::move(context)), semanticContext(std::move(semanticContext)) {
   reachesIntoOuterContext = 0;
 }
 
@@ -26,25 +26,22 @@ ATNConfig::ATNConfig(Ref<ATNConfig> const& c) : ATNConfig(c, c->state, c->contex
 ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state_) : ATNConfig(c, state_, c->context, c->semanticContext) {
 }
 
-ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<SemanticContext> const& semanticContext)
-  : ATNConfig(c, state, c->context, semanticContext) {
+ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<SemanticContext> semanticContext)
+  : ATNConfig(c, state, c->context, std::move(semanticContext)) {
 }
 
-ATNConfig::ATNConfig(Ref<ATNConfig> const& c, Ref<SemanticContext> const& semanticContext)
-  : ATNConfig(c, c->state, c->context, semanticContext) {
+ATNConfig::ATNConfig(Ref<ATNConfig> const& c, Ref<SemanticContext> semanticContext)
+  : ATNConfig(c, c->state, c->context, std::move(semanticContext)) {
 }
 
-ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> const& context)
-  : ATNConfig(c, state, context, c->semanticContext) {
+ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> context)
+  : ATNConfig(c, state, std::move(context), c->semanticContext) {
 }
 
-ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> const& context,
-                     Ref<SemanticContext> const& semanticContext)
-  : state(state), alt(c->alt), context(context), reachesIntoOuterContext(c->reachesIntoOuterContext),
-    semanticContext(semanticContext) {
-}
-
-ATNConfig::~ATNConfig() {
+ATNConfig::ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> context,
+                     Ref<SemanticContext> semanticContext)
+  : state(state), alt(c->alt), context(std::move(context)), reachesIntoOuterContext(c->reachesIntoOuterContext),
+    semanticContext(std::move(semanticContext)) {
 }
 
 size_t ATNConfig::hashCode() const {
@@ -73,22 +70,22 @@ void ATNConfig::setPrecedenceFilterSuppressed(bool value) {
   }
 }
 
-bool ATNConfig::operator == (const ATNConfig &other) const {
+bool ATNConfig::operator==(const ATNConfig &other) const {
   return state->stateNumber == other.state->stateNumber && alt == other.alt &&
     ((context == other.context) || (*context == *other.context)) &&
     *semanticContext == *other.semanticContext &&
     isPrecedenceFilterSuppressed() == other.isPrecedenceFilterSuppressed();
 }
 
-bool ATNConfig::operator != (const ATNConfig &other) const {
+bool ATNConfig::operator!=(const ATNConfig &other) const {
   return !operator==(other);
 }
 
-std::string ATNConfig::toString() {
+std::string ATNConfig::toString() const {
   return toString(true);
 }
 
-std::string ATNConfig::toString(bool showAlt) {
+std::string ATNConfig::toString(bool showAlt) const {
   std::stringstream ss;
   ss << "(";
 

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.h
@@ -77,18 +77,19 @@ namespace atn {
     /// Can be shared between multiple ATNConfig instances.
     Ref<SemanticContext> semanticContext;
 
-    ATNConfig(ATNState *state, size_t alt, Ref<PredictionContext> const& context);
-    ATNConfig(ATNState *state, size_t alt, Ref<PredictionContext> const& context, Ref<SemanticContext> const& semanticContext);
+    ATNConfig(ATNState *state, size_t alt, Ref<PredictionContext> context);
+    ATNConfig(ATNState *state, size_t alt, Ref<PredictionContext> context, Ref<SemanticContext> semanticContext);
 
     ATNConfig(Ref<ATNConfig> const& c); // dup
     ATNConfig(Ref<ATNConfig> const& c, ATNState *state);
-    ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<SemanticContext> const& semanticContext);
-    ATNConfig(Ref<ATNConfig> const& c, Ref<SemanticContext> const& semanticContext);
-    ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> const& context);
-    ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> const& context, Ref<SemanticContext> const& semanticContext);
+    ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<SemanticContext> semanticContext);
+    ATNConfig(Ref<ATNConfig> const& c, Ref<SemanticContext> semanticContext);
+    ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> context);
+    ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> context, Ref<SemanticContext> semanticContext);
 
     ATNConfig(ATNConfig const&) = default;
-    virtual ~ATNConfig();
+
+    virtual ~ATNConfig() = default;
 
     virtual size_t hashCode() const;
 
@@ -97,18 +98,18 @@ namespace atn {
      * as it existed prior to the introduction of the
      * {@link #isPrecedenceFilterSuppressed} method.
      */
-    size_t getOuterContextDepth() const ;
+    size_t getOuterContextDepth() const;
     bool isPrecedenceFilterSuppressed() const;
     void setPrecedenceFilterSuppressed(bool value);
 
     /// An ATN configuration is equal to another if both have
     /// the same state, they predict the same alternative, and
     /// syntactic/semantic contexts are the same.
-    bool operator == (const ATNConfig &other) const;
-    bool operator != (const ATNConfig &other) const;
+    bool operator==(const ATNConfig &other) const;
+    bool operator!=(const ATNConfig &other) const;
 
-    virtual std::string toString();
-    std::string toString(bool showAlt);
+    virtual std::string toString() const;
+    std::string toString(bool showAlt) const;
 
   private:
     /**

--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
@@ -39,10 +39,13 @@ namespace atn {
     /// it's a wildcard whereas it is not for LL context merge.
     const bool fullCtx;
 
-    ATNConfigSet(bool fullCtx = true);
-    ATNConfigSet(const Ref<ATNConfigSet> &old);
+    ATNConfigSet();
 
-    virtual ~ATNConfigSet();
+    explicit ATNConfigSet(bool fullCtx);
+
+    explicit ATNConfigSet(const Ref<ATNConfigSet> &old);
+
+    virtual ~ATNConfigSet() = default;
 
     virtual bool add(const Ref<ATNConfig> &config);
 
@@ -58,7 +61,7 @@ namespace atn {
     /// </summary>
     virtual bool add(const Ref<ATNConfig> &config, PredictionContextMergeCache *mergeCache);
 
-    virtual std::vector<ATNState *> getStates();
+    virtual std::vector<ATNState *> getStates() const;
 
     /**
      * Gets the complete set of represented alternatives for the configuration
@@ -68,8 +71,8 @@ namespace atn {
      *
      * @since 4.3
      */
-    antlrcpp::BitSet getAlts();
-    virtual std::vector<Ref<SemanticContext>> getPredicates();
+    antlrcpp::BitSet getAlts() const;
+    virtual std::vector<Ref<SemanticContext>> getPredicates() const;
 
     virtual Ref<ATNConfig> get(size_t i) const;
 
@@ -77,14 +80,14 @@ namespace atn {
 
     bool addAll(const Ref<ATNConfigSet> &other);
 
-    bool operator == (const ATNConfigSet &other);
-    virtual size_t hashCode();
-    virtual size_t size();
-    virtual bool isEmpty();
+    bool operator==(const ATNConfigSet &other) const;
+    virtual size_t hashCode() const;
+    virtual size_t size() const;
+    virtual bool isEmpty() const;
     virtual void clear();
-    virtual bool isReadonly();
+    virtual bool isReadonly() const;
     virtual void setReadonly(bool readonly);
-    virtual std::string toString();
+    virtual std::string toString() const;
 
   protected:
     /// Indicates that the set of configurations is read-only. Do not
@@ -94,10 +97,10 @@ namespace atn {
     /// we've made this readonly.
     bool _readonly;
 
-    virtual size_t getHash(ATNConfig *c); // Hash differs depending on set type.
+    virtual size_t getHash(const ATNConfig *c) const; // Hash differs depending on set type.
 
   private:
-    size_t _cachedHashCode;
+    mutable std::atomic<size_t> _cachedHashCode;
 
     /// All configs but hashed by (s, i, _, pi) not including context. Wiped out
     /// when we go readonly as this set becomes a DFA state.

--- a/runtime/Cpp/runtime/src/atn/ATNState.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNState.cpp
@@ -13,9 +13,6 @@
 using namespace antlr4::atn;
 using namespace antlrcpp;
 
-ATNState::ATNState() {
-}
-
 ATNState::~ATNState() {
   for (auto *transition : transitions) {
     delete transition;
@@ -28,15 +25,15 @@ const std::vector<std::string> ATNState::serializationNames = {
   "BLOCK_END", "STAR_LOOP_BACK", "STAR_LOOP_ENTRY", "PLUS_LOOP_BACK", "LOOP_END"
 };
 
-size_t ATNState::hashCode() {
+size_t ATNState::hashCode() const {
   return stateNumber;
 }
 
-bool ATNState::operator == (const ATNState &other) {
+bool ATNState::operator==(const ATNState &other) const {
   return stateNumber == other.stateNumber;
 }
 
-bool ATNState::isNonGreedyExitState() {
+bool ATNState::isNonGreedyExitState() const {
   return false;
 }
 

--- a/runtime/Cpp/runtime/src/atn/ATNState.h
+++ b/runtime/Cpp/runtime/src/atn/ATNState.h
@@ -81,15 +81,19 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC ATNState {
   public:
-    ATNState();
+    static constexpr size_t INITIAL_NUM_TRANSITIONS = 4;
+    static constexpr size_t INVALID_STATE_NUMBER = std::numeric_limits<size_t>::max();
+
+    size_t stateNumber = INVALID_STATE_NUMBER;
+    size_t ruleIndex = 0; // at runtime, we don't have Rule objects
+    bool epsilonOnlyTransitions = false;
+
+    ATNState() = default;
     ATNState(ATNState const&) = delete;
 
     virtual ~ATNState();
 
     ATNState& operator=(ATNState const&) = delete;
-
-    static constexpr size_t INITIAL_NUM_TRANSITIONS = 4;
-    static constexpr size_t INVALID_STATE_NUMBER = std::numeric_limits<size_t>::max();
 
     enum {
       ATN_INVALID_TYPE = 0,
@@ -109,18 +113,13 @@ namespace atn {
 
     static const std::vector<std::string> serializationNames;
 
-    size_t stateNumber = INVALID_STATE_NUMBER;
-    size_t ruleIndex = 0; // at runtime, we don't have Rule objects
-    bool epsilonOnlyTransitions = false;
-
-  public:
-    virtual size_t hashCode();
-    bool operator == (const ATNState &other);
+    virtual size_t hashCode() const;
+    bool operator==(const ATNState &other) const;
 
     /// Track the transitions emanating from this ATN state.
     std::vector<Transition*> transitions;
 
-    virtual bool isNonGreedyExitState();
+    virtual bool isNonGreedyExitState() const;
     virtual std::string toString() const;
     virtual void addTransition(Transition *e);
     virtual void addTransition(size_t index, Transition *e);

--- a/runtime/Cpp/runtime/src/atn/AbstractPredicateTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/AbstractPredicateTransition.cpp
@@ -9,6 +9,3 @@ using namespace antlr4::atn;
 
 AbstractPredicateTransition::AbstractPredicateTransition(ATNState *target) : Transition(target) {
 }
-
-AbstractPredicateTransition::~AbstractPredicateTransition() {
-}

--- a/runtime/Cpp/runtime/src/atn/AbstractPredicateTransition.h
+++ b/runtime/Cpp/runtime/src/atn/AbstractPredicateTransition.h
@@ -13,11 +13,8 @@ namespace atn {
   class ANTState;
 
   class ANTLR4CPP_PUBLIC AbstractPredicateTransition : public Transition {
-
   public:
-    AbstractPredicateTransition(ATNState *target);
-    ~AbstractPredicateTransition();
-
+    explicit AbstractPredicateTransition(ATNState *target);
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
@@ -14,14 +14,11 @@ ArrayPredictionContext::ArrayPredictionContext(Ref<SingletonPredictionContext> c
   : ArrayPredictionContext({ a->parent }, { a->returnState }) {
 }
 
-ArrayPredictionContext::ArrayPredictionContext(std::vector<Ref<PredictionContext>> const& parents_,
-                                               std::vector<size_t> const& returnStates)
-  : PredictionContext(calculateHashCode(parents_, returnStates)), parents(parents_), returnStates(returnStates) {
-    assert(parents.size() > 0);
-    assert(returnStates.size() > 0);
-}
-
-ArrayPredictionContext::~ArrayPredictionContext() {
+ArrayPredictionContext::ArrayPredictionContext(std::vector<Ref<PredictionContext>> parents,
+                                               std::vector<size_t> returnStates)
+  : PredictionContext(calculateHashCode(parents, returnStates)), parents(std::move(parents)), returnStates(std::move(returnStates)) {
+    assert(this->parents.size() > 0);
+    assert(this->returnStates.size() > 0);
 }
 
 bool ArrayPredictionContext::isEmpty() const {

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.h
@@ -25,9 +25,9 @@ namespace atn {
     /// Sorted for merge, no duplicates; if present, EMPTY_RETURN_STATE is always last.
     const std::vector<size_t> returnStates;
 
-    ArrayPredictionContext(Ref<SingletonPredictionContext> const& a);
-    ArrayPredictionContext(std::vector<Ref<PredictionContext>> const& parents_, std::vector<size_t> const& returnStates);
-    virtual ~ArrayPredictionContext();
+    explicit ArrayPredictionContext(Ref<SingletonPredictionContext> const &a);
+
+    ArrayPredictionContext(std::vector<Ref<PredictionContext>> parents, std::vector<size_t> returnStates);
 
     virtual bool isEmpty() const override;
     virtual size_t size() const override;

--- a/runtime/Cpp/runtime/src/atn/AtomTransition.h
+++ b/runtime/Cpp/runtime/src/atn/AtomTransition.h
@@ -14,6 +14,7 @@ namespace atn {
   class ANTLR4CPP_PUBLIC AtomTransition final : public Transition {
   public:
     /// The token type or character value; or, signifies special label.
+    /// TODO: rename this to label
     const size_t _label;
 
     AtomTransition(ATNState *target, size_t label);

--- a/runtime/Cpp/runtime/src/atn/BlockEndState.cpp
+++ b/runtime/Cpp/runtime/src/atn/BlockEndState.cpp
@@ -7,9 +7,6 @@
 
 using namespace antlr4::atn;
 
-BlockEndState::BlockEndState() : startState(nullptr) {
-}
-
 size_t BlockEndState::getStateType() {
   return BLOCK_END;
 }

--- a/runtime/Cpp/runtime/src/atn/BlockEndState.h
+++ b/runtime/Cpp/runtime/src/atn/BlockEndState.h
@@ -15,8 +15,6 @@ namespace atn {
   public:
     BlockStartState *startState = nullptr;
 
-    BlockEndState();
-
     virtual size_t getStateType() override;
   };
 

--- a/runtime/Cpp/runtime/src/atn/BlockStartState.cpp
+++ b/runtime/Cpp/runtime/src/atn/BlockStartState.cpp
@@ -4,6 +4,3 @@
  */
 
 #include "BlockStartState.h"
-
-antlr4::atn::BlockStartState::~BlockStartState() {
-}

--- a/runtime/Cpp/runtime/src/atn/BlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/BlockStartState.h
@@ -13,7 +13,6 @@ namespace atn {
   ///  The start of a regular {@code (...)} block.
   class ANTLR4CPP_PUBLIC BlockStartState : public DecisionState {
   public:
-    ~BlockStartState();
     BlockEndState *endState = nullptr;
   };
 

--- a/runtime/Cpp/runtime/src/atn/DecisionInfo.h
+++ b/runtime/Cpp/runtime/src/atn/DecisionInfo.h
@@ -218,7 +218,7 @@ namespace atn {
     /// statistics for a particular decision.
     /// </summary>
     /// <param name="decision"> The decision number </param>
-    DecisionInfo(size_t decision);
+    explicit DecisionInfo(size_t decision);
 
     std::string toString() const;
   };

--- a/runtime/Cpp/runtime/src/atn/DecisionState.cpp
+++ b/runtime/Cpp/runtime/src/atn/DecisionState.cpp
@@ -7,11 +7,6 @@
 
 using namespace antlr4::atn;
 
-void DecisionState::InitializeInstanceFields() {
-  decision = -1;
-  nonGreedy = false;
-}
-
 std::string DecisionState::toString() const {
   return "DECISION " + ATNState::toString();
 }

--- a/runtime/Cpp/runtime/src/atn/DecisionState.h
+++ b/runtime/Cpp/runtime/src/atn/DecisionState.h
@@ -12,16 +12,10 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC DecisionState : public ATNState {
   public:
-    int decision;
-    bool nonGreedy;
+    int decision = -1;
+    bool nonGreedy = false;
 
-  private:
-    void InitializeInstanceFields();
-
-  public:
-    DecisionState() {
-      InitializeInstanceFields();
-    }
+    DecisionState() = default;
 
     virtual std::string toString() const override;
   };

--- a/runtime/Cpp/runtime/src/atn/EmptyPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/EmptyPredictionContext.cpp
@@ -26,7 +26,7 @@ size_t EmptyPredictionContext::getReturnState(size_t /*index*/) const {
   return returnState;
 }
 
-bool EmptyPredictionContext::operator == (const PredictionContext &o) const {
+bool EmptyPredictionContext::operator==(const PredictionContext &o) const {
   return this == &o;
 }
 

--- a/runtime/Cpp/runtime/src/atn/EmptyPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/EmptyPredictionContext.h
@@ -20,7 +20,7 @@ namespace atn {
     virtual size_t getReturnState(size_t index) const override;
     virtual std::string toString() const override;
 
-    virtual bool operator == (const PredictionContext &o) const override;
+    virtual bool operator==(const PredictionContext &o) const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/EpsilonTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/EpsilonTransition.cpp
@@ -14,7 +14,7 @@ EpsilonTransition::EpsilonTransition(ATNState *target, size_t outermostPrecedenc
   : Transition(target), _outermostPrecedenceReturn(outermostPrecedenceReturn) {
 }
 
-size_t EpsilonTransition::outermostPrecedenceReturn() {
+size_t EpsilonTransition::outermostPrecedenceReturn() const {
   return _outermostPrecedenceReturn;
 }
 

--- a/runtime/Cpp/runtime/src/atn/EpsilonTransition.h
+++ b/runtime/Cpp/runtime/src/atn/EpsilonTransition.h
@@ -12,7 +12,7 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC EpsilonTransition final : public Transition {
   public:
-    EpsilonTransition(ATNState *target);
+    explicit EpsilonTransition(ATNState *target);
     EpsilonTransition(ATNState *target, size_t outermostPrecedenceReturn);
 
     /**
@@ -23,7 +23,7 @@ namespace atn {
      * @see ParserATNSimulator#applyPrecedenceFilter(ATNConfigSet)
      * @since 4.4.1
      */
-    size_t outermostPrecedenceReturn();
+    size_t outermostPrecedenceReturn() const;
     virtual SerializationType getSerializationType() const override;
 
     virtual bool isEpsilon() const override;

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
@@ -22,12 +22,6 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlrcpp;
 
-LL1Analyzer::LL1Analyzer(const ATN &atn) : _atn(atn) {
-}
-
-LL1Analyzer::~LL1Analyzer() {
-}
-
 std::vector<misc::IntervalSet> LL1Analyzer::getDecisionLookahead(ATNState *s) const {
   std::vector<misc::IntervalSet> look;
 
@@ -41,7 +35,7 @@ std::vector<misc::IntervalSet> LL1Analyzer::getDecisionLookahead(ATNState *s) co
 
     ATNConfig::Set lookBusy;
     antlrcpp::BitSet callRuleStack;
-    _LOOK(s->transitions[alt]->target, nullptr, PredictionContext::EMPTY,
+    LOOK(s->transitions[alt]->target, nullptr, PredictionContext::EMPTY,
           look[alt], lookBusy, callRuleStack, seeThruPreds, false);
 
     // Wipe out lookahead for this alternative if we found nothing
@@ -64,12 +58,12 @@ misc::IntervalSet LL1Analyzer::LOOK(ATNState *s, ATNState *stopState, RuleContex
 
   ATNConfig::Set lookBusy;
   antlrcpp::BitSet callRuleStack;
-  _LOOK(s, stopState, lookContext, r, lookBusy, callRuleStack, seeThruPreds, true);
+  LOOK(s, stopState, lookContext, r, lookBusy, callRuleStack, seeThruPreds, true);
 
   return r;
 }
 
-void LL1Analyzer::_LOOK(ATNState *s, ATNState *stopState, Ref<PredictionContext> const& ctx, misc::IntervalSet &look,
+void LL1Analyzer::LOOK(ATNState *s, ATNState *stopState, Ref<PredictionContext> const& ctx, misc::IntervalSet &look,
   ATNConfig::Set &lookBusy, antlrcpp::BitSet &calledRuleStack, bool seeThruPreds, bool addEOF) const {
 
   Ref<ATNConfig> c = std::make_shared<ATNConfig>(s, 0, ctx);
@@ -110,7 +104,7 @@ void LL1Analyzer::_LOOK(ATNState *s, ATNState *stopState, Ref<PredictionContext>
        // run thru all possible stack tops in ctx
       for (size_t i = 0; i < ctx->size(); i++) {
         ATNState *returnState = _atn.states[ctx->getReturnState(i)];
-        _LOOK(returnState, stopState, ctx->getParent(i), look, lookBusy, calledRuleStack, seeThruPreds, addEOF);
+        LOOK(returnState, stopState, ctx->getParent(i), look, lookBusy, calledRuleStack, seeThruPreds, addEOF);
       }
       return;
     }
@@ -131,16 +125,16 @@ void LL1Analyzer::_LOOK(ATNState *s, ATNState *stopState, Ref<PredictionContext>
       });
 
       calledRuleStack.set((static_cast<RuleTransition*>(t))->target->ruleIndex);
-      _LOOK(t->target, stopState, newContext, look, lookBusy, calledRuleStack, seeThruPreds, addEOF);
+      LOOK(t->target, stopState, newContext, look, lookBusy, calledRuleStack, seeThruPreds, addEOF);
 
     } else if (is<AbstractPredicateTransition *>(t)) {
       if (seeThruPreds) {
-        _LOOK(t->target, stopState, ctx, look, lookBusy, calledRuleStack, seeThruPreds, addEOF);
+        LOOK(t->target, stopState, ctx, look, lookBusy, calledRuleStack, seeThruPreds, addEOF);
       } else {
         look.add(HIT_PRED);
       }
     } else if (t->isEpsilon()) {
-      _LOOK(t->target, stopState, ctx, look, lookBusy, calledRuleStack, seeThruPreds, addEOF);
+      LOOK(t->target, stopState, ctx, look, lookBusy, calledRuleStack, seeThruPreds, addEOF);
     } else if (t->getSerializationType() == Transition::WILDCARD) {
       look.addAll(misc::IntervalSet::of(Token::MIN_USER_TOKEN_TYPE, static_cast<ssize_t>(_atn.maxTokenType)));
     } else {

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.h
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.h
@@ -6,23 +6,20 @@
 #pragma once
 
 #include "Token.h"
-#include "support/BitSet.h"
-#include "atn/PredictionContext.h"
 #include "atn/ATNConfig.h"
+#include "atn/PredictionContext.h"
+#include "support/BitSet.h"
 
 namespace antlr4 {
 namespace atn {
 
-  class ANTLR4CPP_PUBLIC LL1Analyzer {
+  class ANTLR4CPP_PUBLIC LL1Analyzer final {
   public:
     /// Special value added to the lookahead sets to indicate that we hit
     ///  a predicate during analysis if {@code seeThruPreds==false}.
     static constexpr size_t HIT_PRED = Token::INVALID_TYPE;
 
-    const atn::ATN &_atn;
-
-    LL1Analyzer(const atn::ATN &atn);
-    virtual ~LL1Analyzer();
+    explicit LL1Analyzer(const atn::ATN &atn) : _atn(atn) {}
 
     /// <summary>
     /// Calculates the SLL(1) expected lookahead set for each outgoing transition
@@ -33,7 +30,7 @@ namespace atn {
     /// </summary>
     /// <param name="s"> the ATN state </param>
     /// <returns> the expected symbols for each outgoing transition of {@code s}. </returns>
-    virtual std::vector<misc::IntervalSet> getDecisionLookahead(ATNState *s) const;
+    std::vector<misc::IntervalSet> getDecisionLookahead(ATNState *s) const;
 
     /// <summary>
     /// Compute set of tokens that can follow {@code s} in the ATN in the
@@ -50,7 +47,7 @@ namespace atn {
     /// </param>
     /// <returns> The set of tokens that can follow {@code s} in the ATN in the
     /// specified {@code ctx}. </returns>
-    virtual misc::IntervalSet LOOK(ATNState *s, RuleContext *ctx) const;
+    misc::IntervalSet LOOK(ATNState *s, RuleContext *ctx) const;
 
     /// <summary>
     /// Compute set of tokens that can follow {@code s} in the ATN in the
@@ -69,7 +66,7 @@ namespace atn {
     /// </param>
     /// <returns> The set of tokens that can follow {@code s} in the ATN in the
     /// specified {@code ctx}. </returns>
-    virtual misc::IntervalSet LOOK(ATNState *s, ATNState *stopState, RuleContext *ctx) const;
+    misc::IntervalSet LOOK(ATNState *s, ATNState *stopState, RuleContext *ctx) const;
 
     /// <summary>
     /// Compute set of tokens that can follow {@code s} in the ATN in the
@@ -100,9 +97,12 @@ namespace atn {
     /// <param name="addEOF"> Add <seealso cref="Token#EOF"/> to the result if the end of the
     /// outermost context is reached. This parameter has no effect if {@code ctx}
     /// is {@code null}. </param>
-  protected:
-    virtual void _LOOK(ATNState *s, ATNState *stopState, Ref<PredictionContext> const& ctx, misc::IntervalSet &look,
-      ATNConfig::Set &lookBusy, antlrcpp::BitSet &calledRuleStack, bool seeThruPreds, bool addEOF) const;
+  private:
+    void LOOK(ATNState *s, ATNState *stopState, Ref<PredictionContext> const &ctx,
+              misc::IntervalSet &look, ATNConfig::Set &lookBusy, antlrcpp::BitSet &calledRuleStack,
+              bool seeThruPreds, bool addEOF) const;
+
+    const atn::ATN &_atn;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
@@ -16,13 +16,13 @@
 using namespace antlr4::atn;
 using namespace antlrcpp;
 
-LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> const& context)
-  : ATNConfig(state, alt, context, SemanticContext::NONE), _passedThroughNonGreedyDecision(false) {
+LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> context)
+  : ATNConfig(state, alt, std::move(context), SemanticContext::NONE), _passedThroughNonGreedyDecision(false) {
 }
 
-LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> const& context,
-                               Ref<LexerActionExecutor> const& lexerActionExecutor)
-  : ATNConfig(state, alt, context, SemanticContext::NONE), _lexerActionExecutor(lexerActionExecutor),
+LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> context,
+                               Ref<LexerActionExecutor> lexerActionExecutor)
+  : ATNConfig(state, alt, std::move(context), SemanticContext::NONE), _lexerActionExecutor(std::move(lexerActionExecutor)),
     _passedThroughNonGreedyDecision(false) {
 }
 
@@ -31,21 +31,21 @@ LexerATNConfig::LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state)
    _passedThroughNonGreedyDecision(checkNonGreedyDecision(c, state)) {
 }
 
-LexerATNConfig::LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<LexerActionExecutor> const& lexerActionExecutor)
-  : ATNConfig(c, state, c->context, c->semanticContext), _lexerActionExecutor(lexerActionExecutor),
+LexerATNConfig::LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<LexerActionExecutor> lexerActionExecutor)
+  : ATNConfig(c, state, c->context, c->semanticContext), _lexerActionExecutor(std::move(lexerActionExecutor)),
     _passedThroughNonGreedyDecision(checkNonGreedyDecision(c, state)) {
 }
 
-LexerATNConfig::LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<PredictionContext> const& context)
-  : ATNConfig(c, state, context, c->semanticContext), _lexerActionExecutor(c->_lexerActionExecutor),
+LexerATNConfig::LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<PredictionContext> context)
+  : ATNConfig(c, state, std::move(context), c->semanticContext), _lexerActionExecutor(c->_lexerActionExecutor),
     _passedThroughNonGreedyDecision(checkNonGreedyDecision(c, state)) {
 }
 
-Ref<LexerActionExecutor> LexerATNConfig::getLexerActionExecutor() const {
+const Ref<LexerActionExecutor>& LexerATNConfig::getLexerActionExecutor() const {
   return _lexerActionExecutor;
 }
 
-bool LexerATNConfig::hasPassedThroughNonGreedyDecision() {
+bool LexerATNConfig::hasPassedThroughNonGreedyDecision() const {
   return _passedThroughNonGreedyDecision;
 }
 
@@ -61,7 +61,7 @@ size_t LexerATNConfig::hashCode() const {
   return hashCode;
 }
 
-bool LexerATNConfig::operator == (const LexerATNConfig& other) const
+bool LexerATNConfig::operator==(const LexerATNConfig& other) const
 {
   if (this == &other)
     return true;
@@ -75,7 +75,7 @@ bool LexerATNConfig::operator == (const LexerATNConfig& other) const
     return false;
   }
 
-  return ATNConfig::operator == (other);
+  return ATNConfig::operator==(other);
 }
 
 bool LexerATNConfig::checkNonGreedyDecision(Ref<LexerATNConfig> const& source, ATNState *target) {

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
@@ -12,23 +12,23 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC LexerATNConfig : public ATNConfig {
   public:
-    LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> const& context);
-    LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> const& context, Ref<LexerActionExecutor> const& lexerActionExecutor);
+    LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> context);
+    LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> context, Ref<LexerActionExecutor> lexerActionExecutor);
 
     LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state);
-    LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<LexerActionExecutor> const& lexerActionExecutor);
-    LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<PredictionContext> const& context);
+    LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<LexerActionExecutor> lexerActionExecutor);
+    LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<PredictionContext> context);
 
     /**
      * Gets the {@link LexerActionExecutor} capable of executing the embedded
      * action(s) for the current configuration.
      */
-    Ref<LexerActionExecutor> getLexerActionExecutor() const;
-    bool hasPassedThroughNonGreedyDecision();
+    const Ref<LexerActionExecutor>& getLexerActionExecutor() const;
+    bool hasPassedThroughNonGreedyDecision() const;
 
     virtual size_t hashCode() const override;
 
-    bool operator == (const LexerATNConfig& other) const;
+    bool operator==(const LexerATNConfig& other) const;
 
   private:
     /**

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -263,7 +263,7 @@ void LexerATNSimulator::getReachableConfigSet(CharStream *input, ATNConfigSet *c
 
         bool treatEofAsEpsilon = t == Token::EOF;
         Ref<LexerATNConfig> config = std::make_shared<LexerATNConfig>(std::static_pointer_cast<LexerATNConfig>(c),
-          target, lexerActionExecutor);
+          target, std::move(lexerActionExecutor));
 
         if (closure(input, config, reach, currentAltReachedAcceptState, true, treatEofAsEpsilon)) {
           // any remaining configs for this alt have a lower priority than

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
@@ -88,7 +88,7 @@ namespace atn {
 
     LexerATNSimulator(const ATN &atn, std::vector<dfa::DFA> &decisionToDFA, PredictionContextCache &sharedContextCache);
     LexerATNSimulator(Lexer *recog, const ATN &atn, std::vector<dfa::DFA> &decisionToDFA, PredictionContextCache &sharedContextCache);
-    virtual ~LexerATNSimulator () {}
+    virtual ~LexerATNSimulator() = default;
 
     virtual void copyState(LexerATNSimulator *simulator);
     virtual size_t match(CharStream *input, size_t mode);

--- a/runtime/Cpp/runtime/src/atn/LexerAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerAction.cpp
@@ -4,6 +4,3 @@
  */
 
 #include "LexerAction.h"
-
-antlr4::atn::LexerAction::~LexerAction() {
-}

--- a/runtime/Cpp/runtime/src/atn/LexerAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerAction.h
@@ -21,7 +21,7 @@ namespace atn {
   /// </summary>
   class ANTLR4CPP_PUBLIC LexerAction {
   public:
-    virtual ~LexerAction();
+    virtual ~LexerAction() = default;
 
     /// <summary>
     /// Gets the serialization type of the lexer action.

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
@@ -15,22 +15,19 @@ using namespace antlr4::atn;
 using namespace antlr4::misc;
 using namespace antlrcpp;
 
-LexerActionExecutor::LexerActionExecutor(const std::vector<Ref<LexerAction>> &lexerActions)
-  : _lexerActions(lexerActions), _hashCode(generateHashCode()) {
-}
-
-LexerActionExecutor::~LexerActionExecutor() {
+LexerActionExecutor::LexerActionExecutor(std::vector<Ref<LexerAction>> lexerActions)
+  : _lexerActions(std::move(lexerActions)), _hashCode(generateHashCode()) {
 }
 
 Ref<LexerActionExecutor> LexerActionExecutor::append(Ref<LexerActionExecutor> const& lexerActionExecutor,
-                                                     Ref<LexerAction> const& lexerAction) {
+                                                     Ref<LexerAction> lexerAction) {
   if (lexerActionExecutor == nullptr) {
-    return std::make_shared<LexerActionExecutor>(std::vector<Ref<LexerAction>> { lexerAction });
+    return std::make_shared<LexerActionExecutor>(std::vector<Ref<LexerAction>> { std::move(lexerAction) });
   }
 
   std::vector<Ref<LexerAction>> lexerActions = lexerActionExecutor->_lexerActions; // Make a copy.
-  lexerActions.push_back(lexerAction);
-  return std::make_shared<LexerActionExecutor>(lexerActions);
+  lexerActions.push_back(std::move(lexerAction));
+  return std::make_shared<LexerActionExecutor>(std::move(lexerActions));
 }
 
 Ref<LexerActionExecutor> LexerActionExecutor::fixOffsetBeforeMatch(int offset) {
@@ -49,10 +46,10 @@ Ref<LexerActionExecutor> LexerActionExecutor::fixOffsetBeforeMatch(int offset) {
     return shared_from_this();
   }
 
-  return std::make_shared<LexerActionExecutor>(updatedLexerActions);
+  return std::make_shared<LexerActionExecutor>(std::move(updatedLexerActions));
 }
 
-std::vector<Ref<LexerAction>> LexerActionExecutor::getLexerActions() const {
+const std::vector<Ref<LexerAction>>& LexerActionExecutor::getLexerActions() const {
   return _lexerActions;
 }
 
@@ -84,7 +81,7 @@ size_t LexerActionExecutor::hashCode() const {
   return _hashCode;
 }
 
-bool LexerActionExecutor::operator == (const LexerActionExecutor &obj) const {
+bool LexerActionExecutor::operator==(const LexerActionExecutor &obj) const {
   if (&obj == this) {
     return true;
   }
@@ -92,7 +89,7 @@ bool LexerActionExecutor::operator == (const LexerActionExecutor &obj) const {
   return _hashCode == obj._hashCode && Arrays::equals(_lexerActions, obj._lexerActions);
 }
 
-bool LexerActionExecutor::operator != (const LexerActionExecutor &obj) const {
+bool LexerActionExecutor::operator!=(const LexerActionExecutor &obj) const {
   return !operator==(obj);
 }
 

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
@@ -22,8 +22,7 @@ namespace atn {
     /// <summary>
     /// Constructs an executor for a sequence of <seealso cref="LexerAction"/> actions. </summary>
     /// <param name="lexerActions"> The lexer actions to execute. </param>
-    LexerActionExecutor(const std::vector<Ref<LexerAction>> &lexerActions);
-    virtual ~LexerActionExecutor();
+    explicit LexerActionExecutor(std::vector<Ref<LexerAction>> lexerActions);
 
     /// <summary>
     /// Creates a <seealso cref="LexerActionExecutor"/> which executes the actions for
@@ -40,7 +39,7 @@ namespace atn {
     /// <returns> A <seealso cref="LexerActionExecutor"/> for executing the combine actions
     /// of {@code lexerActionExecutor} and {@code lexerAction}. </returns>
     static Ref<LexerActionExecutor> append(Ref<LexerActionExecutor> const& lexerActionExecutor,
-                                           Ref<LexerAction> const& lexerAction);
+                                           Ref<LexerAction> lexerAction);
 
     /// <summary>
     /// Creates a <seealso cref="LexerActionExecutor"/> which encodes the current offset
@@ -75,7 +74,7 @@ namespace atn {
     /// <summary>
     /// Gets the lexer actions to be executed by this executor. </summary>
     /// <returns> The lexer actions to be executed by this executor. </returns>
-    virtual std::vector<Ref<LexerAction>> getLexerActions() const;
+    virtual const std::vector<Ref<LexerAction>>& getLexerActions() const;
 
     /// <summary>
     /// Execute the actions encapsulated by this executor within the context of a
@@ -98,8 +97,8 @@ namespace atn {
     virtual void execute(Lexer *lexer, CharStream *input, size_t startIndex);
 
     virtual size_t hashCode() const;
-    virtual bool operator == (const LexerActionExecutor &obj) const;
-    virtual bool operator != (const LexerActionExecutor &obj) const;
+    virtual bool operator==(const LexerActionExecutor &obj) const;
+    virtual bool operator!=(const LexerActionExecutor &obj) const;
 
   private:
     const std::vector<Ref<LexerAction>> _lexerActions;

--- a/runtime/Cpp/runtime/src/atn/LexerChannelAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerChannelAction.cpp
@@ -37,7 +37,7 @@ size_t LexerChannelAction::hashCode() const {
   return MurmurHash::finish(hash, 2);
 }
 
-bool LexerChannelAction::operator == (const LexerAction &obj) const {
+bool LexerChannelAction::operator==(const LexerAction &obj) const {
   if (&obj == this) {
     return true;
   }

--- a/runtime/Cpp/runtime/src/atn/LexerChannelAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerChannelAction.h
@@ -25,7 +25,7 @@ namespace atn {
     /// <summary>
     /// Constructs a new {@code channel} action with the specified channel value. </summary>
     /// <param name="channel"> The channel value to pass to <seealso cref="Lexer#setChannel"/>. </param>
-    LexerChannelAction(int channel);
+    explicit LexerChannelAction(int channel);
 
     /// <summary>
     /// Gets the channel to use for the <seealso cref="Token"/> created by the lexer.
@@ -52,7 +52,7 @@ namespace atn {
     virtual void execute(Lexer *lexer) override;
 
     virtual size_t hashCode() const override;
-    virtual bool operator == (const LexerAction &obj) const override;
+    virtual bool operator==(const LexerAction &obj) const override;
     virtual std::string toString() const override;
 
   private:

--- a/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.cpp
@@ -13,8 +13,8 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
 
-LexerIndexedCustomAction::LexerIndexedCustomAction(int offset, Ref<LexerAction> const& action)
-  : _offset(offset), _action(action) {
+LexerIndexedCustomAction::LexerIndexedCustomAction(int offset, Ref<LexerAction> action)
+  : _offset(offset), _action(std::move(action)) {
 }
 
 int LexerIndexedCustomAction::getOffset() const {
@@ -45,7 +45,7 @@ size_t LexerIndexedCustomAction::hashCode() const {
   return MurmurHash::finish(hash, 2);
 }
 
-bool LexerIndexedCustomAction::operator == (const LexerAction &obj) const {
+bool LexerIndexedCustomAction::operator==(const LexerAction &obj) const {
   if (&obj == this) {
     return true;
   }

--- a/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.h
@@ -38,7 +38,7 @@ namespace atn {
     /// executed. </param>
     /// <param name="action"> The lexer action to execute at a particular offset in the
     /// input <seealso cref="CharStream"/>. </param>
-    LexerIndexedCustomAction(int offset, Ref<LexerAction> const& action);
+    LexerIndexedCustomAction(int offset, Ref<LexerAction> action);
 
     /// <summary>
     /// Gets the location in the input <seealso cref="CharStream"/> at which the lexer
@@ -69,7 +69,7 @@ namespace atn {
 
     virtual void execute(Lexer *lexer) override;
     virtual size_t hashCode() const override;
-    virtual bool operator == (const LexerAction &obj) const override;
+    virtual bool operator==(const LexerAction &obj) const override;
     virtual std::string toString() const override;
 
   private:

--- a/runtime/Cpp/runtime/src/atn/LexerModeAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerModeAction.cpp
@@ -15,7 +15,7 @@ using namespace antlr4::misc;
 LexerModeAction::LexerModeAction(int mode) : _mode(mode) {
 }
 
-int LexerModeAction::getMode() {
+int LexerModeAction::getMode() const {
   return _mode;
 }
 
@@ -38,7 +38,7 @@ size_t LexerModeAction::hashCode() const {
   return MurmurHash::finish(hash, 2);
 }
 
-bool LexerModeAction::operator == (const LexerAction &obj) const {
+bool LexerModeAction::operator==(const LexerAction &obj) const {
   if (&obj == this) {
     return true;
   }

--- a/runtime/Cpp/runtime/src/atn/LexerModeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerModeAction.h
@@ -23,13 +23,13 @@ namespace atn {
     /// <summary>
     /// Constructs a new {@code mode} action with the specified mode value. </summary>
     /// <param name="mode"> The mode value to pass to <seealso cref="Lexer#mode"/>. </param>
-    LexerModeAction(int mode);
+    explicit LexerModeAction(int mode);
 
     /// <summary>
     /// Get the lexer mode this action should transition the lexer to.
     /// </summary>
     /// <returns> The lexer mode for this {@code mode} command. </returns>
-    int getMode();
+    int getMode() const;
 
     /// <summary>
     /// {@inheritDoc} </summary>

--- a/runtime/Cpp/runtime/src/atn/LexerMoreAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerMoreAction.cpp
@@ -12,12 +12,9 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
 
-const Ref<LexerMoreAction> LexerMoreAction::getInstance() {
+const Ref<LexerMoreAction>& LexerMoreAction::getInstance() {
   static Ref<LexerMoreAction> instance(new LexerMoreAction());
   return instance;
-}
-
-LexerMoreAction::LexerMoreAction() {
 }
 
 LexerActionType LexerMoreAction::getActionType() const {
@@ -38,7 +35,7 @@ size_t LexerMoreAction::hashCode() const {
   return MurmurHash::finish(hash, 1);
 }
 
-bool LexerMoreAction::operator == (const LexerAction &obj) const {
+bool LexerMoreAction::operator==(const LexerAction &obj) const {
   return &obj == this;
 }
 

--- a/runtime/Cpp/runtime/src/atn/LexerMoreAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerMoreAction.h
@@ -25,7 +25,7 @@ namespace atn {
     /// <summary>
     /// Provides a singleton instance of this parameterless lexer action.
     /// </summary>
-    static const Ref<LexerMoreAction> getInstance();
+    static const Ref<LexerMoreAction>& getInstance();
 
     /// <summary>
     /// {@inheritDoc} </summary>
@@ -45,12 +45,12 @@ namespace atn {
     virtual void execute(Lexer *lexer) override;
 
     virtual size_t hashCode() const override;
-    virtual bool operator == (const LexerAction &obj) const override;
+    virtual bool operator==(const LexerAction &obj) const override;
     virtual std::string toString() const override;
 
   private:
     /// Constructs the singleton instance of the lexer {@code more} command.
-    LexerMoreAction();
+    LexerMoreAction() = default;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerPopModeAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerPopModeAction.cpp
@@ -12,12 +12,9 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
 
-const Ref<LexerPopModeAction> LexerPopModeAction::getInstance() {
+const Ref<LexerPopModeAction>& LexerPopModeAction::getInstance() {
   static Ref<LexerPopModeAction> instance(new LexerPopModeAction());
   return instance;
-}
-
-LexerPopModeAction::LexerPopModeAction() {
 }
 
 LexerActionType LexerPopModeAction::getActionType() const {
@@ -38,7 +35,7 @@ size_t LexerPopModeAction::hashCode() const {
   return MurmurHash::finish(hash, 1);
 }
 
-bool LexerPopModeAction::operator == (const LexerAction &obj) const {
+bool LexerPopModeAction::operator==(const LexerAction &obj) const {
   return &obj == this;
 }
 

--- a/runtime/Cpp/runtime/src/atn/LexerPopModeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerPopModeAction.h
@@ -25,7 +25,7 @@ namespace atn {
     /// <summary>
     /// Provides a singleton instance of this parameterless lexer action.
     /// </summary>
-    static const Ref<LexerPopModeAction> getInstance();
+    static const Ref<LexerPopModeAction>& getInstance();
 
     /// <summary>
     /// {@inheritDoc} </summary>
@@ -45,12 +45,12 @@ namespace atn {
     virtual void execute(Lexer *lexer) override;
 
     virtual size_t hashCode() const override;
-    virtual bool operator == (const LexerAction &obj) const override;
+    virtual bool operator==(const LexerAction &obj) const override;
     virtual std::string toString() const override;
 
   private:
     /// Constructs the singleton instance of the lexer {@code popMode} command.
-    LexerPopModeAction();
+    LexerPopModeAction() = default;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerPushModeAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerPushModeAction.cpp
@@ -38,7 +38,7 @@ size_t LexerPushModeAction::hashCode() const {
   return MurmurHash::finish(hash, 2);
 }
 
-bool LexerPushModeAction::operator == (const LexerAction &obj) const {
+bool LexerPushModeAction::operator==(const LexerAction &obj) const {
   if (&obj == this) {
     return true;
   }

--- a/runtime/Cpp/runtime/src/atn/LexerPushModeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerPushModeAction.h
@@ -23,7 +23,7 @@ namespace atn {
     /// <summary>
     /// Constructs a new {@code pushMode} action with the specified mode value. </summary>
     /// <param name="mode"> The mode value to pass to <seealso cref="Lexer#pushMode"/>. </param>
-    LexerPushModeAction(int mode);
+    explicit LexerPushModeAction(int mode);
 
     /// <summary>
     /// Get the lexer mode this action should transition the lexer to.
@@ -50,7 +50,7 @@ namespace atn {
     virtual void execute(Lexer *lexer) override;
 
     virtual size_t hashCode() const override;
-    virtual bool operator == (const LexerAction &obj) const override;
+    virtual bool operator==(const LexerAction &obj) const override;
     virtual std::string toString() const override;
 
   private:

--- a/runtime/Cpp/runtime/src/atn/LexerSkipAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerSkipAction.cpp
@@ -12,12 +12,9 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
 
-const Ref<LexerSkipAction> LexerSkipAction::getInstance() {
+const Ref<LexerSkipAction>& LexerSkipAction::getInstance() {
   static Ref<LexerSkipAction> instance(new LexerSkipAction());
   return instance;
-}
-
-LexerSkipAction::LexerSkipAction() {
 }
 
 LexerActionType LexerSkipAction::getActionType() const {

--- a/runtime/Cpp/runtime/src/atn/LexerSkipAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerSkipAction.h
@@ -23,7 +23,7 @@ namespace atn {
   class ANTLR4CPP_PUBLIC LexerSkipAction final : public LexerAction {
   public:
     /// Provides a singleton instance of this parameterless lexer action.
-    static const Ref<LexerSkipAction> getInstance();
+    static const Ref<LexerSkipAction>& getInstance();
 
     /// <summary>
     /// {@inheritDoc} </summary>
@@ -43,12 +43,12 @@ namespace atn {
     virtual void execute(Lexer *lexer) override;
 
     virtual size_t hashCode() const override;
-    virtual bool operator == (const LexerAction &obj) const override;
+    virtual bool operator==(const LexerAction &obj) const override;
     virtual std::string toString() const override;
 
   private:
     /// Constructs the singleton instance of the lexer {@code skip} command.
-    LexerSkipAction();
+    LexerSkipAction() = default;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerTypeAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerTypeAction.cpp
@@ -38,7 +38,7 @@ size_t LexerTypeAction::hashCode() const {
   return MurmurHash::finish(hash, 2);
 }
 
-bool LexerTypeAction::operator == (const LexerAction &obj) const {
+bool LexerTypeAction::operator==(const LexerAction &obj) const {
   if (&obj == this) {
     return true;
   }

--- a/runtime/Cpp/runtime/src/atn/LexerTypeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerTypeAction.h
@@ -18,7 +18,7 @@ namespace atn {
     /// <summary>
     /// Constructs a new {@code type} action with the specified token type value. </summary>
     /// <param name="type"> The type to assign to the token using <seealso cref="Lexer#setType"/>. </param>
-    LexerTypeAction(int type);
+    explicit LexerTypeAction(int type);
 
     /// <summary>
     /// Gets the type to assign to a token created by the lexer. </summary>
@@ -44,7 +44,7 @@ namespace atn {
     virtual void execute(Lexer *lexer) override;
 
     virtual size_t hashCode() const override;
-    virtual bool operator == (const LexerAction &obj) const override;
+    virtual bool operator==(const LexerAction &obj) const override;
     virtual std::string toString() const override;
 
   private:

--- a/runtime/Cpp/runtime/src/atn/NotSetTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/NotSetTransition.cpp
@@ -10,7 +10,7 @@
 using namespace antlr4;
 using namespace antlr4::atn;
 
-NotSetTransition::NotSetTransition(ATNState *target, const misc::IntervalSet &set) : SetTransition(target, set) {
+NotSetTransition::NotSetTransition(ATNState *target, misc::IntervalSet set) : SetTransition(target, std::move(set)) {
 }
 
 Transition::SerializationType NotSetTransition::getSerializationType() const {

--- a/runtime/Cpp/runtime/src/atn/NotSetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/NotSetTransition.h
@@ -12,7 +12,7 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC NotSetTransition final : public SetTransition {
   public:
-    NotSetTransition(ATNState *target, const misc::IntervalSet &set);
+    NotSetTransition(ATNState *target, misc::IntervalSet set);
 
     virtual SerializationType getSerializationType() const override;
 

--- a/runtime/Cpp/runtime/src/atn/OrderedATNConfigSet.cpp
+++ b/runtime/Cpp/runtime/src/atn/OrderedATNConfigSet.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t OrderedATNConfigSet::getHash(ATNConfig *c) {
+size_t OrderedATNConfigSet::getHash(const ATNConfig *c) const {
   return c->hashCode();
 }

--- a/runtime/Cpp/runtime/src/atn/OrderedATNConfigSet.h
+++ b/runtime/Cpp/runtime/src/atn/OrderedATNConfigSet.h
@@ -13,7 +13,7 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC OrderedATNConfigSet : public ATNConfigSet {
   protected:
-    virtual size_t getHash(ATNConfig *c) override;
+    size_t getHash(const ATNConfig *c) const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/PlusLoopbackState.h
+++ b/runtime/Cpp/runtime/src/atn/PlusLoopbackState.h
@@ -13,7 +13,6 @@ namespace atn {
   /// Decision state for {@code A+} and {@code (A|B)+}. It has two transitions:
   /// one to the loop back to start of the block and one to exit.
   class ANTLR4CPP_PUBLIC PlusLoopbackState final : public DecisionState {
-
   public:
     virtual size_t getStateType() override;
   };

--- a/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.cpp
@@ -11,7 +11,7 @@ using namespace antlr4;
 using namespace antlr4::atn;
 
 PredicateEvalInfo::PredicateEvalInfo(size_t decision, TokenStream *input, size_t startIndex, size_t stopIndex,
-  Ref<SemanticContext> const& semctx, bool evalResult, size_t predictedAlt, bool fullCtx)
+  Ref<SemanticContext> semctx, bool evalResult, size_t predictedAlt, bool fullCtx)
   : DecisionEventInfo(decision, nullptr, input, startIndex, stopIndex, fullCtx),
-    semctx(semctx), predictedAlt(predictedAlt), evalResult(evalResult) {
+    semctx(std::move(semctx)), predictedAlt(predictedAlt), evalResult(evalResult) {
 }

--- a/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.h
+++ b/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.h
@@ -55,7 +55,7 @@ namespace atn {
     /// <seealso cref= ParserATNSimulator#evalSemanticContext(SemanticContext, ParserRuleContext, int, boolean) </seealso>
     /// <seealso cref= SemanticContext#eval(Recognizer, RuleContext) </seealso>
     PredicateEvalInfo(size_t decision, TokenStream *input, size_t startIndex, size_t stopIndex,
-                      Ref<SemanticContext> const& semctx, bool evalResult, size_t predictedAlt, bool fullCtx);
+                      Ref<SemanticContext> semctx, bool evalResult, size_t predictedAlt, bool fullCtx);
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.h
@@ -13,7 +13,7 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC ProfilingATNSimulator : public ParserATNSimulator {
   public:
-    ProfilingATNSimulator(Parser *parser);
+    explicit ProfilingATNSimulator(Parser *parser);
 
     virtual size_t adaptivePredict(TokenStream *input, size_t decision, ParserRuleContext *outerContext) override;
 

--- a/runtime/Cpp/runtime/src/atn/RuleStartState.cpp
+++ b/runtime/Cpp/runtime/src/atn/RuleStartState.cpp
@@ -7,10 +7,6 @@
 
 using namespace antlr4::atn;
 
-RuleStartState::RuleStartState() {
-  isLeftRecursiveRule = false;
-}
-
 size_t RuleStartState::getStateType() {
   return RULE_START;
 }

--- a/runtime/Cpp/runtime/src/atn/RuleStartState.h
+++ b/runtime/Cpp/runtime/src/atn/RuleStartState.h
@@ -12,8 +12,6 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC RuleStartState final : public ATNState {
   public:
-    RuleStartState();
-
     RuleStopState *stopState = nullptr;
     bool isLeftRecursiveRule = false;
 

--- a/runtime/Cpp/runtime/src/atn/RuleStopState.h
+++ b/runtime/Cpp/runtime/src/atn/RuleStopState.h
@@ -15,7 +15,6 @@ namespace atn {
   /// references to all calls to this rule to compute FOLLOW sets for
   /// error handling.
   class ANTLR4CPP_PUBLIC RuleStopState final : public ATNState {
-
   public:
     virtual size_t getStateType() override;
 

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
@@ -137,11 +137,11 @@ SemanticContext::AND::AND(Ref<SemanticContext> const& a, Ref<SemanticContext> co
   std::copy(operands.begin(), operands.end(), std::back_inserter(opnds));
 }
 
-std::vector<Ref<SemanticContext>> SemanticContext::AND::getOperands() const {
+const std::vector<Ref<SemanticContext>>& SemanticContext::AND::getOperands() const {
   return opnds;
 }
 
-bool SemanticContext::AND::operator == (const SemanticContext &other) const {
+bool SemanticContext::AND::operator==(const SemanticContext &other) const {
   if (this == &other)
     return true;
 
@@ -239,11 +239,11 @@ SemanticContext::OR::OR(Ref<SemanticContext> const& a, Ref<SemanticContext> cons
   std::copy(operands.begin(), operands.end(), std::back_inserter(opnds));
 }
 
-std::vector<Ref<SemanticContext>> SemanticContext::OR::getOperands() const {
+const std::vector<Ref<SemanticContext>>& SemanticContext::OR::getOperands() const {
   return opnds;
 }
 
-bool SemanticContext::OR::operator == (const SemanticContext &other) const {
+bool SemanticContext::OR::operator==(const SemanticContext &other) const {
   if (this == &other)
     return true;
 
@@ -311,10 +311,7 @@ std::string SemanticContext::OR::toString() const {
 
 const Ref<SemanticContext> SemanticContext::NONE = std::make_shared<Predicate>(INVALID_INDEX, INVALID_INDEX, false);
 
-SemanticContext::~SemanticContext() {
-}
-
-bool SemanticContext::operator != (const SemanticContext &other) const {
+bool SemanticContext::operator!=(const SemanticContext &other) const {
   return !(*this == other);
 }
 
@@ -368,10 +365,4 @@ std::vector<Ref<SemanticContext::PrecedencePredicate>> SemanticContext::filterPr
   }
 
   return result;
-}
-
-
-//------------------ Operator -----------------------------------------------------------------------------------------
-
-SemanticContext::Operator::~Operator() {
 }

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.h
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.h
@@ -43,12 +43,12 @@ namespace atn {
      */
     static const Ref<SemanticContext> NONE;
 
-    virtual ~SemanticContext();
+    virtual ~SemanticContext() = default;
 
     virtual size_t hashCode() const = 0;
     virtual std::string toString() const = 0;
-    virtual bool operator == (const SemanticContext &other) const = 0;
-    virtual bool operator != (const SemanticContext &other) const;
+    virtual bool operator==(const SemanticContext &other) const = 0;
+    virtual bool operator!=(const SemanticContext &other) const;
 
     /// <summary>
     /// For context independent predicates, we evaluate them without a local
@@ -126,7 +126,7 @@ namespace atn {
     PrecedencePredicate();
 
   public:
-    PrecedencePredicate(int precedence);
+    explicit PrecedencePredicate(int precedence);
 
     virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) override;
     virtual Ref<SemanticContext> evalPrecedence(Recognizer *parser, RuleContext *parserCallStack) override;
@@ -144,8 +144,6 @@ namespace atn {
    */
   class ANTLR4CPP_PUBLIC SemanticContext::Operator : public SemanticContext {
   public:
-    virtual ~Operator() override;
-
     /**
      * Gets the operands for the semantic context operator.
      *
@@ -155,7 +153,7 @@ namespace atn {
      * @since 4.3
      */
 
-    virtual std::vector<Ref<SemanticContext>> getOperands() const = 0;
+    virtual const std::vector<Ref<SemanticContext>>& getOperands() const = 0;
   };
 
   /**
@@ -168,8 +166,8 @@ namespace atn {
 
     AND(Ref<SemanticContext> const& a, Ref<SemanticContext> const& b) ;
 
-    virtual std::vector<Ref<SemanticContext>> getOperands() const override;
-    virtual bool operator == (const SemanticContext &other) const override;
+    virtual const std::vector<Ref<SemanticContext>>& getOperands() const override;
+    virtual bool operator==(const SemanticContext &other) const override;
     virtual size_t hashCode() const override;
 
     /**
@@ -191,8 +189,8 @@ namespace atn {
 
     OR(Ref<SemanticContext> const& a, Ref<SemanticContext> const& b);
 
-    virtual std::vector<Ref<SemanticContext>> getOperands() const override;
-    virtual bool operator == (const SemanticContext &other) const override;
+    virtual const std::vector<Ref<SemanticContext>>& getOperands() const override;
+    virtual bool operator==(const SemanticContext &other) const override;
     virtual size_t hashCode() const override;
 
     /**

--- a/runtime/Cpp/runtime/src/atn/SetTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/SetTransition.cpp
@@ -11,8 +11,8 @@
 using namespace antlr4;
 using namespace antlr4::atn;
 
-SetTransition::SetTransition(ATNState *target, const misc::IntervalSet &aSet)
-  : Transition(target), set(aSet.isEmpty() ? misc::IntervalSet::of(Token::INVALID_TYPE) : aSet) {
+SetTransition::SetTransition(ATNState *target, misc::IntervalSet aSet)
+  : Transition(target), set(aSet.isEmpty() ? misc::IntervalSet::of(Token::INVALID_TYPE) : std::move(aSet)) {
 }
 
 Transition::SerializationType SetTransition::getSerializationType() const {

--- a/runtime/Cpp/runtime/src/atn/SetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/SetTransition.h
@@ -16,7 +16,7 @@ namespace atn {
   public:
     const misc::IntervalSet set;
 
-    SetTransition(ATNState *target, const misc::IntervalSet &set);
+    SetTransition(ATNState *target, misc::IntervalSet set);
 
     virtual SerializationType getSerializationType() const override;
 

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
@@ -9,22 +9,19 @@
 
 using namespace antlr4::atn;
 
-SingletonPredictionContext::SingletonPredictionContext(Ref<PredictionContext> const& parent, size_t returnState)
+SingletonPredictionContext::SingletonPredictionContext(Ref<PredictionContext> parent, size_t returnState)
   : PredictionContext(parent ? calculateHashCode(parent, returnState) : calculateEmptyHashCode()),
-    parent(parent), returnState(returnState) {
+    parent(std::move(parent)), returnState(returnState) {
   assert(returnState != ATNState::INVALID_STATE_NUMBER);
 }
 
-SingletonPredictionContext::~SingletonPredictionContext() {
-}
-
-Ref<SingletonPredictionContext> SingletonPredictionContext::create(Ref<PredictionContext> const& parent, size_t returnState) {
+Ref<SingletonPredictionContext> SingletonPredictionContext::create(Ref<PredictionContext> parent, size_t returnState) {
 
   if (returnState == EMPTY_RETURN_STATE && parent) {
     // someone can pass in the bits of an array ctx that mean $
     return std::dynamic_pointer_cast<SingletonPredictionContext>(EMPTY);
   }
-  return std::make_shared<SingletonPredictionContext>(parent, returnState);
+  return std::make_shared<SingletonPredictionContext>(std::move(parent), returnState);
 }
 
 size_t SingletonPredictionContext::size() const {

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.h
@@ -20,10 +20,10 @@ namespace atn {
     const Ref<PredictionContext> parent;
     const size_t returnState;
 
-    SingletonPredictionContext(Ref<PredictionContext> const& parent, size_t returnState);
-    virtual ~SingletonPredictionContext();
+    SingletonPredictionContext(Ref<PredictionContext> parent, size_t returnState);
+    virtual ~SingletonPredictionContext() = default;
 
-    static Ref<SingletonPredictionContext> create(Ref<PredictionContext> const& parent, size_t returnState);
+    static Ref<SingletonPredictionContext> create(Ref<PredictionContext> parent, size_t returnState);
 
     virtual size_t size() const override;
     virtual Ref<PredictionContext> getParent(size_t index) const override;

--- a/runtime/Cpp/runtime/src/atn/StarBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/StarBlockStartState.h
@@ -12,7 +12,6 @@ namespace atn {
 
   /// The block that begins a closure loop.
   class ANTLR4CPP_PUBLIC StarBlockStartState final : public BlockStartState {
-
   public:
     virtual size_t getStateType() override;
   };

--- a/runtime/Cpp/runtime/src/atn/StarLoopEntryState.cpp
+++ b/runtime/Cpp/runtime/src/atn/StarLoopEntryState.cpp
@@ -7,9 +7,6 @@
 
 using namespace antlr4::atn;
 
-StarLoopEntryState::StarLoopEntryState() : DecisionState(), isPrecedenceDecision(false) {
-}
-
 size_t StarLoopEntryState::getStateType() {
   return STAR_LOOP_ENTRY;
 }

--- a/runtime/Cpp/runtime/src/atn/StarLoopEntryState.h
+++ b/runtime/Cpp/runtime/src/atn/StarLoopEntryState.h
@@ -12,8 +12,6 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC StarLoopEntryState final : public DecisionState {
   public:
-    StarLoopEntryState();
-
     /**
      * Indicates whether this state can benefit from a precedence DFA during SLL
      * decision making.

--- a/runtime/Cpp/runtime/src/atn/StarLoopbackState.cpp
+++ b/runtime/Cpp/runtime/src/atn/StarLoopbackState.cpp
@@ -10,7 +10,7 @@
 
 using namespace antlr4::atn;
 
-StarLoopEntryState *StarLoopbackState::getLoopEntryState() {
+StarLoopEntryState *StarLoopbackState::getLoopEntryState() const {
   return dynamic_cast<StarLoopEntryState *>(transitions[0]->target);
 }
 

--- a/runtime/Cpp/runtime/src/atn/StarLoopbackState.h
+++ b/runtime/Cpp/runtime/src/atn/StarLoopbackState.h
@@ -12,7 +12,7 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC StarLoopbackState final : public ATNState {
   public:
-    StarLoopEntryState *getLoopEntryState();
+    StarLoopEntryState *getLoopEntryState() const;
 
     virtual size_t getStateType() override;
   };

--- a/runtime/Cpp/runtime/src/atn/TokensStartState.h
+++ b/runtime/Cpp/runtime/src/atn/TokensStartState.h
@@ -12,7 +12,6 @@ namespace atn {
 
   /// The Tokens rule start state linking to each lexer rule start state.
   class ANTLR4CPP_PUBLIC TokensStartState final : public DecisionState {
-
   public:
     virtual size_t getStateType() override;
   };

--- a/runtime/Cpp/runtime/src/atn/Transition.cpp
+++ b/runtime/Cpp/runtime/src/atn/Transition.cpp
@@ -25,9 +25,6 @@ Transition::Transition(ATNState *target) {
   this->target = target;
 }
 
-Transition::~Transition() {
-}
-
 bool Transition::isEpsilon() const {
   return false;
 }

--- a/runtime/Cpp/runtime/src/atn/Transition.h
+++ b/runtime/Cpp/runtime/src/atn/Transition.h
@@ -45,10 +45,10 @@ namespace atn {
     // ml: this is a reference into the ATN.
     ATNState *target;
 
-    virtual ~Transition();
+    virtual ~Transition() = default;
 
   protected:
-    Transition(ATNState *target);
+    explicit Transition(ATNState *target);
 
   public:
     virtual SerializationType getSerializationType() const = 0;

--- a/runtime/Cpp/runtime/src/atn/WildcardTransition.h
+++ b/runtime/Cpp/runtime/src/atn/WildcardTransition.h
@@ -12,7 +12,7 @@ namespace atn {
 
   class ANTLR4CPP_PUBLIC WildcardTransition final : public Transition {
   public:
-    WildcardTransition(ATNState *target);
+    explicit WildcardTransition(ATNState *target);
 
     virtual SerializationType getSerializationType() const override;
 

--- a/runtime/Cpp/runtime/src/misc/IntervalSet.h
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.h
@@ -23,7 +23,7 @@ namespace misc {
    * the range {@link Integer#MIN_VALUE} to {@link Integer#MAX_VALUE}
    * (inclusive).</p>
    */
-  class ANTLR4CPP_PUBLIC IntervalSet {
+  class ANTLR4CPP_PUBLIC IntervalSet final {
   public:
     static IntervalSet const COMPLETE_CHAR_SET;
     static IntervalSet const EMPTY_SET;

--- a/runtime/Cpp/runtime/src/support/BitSet.h
+++ b/runtime/Cpp/runtime/src/support/BitSet.h
@@ -54,7 +54,7 @@ namespace antlrcpp {
       return result;
     }
 
-    std::string toString(){
+    std::string toString() const {
       std::stringstream stream;
       stream << "{";
       bool valueAdded = false;


### PR DESCRIPTION
Various changes related to optimizations, cleanup, and const correctness fixes. The optimizations are related to `std::shared_ptr` and getting rid of unnecessary copying when possible as we as some prerequisite work for future improvements. The cleanup is marking things as final or removing odd whitespace. The const correctness is self explanatory.

Additionally this makes LL1Analyzer final and removes its virtual methods. Its not possible for generated code to override the LL1Analyzer and having virtual in the hot path is not free, unlike Java. In C++ virtual methods effectively guarantee CPU cache misses.

Lastly it moves a few methods in the hot path to be inline, specifically Recognizer::set/getState.