### PR TITLE
[C++] Fix missing virtual destructors

### DIFF
--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
@@ -24,6 +24,8 @@ namespace atn {
     /// <param name="lexerActions"> The lexer actions to execute. </param>
     explicit LexerActionExecutor(std::vector<Ref<LexerAction>> lexerActions);
 
+    virtual ~LexerActionExecutor() = default;
+
     /// <summary>
     /// Creates a <seealso cref="LexerActionExecutor"/> which executes the actions for
     /// the input {@code lexerActionExecutor} followed by a specified

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
@@ -28,9 +28,6 @@ const Ref<PredictionContext> PredictionContext::EMPTY = std::make_shared<EmptyPr
 PredictionContext::PredictionContext(size_t cachedHashCode) : id(globalNodeCount.fetch_add(1, std::memory_order_relaxed)), cachedHashCode(cachedHashCode)  {
 }
 
-PredictionContext::~PredictionContext() {
-}
-
 Ref<PredictionContext> PredictionContext::fromRuleContext(const ATN &atn, RuleContext *outerContext) {
   if (outerContext == nullptr) {
     return PredictionContext::EMPTY;

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.h
@@ -65,10 +65,11 @@ namespace atn {
     const size_t cachedHashCode;
 
   protected:
-    PredictionContext(size_t cachedHashCode);
-    ~PredictionContext();
+    explicit PredictionContext(size_t cachedHashCode);
 
   public:
+    virtual ~PredictionContext() = default;
+
     /// Convert a RuleContext tree to a PredictionContext graph.
     /// Return EMPTY if outerContext is empty.
     static Ref<PredictionContext> fromRuleContext(const ATN &atn, RuleContext *outerContext);


### PR DESCRIPTION
Fix broken compilation due to missing virtual destructors on `LexerActionExecutor` and `PredictionContext`. I removed the former previously thinking `std::enable_shared_from_this` was virtual itself, but apparently its not. `PredictionContext` was never virtual and it should have been.