### PR TITLE
Get rid of ATN serialization restrictions (ATN states size can be > 65535, up to 2^31-1), remove excess serialization and allocations

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
@@ -366,9 +366,10 @@ public abstract class BaseRuntimeTest {
 		}
 
 		if (group.equals("LexerExec")) {
-			descriptors.add(GeneratedLexerDescriptors.getLineSeparatorLfTest(targetName));
-			descriptors.add(GeneratedLexerDescriptors.getLineSeparatorCrLfTest(targetName));
+			descriptors.add(GeneratedLexerDescriptors.getLineSeparatorLfDescriptor(targetName));
+			descriptors.add(GeneratedLexerDescriptors.getLineSeparatorCrLfDescriptor(targetName));
 			descriptors.add(GeneratedLexerDescriptors.getLargeLexerDescriptor(targetName));
+			descriptors.add(GeneratedLexerDescriptors.getAtnStatesSizeMoreThan65535Descriptor(targetName));
 		}
 
 		return descriptors.toArray(new RuntimeTestDescriptor[0]);

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/GeneratedLexerDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/GeneratedLexerDescriptors.java
@@ -1,7 +1,9 @@
 package org.antlr.v4.test.runtime;
 
+import java.util.Collections;
+
 public class GeneratedLexerDescriptors {
-	static RuntimeTestDescriptor getLineSeparatorLfTest(String targetName) {
+	static RuntimeTestDescriptor getLineSeparatorLfDescriptor(String targetName) {
 		UniversalRuntimeTestDescriptor result = new UniversalRuntimeTestDescriptor();
 		result.name = "LineSeparatorLf";
 		result.targetName = targetName;
@@ -20,7 +22,7 @@ public class GeneratedLexerDescriptors {
 		return result;
 	}
 
-	static RuntimeTestDescriptor getLineSeparatorCrLfTest(String targetName) {
+	static RuntimeTestDescriptor getLineSeparatorCrLfDescriptor(String targetName) {
 		UniversalRuntimeTestDescriptor result = new UniversalRuntimeTestDescriptor();
 		result.name = "LineSeparatorCrLf";
 		result.targetName = targetName;
@@ -63,6 +65,52 @@ public class GeneratedLexerDescriptors {
 		result.input = "KW400";
 		result.output = "[@0,0:4='KW400',<402>,1:0]\n" +
 				"[@1,5:4='<EOF>',<-1>,1:5]\n";
+		return result;
+	}
+
+	static RuntimeTestDescriptor getAtnStatesSizeMoreThan65535Descriptor(String targetName) {
+		UniversalRuntimeTestDescriptor result = new UniversalRuntimeTestDescriptor();
+		result.name = "AtnStatesSizeMoreThan65535";
+		result.notes = "Regression for https://github.com/antlr/antlr4/issues/1863";
+		result.targetName = targetName;
+		result.testType = "Lexer";
+
+		final int tokensCount = 1024;
+		final String suffix = String.join("", Collections.nCopies(70, "_"));
+
+		String grammarName = "L";
+		StringBuilder grammar = new StringBuilder();
+		grammar.append("lexer grammar ").append(grammarName).append(";\n");
+		grammar.append('\n');
+		StringBuilder input = new StringBuilder();
+		StringBuilder output = new StringBuilder();
+		int startOffset;
+		int stopOffset = -2;
+		for (int i = 0; i < tokensCount; i++) {
+			String value = "T_" + i + suffix;
+			grammar.append(value).append(": '").append(value).append("';\n");
+			input.append(value).append('\n');
+
+			startOffset = stopOffset + 2;
+			stopOffset += value.length() + 1;
+
+			output.append("[@").append(i).append(',').append(startOffset).append(':').append(stopOffset)
+					.append("='").append(value).append("',<").append(i + 1).append(">,").append(i + 1)
+					.append(":0]\n");
+		}
+
+		grammar.append("\n");
+		grammar.append("WS: [ \\t\\r\\n]+ -> skip;\n");
+
+		startOffset = stopOffset + 2;
+		stopOffset = startOffset - 1;
+		output.append("[@").append(tokensCount).append(',').append(startOffset).append(':').append(stopOffset)
+				.append("='<EOF>',<-1>,").append(tokensCount + 1).append(":0]\n");
+
+		result.grammar = grammar.toString();
+		result.grammarName = grammarName;
+		result.input = input.toString();
+		result.output = output.toString();
 		return result;
 	}
 }

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
@@ -462,7 +462,7 @@ public class BaseJavaTest extends BaseRuntimeTestSupport implements RuntimeTestS
             anal.process();
 
 			CodeGenerator gen = CodeGenerator.create(g);
-			ST outputFileST = gen.generateParser(false);
+			ST outputFileST = gen.generateParser(false, null);
 			String output = outputFileST.render();
 			//System.out.println(output);
 			String b = "#" + actionName + "#";

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataReader.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataReader.java
@@ -1,0 +1,53 @@
+package org.antlr.v4.runtime.atn;
+
+import java.util.UUID;
+
+public class ATNDataReader {
+	private final char[] data;
+	private int p;
+
+	public ATNDataReader(char[] data) {
+		this.data = data;
+	}
+
+	public UUID readUUID() {
+		long leastSigBits = ((long) readUInt32() & 0x00000000FFFFFFFFL) | ((long) readUInt32() << 32);
+		long mostSigBits = (long) readUInt32() | ((long) readUInt32() << 32);
+		return new UUID(mostSigBits, leastSigBits);
+	}
+
+	public int readUInt32() {
+		return readUInt16() | (readUInt16() << 16);
+	}
+
+	public int readCompactUInt32() {
+		int value = readUInt16();
+		return value < 0b1000_0000_0000_0000 && value >= 0
+				? value
+				: (readUInt16() << 15) | (value & 0b0111_1111_1111_1111);
+	}
+
+	public int readUInt16() {
+		return readUInt16(true);
+	}
+
+	public int readUInt16(boolean normalize) {
+		int result = data[p++];
+		// Each char value in data is shifted by +2 at the entry to this method.
+		// This is an encoding optimization targeting the serialized values 0
+		// and -1 (serialized to 0xFFFF), each of which are very common in the
+		// serialized form of the ATN. In the modified UTF-8 that Java uses for
+		// compiled string literals, these two character values have multi-byte
+		// forms. By shifting each value by +2, they become characters 2 and 1
+		// prior to writing the string, each of which have single-byte
+		// representations. Since the shift occurs in the tool during ATN
+		// serialization, each target is responsible for adjusting the values
+		// during deserialization.
+		//
+		// As a special case, note that the first element of data is not
+		// adjusted because it contains the major version number of the
+		// serialized ATN, which was fixed at 3 at the time the value shifting
+		// was implemented.
+		return normalize ? (result > 1 ? result - ATNDataWriter.OptimizeOffset : result + 65534) : result;
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataWriter.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataWriter.java
@@ -1,0 +1,53 @@
+package org.antlr.v4.runtime.atn;
+
+import org.antlr.v4.runtime.misc.IntegerList;
+
+import java.util.UUID;
+
+public class ATNDataWriter {
+	public static final int OptimizeOffset = 2;
+
+	private final IntegerList data;
+
+	public ATNDataWriter(IntegerList data) {
+		this.data = data;
+	}
+
+	public void writeUUID(UUID uuid) {
+		long leastSignificantBits = uuid.getLeastSignificantBits();
+		writeUInt32((int)leastSignificantBits);
+		writeUInt32((int)(leastSignificantBits >> 32));
+		long mostSignificantBits = uuid.getMostSignificantBits();
+		writeUInt32((int)mostSignificantBits);
+		writeUInt32((int)(mostSignificantBits >> 32));
+	}
+
+	public void writeUInt32(int value) {
+		writeUInt16((char)value);
+		writeUInt16((char)(value >> 16));
+	}
+
+	public void writeCompactUInt32(int value) {
+		if (value < 0b1000_0000_0000_0000) {
+			writeUInt16(value);
+		} else {
+			writeUInt16((value & 0b0111_1111_1111_1111) | (1 << 15));
+			writeUInt16(value >>> 15);
+		}
+	}
+
+	public void writeUInt16(int value) {
+		writeUInt16(value, true);
+	}
+
+	public void writeUInt16(int value, boolean optimize) {
+		if (value < Character.MIN_VALUE || value > Character.MAX_VALUE) {
+			throw new UnsupportedOperationException("Serialized ATN data element "+
+					data.size() + " element " + value + " out of range "+
+					(int)Character.MIN_VALUE + ".." + (int)Character.MAX_VALUE);
+		}
+		// Note: This value shifting loop is documented in ATNDeserializer.
+		// don't adjust the first value since that's the version number
+		data.add(optimize ? (value + OptimizeOffset) & 0xFFFF : value);
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSerializer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSerializer.java
@@ -12,7 +12,6 @@ import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.misc.IntervalSet;
 import org.antlr.v4.runtime.misc.Utils;
 
-import java.io.InvalidClassException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -20,22 +19,21 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.UUID;
 
 public class ATNSerializer {
+	public static char[] getSerializedAsChars(ATN atn) {
+		return Utils.toCharArray(getSerialized(atn));
+	}
+
+	public static IntegerList getSerialized(ATN atn) {
+		return new ATNSerializer(atn).serialize();
+	}
+
 	public final ATN atn;
-	private final List<String> tokenNames;
 
 	public ATNSerializer(ATN atn) {
 		assert atn.grammarType != null;
 		this.atn = atn;
-		this.tokenNames = null;
-	}
-
-	public ATNSerializer(ATN atn, List<String> tokenNames) {
-		assert atn.grammarType != null;
-		this.atn = atn;
-		this.tokenNames = tokenNames;
 	}
 
 	/** Serialize state descriptors, edge descriptors, and decision&rarr;state map
@@ -347,196 +345,5 @@ public class ATNSerializer {
 				}
 			}
 		}
-	}
-
-	public String decode(char[] data) {
-		ATNDataReader dataReader = new ATNDataReader(data);
-		StringBuilder buf = new StringBuilder();
-		int version = dataReader.readUInt16(false);
-		if (version != ATNDeserializer.SERIALIZED_VERSION) {
-			String reason = String.format("Could not deserialize ATN with version %d (expected %d).", version, ATNDeserializer.SERIALIZED_VERSION);
-			throw new UnsupportedOperationException(new InvalidClassException(ATN.class.getName(), reason));
-		}
-
-		UUID uuid = dataReader.readUUID();
-		if (!uuid.equals(ATNDeserializer.SERIALIZED_UUID)) {
-			String reason = String.format(Locale.getDefault(), "Could not deserialize ATN with UUID %s (expected %s).", uuid, ATNDeserializer.SERIALIZED_UUID);
-			throw new UnsupportedOperationException(new InvalidClassException(ATN.class.getName(), reason));
-		}
-
-		dataReader.read(); // skip grammarType
-		int maxType = dataReader.read();
-		buf.append("max type ").append(maxType).append("\n");
-		int nstates = dataReader.read();
-		for (int i=0; i<nstates; i++) {
-			int stype = dataReader.read();
-			if ( stype==ATNState.INVALID_TYPE ) continue; // ignore bad type of states
-			int ruleIndex = dataReader.read();
-
-			String arg = "";
-			if ( stype == ATNState.LOOP_END ) {
-				int loopBackStateNumber = dataReader.read();
-				arg = " "+loopBackStateNumber;
-			}
-			else if ( stype == ATNState.PLUS_BLOCK_START || stype == ATNState.STAR_BLOCK_START || stype == ATNState.BLOCK_START ) {
-				int endStateNumber = dataReader.read();
-				arg = " "+endStateNumber;
-			}
-			buf.append(i).append(":")
-				.append(ATNState.serializationNames.get(stype)).append(" ")
-				.append(ruleIndex).append(arg).append("\n");
-		}
-		// this code is meant to model the form of ATNDeserializer.deserialize,
-		// since both need to be updated together whenever a change is made to
-		// the serialization format. The "dead" code is only used in debugging
-		// and testing scenarios, so the form you see here was kept for
-		// improved maintainability.
-		// start
-		int numNonGreedyStates = dataReader.read();
-		for (int i = 0; i < numNonGreedyStates; i++) {
-			dataReader.read(); // Skip stateNumber
-		}
-		int numPrecedenceStates = dataReader.read();
-		for (int i = 0; i < numPrecedenceStates; i++) {
-			dataReader.read(); // Skip stateNumber
-		}
-		// finish
-		int nrules = dataReader.read();
-		for (int i=0; i<nrules; i++) {
-			int s = dataReader.read();
-			buf.append("rule ").append(i).append(":").append(s);
-			if (atn.grammarType == ATNType.LEXER) {
-				buf.append(" ").append(dataReader.read());
-			}
-			buf.append('\n');
-		}
-		int nmodes = dataReader.read();
-		for (int i=0; i<nmodes; i++) {
-			int s = dataReader.read();
-			buf.append("mode ").append(i).append(":").append(s).append('\n');
-		}
-		int offset = appendSets(buf, dataReader, 0, UnicodeSerializeMode.UNICODE_BMP);
-		appendSets(buf, dataReader, offset, UnicodeSerializeMode.UNICODE_SMP);
-		int nedges = dataReader.read();
-		for (int i=0; i<nedges; i++) {
-			int src = dataReader.read();
-			int trg = dataReader.read();
-			int ttype = dataReader.read();
-			int arg1 = dataReader.read();
-			int arg2 = dataReader.read();
-			int arg3 = dataReader.read();
-			buf.append(src).append("->").append(trg)
-				.append(" ").append(Transition.serializationNames.get(ttype))
-				.append(" ").append(arg1).append(",").append(arg2).append(",").append(arg3)
-				.append("\n");
-		}
-		int ndecisions = dataReader.read();
-		for (int i=0; i<ndecisions; i++) {
-			int s = dataReader.read();
-			buf.append(i).append(":").append(s).append("\n");
-		}
-		if (atn.grammarType == ATNType.LEXER) {
-			// this code is meant to model the form of ATNDeserializer.deserialize,
-			// since both need to be updated together whenever a change is made to
-			// the serialization format. The "dead" code is only used in debugging
-			// and testing scenarios, so the form you see here was kept for
-			// improved maintainability.
-			int lexerActionCount = dataReader.read();
-			for (int i = 0; i < lexerActionCount; i++) {
-				dataReader.read(); // Skip actionType
-				dataReader.read();
-				dataReader.read();
-			}
-		}
-		return buf.toString();
-	}
-
-	private int appendSets(StringBuilder buf, ATNDataReader dataReader, int setIndexOffset, UnicodeSerializeMode mode) {
-		int nsets = dataReader.read();
-		for (int i=0; i<nsets; i++) {
-			int nintervals = dataReader.read();
-			buf.append(i + setIndexOffset).append(":");
-			boolean containsEof = dataReader.read() != 0;
-			if (containsEof) {
-				buf.append(getTokenName(Token.EOF));
-			}
-
-			for (int j=0; j<nintervals; j++) {
-				if ( containsEof || j>0 ) {
-					buf.append(", ");
-				}
-
-				int a, b;
-				if (mode == UnicodeSerializeMode.UNICODE_BMP) {
-					a = dataReader.readUInt16();
-					b = dataReader.readUInt16();
-				} else {
-					a = dataReader.readInt32();
-					b = dataReader.readInt32();
-				}
-				buf.append(getTokenName(a)).append("..").append(getTokenName(b));
-			}
-			buf.append("\n");
-		}
-		return nsets;
-	}
-
-	public String getTokenName(int t) {
-		if ( t==-1 ) return "EOF";
-
-		if ( atn.grammarType == ATNType.LEXER &&
-			 t >= Character.MIN_VALUE && t <= Character.MAX_VALUE )
-		{
-			switch (t) {
-			case '\n':
-				return "'\\n'";
-			case '\r':
-				return "'\\r'";
-			case '\t':
-				return "'\\t'";
-			case '\b':
-				return "'\\b'";
-			case '\f':
-				return "'\\f'";
-			case '\\':
-				return "'\\\\'";
-			case '\'':
-				return "'\\''";
-			default:
-				if ( Character.UnicodeBlock.of((char)t)==Character.UnicodeBlock.BASIC_LATIN &&
-					 !Character.isISOControl((char)t) ) {
-					return '\''+Character.toString((char)t)+'\'';
-				}
-				// turn on the bit above max "\uFFFF" value so that we pad with zeros
-				// then only take last 4 digits
-				String hex = Integer.toHexString(t|0x10000).toUpperCase().substring(1,5);
-				return "'\\u"+hex+"'";
-			}
-		}
-
-		if (tokenNames != null && t >= 0 && t < tokenNames.size()) {
-			return tokenNames.get(t);
-		}
-
-		return String.valueOf(t);
-	}
-
-	/** Used by Java target to encode short/int array as chars in string. */
-	public static String getSerializedAsString(ATN atn) {
-		return new String(getSerializedAsChars(atn));
-	}
-
-	public static IntegerList getSerialized(ATN atn) {
-		return new ATNSerializer(atn).serialize();
-	}
-
-	public static char[] getSerializedAsChars(ATN atn) {
-		return Utils.toCharArray(getSerialized(atn));
-	}
-
-	public static String getDecoded(ATN atn, List<String> tokenNames) {
-		IntegerList serialized = getSerialized(atn);
-		char[] data = Utils.toCharArray(serialized);
-		return new ATNSerializer(atn, tokenNames).decode(data);
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
@@ -98,11 +98,8 @@ public abstract class ATNSimulator {
 		if ( sharedContextCache==null ) return context;
 
 		synchronized (sharedContextCache) {
-			IdentityHashMap<PredictionContext, PredictionContext> visited =
-				new IdentityHashMap<PredictionContext, PredictionContext>();
-			return PredictionContext.getCachedContext(context,
-													  sharedContextCache,
-													  visited);
+			IdentityHashMap<PredictionContext, PredictionContext> visited = new IdentityHashMap<>();
+			return PredictionContext.getCachedContext(context, sharedContextCache, visited);
 		}
 	}
 
@@ -128,38 +125,6 @@ public abstract class ATNSimulator {
 	@Deprecated
 	public static void checkCondition(boolean condition, String message) {
 		new ATNDeserializer().checkCondition(condition, message);
-	}
-
-	/**
-	 * @deprecated Use {@link ATNDeserializer#toInt} instead.
-	 */
-	@Deprecated
-	public static int toInt(char c) {
-		return ATNDeserializer.toInt(c);
-	}
-
-	/**
-	 * @deprecated Use {@link ATNDeserializer#toInt32} instead.
-	 */
-	@Deprecated
-	public static int toInt32(char[] data, int offset) {
-		return ATNDeserializer.toInt32(data, offset);
-	}
-
-	/**
-	 * @deprecated Use {@link ATNDeserializer#toLong} instead.
-	 */
-	@Deprecated
-	public static long toLong(char[] data, int offset) {
-		return ATNDeserializer.toLong(data, offset);
-	}
-
-	/**
-	 * @deprecated Use {@link ATNDeserializer#toUUID} instead.
-	 */
-	@Deprecated
-	public static UUID toUUID(char[] data, int offset) {
-		return ATNDeserializer.toUUID(data, offset);
 	}
 
 	/**

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/UnicodeSerializeMode.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/UnicodeSerializeMode.java
@@ -1,6 +1,6 @@
 package org.antlr.v4.runtime.atn;
 
-enum UnicodeSerializeMode {
+public enum UnicodeSerializeMode {
 	UNICODE_BMP,
 	UNICODE_SMP
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/UnicodeSerializeMode.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/UnicodeSerializeMode.java
@@ -1,0 +1,6 @@
+package org.antlr.v4.runtime.atn;
+
+enum UnicodeSerializeMode {
+	UNICODE_BMP,
+	UNICODE_SMP
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/misc/IntegerList.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/IntegerList.java
@@ -15,11 +15,10 @@ import java.util.List;
  */
 public class IntegerList {
 
-	private static int[] EMPTY_DATA = new int[0];
+	private static final int[] EMPTY_DATA = new int[0];
 
 	private static final int INITIAL_SIZE = 4;
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
-
 
 	private int[] _data;
 
@@ -34,12 +33,7 @@ public class IntegerList {
 			throw new IllegalArgumentException();
 		}
 
-		if (capacity == 0) {
-			_data = EMPTY_DATA;
-		}
-		else {
-			_data = new int[capacity];
-		}
+		_data = capacity == 0 ? EMPTY_DATA : new int[capacity];
 	}
 
 	public IntegerList(IntegerList list) {
@@ -256,13 +250,7 @@ public class IntegerList {
 			throw new OutOfMemoryError();
 		}
 
-		int newLength;
-		if (_data.length == 0) {
-			newLength = INITIAL_SIZE;
-		}
-		else {
-			newLength = _data.length;
-		}
+		int newLength = _data.length == 0 ? INITIAL_SIZE : _data.length;
 
 		while (newLength < capacity) {
 			newLength = newLength * 2;

--- a/tool-testsuite/test/org/antlr/v4/test/tool/ATNDeserializerHelper.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/ATNDeserializerHelper.java
@@ -1,0 +1,199 @@
+package org.antlr.v4.test.tool;
+
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.atn.*;
+import org.antlr.v4.runtime.misc.IntegerList;
+import org.antlr.v4.runtime.misc.Utils;
+
+import java.io.InvalidClassException;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+public class ATNDeserializerHelper {
+	public static String getDecoded(ATN atn, List<String> tokenNames) {
+		IntegerList serialized = new ATNSerializer(atn).serialize();
+		char[] data = Utils.toCharArray(serialized);
+		return new ATNDeserializerHelper(atn, tokenNames).decode(data);
+	}
+
+	public final ATN atn;
+	private final List<String> tokenNames;
+
+	public ATNDeserializerHelper(ATN atn, List<String> tokenNames) {
+		this.atn = atn;
+		this.tokenNames = tokenNames;
+	}
+
+	public String decode(char[] data) {
+		ATNDataReader dataReader = new ATNDataReader(data);
+		StringBuilder buf = new StringBuilder();
+		int version = dataReader.readUInt16(false);
+		if (version != ATNDeserializer.SERIALIZED_VERSION) {
+			String reason = String.format("Could not deserialize ATN with version %d (expected %d).", version, ATNDeserializer.SERIALIZED_VERSION);
+			throw new UnsupportedOperationException(new InvalidClassException(ATN.class.getName(), reason));
+		}
+
+		UUID uuid = dataReader.readUUID();
+		if (!uuid.equals(ATNDeserializer.SERIALIZED_UUID)) {
+			String reason = String.format(Locale.getDefault(), "Could not deserialize ATN with UUID %s (expected %s).", uuid, ATNDeserializer.SERIALIZED_UUID);
+			throw new UnsupportedOperationException(new InvalidClassException(ATN.class.getName(), reason));
+		}
+
+		dataReader.read(); // skip grammarType
+		int maxType = dataReader.read();
+		buf.append("max type ").append(maxType).append("\n");
+		int nstates = dataReader.read();
+		for (int i=0; i<nstates; i++) {
+			int stype = dataReader.read();
+			if ( stype== ATNState.INVALID_TYPE ) continue; // ignore bad type of states
+			int ruleIndex = dataReader.read();
+
+			String arg = "";
+			if ( stype == ATNState.LOOP_END ) {
+				int loopBackStateNumber = dataReader.read();
+				arg = " "+loopBackStateNumber;
+			}
+			else if ( stype == ATNState.PLUS_BLOCK_START || stype == ATNState.STAR_BLOCK_START || stype == ATNState.BLOCK_START ) {
+				int endStateNumber = dataReader.read();
+				arg = " "+endStateNumber;
+			}
+			buf.append(i).append(":")
+					.append(ATNState.serializationNames.get(stype)).append(" ")
+					.append(ruleIndex).append(arg).append("\n");
+		}
+		// this code is meant to model the form of ATNDeserializer.deserialize,
+		// since both need to be updated together whenever a change is made to
+		// the serialization format. The "dead" code is only used in debugging
+		// and testing scenarios, so the form you see here was kept for
+		// improved maintainability.
+		// start
+		int numNonGreedyStates = dataReader.read();
+		for (int i = 0; i < numNonGreedyStates; i++) {
+			dataReader.read(); // Skip stateNumber
+		}
+		int numPrecedenceStates = dataReader.read();
+		for (int i = 0; i < numPrecedenceStates; i++) {
+			dataReader.read(); // Skip stateNumber
+		}
+		// finish
+		int nrules = dataReader.read();
+		for (int i=0; i<nrules; i++) {
+			int s = dataReader.read();
+			buf.append("rule ").append(i).append(":").append(s);
+			if (atn.grammarType == ATNType.LEXER) {
+				buf.append(" ").append(dataReader.read());
+			}
+			buf.append('\n');
+		}
+		int nmodes = dataReader.read();
+		for (int i=0; i<nmodes; i++) {
+			int s = dataReader.read();
+			buf.append("mode ").append(i).append(":").append(s).append('\n');
+		}
+		int offset = appendSets(buf, dataReader, 0, UnicodeSerializeMode.UNICODE_BMP);
+		appendSets(buf, dataReader, offset, UnicodeSerializeMode.UNICODE_SMP);
+		int nedges = dataReader.read();
+		for (int i=0; i<nedges; i++) {
+			int src = dataReader.read();
+			int trg = dataReader.read();
+			int ttype = dataReader.read();
+			int arg1 = dataReader.read();
+			int arg2 = dataReader.read();
+			int arg3 = dataReader.read();
+			buf.append(src).append("->").append(trg)
+					.append(" ").append(Transition.serializationNames.get(ttype))
+					.append(" ").append(arg1).append(",").append(arg2).append(",").append(arg3)
+					.append("\n");
+		}
+		int ndecisions = dataReader.read();
+		for (int i=0; i<ndecisions; i++) {
+			int s = dataReader.read();
+			buf.append(i).append(":").append(s).append("\n");
+		}
+		if (atn.grammarType == ATNType.LEXER) {
+			// this code is meant to model the form of ATNDeserializer.deserialize,
+			// since both need to be updated together whenever a change is made to
+			// the serialization format. The "dead" code is only used in debugging
+			// and testing scenarios, so the form you see here was kept for
+			// improved maintainability.
+			int lexerActionCount = dataReader.read();
+			for (int i = 0; i < lexerActionCount; i++) {
+				dataReader.read(); // Skip actionType
+				dataReader.read();
+				dataReader.read();
+			}
+		}
+		return buf.toString();
+	}
+
+	public String getTokenName(int t) {
+		if ( t==-1 ) return "EOF";
+
+		if ( atn.grammarType == ATNType.LEXER &&
+				t >= Character.MIN_VALUE && t <= Character.MAX_VALUE )
+		{
+			switch (t) {
+				case '\n':
+					return "'\\n'";
+				case '\r':
+					return "'\\r'";
+				case '\t':
+					return "'\\t'";
+				case '\b':
+					return "'\\b'";
+				case '\f':
+					return "'\\f'";
+				case '\\':
+					return "'\\\\'";
+				case '\'':
+					return "'\\''";
+				default:
+					if ( Character.UnicodeBlock.of((char)t)==Character.UnicodeBlock.BASIC_LATIN &&
+							!Character.isISOControl((char)t) ) {
+						return '\''+Character.toString((char)t)+'\'';
+					}
+					// turn on the bit above max "\uFFFF" value so that we pad with zeros
+					// then only take last 4 digits
+					String hex = Integer.toHexString(t|0x10000).toUpperCase().substring(1,5);
+					return "'\\u"+hex+"'";
+			}
+		}
+
+		if (tokenNames != null && t >= 0 && t < tokenNames.size()) {
+			return tokenNames.get(t);
+		}
+
+		return String.valueOf(t);
+	}
+
+	private int appendSets(StringBuilder buf, ATNDataReader dataReader, int setIndexOffset, UnicodeSerializeMode mode) {
+		int nsets = dataReader.read();
+		for (int i=0; i<nsets; i++) {
+			int nintervals = dataReader.read();
+			buf.append(i + setIndexOffset).append(":");
+			boolean containsEof = dataReader.read() != 0;
+			if (containsEof) {
+				buf.append(getTokenName(Token.EOF));
+			}
+
+			for (int j=0; j<nintervals; j++) {
+				if ( containsEof || j>0 ) {
+					buf.append(", ");
+				}
+
+				int a, b;
+				if (mode == UnicodeSerializeMode.UNICODE_BMP) {
+					a = dataReader.readUInt16();
+					b = dataReader.readUInt16();
+				} else {
+					a = dataReader.readInt32();
+					b = dataReader.readInt32();
+				}
+				buf.append(getTokenName(a)).append("..").append(getTokenName(b));
+			}
+			buf.append("\n");
+		}
+		return nsets;
+	}
+}

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestATNDeserialization.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestATNDeserialization.java
@@ -208,9 +208,9 @@ public class TestATNDeserialization extends BaseJavaToolTest {
 	protected void checkDeserializationIsStable(Grammar g) {
 		ATN atn = createATN(g, false);
 		char[] data = Utils.toCharArray(ATNSerializer.getSerialized(atn));
-		String atnData = ATNSerializer.getDecoded(atn, Arrays.asList(g.getTokenNames()));
+		String atnData = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(g.getTokenNames()));
 		ATN atn2 = new ATNDeserializer().deserialize(data);
-		String atn2Data = ATNSerializer.getDecoded(atn2, Arrays.asList(g.getTokenNames()));
+		String atn2Data = ATNDeserializerHelper.getDecoded(atn2, Arrays.asList(g.getTokenNames()));
 
 		assertEquals(atnData, atn2Data);
 	}

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestATNSerialization.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestATNSerialization.java
@@ -7,7 +7,6 @@
 package org.antlr.v4.test.tool;
 
 import org.antlr.v4.runtime.atn.ATN;
-import org.antlr.v4.runtime.atn.ATNSerializer;
 import org.antlr.v4.tool.DOTGenerator;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.LexerGrammar;
@@ -43,7 +42,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"3->4 ATOM 2,0,0\n" +
 				"4->1 EPSILON 0,0,0\n";
 		ATN atn = createATN(g, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(g.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(g.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -65,7 +64,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"3->4 ATOM 0,0,1\n" +
 				"4->1 EPSILON 0,0,0\n";
 		ATN atn = createATN(g, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(g.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(g.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -86,7 +85,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"2->3 SET 0,0,0\n" +
 				"3->1 EPSILON 0,0,0\n";
 		ATN atn = createATN(g, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(g.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(g.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -109,7 +108,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"3->1 EPSILON 0,0,0\n";
 		ATN atn = createATN(g, true);
 		DOTGenerator gen = new DOTGenerator(g);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(g.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(g.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -130,7 +129,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"2->3 WILDCARD 0,0,0\n" +
 			"3->1 EPSILON 0,0,0\n";
 		ATN atn = createATN(g, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(g.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(g.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -158,7 +157,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"6->1 EPSILON 0,0,0\n" +
 				"0:5\n";
 		ATN atn = createATN(g, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(g.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(g.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -193,7 +192,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"9->1 EPSILON 0,0,0\n" +
 				"0:8\n";
 		ATN atn = createATN(g, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(g.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(g.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -225,7 +224,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"8->1 EPSILON 0,0,0\n" +
 				"0:5\n";
 		ATN atn = createATN(g, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(g.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(g.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -254,7 +253,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"6->7 ATOM 1,0,0\n" +
 				"7->3 EPSILON 0,0,0\n";
 		ATN atn = createATN(g, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(g.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(g.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -287,7 +286,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"8->4 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -311,7 +310,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -335,7 +334,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -370,7 +369,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"8->4 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -394,7 +393,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -417,7 +416,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -442,7 +441,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"5->2 EPSILON 0,0,0\n" +
 				"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -471,7 +470,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"0:0\n" +
 				"1:5\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -502,7 +501,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"0:0\n" +
 				"1:6\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -549,7 +548,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"14->6 EPSILON 0,0,0\n" +
 				"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -573,7 +572,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -597,7 +596,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -621,7 +620,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -645,7 +644,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -669,7 +668,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -693,7 +692,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -717,7 +716,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -741,7 +740,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -765,7 +764,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -789,7 +788,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -813,7 +812,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -837,7 +836,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"4->2 EPSILON 0,0,0\n" +
 			"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -900,7 +899,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"1:1\n" +
 				"2:11\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -927,7 +926,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"5->2 EPSILON 0,0,0\n" +
 				"0:0\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -984,7 +983,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"0:0\n" +
 			"1:1\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 
@@ -1035,7 +1034,7 @@ public class TestATNSerialization extends BaseJavaToolTest {
 			"1:1\n" +
 			"2:2\n";
 		ATN atn = createATN(lg, true);
-		String result = ATNSerializer.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
+		String result = ATNDeserializerHelper.getDecoded(atn, Arrays.asList(lg.getTokenNames()));
 		assertEquals(expecting, result);
 	}
 

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestCodeGeneration.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestCodeGeneration.java
@@ -131,7 +131,7 @@ public class TestCodeGeneration extends BaseJavaToolTest {
 			g.atn = factory.createATN();
 
 			CodeGenerator gen = CodeGenerator.create(g);
-			ST outputFileST = gen.generateParser();
+			ST outputFileST = gen.generateParser(null);
 
 //			STViz viz = outputFileST.inspect();
 //			try {

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -395,19 +395,19 @@ public class Tool {
 
 		if ( generate_ATN_dot ) generateATNs(g);
 
-		if (gencode && g.tool.getNumErrors()==0 ) generateInterpreterData(g);
+		IntegerList atnData = gencode && g.tool.getNumErrors()==0
+			? generateInterpreterData(g)
+			: null;
 
 		// PERFORM GRAMMAR ANALYSIS ON ATN: BUILD DECISION DFAs
 		AnalysisPipeline anal = new AnalysisPipeline(g);
 		anal.process();
 
-		//if ( generate_DFA_dot ) generateDFAs(g);
-
 		if ( g.tool.getNumErrors()>prevErrors ) return;
 
 		// GENERATE CODE
 		if ( gencode ) {
-			CodeGenPipeline gen = new CodeGenPipeline(g, codeGenerator);
+			CodeGenPipeline gen = new CodeGenPipeline(g, codeGenerator, atnData);
 			gen.process();
 		}
 	}
@@ -695,27 +695,27 @@ public class Tool {
 		}
 	}
 
-	private void generateInterpreterData(Grammar g) {
+	private IntegerList generateInterpreterData(Grammar g) {
 		StringBuilder content = new StringBuilder();
 
 		content.append("token literal names:\n");
 		String[] names = g.getTokenLiteralNames();
 		for (String name : names) {
-			content.append(name + "\n");
+			content.append(name).append("\n");
 		}
 		content.append("\n");
 
 		content.append("token symbolic names:\n");
 		names = g.getTokenSymbolicNames();
 		for (String name : names) {
-			content.append(name + "\n");
+			content.append(name).append("\n");
 		}
 		content.append("\n");
 
 		content.append("rule names:\n");
 		names = g.getRuleNames();
 		for (String name : names) {
-			content.append(name + "\n");
+			content.append(name).append("\n");
 		}
 		content.append("\n");
 
@@ -724,33 +724,31 @@ public class Tool {
 			content.append("DEFAULT_TOKEN_CHANNEL\n");
 			content.append("HIDDEN\n");
 			for (String channel : g.channelValueToNameList) {
-				content.append(channel + "\n");
+				content.append(channel).append("\n");
 			}
 			content.append("\n");
 
 			content.append("mode names:\n");
 			for (String mode : ((LexerGrammar)g).modes.keySet()) {
-				content.append(mode + "\n");
+				content.append(mode).append("\n");
 			}
 		}
 		content.append("\n");
 
-		IntegerList serializedATN = ATNSerializer.getSerialized(g.atn);
+		IntegerList atnData = ATNSerializer.getSerialized(g.atn);
 		content.append("atn:\n");
-		content.append(serializedATN.toString());
+		content.append(atnData.toString());
 
 		try {
-			Writer fw = getOutputFileWriter(g, g.name + ".interp");
-			try {
+			try (Writer fw = getOutputFileWriter(g, g.name + ".interp")) {
 				fw.write(content.toString());
-			}
-			finally {
-				fw.close();
 			}
 		}
 		catch (IOException ioe) {
 			errMgr.toolError(ErrorType.CANNOT_WRITE_FILE, ioe);
 		}
+
+		return atnData;
 	}
 
 	/** This method is used by all code generators to create new output

--- a/tool/src/org/antlr/v4/codegen/BlankOutputModelFactory.java
+++ b/tool/src/org/antlr/v4/codegen/BlankOutputModelFactory.java
@@ -15,6 +15,7 @@ import org.antlr.v4.codegen.model.Parser;
 import org.antlr.v4.codegen.model.ParserFile;
 import org.antlr.v4.codegen.model.RuleFunction;
 import org.antlr.v4.codegen.model.SrcOp;
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.runtime.misc.IntervalSet;
 import org.antlr.v4.tool.Alternative;
 import org.antlr.v4.tool.Rule;
@@ -29,7 +30,7 @@ public abstract class BlankOutputModelFactory implements OutputModelFactory {
 	public ParserFile parserFile(String fileName) { return null; }
 
 	@Override
-	public Parser parser(ParserFile file) { return null; }
+	public Parser parser(ParserFile file, IntegerList atnData) { return null; }
 
 	@Override
 	public RuleFunction rule(Rule r) { return null; }

--- a/tool/src/org/antlr/v4/codegen/CodeGenPipeline.java
+++ b/tool/src/org/antlr/v4/codegen/CodeGenPipeline.java
@@ -5,19 +5,21 @@
  */
 package org.antlr.v4.codegen;
 
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.tool.ErrorType;
 import org.antlr.v4.tool.Grammar;
-import org.antlr.v4.tool.Rule;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.gui.STViz;
 
 public class CodeGenPipeline {
 	final Grammar g;
 	final CodeGenerator gen;
+	final IntegerList atnData;
 
-	public CodeGenPipeline(Grammar g, CodeGenerator gen) {
+	public CodeGenPipeline(Grammar g, CodeGenerator gen, IntegerList atnData) {
 		this.g = g;
 		this.gen = gen;
+		this.atnData = atnData;
 	}
 
 	public void process() {
@@ -28,24 +30,24 @@ public class CodeGenPipeline {
 
 		if ( g.isLexer() ) {
 			if (gen.getTarget().needsHeader()) {
-				ST lexer = gen.generateLexer(true); // Header file if needed.
+				ST lexer = gen.generateLexer(true, atnData); // Header file if needed.
 				if (g.tool.errMgr.getNumErrors() == errorCount) {
 					writeRecognizer(lexer, gen, true);
 				}
 			}
-			ST lexer = gen.generateLexer(false);
+			ST lexer = gen.generateLexer(false, atnData);
 			if (g.tool.errMgr.getNumErrors() == errorCount) {
 				writeRecognizer(lexer, gen, false);
 			}
 		}
 		else {
 			if (gen.getTarget().needsHeader()) {
-				ST parser = gen.generateParser(true);
+				ST parser = gen.generateParser(true, atnData);
 				if (g.tool.errMgr.getNumErrors() == errorCount) {
 					writeRecognizer(parser, gen, true);
 				}
 			}
-			ST parser = gen.generateParser(false);
+			ST parser = gen.generateParser(false, atnData);
 			if (g.tool.errMgr.getNumErrors() == errorCount) {
 				writeRecognizer(parser, gen, false);
 			}

--- a/tool/src/org/antlr/v4/codegen/CodeGenerator.java
+++ b/tool/src/org/antlr/v4/codegen/CodeGenerator.java
@@ -9,6 +9,7 @@ package org.antlr.v4.codegen;
 import org.antlr.v4.Tool;
 import org.antlr.v4.codegen.model.OutputModelObject;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.tool.ErrorType;
 import org.antlr.v4.tool.Grammar;
 import org.stringtemplate.v4.AutoIndentWriter;
@@ -76,9 +77,9 @@ public class CodeGenerator {
 
 	// CREATE TEMPLATES BY WALKING MODEL
 
-	private OutputModelController createController() {
+	private OutputModelController createController(IntegerList atnData) {
 		OutputModelFactory factory = new ParserFactory(this);
-		OutputModelController controller = new OutputModelController(factory);
+		OutputModelController controller = new OutputModelController(factory, atnData);
 		factory.setController(controller);
 		return controller;
 	}
@@ -88,23 +89,23 @@ public class CodeGenerator {
 		return walker.walk(outputModel, header);
 	}
 
-	public ST generateLexer() { return generateLexer(false); }
-	public ST generateLexer(boolean header) { return walk(createController().buildLexerOutputModel(header), header); }
+	public ST generateLexer(IntegerList atnData) { return generateLexer(false, atnData); }
+	public ST generateLexer(boolean header, IntegerList atnData) { return walk(createController(atnData).buildLexerOutputModel(header), header); }
 
-	public ST generateParser() { return generateParser(false); }
-	public ST generateParser(boolean header) { return walk(createController().buildParserOutputModel(header), header); }
+	public ST generateParser(IntegerList atnData) { return generateParser(false, atnData); }
+	public ST generateParser(boolean header, IntegerList atnData) { return walk(createController(atnData).buildParserOutputModel(header), header); }
 
 	public ST generateListener() { return generateListener(false); }
-	public ST generateListener(boolean header) { return walk(createController().buildListenerOutputModel(header), header); }
+	public ST generateListener(boolean header) { return walk(createController(null).buildListenerOutputModel(header), header); }
 
 	public ST generateBaseListener() { return generateBaseListener(false); }
-	public ST generateBaseListener(boolean header) { return walk(createController().buildBaseListenerOutputModel(header), header); }
+	public ST generateBaseListener(boolean header) { return walk(createController(null).buildBaseListenerOutputModel(header), header); }
 
 	public ST generateVisitor() { return generateVisitor(false); }
-	public ST generateVisitor(boolean header) { return walk(createController().buildVisitorOutputModel(header), header); }
+	public ST generateVisitor(boolean header) { return walk(createController(null).buildVisitorOutputModel(header), header); }
 
 	public ST generateBaseVisitor() { return generateBaseVisitor(false); }
-	public ST generateBaseVisitor(boolean header) { return walk(createController().buildBaseVisitorOutputModel(header), header); }
+	public ST generateBaseVisitor(boolean header) { return walk(createController(null).buildBaseVisitorOutputModel(header), header); }
 
 	/** Generate a token vocab file with all the token names/types.  For example:
 	 *  ID=7

--- a/tool/src/org/antlr/v4/codegen/OutputModelController.java
+++ b/tool/src/org/antlr/v4/codegen/OutputModelController.java
@@ -33,6 +33,7 @@ import org.antlr.v4.codegen.model.decl.CodeBlock;
 import org.antlr.v4.misc.Utils;
 import org.antlr.v4.parse.ANTLRParser;
 import org.antlr.v4.parse.GrammarASTAdaptor;
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.tool.Alternative;
 import org.antlr.v4.tool.ErrorType;
 import org.antlr.v4.tool.Grammar;
@@ -72,9 +73,11 @@ public class OutputModelController {
 	public Alternative currentOuterMostAlt;
 	public CodeBlock currentBlock;
 	public CodeBlockForOuterMostAlt currentOuterMostAlternativeBlock;
+	public IntegerList atnData;
 
-	public OutputModelController(OutputModelFactory factory) {
+	public OutputModelController(OutputModelFactory factory, IntegerList atnData) {
 		this.delegate = factory;
+		this.atnData = atnData;
 	}
 
 	public void addExtension(CodeGeneratorExtension ext) { extensions.add(ext); }
@@ -138,7 +141,7 @@ public class OutputModelController {
 	}
 
 	public Parser parser(ParserFile file) {
-		Parser p = delegate.parser(file);
+		Parser p = delegate.parser(file, atnData);
 		for (CodeGeneratorExtension ext : extensions) p = ext.parser(p);
 		return p;
 	}
@@ -148,7 +151,7 @@ public class OutputModelController {
 	}
 
 	public Lexer lexer(LexerFile file) {
-		return new Lexer(delegate, file);
+		return new Lexer(delegate, file, atnData);
 	}
 
 	/** Create RuleFunction per rule and update sempreds,actions of parser

--- a/tool/src/org/antlr/v4/codegen/OutputModelFactory.java
+++ b/tool/src/org/antlr/v4/codegen/OutputModelFactory.java
@@ -18,6 +18,7 @@ import org.antlr.v4.codegen.model.ParserFile;
 import org.antlr.v4.codegen.model.RuleFunction;
 import org.antlr.v4.codegen.model.SrcOp;
 import org.antlr.v4.codegen.model.decl.CodeBlock;
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.runtime.misc.IntervalSet;
 import org.antlr.v4.tool.Alternative;
 import org.antlr.v4.tool.Grammar;
@@ -39,7 +40,7 @@ public interface OutputModelFactory {
 
 	ParserFile parserFile(String fileName);
 
-	Parser parser(ParserFile file);
+	Parser parser(ParserFile file, IntegerList atnData);
 
 	LexerFile lexerFile(String fileName);
 

--- a/tool/src/org/antlr/v4/codegen/ParserFactory.java
+++ b/tool/src/org/antlr/v4/codegen/ParserFactory.java
@@ -42,6 +42,7 @@ import org.antlr.v4.parse.ANTLRParser;
 import org.antlr.v4.runtime.atn.DecisionState;
 import org.antlr.v4.runtime.atn.PlusLoopbackState;
 import org.antlr.v4.runtime.atn.StarLoopEntryState;
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.runtime.misc.IntervalSet;
 import org.antlr.v4.tool.Alternative;
 import org.antlr.v4.tool.LeftRecursiveRule;
@@ -63,19 +64,15 @@ public class ParserFactory extends DefaultOutputModelFactory {
 	}
 
 	@Override
-	public Parser parser(ParserFile file) {
-		return new Parser(this, file);
+	public Parser parser(ParserFile file, IntegerList atnData) {
+		return new Parser(this, file, atnData);
 	}
 
 	@Override
 	public RuleFunction rule(Rule r) {
-		if ( r instanceof LeftRecursiveRule ) {
-			return new LeftRecursiveRuleFunction(this, (LeftRecursiveRule)r);
-		}
-		else {
-			RuleFunction rf = new RuleFunction(this, r);
-			return rf;
-		}
+		return r instanceof LeftRecursiveRule
+				? new LeftRecursiveRuleFunction(this, (LeftRecursiveRule) r)
+				: new RuleFunction(this, r);
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/model/Lexer.java
+++ b/tool/src/org/antlr/v4/codegen/model/Lexer.java
@@ -8,6 +8,7 @@ package org.antlr.v4.codegen.model;
 
 import org.antlr.v4.codegen.OutputModelFactory;
 import org.antlr.v4.codegen.Target;
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.LexerGrammar;
 import org.antlr.v4.tool.Rule;
@@ -24,9 +25,9 @@ public class Lexer extends Recognizer {
 	@ModelElement public LinkedHashMap<Rule, RuleActionFunction> actionFuncs =
 		new LinkedHashMap<Rule, RuleActionFunction>();
 
-	public Lexer(OutputModelFactory factory, LexerFile file) {
-		super(factory);
-		this.file = file; // who contains us?
+	public Lexer(OutputModelFactory factory, LexerFile file, IntegerList atnData) {
+		super(factory, atnData);
+		this.file = file;
 
 		Grammar g = factory.getGrammar();
 		Target target = factory.getGenerator().getTarget();

--- a/tool/src/org/antlr/v4/codegen/model/OutputModelObject.java
+++ b/tool/src/org/antlr/v4/codegen/model/OutputModelObject.java
@@ -11,10 +11,12 @@ import org.antlr.v4.tool.ast.GrammarAST;
 
 /** */
 public abstract class OutputModelObject {
-	public OutputModelFactory factory;
-	public GrammarAST ast;
+	public final OutputModelFactory factory;
+	public final GrammarAST ast;
 
-	public OutputModelObject() {}
+	public OutputModelObject() {
+		this(null);
+	}
 
 	public OutputModelObject(OutputModelFactory factory) { this(factory, null); }
 

--- a/tool/src/org/antlr/v4/codegen/model/Parser.java
+++ b/tool/src/org/antlr/v4/codegen/model/Parser.java
@@ -7,17 +7,18 @@
 package org.antlr.v4.codegen.model;
 
 import org.antlr.v4.codegen.OutputModelFactory;
+import org.antlr.v4.runtime.misc.IntegerList;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class Parser extends Recognizer {
-	public ParserFile file;
+	public final ParserFile file;
 
-	@ModelElement public List<RuleFunction> funcs = new ArrayList<RuleFunction>();
+	@ModelElement public final List<RuleFunction> funcs = new ArrayList<RuleFunction>();
 
-	public Parser(OutputModelFactory factory, ParserFile file) {
-		super(factory);
-		this.file = file; // who contains us?
+	public Parser(OutputModelFactory factory, ParserFile file, IntegerList atnData) {
+		super(factory, atnData);
+		this.file = file;
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/Recognizer.java
+++ b/tool/src/org/antlr/v4/codegen/model/Recognizer.java
@@ -9,6 +9,7 @@ import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.OutputModelFactory;
 import org.antlr.v4.codegen.model.chunk.ActionChunk;
 import org.antlr.v4.codegen.model.chunk.ActionText;
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.Rule;
 
@@ -21,11 +22,11 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class Recognizer extends OutputModelObject {
-	public String name;
-	public String grammarName;
-	public String grammarFileName;
-	public String accessLevel;
-	public Map<String,Integer> tokens;
+	public final String name;
+	public final String grammarName;
+	public final String grammarFileName;
+	public final String accessLevel;
+	public final Map<String,Integer> tokens;
 
 	/**
 	 * @deprecated This field is provided only for compatibility with code
@@ -33,19 +34,19 @@ public abstract class Recognizer extends OutputModelObject {
 	 * {@link #literalNames} and {@link #symbolicNames}.
 	 */
 	@Deprecated
-	public List<String> tokenNames;
+	public final List<String> tokenNames;
 
-	public List<String> literalNames;
-	public List<String> symbolicNames;
-	public Set<String> ruleNames;
-	public Collection<Rule> rules;
-	@ModelElement public ActionChunk superClass;
+	public final List<String> literalNames;
+	public final List<String> symbolicNames;
+	public final Set<String> ruleNames;
+	public final Collection<Rule> rules;
+	@ModelElement public final ActionChunk superClass;
 
-	@ModelElement public SerializedATN atn;
-	@ModelElement public LinkedHashMap<Rule, RuleSempredFunction> sempredFuncs =
+	@ModelElement public final SerializedATN atn;
+	@ModelElement public final LinkedHashMap<Rule, RuleSempredFunction> sempredFuncs =
 		new LinkedHashMap<Rule, RuleSempredFunction>();
 
-	public Recognizer(OutputModelFactory factory) {
+	public Recognizer(OutputModelFactory factory, IntegerList atnData) {
 		super(factory);
 
 		Grammar g = factory.getGrammar();
@@ -63,13 +64,10 @@ public abstract class Recognizer extends OutputModelObject {
 
 		ruleNames = g.rules.keySet();
 		rules = g.rules.values();
-		atn = new SerializedATN(factory, g.atn);
-		if (g.getOptionString("superClass") != null) {
-			superClass = new ActionText(null, g.getOptionString("superClass"));
-		}
-		else {
-			superClass = null;
-		}
+		atn = atnData != null ? new SerializedATN(factory, atnData) : new SerializedATN(factory, g.atn);
+		superClass = g.getOptionString("superClass") != null
+				? new ActionText(null, g.getOptionString("superClass"))
+				: null;
 
 		CodeGenerator gen = factory.getGenerator();
 		tokenNames = translateTokenStringsToTarget(g.getTokenDisplayNames(), gen);

--- a/tool/src/org/antlr/v4/codegen/model/SerializedATN.java
+++ b/tool/src/org/antlr/v4/codegen/model/SerializedATN.java
@@ -7,6 +7,7 @@
 package org.antlr.v4.codegen.model;
 
 import org.antlr.v4.codegen.OutputModelFactory;
+import org.antlr.v4.codegen.Target;
 import org.antlr.v4.runtime.atn.ATN;
 import org.antlr.v4.runtime.atn.ATNSerializer;
 import org.antlr.v4.runtime.misc.IntegerList;
@@ -16,16 +17,21 @@ import java.util.List;
 
 public class SerializedATN extends OutputModelObject {
 	// TODO: make this into a kind of decl or multiple?
-	public List<String> serialized;
+	public final List<String> serialized;
+
 	public SerializedATN(OutputModelFactory factory, ATN atn) {
+		this(factory, ATNSerializer.getSerialized(atn));
+	}
+
+	public SerializedATN(OutputModelFactory factory, IntegerList data) {
 		super(factory);
-		IntegerList data = ATNSerializer.getSerialized(atn);
-		serialized = new ArrayList<String>(data.size());
-		for (int c : data.toArray()) {
-			String encoded = factory.getGenerator().getTarget().encodeIntAsCharEscape(c == -1 ? Character.MAX_VALUE : c);
-			serialized.add(encoded);
+		int dataSize = data.size();
+		serialized = new ArrayList<>(dataSize);
+		Target target = factory.getGenerator().getTarget();
+		for (int i = 0; i < dataSize; i++) {
+			int c = data.get(i);
+			serialized.add(target.encodeIntAsCharEscape(c == -1 ? Character.MAX_VALUE : c));
 		}
-//		System.out.println(ATNSerializer.getDecoded(factory.getGrammar(), atn));
 	}
 
 	public String[][] getSegments() {


### PR DESCRIPTION
It's the limit of serialization, not of ANTLR tool itself. It can be and should be fixed. I've fixed it by using int serialization with varying bytes count that depends on int value:

```java
public void writeCompactUInt32(int value) {
	if (value < 0b1000_0000_0000_0000) {
		writeUInt16(value);
	} else {
		writeUInt16((value & 0b0111_1111_1111_1111) | (1 << 15));
		writeUInt16(value >>> 15);
	}
}
```

All changes are back-compatible excluding quite large lexers or parsers (with more than 32768 states). But actually, it does not matter as I've said before because of [version check on runtime](https://github.com/antlr/antlr4/blob/master/runtime/Java/src/org/antlr/v4/runtime/RuntimeMetaData.java#L144-L167).

If it's okay for Java, I'll fix other runtimes as well.

Fixes #1863, #2732, #3338

The PR depends on #3488
