### PR TITLE
Fix .interp file parsing test for the Java runtime.

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTestSupport.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTestSupport.java
@@ -225,6 +225,7 @@ public abstract class BaseRuntimeTestSupport implements RuntimeTestSupport {
 
 		return atn;
 	}
+
 	protected void semanticProcess(Grammar g) {
 		if ( g.ast!=null && !g.ast.hasErrors ) {
 //			System.out.println(g.ast.toStringTree());

--- a/runtime/Java/src/org/antlr/v4/runtime/VocabularyImpl.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/VocabularyImpl.java
@@ -173,4 +173,18 @@ public class VocabularyImpl implements Vocabulary {
 
 		return Integer.toString(tokenType);
 	}
+
+	// Because this is an actual implementation object, we can provide access methods for vocabulary symbols
+
+	public String[] getLiteralNames() {
+		return literalNames;
+	}
+
+	public String[] getSymbolicNames() {
+		return symbolicNames;
+	}
+
+	public String[] getDisplayNames() {
+		return displayNames;
+	}
 }

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -390,7 +390,15 @@ public class Tool {
 
 		if ( generate_ATN_dot ) generateATNs(g);
 
-		if (gencode && g.tool.getNumErrors()==0 ) generateInterpreterData(g);
+		if (gencode && g.tool.getNumErrors()==0 ) {
+			String interpFile = generateInterpreterData(g);
+			try (Writer fw = getOutputFileWriter(g, g.name + ".interp")) {
+				fw.write(interpFile);
+			}
+			catch (IOException ioe) {
+				errMgr.toolError(ErrorType.CANNOT_WRITE_FILE, ioe);
+			}
+		}
 
 		// PERFORM GRAMMAR ANALYSIS ON ATN: BUILD DECISION DFAs
 		AnalysisPipeline anal = new AnalysisPipeline(g);
@@ -690,7 +698,7 @@ public class Tool {
 		}
 	}
 
-	private void generateInterpreterData(Grammar g) {
+	public static String generateInterpreterData(Grammar g) {
 		StringBuilder content = new StringBuilder();
 
 		content.append("token literal names:\n");
@@ -738,18 +746,7 @@ public class Tool {
 		content.append("atn:\n");
 		content.append(serializedATN.toString());
 
-		try {
-			Writer fw = getOutputFileWriter(g, g.name + ".interp");
-			try {
-				fw.write(content.toString());
-			}
-			finally {
-				fw.close();
-			}
-		}
-		catch (IOException ioe) {
-			errMgr.toolError(ErrorType.CANNOT_WRITE_FILE, ioe);
-		}
+		return content.toString();
 	}
 
 	/** This method is used by all code generators to create new output


### PR DESCRIPTION
Also includes separating the generation of the .interp file from writing it out so that we can use both independently.

Still working on the Python part.