### PR TITLE
Revert docker version upgrade

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -326,3 +326,5 @@ YYYY/MM/DD, github id, Full name, email
 2021/12/16, Ketler13, Oleksandr Martyshchenko, oleksandr.martyshchenko@gmail.com
 2021/12/25, Tinker1024, Tinker1024, tinker@huawei.com
 2021/12/31, Biswa96, Biswapriyo Nath, nathbappai@gmail.com
+2022/01/18, shadetheartist, b.derehemi@gmail.com
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM adoptopenjdk/openjdk11:alpine AS builder
 
 WORKDIR /opt/antlr4
 
-ARG ANTLR_VERSION="4.10"
+ARG ANTLR_VERSION="4.9.3"
 ARG MAVEN_OPTS="-Xmx1G"
 
 


### PR DESCRIPTION
The version change to 4.10 does not have a corresponding tag in the repo yet and so i get the error

`error: pathspec '4.10' did not match any file(s) known to git`

Reverting the version to 4.9.3 fixes the issue, but i would assume the proper response here would be to add a tag for 4.10 to the repo.