### PR TITLE
Optimize ATN serialization data

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/BaseSwiftTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/swift/BaseSwiftTest.java
@@ -396,12 +396,10 @@ public class BaseSwiftTest extends BaseRuntimeTestSupport implements RuntimeTest
 		List<String> files = new ArrayList<>();
 		if (lexerName != null) {
 			files.add(lexerName + ".swift");
-			files.add(lexerName + "ATN.swift");
 		}
 
 		if (parserName != null) {
 			files.add(parserName + ".swift");
-			files.add(parserName + "ATN.swift");
 			Set<String> optionsSet = new HashSet<>(Arrays.asList(extraOptions));
 			String grammarName = grammarFileName.substring(0, grammarFileName.lastIndexOf('.'));
 			if (!optionsSet.contains("-no-listener")) {

--- a/runtime/Swift/Sources/Antlr4/Parser.swift
+++ b/runtime/Swift/Sources/Antlr4/Parser.swift
@@ -423,7 +423,7 @@ open class Parser: Recognizer<ParserATNSimulator> {
 
             var opts = ATNDeserializationOptions()
             opts.generateRuleBypassTransitions = true
-            let result = try! ATNDeserializer(opts).deserialize(Array(serializedAtn))
+            let result = try! ATNDeserializer(opts).deserialize(serializedAtn)
             bypassAltsAtnCache[serializedAtn] = result
             return result
         }

--- a/runtime/Swift/Sources/Antlr4/atn/ATNDeserializer.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATNDeserializer.swift
@@ -22,10 +22,10 @@ public class ATNDeserializer {
         self.deserializationOptions = deserializationOptions ?? ATNDeserializationOptions()
     }
 
-    public func deserialize(_ inData: [Character]) throws -> ATN {
-        let data = inData.map { Int(integerLiteral: $0.unicodeValue) }
-
+    public func deserialize(_ str: String) throws -> ATN {
+        let data = str.utf16.map { element in Int(element) }
         var p = 0
+
         let version = data[p]
         p += 1
         if version != ATNDeserializer.SERIALIZED_VERSION {
@@ -57,8 +57,7 @@ public class ATNDeserializer {
 
             var ruleIndex = data[p]
             p += 1
-            if ruleIndex == Int.max {
-                // Character.MAX_VALUE
+            if ruleIndex == UInt16.max {
                 ruleIndex = -1
             }
 
@@ -117,7 +116,7 @@ public class ATNDeserializer {
             if atn.grammarType == ATNType.lexer {
                 var tokenType = data[p]
                 p += 1
-                if tokenType == 0xFFFF {
+                if tokenType == UInt16.max {
                     tokenType = CommonToken.EOF
                 }
 
@@ -180,12 +179,14 @@ public class ATNDeserializer {
         //
         let ndecisions = data[p]
         p += 1
-        for i in 1...ndecisions {
-            let s = data[p]
-            p += 1
-            let decState = atn.states[s] as! DecisionState
-            atn.appendDecisionToState(decState)
-            decState.decision = i - 1
+        if (ndecisions >= 1) {
+            for i in 1...ndecisions {
+                let s = data[p]
+                p += 1
+                let decState = atn.states[s] as! DecisionState
+                atn.appendDecisionToState(decState)
+                decState.decision = i - 1
+            }
         }
 
         //
@@ -200,13 +201,13 @@ public class ATNDeserializer {
                 p += 1
                 var data1 = data[p]
                 p += 1
-                if data1 == 0xFFFF {
+                if data1 == UInt16.max {
                     data1 = -1
                 }
 
                 var data2 = data[p]
                 p += 1
-                if data2 == 0xFFFF {
+                if data2 == UInt16.max {
                     data2 = -1
                 }
 
@@ -219,7 +220,6 @@ public class ATNDeserializer {
         try finalizeATN(atn)
         return atn
     }
-
 
     private func readUnicodeInt(_ data: [Int], _ p: inout Int) -> Int {
         let result = data[p]
@@ -252,201 +252,6 @@ public class ATNDeserializer {
                 try! set.add(readUnicode(data, &p), readUnicode(data, &p))
             }
         }
-    }
-
-    public func deserializeFromJson(_ jsonStr: String) -> ATN {
-        guard !jsonStr.isEmpty else {
-            fatalError("ATN Serialization is empty,Please include *LexerATN.json and  *ParserATN.json in TARGETS-Build Phases-Copy Bundle Resources")
-        }
-        if let JSONData = jsonStr.data(using: .utf8) {
-            do {
-                let JSON = try JSONSerialization.jsonObject(with: JSONData, options: JSONSerialization.ReadingOptions(rawValue: 0))
-                guard let JSONDictionary = JSON as? [String: Any] else {
-                    fatalError("deserializeFromJson Not a Dictionary")
-                }
-
-                return try dictToJson(JSONDictionary)
-
-            } catch let JSONError {
-                print("\(JSONError)")
-            }
-        }
-
-        fatalError("Could not deserialize ATN ")
-    }
-
-    public func dictToJson(_ dict: [String: Any]) throws -> ATN {
-        let version = dict["version"] as! Int
-        if version != ATNDeserializer.SERIALIZED_VERSION {
-            let reason = "Could not deserialize ATN with version \(version) (expected \(ATNDeserializer.SERIALIZED_VERSION))."
-            throw ANTLRError.unsupportedOperation(msg: reason)
-        }
-
-        let grammarType = ATNType(rawValue: dict["grammarType"] as! Int)!
-        let maxTokenType = dict["maxTokenType"] as! Int
-        let atn = ATN(grammarType, maxTokenType)
-
-        //
-        // STATES
-        //
-        var loopBackStateNumbers = [(LoopEndState, Int)]()
-        var endStateNumbers = [(BlockStartState, Int)]()
-
-        let states = dict["states"] as! [[String: Any]]
-
-        for state in states {
-            let ruleIndex = state["ruleIndex"] as! Int
-            let stype = state["stateType"] as! Int
-            let s = try stateFactory(stype, ruleIndex)!
-            if stype == ATNState.LOOP_END {
-                // special case
-                let loopBackStateNumber = state["detailStateNumber"] as! Int
-                loopBackStateNumbers.append((s as! LoopEndState, loopBackStateNumber))
-            }
-            else if let bsState = s as? BlockStartState {
-                let endStateNumber = state["detailStateNumber"] as! Int
-                endStateNumbers.append((bsState, endStateNumber))
-            }
-            atn.addState(s)
-        }
-
-        // delay the assignment of loop back and end states until we know all the state instances have been initialized
-        for pair in loopBackStateNumbers {
-            pair.0.loopBackState = atn.states[pair.1]
-        }
-
-        for pair in endStateNumbers {
-            pair.0.endState = atn.states[pair.1] as? BlockEndState
-        }
-
-        let numNonGreedyStates = dict["nonGreedyStates"] as! [Int]
-        for numNonGreedyState in numNonGreedyStates {
-            (atn.states[numNonGreedyState] as! DecisionState).nonGreedy = true
-        }
-
-        let numPrecedenceStates = dict["precedenceStates"] as! [Int]
-        for numPrecedenceState in numPrecedenceStates {
-            (atn.states[numPrecedenceState] as! RuleStartState).isPrecedenceRule = true
-        }
-
-        //
-        // RULES
-        //
-        let ruleToStartState = dict["ruleToStartState"] as! [[String: Any]]
-        let nrules = ruleToStartState.count
-        var ruleToTokenType = [Int]()
-        var ruleToStartStateParsed = [RuleStartState]()
-        for i in 0..<nrules {
-            let currentRuleToStartState = ruleToStartState[i]
-            let s = currentRuleToStartState["stateNumber"] as! Int
-            let startState = atn.states[s] as! RuleStartState
-            ruleToStartStateParsed.append(startState)
-
-            if atn.grammarType == ATNType.lexer {
-                var tokenType = currentRuleToStartState["ruleToTokenType"] as! Int
-                if tokenType == -1 {
-                    tokenType = CommonToken.EOF
-                }
-                ruleToTokenType.append(tokenType)
-            }
-        }
-        atn.ruleToStartState = ruleToStartStateParsed
-        if atn.grammarType == ATNType.lexer {
-            atn.ruleToTokenType = ruleToTokenType
-        }
-
-        fillRuleToStopState(atn)
-
-        //
-        // MODES
-        //
-        let modeToStartState = dict["modeToStartState"] as! [Int]
-        for stateNumber in modeToStartState {
-            atn.appendModeToStartState(atn.states[stateNumber] as! TokensStartState)
-        }
-
-        //
-        // SETS
-        //
-        var sets = [IntervalSet]()
-        let nsets = dict["nsets"] as! Int
-        let intervalSet = dict["IntervalSet"] as! [[String: Any]]
-
-        for i in 0..<nsets {
-            let setBuilder = intervalSet[i]
-            let nintervals = setBuilder["size"] as! Int
-
-            let set = IntervalSet()
-            sets.append(set)
-
-            let containsEof = (setBuilder["containsEof"] as! Int) != 0
-            if containsEof {
-                try! set.add(-1)
-            }
-            let intervalsBuilder = setBuilder["Intervals"] as! [[String: Any]]
-
-            for j in 0..<nintervals {
-                let vals = intervalsBuilder[j]
-                try! set.add((vals["a"] as! Int), (vals["b"] as! Int))
-            }
-        }
-
-
-        //
-        // EDGES
-        //
-        let allTransitions = dict["allTransitionsBuilder"] as! [[[String: Any]]]
-
-        for transitionsBuilder in allTransitions {
-            for transition in transitionsBuilder {
-                let src = transition["src"] as! Int
-                let trg = transition["trg"] as! Int
-                let ttype = transition["edgeType"] as! Int
-                let arg1 = transition["arg1"] as! Int
-                let arg2 = transition["arg2"] as! Int
-                let arg3 = transition["arg3"] as! Int
-                let trans = try edgeFactory(atn, ttype, src, trg, arg1, arg2, arg3, sets)
-
-                let srcState = atn.states[src]!
-                srcState.addTransition(trans)
-            }
-        }
-
-        deriveEdgesForRuleStopStates(atn)
-        try validateStates(atn)
-
-        //
-        // DECISIONS
-        //
-        let ndecisions = dict["decisionToState"] as! [Int]
-        let length = ndecisions.count
-        for i in 0..<length {
-            let s = ndecisions[i]
-            let decState = atn.states[s] as! DecisionState
-            atn.appendDecisionToState(decState)
-            decState.decision = i
-        }
-
-        //
-        // LEXER ACTIONS
-        //
-        if atn.grammarType == ATNType.lexer {
-            let lexerActionsBuilder = dict["lexerActions"] as! [[String: Any]]
-
-            var lexerActions = [LexerAction]()
-            for lexerActionDict in lexerActionsBuilder {
-                let actionTypeValue = lexerActionDict["actionType"] as! Int
-                let actionType = LexerActionType(rawValue: actionTypeValue)!
-                let data1 = lexerActionDict["a"] as! Int
-                let data2 = lexerActionDict["b"] as! Int
-                let lexerAction = lexerActionFactory(actionType, data1, data2)
-                lexerActions.append(lexerAction)
-            }
-            atn.lexerActions = lexerActions
-        }
-
-        try finalizeATN(atn)
-        return atn
     }
 
     private func fillRuleToStopState(_ atn: ATN) {

--- a/runtime/Swift/Sources/Antlr4/misc/InterpreterDataReader.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/InterpreterDataReader.swift
@@ -109,7 +109,7 @@ public class InterpreterDataReader {
         self.ruleNames = ruleNames
         self.channelNames = channelNames
         self.modeNames = modeNames
-        let atnSerialized = atnText.map{Character(UnicodeScalar(UInt16($0.trimmingCharacters(in:.whitespaces))!)!)}
+        let atnSerialized = String(atnText.map{Character(UnicodeScalar(UInt16($0.trimmingCharacters(in:.whitespaces))!)!)})
         atn = try ATNDeserializer().deserialize(atnSerialized)
     }
         

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -1049,7 +1049,7 @@ public partial class <lexer.name> : <superClass; null="Lexer"> {
 
 SerializedATN(model) ::= <<
 private static char[] _serializedATN = {
-	<model.serialized; separator=", ", wrap>,
+	<model.serialized: {s | '<s>'}; separator=",", wrap>
 };
 
 public static readonly ATN _ATN =

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -383,13 +383,12 @@ static std::vector\<uint16_t> _serializedATN;
 
 // Constructs the serialized ATN and writes init code for static member vars.
 SerializedATN(model) ::= <<
-<model.segments: {segment | static const uint16_t serializedATNSegment<i0>[] = {
-  <segment; wrap={<\n>   }>
-\};}; separator="\n">
+static const uint16_t serializedATNSegment[] = {
+	<model.serialized: {s | <s>}; separator=",", wrap>
+};
 
-<model.segments: {segment | _serializedATN.insert(_serializedATN.end(), serializedATNSegment<i0>,
-  serializedATNSegment<i0> + sizeof(serializedATNSegment<i0>) / sizeof(serializedATNSegment<i0>[0]));
-}>
+_serializedATN.insert(_serializedATN.end(), serializedATNSegment,
+  serializedATNSegment + sizeof(serializedATNSegment) / sizeof(serializedATNSegment[0]));
 
 atn::ATNDeserializer deserializer;
 _atn = deserializer.deserialize(_serializedATN);

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
@@ -853,17 +853,8 @@ class <lexer.name> extends <superClass; null="Lexer"> {
 >>
 
 SerializedATN(model) ::= <<
-<if(rest(model.segments))>
-<! requires segmented representation !>
-<model.segments:{segment|static final String _serializedATNSegment<i0> =
-  '<segment; wrap={'<\n><\t>'}>';}; separator="\n">
-static final String _serializedATN = [
-    <model.segments:{segment | _serializedATNSegment<i0>}; separator=",\n">
-  ].join();
-<else>
-<! only one segment, can be inlined !>
 static const String _serializedATN = '<model.serialized; wrap={'<\n><\t>'}>';
-<endif>
+
 static final ATN _ATN =
     ATNDeserializer().deserialize(_serializedATN.codeUnits);
 >>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
@@ -1209,19 +1209,8 @@ namespace<if(lexerFile.genPackage)> <lexerFile.genPackage><endif> {
 >>
 
 SerializedATN(model) ::= <<
-<if(rest(model.segments))>
-/**
- * @var string
- */
-private const SERIALIZED_ATN =
-	<model.segments:{segment| "<segment; wrap={" .<\n>"}>"}; separator=" .\n">;
-<else>
-/**
- * @var string
- */
 private const SERIALIZED_ATN =
 	"<model.serialized; wrap={" .<\n>    "}>";
-<endif>
 >>
 
 /**

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -300,10 +300,7 @@ case  <f.ruleIndex>:
 	<atn>
 
 	<accessLevelNotOpen(parser)>
-	static let _serializedATN = <parser.name>ATN().jsonString
-
-	<accessLevelNotOpen(parser)>
-	static let _ATN = ATNDeserializer().deserializeFromJson(_serializedATN)
+	static let _ATN = try! ATNDeserializer().deserialize(_serializedATN)
 }
 >>
 
@@ -1047,19 +1044,14 @@ Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 	<atn>
 
 	<accessLevelNotOpen(lexer)>
-	static let _serializedATN: String = <lexer.name>ATN().jsonString
-
-	<accessLevelNotOpen(lexer)>
-	static let _ATN: ATN = ATNDeserializer().deserializeFromJson(_serializedATN)
+	static let _ATN: ATN = try! ATNDeserializer().deserialize(_serializedATN)
 }
 >>
 
-/** Don't need to define anything. The tool generates a XParserATN.swift file (and same for lexer)
- *  which is referenced from static field _serializedATN.  This json string is passed to
- *  deserializeFromJson(). Note this is not the "serialization as array of ints" that other targets
- *  do. It is more or less the output of ATNPrinter which gets read back in.
- */
 SerializedATN(model) ::= <<
+static let _serializedATN: String = """
+	<model.serialized; wrap={\\<\n>}>
+	"""
 >>
 
 /** Using a type to init value map, try to init a type; if not in table

--- a/tool/src/org/antlr/v4/codegen/Target.java
+++ b/tool/src/org/antlr/v4/codegen/Target.java
@@ -392,6 +392,7 @@ public abstract class Target {
 				return String.format("\\x%X", v);
 			case "Dart":
 			case "PHP":
+			case "Swift":
 				return String.format("\\u{%X}", v);
 		}
 	}

--- a/tool/src/org/antlr/v4/codegen/target/CSharpTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/CSharpTarget.java
@@ -119,26 +119,6 @@ public class CSharpTarget extends Target {
 	}
 
 	@Override
-	public String encodeIntAsCharEscape(int v) {
-		if (v < Character.MIN_VALUE || v > Character.MAX_VALUE) {
-			throw new IllegalArgumentException(String.format("Cannot encode the specified value: %d", v));
-		}
-
-		String formatted;
-		if (v >= 0 && v < targetCharValueEscape.length && targetCharValueEscape[v] != null) {
-			formatted = targetCharValueEscape[v];
-		}
-		else if (v >= 0x20 && v < 127 && (v < '0' || v > '9') && (v < 'a' || v > 'f') && (v < 'A' || v > 'F')) {
-			formatted = Character.toString((char)v);
-		}
-		else {
-			formatted = String.format("\\x%X", v & 0xFFFF);
-		}
-
-		return "'" + formatted + "'";
-	}
-
-	@Override
 	protected STGroup loadTemplates() {
 		// override the superclass behavior to put all C# templates in the same folder
 		STGroup result = new STGroupFile(CodeGenerator.TEMPLATE_ROOT+"/CSharp/"+ getLanguage()+STGroup.GROUP_FILE_EXTENSION);

--- a/tool/src/org/antlr/v4/codegen/target/CSharpTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/CSharpTarget.java
@@ -15,9 +15,7 @@ import org.stringtemplate.v4.STGroupFile;
 import org.stringtemplate.v4.StringRenderer;
 import org.stringtemplate.v4.misc.STMessage;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class CSharpTarget extends Target {
 	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
@@ -101,11 +99,31 @@ public class CSharpTarget extends Target {
 		"while"
 	));
 
+	protected static final Map<Character, String> targetCharValueEscape;
+	static {
+		// https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/strings/#string-escape-sequences
+		HashMap<Character, String> map = new HashMap<>();
+		addEscapedChar(map, '\'');
+		addEscapedChar(map, '\"');
+		addEscapedChar(map, '\\');
+		addEscapedChar(map, '\0', '0');
+		addEscapedChar(map, (char)0x0007, 'a');
+		addEscapedChar(map, (char)0x0008, 'b');
+		addEscapedChar(map, '\f', 'f');
+		addEscapedChar(map, '\n', 'n');
+		addEscapedChar(map, '\r', 'r');
+		addEscapedChar(map, '\t', 't');
+		addEscapedChar(map, (char)0x000B, 'v');
+		targetCharValueEscape = map;
+	}
+
 	public CSharpTarget(CodeGenerator gen) {
 		super(gen);
-		targetCharValueEscape[0] = "\\0";
-		targetCharValueEscape[0x0007] = "\\a";
-		targetCharValueEscape[0x000B] = "\\v";
+	}
+
+	@Override
+	public Map<Character, String> getTargetCharValueEscape() {
+		return targetCharValueEscape;
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/CppTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/CppTarget.java
@@ -16,11 +16,28 @@ import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 import org.stringtemplate.v4.misc.STMessage;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class CppTarget extends Target {
+	protected static final Map<Character, String> targetCharValueEscape;
+	static {
+		// https://stackoverflow.com/a/10220539/1046374
+		HashMap<Character, String> map = new HashMap<>();
+		addEscapedChar(map, (char)0x0007, 'a');
+		addEscapedChar(map, (char)0x0008, 'b');
+		addEscapedChar(map, '\t', 't');
+		addEscapedChar(map, '\n', 'n');
+		addEscapedChar(map, (char)0x000B, 'v');
+		addEscapedChar(map, '\f', 'f');
+		addEscapedChar(map, '\r', 'r');
+		addEscapedChar(map, (char)0x001B, 'e');
+		addEscapedChar(map, '\"');
+		addEscapedChar(map, '\'');
+		addEscapedChar(map, '?');
+		addEscapedChar(map, '\\');
+		targetCharValueEscape = map;
+	}
+
 	protected static final HashSet<String> reservedWords =  new HashSet<>(Arrays.asList(
 		"alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand",
 		"bitor", "bool", "break", "case", "catch", "char", "char16_t",
@@ -43,7 +60,11 @@ public class CppTarget extends Target {
 
 	public CppTarget(CodeGenerator gen) {
 		super(gen);
-		targetCharValueEscape['?'] = "\\?";
+	}
+
+	@Override
+	public Map<Character, String> getTargetCharValueEscape() {
+		return targetCharValueEscape;
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/CppTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/CppTarget.java
@@ -66,11 +66,6 @@ public class CppTarget extends Target {
 	}
 
 	@Override
-	public String encodeIntAsCharEscape(int v) {
-		return "0x" + Integer.toHexString(v) + ", ";
-	}
-
-	@Override
 	public String getRecognizerFileName(boolean header) {
 		ST extST = getTemplates().getInstanceOf(header ? "headerFileExtension" : "codeFileExtension");
 		String recognizerName = gen.g.getRecognizerName();

--- a/tool/src/org/antlr/v4/codegen/target/DartTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/DartTarget.java
@@ -11,11 +11,19 @@ import org.antlr.v4.codegen.Target;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class DartTarget extends Target {
+	protected static final Map<Character, String> targetCharValueEscape;
+	static {
+		HashMap<Character, String> map = new HashMap<>();
+		for (Map.Entry<Character, String> entry : defaultCharValueEscape.entrySet()) {
+			map.put(entry.getKey(), entry.getValue());
+		}
+		addEscapedChar(map, '$');
+		targetCharValueEscape = map;
+	}
+
 	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
 		"abstract", "dynamic", "implements", "show",
 		"as", "else", "import", "static",
@@ -38,7 +46,11 @@ public class DartTarget extends Target {
 
 	public DartTarget(CodeGenerator gen) {
 		super(gen);
-		targetCharValueEscape['$'] = "\\$";
+	}
+
+	@Override
+	public Map<Character, String> getTargetCharValueEscape() {
+		return targetCharValueEscape;
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/DartTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/DartTarget.java
@@ -8,7 +8,6 @@ package org.antlr.v4.codegen.target;
 
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.Target;
-import org.antlr.v4.tool.ast.GrammarAST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
@@ -39,7 +38,6 @@ public class DartTarget extends Target {
 
 	public DartTarget(CodeGenerator gen) {
 		super(gen);
-
 		targetCharValueEscape['$'] = "\\$";
 	}
 
@@ -59,14 +57,5 @@ public class DartTarget extends Target {
 		result.registerRenderer(String.class, new StringRenderer(), true);
 
 		return result;
-	}
-
-	@Override
-	public String encodeIntAsCharEscape(int v) {
-		if (v < Character.MIN_VALUE || v > Character.MAX_VALUE) {
-			throw new IllegalArgumentException(String.format("Cannot encode the specified value: %d", v));
-		}
-
-		return String.format("\\u{%X}", v & 0xFFFF);
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/GoTarget.java
@@ -10,7 +10,6 @@ import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.Target;
 import org.antlr.v4.parse.ANTLRParser;
 import org.antlr.v4.tool.Grammar;
-import org.antlr.v4.tool.ast.GrammarAST;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
@@ -18,10 +17,7 @@ import org.stringtemplate.v4.StringRenderer;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 
 public class GoTarget extends Target {
 	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(

--- a/tool/src/org/antlr/v4/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/GoTarget.java
@@ -99,11 +99,6 @@ public class GoTarget extends Target {
 	}
 
 	@Override
-	public String encodeIntAsCharEscape(int v) {
-		return Integer.toString(v);
-	}
-
-	@Override
 	public int getInlineTestSetWordSize() {
 		return 32;
 	}

--- a/tool/src/org/antlr/v4/codegen/target/JavaScriptTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/JavaScriptTarget.java
@@ -52,24 +52,6 @@ public class JavaScriptTarget extends Target {
 	}
 
 	@Override
-	public String encodeIntAsCharEscape(int v) {
-		if (v < Character.MIN_VALUE || v > Character.MAX_VALUE) {
-			throw new IllegalArgumentException(String.format("Cannot encode the specified value: %d", v));
-		}
-
-		if (v >= 0 && v < targetCharValueEscape.length && targetCharValueEscape[v] != null) {
-			return targetCharValueEscape[v];
-		}
-
-		if (v >= 0x20 && v < 127) {
-			return String.valueOf((char)v);
-		}
-
-		String hex = Integer.toHexString(v|0x10000).substring(1,5);
-		return "\\u"+hex;
-	}
-
-	@Override
 	public int getInlineTestSetWordSize() {
 		return 32;
 	}

--- a/tool/src/org/antlr/v4/codegen/target/JavaTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/JavaTarget.java
@@ -11,10 +11,7 @@ import org.antlr.v4.codegen.Target;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 
 public class JavaTarget extends Target {
 	/**
@@ -40,7 +37,7 @@ public class JavaTarget extends Target {
 		super(gen);
 	}
 
-    @Override
+	@Override
     public Set<String> getReservedWords() {
 		return reservedWords;
 	}

--- a/tool/src/org/antlr/v4/codegen/target/PHPTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/PHPTarget.java
@@ -11,9 +11,7 @@ import org.antlr.v4.codegen.Target;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class PHPTarget extends Target {
 	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
@@ -45,11 +43,29 @@ public class PHPTarget extends Target {
 		"rule", "parserRule"
 	));
 
+	protected static final Map<Character, String> targetCharValueEscape;
+	static {
+		// https://www.php.net/manual/en/language.types.string.php
+		HashMap<Character, String> map = new HashMap<>();
+		addEscapedChar(map, '\n', 'n');
+		addEscapedChar(map, '\r', 'r');
+		addEscapedChar(map, '\t', 't');
+		addEscapedChar(map, (char)0x000B, 'v');
+		addEscapedChar(map, (char)0x001B, 'e');
+		addEscapedChar(map, '\f', 'f');
+		addEscapedChar(map, '\\');
+		addEscapedChar(map, '$');
+		addEscapedChar(map, '\"');
+		targetCharValueEscape = map;
+	}
+
 	public PHPTarget(CodeGenerator gen) {
 		super(gen);
-		targetCharValueEscape['$'] = "\\$";
-		targetCharValueEscape['\b'] = null;
-		targetCharValueEscape['\''] = null;
+	}
+
+	@Override
+	public Map<Character, String> getTargetCharValueEscape() {
+		return targetCharValueEscape;
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/PHPTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/PHPTarget.java
@@ -48,20 +48,13 @@ public class PHPTarget extends Target {
 	public PHPTarget(CodeGenerator gen) {
 		super(gen);
 		targetCharValueEscape['$'] = "\\$";
+		targetCharValueEscape['\b'] = null;
+		targetCharValueEscape['\''] = null;
 	}
 
 	@Override
 	protected Set<String> getReservedWords() {
 		return reservedWords;
-	}
-
-	@Override
-	public String encodeIntAsCharEscape(int v) {
-		if (v < Character.MIN_VALUE || v > Character.MAX_VALUE) {
-			throw new IllegalArgumentException(String.format("Cannot encode the specified value: %d", v));
-		}
-
-		return String.format("\\u{%X}", v & 0xFFFF);
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/Python2Target.java
+++ b/tool/src/org/antlr/v4/codegen/target/Python2Target.java
@@ -11,10 +11,7 @@ import org.antlr.v4.codegen.Target;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 
 public class Python2Target extends Target {
 	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
@@ -48,8 +45,30 @@ public class Python2Target extends Target {
 		"rule", "parserRule"
 	));
 
+	protected static final Map<Character, String> targetCharValueEscape;
+	static {
+		// https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
+		HashMap<Character, String> map = new HashMap<>();
+		addEscapedChar(map, '\\');
+		addEscapedChar(map, '\'');
+		addEscapedChar(map, '\"');
+		addEscapedChar(map, (char)0x0007, 'a');
+		addEscapedChar(map, (char)0x0008, 'b');
+		addEscapedChar(map, '\f', 'f');
+		addEscapedChar(map, '\n', 'n');
+		addEscapedChar(map, '\r', 'r');
+		addEscapedChar(map, '\t', 't');
+		addEscapedChar(map, (char)0x000B, 'v');
+		targetCharValueEscape = map;
+	}
+
 	public Python2Target(CodeGenerator gen) {
 		super(gen);
+	}
+
+	@Override
+	public Map<Character, String> getTargetCharValueEscape() {
+		return targetCharValueEscape;
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/Python2Target.java
+++ b/tool/src/org/antlr/v4/codegen/target/Python2Target.java
@@ -8,7 +8,6 @@ package org.antlr.v4.codegen.target;
 
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.Target;
-import org.antlr.v4.tool.ast.GrammarAST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 

--- a/tool/src/org/antlr/v4/codegen/target/Python3Target.java
+++ b/tool/src/org/antlr/v4/codegen/target/Python3Target.java
@@ -11,10 +11,7 @@ import org.antlr.v4.codegen.Target;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 
 public class Python3Target extends Target {
 	protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
@@ -47,8 +44,30 @@ public class Python3Target extends Target {
 		"rule", "parserRule"
 	));
 
+	protected static final Map<Character, String> targetCharValueEscape;
+	static {
+		// https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
+		HashMap<Character, String> map = new HashMap<>();
+		addEscapedChar(map, '\\');
+		addEscapedChar(map, '\'');
+		addEscapedChar(map, '\"');
+		addEscapedChar(map, (char)0x0007, 'a');
+		addEscapedChar(map, (char)0x0008, 'b');
+		addEscapedChar(map, '\f', 'f');
+		addEscapedChar(map, '\n', 'n');
+		addEscapedChar(map, '\r', 'r');
+		addEscapedChar(map, '\t', 't');
+		addEscapedChar(map, (char)0x000B, 'v');
+		targetCharValueEscape = map;
+	}
+
 	public Python3Target(CodeGenerator gen) {
 		super(gen);
+	}
+
+	@Override
+	public Map<Character, String> getTargetCharValueEscape() {
+		return targetCharValueEscape;
 	}
 
 	@Override

--- a/tool/src/org/antlr/v4/codegen/target/SwiftTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/SwiftTarget.java
@@ -8,50 +8,14 @@ package org.antlr.v4.codegen.target;
 
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.Target;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.atn.ATN;
-import org.antlr.v4.runtime.atn.ATNDeserializer;
-import org.antlr.v4.runtime.atn.ATNState;
-import org.antlr.v4.runtime.atn.ATNType;
-import org.antlr.v4.runtime.atn.ActionTransition;
-import org.antlr.v4.runtime.atn.AtomTransition;
-import org.antlr.v4.runtime.atn.BlockStartState;
-import org.antlr.v4.runtime.atn.DecisionState;
-import org.antlr.v4.runtime.atn.LexerAction;
-import org.antlr.v4.runtime.atn.LexerChannelAction;
-import org.antlr.v4.runtime.atn.LexerCustomAction;
-import org.antlr.v4.runtime.atn.LexerModeAction;
-import org.antlr.v4.runtime.atn.LexerPushModeAction;
-import org.antlr.v4.runtime.atn.LexerTypeAction;
-import org.antlr.v4.runtime.atn.LoopEndState;
-import org.antlr.v4.runtime.atn.PrecedencePredicateTransition;
-import org.antlr.v4.runtime.atn.PredicateTransition;
-import org.antlr.v4.runtime.atn.RangeTransition;
-import org.antlr.v4.runtime.atn.RuleStartState;
-import org.antlr.v4.runtime.atn.RuleTransition;
-import org.antlr.v4.runtime.atn.SetTransition;
-import org.antlr.v4.runtime.atn.Transition;
-import org.antlr.v4.runtime.misc.IntegerList;
-import org.antlr.v4.runtime.misc.Interval;
-import org.antlr.v4.runtime.misc.IntervalSet;
-import org.antlr.v4.tool.ErrorType;
 import org.antlr.v4.tool.Grammar;
-import org.antlr.v4.tool.ast.GrammarAST;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
-import javax.json.Json;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
-import java.io.IOException;
-import java.io.Writer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +24,21 @@ public class SwiftTarget extends Target {
     /**
      * The Swift target can cache the code generation templates.
      */
-    private static final ThreadLocal<STGroup> targetTemplates = new ThreadLocal<STGroup>();
+    private static final ThreadLocal<STGroup> targetTemplates = new ThreadLocal<>();
+
+	protected static final Map<Character, String> targetCharValueEscape;
+	static {
+		// https://docs.swift.org/swift-book/LanguageGuide/StringsAndCharacters.html
+		HashMap<Character, String> map = new HashMap<>();
+		addEscapedChar(map, '\0', '0');
+		addEscapedChar(map, '\\');
+		addEscapedChar(map, '\t', 't');
+		addEscapedChar(map, '\n', 'n');
+		addEscapedChar(map, '\r', 'r');
+		addEscapedChar(map, '\"');
+		addEscapedChar(map, '\'');
+		targetCharValueEscape = map;
+	}
 
     protected static final HashSet<String> reservedWords = new HashSet<>(Arrays.asList(
             "associatedtype", "class", "deinit", "enum", "extension", "func", "import", "init", "inout", "internal",
@@ -76,12 +54,14 @@ public class SwiftTarget extends Target {
              "rule", "parserRule"
 	));
 
-    public String lexerAtnJSON = null;
-    public String parserAtnJSON = null;
-
     public SwiftTarget(CodeGenerator gen) {
         super(gen);
     }
+
+	@Override
+	public Map<Character, String> getTargetCharValueEscape() {
+		return targetCharValueEscape;
+	}
 
 	@Override
 	protected Set<String> getReservedWords() {
@@ -94,66 +74,10 @@ public class SwiftTarget extends Target {
 	}
 
     @Override
-    protected void genFile(Grammar g,
-                           ST outputFileST,
-                           String fileName)
-    {
+    protected void genFile(Grammar g, ST outputFileST, String fileName) {
         super.genFile(g,outputFileST,fileName);
-
-        if (g.isLexer()  && lexerAtnJSON == null) {
-            lexerAtnJSON = getLexerOrParserATNJson(g, fileName);
-        }
-        else if (!g.isLexer()  && parserAtnJSON == null && g.atn != null) {
-            parserAtnJSON = getLexerOrParserATNJson(g, fileName);
-        }
-
-        if (fileName.endsWith(CodeGenerator.VOCAB_FILE_EXTENSION)) {
-            String jsonFileName = fileName.substring(0,fileName.lastIndexOf(CodeGenerator.VOCAB_FILE_EXTENSION));
-            if (lexerAtnJSON != null) {
-                jsonFileName = jsonFileName +   "ATN.swift";
-                // System.out.println(jsonFileName);
-                //System.out.println(lexerAtnJSON);
-                writeFile(lexerAtnJSON,g,jsonFileName);
-            }
-
-            if (parserAtnJSON != null) {
-                jsonFileName = jsonFileName +   "ParserATN.swift";
-                // System.out.println(jsonFileName);
-                //System.out.println(parserAtnJSON);
-                writeFile(parserAtnJSON,g,jsonFileName);
-            }
-        }
-
-//        else if (g instanceof ParseR) {
-//            System.out.println("parserGrammar");
-//        }
-//
-        //getCodeGenerator().write(outputFileST, fileName);
     }
 
-    private String getLexerOrParserATNJson(Grammar g, String fileName) {
-        ST extST = getTemplates().getInstanceOf("codeFileExtension");
-        String className = fileName.substring(0,fileName.lastIndexOf(extST.render()));
-
-        String JSON = "class " + className + "ATN {\n" +
-                "    let jsonString: String = \"" +
-                serializeTojson(g.atn).replaceAll("\"","\\\\\"") +"\"\n}" ;  //.replaceAll("\"", "\\\\\"");
-        return JSON;
-    }
-
-    private  void writeFile(String content,Grammar g,String fileName) {
-
-        try {
-            Writer w =    this.getCodeGenerator().tool.getOutputFileWriter(g, fileName);
-            w.write(content);
-            w.close();
-        }
-        catch (IOException ioe) {
-            this.getCodeGenerator().tool.errMgr.toolError(ErrorType.CANNOT_WRITE_FILE,
-                    ioe,
-                    fileName);
-        }
-    }
     @Override
     protected STGroup loadTemplates() {
         STGroup result = targetTemplates.get();
@@ -165,359 +89,8 @@ public class SwiftTarget extends Target {
 
         return result;
     }
-    //added by janyou -->
-    public String serializeTojson(ATN atn) {
-        JsonObjectBuilder builder =  Json.createObjectBuilder();
-        builder.add("version", ATNDeserializer.SERIALIZED_VERSION);
 
-        // convert grammar type to ATN const to avoid dependence on ANTLRParser
-        builder.add("grammarType",atn.grammarType.ordinal());
-        builder.add("maxTokenType",atn.maxTokenType);
-
-        //states
-        int nedges = 0;
-
-        Map<IntervalSet, Integer> setIndices = new HashMap<IntervalSet, Integer>();
-        List<IntervalSet> sets = new ArrayList<IntervalSet>();
-        JsonArrayBuilder statesBuilder = Json.createArrayBuilder() ;
-        IntegerList nonGreedyStates = new IntegerList();
-        IntegerList precedenceStates = new IntegerList();
-        for (ATNState s : atn.states) {
-            JsonObjectBuilder stateBuilder = Json.createObjectBuilder();
-            if ( s==null ) { // might be optimized away
-                statesBuilder.addNull();
-                continue;
-            }
-
-            int stateType = s.getStateType();
-
-            stateBuilder.add("stateType",stateType);
-            //stateBuilder.add("stateNumber",s.stateNumber);
-            stateBuilder.add("ruleIndex",s.ruleIndex);
-
-            if (s instanceof DecisionState && ((DecisionState)s).nonGreedy) {
-                nonGreedyStates.add(s.stateNumber);
-            }
-
-            if (s instanceof RuleStartState && ((RuleStartState)s).isLeftRecursiveRule) {
-                precedenceStates.add(s.stateNumber);
-            }
-
-
-            if ( s.getStateType() == ATNState.LOOP_END ) {
-                stateBuilder.add("detailStateNumber",((LoopEndState)s).loopBackState.stateNumber);
-            }
-            else if ( s instanceof BlockStartState ) {
-                stateBuilder.add("detailStateNumber",((BlockStartState)s).endState.stateNumber);
-            }
-
-            if (s.getStateType() != ATNState.RULE_STOP) {
-                // the deserializer can trivially derive these edges, so there's no need to serialize them
-                nedges += s.getNumberOfTransitions();
-            }
-            for (int i=0; i<s.getNumberOfTransitions(); i++) {
-                Transition t = s.transition(i);
-                int edgeType = Transition.serializationTypes.get(t.getClass());
-                if ( edgeType == Transition.SET || edgeType == Transition.NOT_SET ) {
-                    SetTransition st = (SetTransition)t;
-                    if (!setIndices.containsKey(st.set)) {
-                        sets.add(st.set);
-                        setIndices.put(st.set, sets.size() - 1);
-                    }
-                }
-            }
-            statesBuilder.add(stateBuilder);
-        }
-        builder.add("states",statesBuilder);
-
-
-        // non-greedy states
-        JsonArrayBuilder nonGreedyStatesBuilder = Json.createArrayBuilder() ;
-        for (int i = 0; i < nonGreedyStates.size(); i++) {
-            nonGreedyStatesBuilder.add(nonGreedyStates.get(i));
-        }
-        builder.add("nonGreedyStates",nonGreedyStatesBuilder);
-
-
-        // precedence states
-        JsonArrayBuilder precedenceStatesBuilder = Json.createArrayBuilder() ;
-        for (int i = 0; i < precedenceStates.size(); i++) {
-            precedenceStatesBuilder.add(precedenceStates.get(i));
-        }
-        builder.add("precedenceStates",precedenceStatesBuilder);
-
-        JsonArrayBuilder ruleToStartStateBuilder = Json.createArrayBuilder() ;
-        int nrules = atn.ruleToStartState.length;
-
-        for (int r=0; r<nrules; r++) {
-            JsonObjectBuilder stateBuilder = Json.createObjectBuilder();
-            ATNState ruleStartState = atn.ruleToStartState[r];
-
-            stateBuilder.add("stateNumber",ruleStartState.stateNumber);
-            if (atn.grammarType == ATNType.LEXER) {
-//				if (atn.ruleToTokenType[r] == Token.EOF) {
-//					//data.add(Character.MAX_VALUE);
-//					stateBuilder.add("ruleToTokenType",-1);
-//				}
-//				else {
-//					//data.add(atn.ruleToTokenType[r]);
-                stateBuilder.add("ruleToTokenType",atn.ruleToTokenType[r]);
-//				}
-            }
-            ruleToStartStateBuilder.add(stateBuilder);
-        }
-        builder.add("ruleToStartState",ruleToStartStateBuilder);
-
-
-        JsonArrayBuilder modeToStartStateBuilder = Json.createArrayBuilder() ;
-        int nmodes = atn.modeToStartState.size();
-        if ( nmodes>0 ) {
-            for (ATNState modeStartState : atn.modeToStartState) {
-
-                modeToStartStateBuilder.add(modeStartState.stateNumber);
-            }
-        }
-        builder.add("modeToStartState",modeToStartStateBuilder);
-
-
-        JsonArrayBuilder nsetsBuilder = Json.createArrayBuilder() ;
-        int nsets = sets.size();
-        //data.add(nsets);
-        builder.add("nsets",nsets);
-
-        for (IntervalSet set : sets) {
-            JsonObjectBuilder setBuilder = Json.createObjectBuilder();
-            boolean containsEof = set.contains(Token.EOF);
-            if (containsEof && set.getIntervals().get(0).b == Token.EOF) {
-                //data.add(set.getIntervals().size() - 1);
-
-                setBuilder.add("size",set.getIntervals().size() - 1);
-            }
-            else {
-                //data.add(set.getIntervals().size());
-
-                setBuilder.add("size",set.getIntervals().size());
-            }
-            setBuilder.add("containsEof",containsEof ? 1 : 0);
-            JsonArrayBuilder IntervalsBuilder = Json.createArrayBuilder() ;
-            for (Interval I : set.getIntervals()) {
-                JsonObjectBuilder IntervalBuilder = Json.createObjectBuilder();
-                if (I.a == Token.EOF) {
-                    if (I.b == Token.EOF) {
-                        continue;
-                    }
-                    else {
-                        IntervalBuilder.add("a",0);
-                        //data.add(0);
-                    }
-                }
-                else {
-                    IntervalBuilder.add("a",I.a);
-
-                    //data.add(I.a);
-                }
-                IntervalBuilder.add("b",I.b);
-                IntervalsBuilder.add(IntervalBuilder);
-            }
-            setBuilder.add("Intervals",IntervalsBuilder);
-            nsetsBuilder.add(setBuilder);
-        }
-
-        builder.add("IntervalSet",nsetsBuilder);
-        //builder.add("nedges",nedges);
-        JsonArrayBuilder allTransitionsBuilder = Json.createArrayBuilder() ;
-
-        for (ATNState s : atn.states) {
-
-            if ( s==null ) {
-                // might be optimized away
-                continue;
-            }
-
-            if (s.getStateType() == ATNState.RULE_STOP) {
-                continue;
-            }
-            JsonArrayBuilder  transitionsBuilder = Json.createArrayBuilder() ;
-
-            for (int i=0; i<s.getNumberOfTransitions(); i++) {
-                JsonObjectBuilder transitionBuilder = Json.createObjectBuilder();
-                Transition t = s.transition(i);
-
-                if (atn.states.get(t.target.stateNumber) == null) {
-                    throw new IllegalStateException("Cannot serialize a transition to a removed state.");
-                }
-
-                int src = s.stateNumber;
-                int trg = t.target.stateNumber;
-                int edgeType = Transition.serializationTypes.get(t.getClass());
-                int arg1 = 0;
-                int arg2 = 0;
-                int arg3 = 0;
-                switch ( edgeType ) {
-                    case Transition.RULE :
-                        trg = ((RuleTransition)t).followState.stateNumber;
-                        arg1 = ((RuleTransition)t).target.stateNumber;
-                        arg2 = ((RuleTransition)t).ruleIndex;
-                        arg3 = ((RuleTransition)t).precedence;
-                        break;
-                    case Transition.PRECEDENCE:
-                        PrecedencePredicateTransition ppt = (PrecedencePredicateTransition)t;
-                        arg1 = ppt.precedence;
-                        break;
-                    case Transition.PREDICATE :
-                        PredicateTransition pt = (PredicateTransition)t;
-                        arg1 = pt.ruleIndex;
-                        arg2 = pt.predIndex;
-                        arg3 = pt.isCtxDependent ? 1 : 0 ;
-                        break;
-                    case Transition.RANGE :
-                        arg1 = ((RangeTransition)t).from;
-                        arg2 = ((RangeTransition)t).to;
-                        if (arg1 == Token.EOF) {
-                            arg1 = 0;
-                            arg3 = 1;
-                        }
-
-                        break;
-                    case Transition.ATOM :
-                        arg1 = ((AtomTransition)t).label;
-                        if (arg1 == Token.EOF) {
-                            arg1 = 0;
-                            arg3 = 1;
-                        }
-
-                        break;
-                    case Transition.ACTION :
-                        ActionTransition at = (ActionTransition)t;
-                        arg1 = at.ruleIndex;
-                        arg2 = at.actionIndex;
-//						if (arg2 == -1) {
-//							arg2 = 0xFFFF;
-//						}
-
-                        arg3 = at.isCtxDependent ? 1 : 0 ;
-                        break;
-                    case Transition.SET :
-                        arg1 = setIndices.get(((SetTransition)t).set);
-                        break;
-                    case Transition.NOT_SET :
-                        arg1 = setIndices.get(((SetTransition)t).set);
-                        break;
-                    case Transition.WILDCARD :
-                        break;
-                }
-                transitionBuilder.add("src",src);
-                transitionBuilder.add("trg",trg);
-                transitionBuilder.add("edgeType",edgeType);
-                transitionBuilder.add("arg1",arg1);
-                transitionBuilder.add("arg2",arg2);
-                transitionBuilder.add("arg3",arg3);
-                transitionsBuilder.add(transitionBuilder);
-            }
-            allTransitionsBuilder.add(transitionsBuilder);
-        }
-
-        builder.add("allTransitionsBuilder",allTransitionsBuilder);
-        int ndecisions = atn.decisionToState.size();
-        //data.add(ndecisions);
-        JsonArrayBuilder  decisionToStateBuilder = Json.createArrayBuilder() ;
-
-        for (DecisionState decStartState : atn.decisionToState) {
-            //data.add(decStartState.stateNumber);
-            decisionToStateBuilder.add(decStartState.stateNumber);
-        }
-        builder.add("decisionToState",decisionToStateBuilder);
-        //
-        // LEXER ACTIONS
-        //
-        JsonArrayBuilder  lexerActionsBuilder = Json.createArrayBuilder() ;
-
-        if (atn.grammarType == ATNType.LEXER) {
-            //data.add(atn.lexerActions.length);
-            for (LexerAction action : atn.lexerActions) {
-                JsonObjectBuilder lexerActionBuilder = Json.createObjectBuilder();
-
-                lexerActionBuilder.add("actionType",action.getActionType().ordinal());
-                //data.add(action.getActionType().ordinal());
-                switch (action.getActionType()) {
-                    case CHANNEL:
-                        int channel = ((LexerChannelAction)action).getChannel();
-
-                        lexerActionBuilder.add("a",channel);
-                        lexerActionBuilder.add("b",0);
-                        break;
-
-                    case CUSTOM:
-                        int ruleIndex = ((LexerCustomAction)action).getRuleIndex();
-                        int actionIndex = ((LexerCustomAction)action).getActionIndex();
-
-                        lexerActionBuilder.add("a",ruleIndex);
-                        lexerActionBuilder.add("b",actionIndex);
-                        break;
-
-                    case MODE:
-                        int mode = ((LexerModeAction)action).getMode();
-
-                        lexerActionBuilder.add("a",mode);
-                        lexerActionBuilder.add("b",0);
-                        break;
-
-
-                    case MORE:
-
-                        lexerActionBuilder.add("a",0);
-                        lexerActionBuilder.add("b",0);
-                        break;
-
-                    case POP_MODE:
-                        lexerActionBuilder.add("a",0);
-                        lexerActionBuilder.add("b",0);
-                        break;
-
-                    case PUSH_MODE:
-                        mode = ((LexerPushModeAction)action).getMode();
-
-                        lexerActionBuilder.add("a",mode);
-                        lexerActionBuilder.add("b",0);
-                        break;
-
-                    case SKIP:
-                        lexerActionBuilder.add("a",0);
-                        lexerActionBuilder.add("b",0);
-                        break;
-
-                    case TYPE:
-                        int type = ((LexerTypeAction)action).getType();
-
-                        lexerActionBuilder.add("a",type);
-                        lexerActionBuilder.add("b",0);
-                        break;
-
-                    default:
-                        String message = String.format(Locale.getDefault(), "The specified lexer action type %s is not valid.", action.getActionType());
-                        throw new IllegalArgumentException(message);
-                }
-                lexerActionsBuilder.add(lexerActionBuilder);
-            }
-        }
-        builder.add("lexerActions",lexerActionsBuilder);
-        // don't adjust the first value since that's the version number
-//		for (int i = 1; i < data.size(); i++) {
-//			if (data.get(i) < Character.MIN_VALUE || data.get(i) > Character.MAX_VALUE) {
-//				throw new UnsupportedOperationException("Serialized ATN data element out of range.");
-//			}
-//
-//			int value = (data.get(i) + 2) & 0xFFFF;
-//			data.set(i, value);
-//		}
-        JsonObject data = builder.build();
-        //  System.out.print(data.toString());
-        return data.toString();
-    }
-
-    //<--
     protected static class SwiftStringRenderer extends StringRenderer {
-
         @Override
         public String toString(Object o, String formatString, Locale locale) {
             if ("java-escape".equals(formatString)) {
@@ -527,6 +100,5 @@ public class SwiftTarget extends Target {
 
             return super.toString(o, formatString, locale);
         }
-
     }
 }


### PR DESCRIPTION
Using plain chars for serialized ATN data instead of escaped where it's possible. Fixed the bug with the max size of ATN segment introduced in https://github.com/antlr/antlr4/pull/3438.

I've compared the size of source files for [`largeLexer`](https://github.com/antlr/antlr4/blob/master/runtime-testsuite/test/org/antlr/v4/test/runtime/GeneratedLexerDescriptors.java#L42) test:

| Language   | Before (KB) | After (KB) | Comment                             |
| ---------- | ------ | ----- | ----------------------------------- |
| Java       | 1331   | 902   |                                     |
| C#         | 2713   | 1997  |                                     |
| Dart       | 2582   | 1468  | + Fixed max ATN segment               |
| JavaScript | 2148   | 1702  |                                     |
| Go         | -      | -     | No change because of plain ushort16 |
| PHP        | 2287   | 971   | + Fixed max ATN segment               |
| Python     | 1711   | 1102  |                                     |
| Cpp        | 3158   | 1212  | + Fixed max ATN segment               |
| Swift      | 4900  | 1400  | JSON -> Binary serialization  (6900 -> 3400 for compilied files)  |

Also, I've fixed binary serialization in Swift and replaced JSON serialization.

Please do not squash since all commits are atomic.