### PR TITLE
[C++] Fix Windows min/max macro collision

### DIFF
--- a/runtime/Cpp/runtime/src/antlr4-common.h
+++ b/runtime/Cpp/runtime/src/antlr4-common.h
@@ -49,7 +49,7 @@
     #endif
   #endif
 
-  #define GUID_WINDOWS
+  #define ANTLR4CPP_GUID_WINDOWS 1
 
   #ifdef _WIN64
     typedef __int64 ssize_t;
@@ -68,14 +68,14 @@
   #endif
 
 #elif defined(__APPLE__)
-  #define GUID_CFUUID
+  #define ANTLR4CPP_GUID_CFUUID 1
   #if __GNUC__ >= 4
     #define ANTLR4CPP_PUBLIC __attribute__ ((visibility ("default")))
   #else
     #define ANTLR4CPP_PUBLIC
   #endif
 #else
-  #define GUID_LIBUUID
+  #define ANTLR4CPP_GUID_LIBUUID 1
   #if __GNUC__ >= 6
     #define ANTLR4CPP_PUBLIC __attribute__ ((visibility ("default")))
   #else
@@ -84,9 +84,9 @@
 #endif
 
 #ifdef __has_builtin
-#define ANTLR4_HAVE_BUILTIN(x) __has_builtin(x)
+#define ANTLR4CPP_HAVE_BUILTIN(x) __has_builtin(x)
 #else
-#define ANTLR4_HAVE_BUILTIN(x) 0
+#define ANTLR4CPP_HAVE_BUILTIN(x) 0
 #endif
 
 #include "support/Guid.h"

--- a/runtime/Cpp/runtime/src/misc/MurmurHash.cpp
+++ b/runtime/Cpp/runtime/src/misc/MurmurHash.cpp
@@ -25,7 +25,7 @@ using namespace antlr4::misc;
 #define ROTL32(x,y)	_rotl(x,y)
 #define ROTL64(x,y)	_rotl64(x,y)
 
-#elif ANTLR4_HAVE_BUILTIN(__builtin_rotateleft32) && ANTLR4_HAVE_BUILTIN(__builtin_rotateleft64)
+#elif ANTLR4CPP_HAVE_BUILTIN(__builtin_rotateleft32) && ANTLR4CPP_HAVE_BUILTIN(__builtin_rotateleft64)
 
 #define ROTL32(x, y) __builtin_rotateleft32(x, y)
 #define ROTL64(x, y) __builtin_rotateleft64(x, y)

--- a/runtime/Cpp/runtime/src/support/Guid.cpp
+++ b/runtime/Cpp/runtime/src/support/Guid.cpp
@@ -24,21 +24,27 @@
 
 #include <algorithm>
 
-#include "Guid.h"
+#include "support/Guid.h"
 
-#ifdef GUID_LIBUUID
+#ifdef ANTLR4CPP_GUID_LIBUUID
 #include <uuid/uuid.h>
 #endif
 
-#ifdef GUID_CFUUID
+#ifdef ANTLR4CPP_GUID_CFUUID
 #include <CoreFoundation/CFUUID.h>
 #endif
 
-#ifdef GUID_WINDOWS
+#ifdef ANTLR4CPP_GUID_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX 1
+#endif
 #include <objbase.h>
 #endif
 
-#ifdef GUID_ANDROID
+#ifdef ANTLR4CPP_GUID_ANDROID
 #include <jni.h>
 #endif
 
@@ -153,7 +159,7 @@ std::string Guid::toString() const {
 
 // This is the linux friendly implementation, but it could work on other
 // systems that have libuuid available
-#ifdef GUID_LIBUUID
+#ifdef ANTLR4CPP_GUID_LIBUUID
 Guid GuidGenerator::newGuid()
 {
   uuid_t id;
@@ -163,7 +169,7 @@ Guid GuidGenerator::newGuid()
 #endif
 
 // this is the mac and ios version
-#ifdef GUID_CFUUID
+#ifdef ANTLR4CPP_GUID_CFUUID
 Guid GuidGenerator::newGuid()
 {
   auto newId = CFUUIDCreate(NULL);
@@ -194,7 +200,7 @@ Guid GuidGenerator::newGuid()
 #endif
 
 // obviously this is the windows version
-#ifdef GUID_WINDOWS
+#ifdef ANTLR4CPP_GUID_WINDOWS
 Guid GuidGenerator::newGuid()
 {
   GUID newId;
@@ -228,7 +234,7 @@ Guid GuidGenerator::newGuid()
 #endif
 
 // android version that uses a call to a java api
-#ifdef GUID_ANDROID
+#ifdef ANTLR4CPP_GUID_ANDROID
 GuidGenerator::GuidGenerator(JNIEnv *env)
 {
   _env = env;

--- a/runtime/Cpp/runtime/src/support/Guid.h
+++ b/runtime/Cpp/runtime/src/support/Guid.h
@@ -32,7 +32,9 @@
 #include <string>
 #include <vector>
 
-#ifdef GUID_ANDROID
+#include "antlr4-common.h"
+
+#ifdef ANTLR4CPP_GUID_ANDROID
 #include <jni.h>
 #endif
 
@@ -133,7 +135,7 @@ private:
 // each platform, but the use of newGuid is uniform.
 class GuidGenerator final {
 public:
-#ifdef GUID_ANDROID
+#ifdef ANTLR4CPP_GUID_ANDROID
   GuidGenerator(JNIEnv *env);
 #else
   GuidGenerator() { }
@@ -141,7 +143,7 @@ public:
 
   Guid newGuid();
 
-#ifdef GUID_ANDROID
+#ifdef ANTLR4CPP_GUID_ANDROID
 private:
   JNIEnv *_env;
   jclass _uuidClass;


### PR DESCRIPTION
Set `WIN32_LEAN_AND_MEAN` and `NOMINMAX` when including a Windows API related header in `support/Guid.cpp`. This resolves #3489. Additionally I updated the macros to be prefixed with `ANTLR4CPP_` which is best practice for public headers.