### PR TITLE
increase Windows CI concurrency for all targets except Dart

### DIFF
--- a/.github/scripts-windows/run-tests-csharp.cmd
+++ b/.github/scripts-windows/run-tests-csharp.cmd
@@ -1,5 +1,5 @@
 dotnet build runtime/CSharp/src/Antlr4.csproj -c Release
 dotnet pack runtime/CSharp/src/Antlr4.csproj -c Release
 cd runtime-testsuite
-mvn -Dtest=csharp.** test
+mvn -Dparallel=classes -DthreadCount=2 -Dtest=csharp.** test
 cd ..

--- a/.github/scripts-windows/run-tests-go.cmd
+++ b/.github/scripts-windows/run-tests-go.cmd
@@ -1,3 +1,3 @@
 cd runtime-testsuite
-mvn -Dtest=go.** test
+mvn -Dparallel=classes -DthreadCount=2 -Dtest=go.** test
 cd ..

--- a/.github/scripts-windows/run-tests-java.cmd
+++ b/.github/scripts-windows/run-tests-java.cmd
@@ -1,3 +1,3 @@
 cd runtime-testsuite
-mvn -Dtest=java.** test
+mvn -Dparallel=classes -DthreadCount=2 -Dtest=java.** test
 cd ..

--- a/.github/scripts-windows/run-tests-javascript.cmd
+++ b/.github/scripts-windows/run-tests-javascript.cmd
@@ -1,3 +1,3 @@
 cd runtime-testsuite
-mvn -Dtest=javascript.** test 
+mvn -Dparallel=classes -DthreadCount=2 -Dtest=javascript.** test
 cd ..

--- a/.github/scripts-windows/run-tests-php.cmd
+++ b/.github/scripts-windows/run-tests-php.cmd
@@ -4,5 +4,5 @@ git clone https://github.com/antlr/antlr-php-runtime.git
 move antlr-php-runtime runtime\PHP
 
 cd runtime-testsuite
-mvn -Dtest=php.** test -Dantlr-php-php="C:\tools\php81\php.exe"
+mvn -Dparallel=classes -DthreadCount=2 -Dtest=php.** test -Dantlr-php-php="C:\tools\php81\php.exe"
 cd ..

--- a/.github/scripts-windows/run-tests-python2.cmd
+++ b/.github/scripts-windows/run-tests-python2.cmd
@@ -1,3 +1,3 @@
 cd runtime-testsuite
-mvn -Dantlr-python2-python="C:\Python27\python.exe" -Dtest=python2.** test 
+mvn -Dparallel=classes -DthreadCount=2 -Dantlr-python2-python="C:\Python27\python.exe" -Dtest=python2.** test
 cd ..

--- a/.github/scripts-windows/run-tests-python3.cmd
+++ b/.github/scripts-windows/run-tests-python3.cmd
@@ -1,3 +1,3 @@
 cd runtime-testsuite
-mvn -Dantlr-python3-python="C:\Python310\python.exe" -Dtest=python3.** test 
+mvn -Dparallel=classes -DthreadCount=2 -Dantlr-python3-python="C:\Python310\python.exe" -Dtest=python3.** test
 cd ..


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->