### PR TITLE
[C++] Fix const correctness in ATN and DFA

### DIFF
--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
@@ -308,7 +308,7 @@ misc::IntervalSet DefaultErrorStrategy::getErrorRecoverySet(Parser *recognizer) 
   while (ctx->invokingState != ATNState::INVALID_STATE_NUMBER) {
     // compute what follows who invoked us
     atn::ATNState *invokingState = atn.states[ctx->invokingState];
-    atn::RuleTransition *rt = dynamic_cast<atn::RuleTransition*>(invokingState->transitions[0]);
+    const atn::RuleTransition *rt = dynamic_cast<const atn::RuleTransition*>(invokingState->transitions[0].get());
     misc::IntervalSet follow = atn.nextTokens(rt->followState);
     recoverSet.addAll(follow);
 

--- a/runtime/Cpp/runtime/src/FailedPredicateException.cpp
+++ b/runtime/Cpp/runtime/src/FailedPredicateException.cpp
@@ -26,10 +26,10 @@ FailedPredicateException::FailedPredicateException(Parser *recognizer, const std
                          recognizer->getInputStream(), recognizer->getContext(), recognizer->getCurrentToken()) {
 
   atn::ATNState *s = recognizer->getInterpreter<atn::ATNSimulator>()->atn.states[recognizer->getState()];
-  atn::Transition *transition = s->transitions[0];
-  if (is<atn::PredicateTransition*>(transition)) {
-    _ruleIndex = static_cast<atn::PredicateTransition *>(transition)->ruleIndex;
-    _predicateIndex = static_cast<atn::PredicateTransition *>(transition)->predIndex;
+  const atn::Transition *transition = s->transitions[0].get();
+  if (is<const atn::PredicateTransition*>(transition)) {
+    _ruleIndex = static_cast<const atn::PredicateTransition *>(transition)->ruleIndex;
+    _predicateIndex = static_cast<const atn::PredicateTransition *>(transition)->predIndex;
   } else {
     _ruleIndex = 0;
     _predicateIndex = 0;

--- a/runtime/Cpp/runtime/src/FailedPredicateException.h
+++ b/runtime/Cpp/runtime/src/FailedPredicateException.h
@@ -15,7 +15,7 @@ namespace antlr4 {
   /// prediction.
   class ANTLR4CPP_PUBLIC FailedPredicateException : public RecognitionException {
   public:
-    FailedPredicateException(Parser *recognizer);
+    explicit FailedPredicateException(Parser *recognizer);
     FailedPredicateException(Parser *recognizer, const std::string &predicate);
     FailedPredicateException(Parser *recognizer, const std::string &predicate, const std::string &message);
 

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -484,7 +484,7 @@ bool Parser::isExpectedToken(size_t symbol) {
 
   while (ctx && ctx->invokingState != ATNState::INVALID_STATE_NUMBER && following.contains(Token::EPSILON)) {
     atn::ATNState *invokingState = atn.states[ctx->invokingState];
-    atn::RuleTransition *rt = static_cast<atn::RuleTransition*>(invokingState->transitions[0]);
+    const atn::RuleTransition *rt = static_cast<const atn::RuleTransition*>(invokingState->transitions[0].get());
     following = atn.nextTokens(rt->followState);
     if (following.contains(symbol)) {
       return true;

--- a/runtime/Cpp/runtime/src/ParserInterpreter.cpp
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.cpp
@@ -152,7 +152,7 @@ void ParserInterpreter::visitState(atn::ATNState *p) {
     predictedAlt = visitDecisionState(dynamic_cast<DecisionState *>(p));
   }
 
-  atn::Transition *transition = p->transitions[predictedAlt - 1];
+  const atn::Transition *transition = p->transitions[predictedAlt - 1].get();
   switch (transition->getSerializationType()) {
     case atn::Transition::EPSILON:
       if (p->getStateType() == ATNState::STAR_LOOP_ENTRY &&
@@ -167,7 +167,7 @@ void ParserInterpreter::visitState(atn::ATNState *p) {
       break;
 
     case atn::Transition::ATOM:
-      match(static_cast<int>(static_cast<atn::AtomTransition*>(transition)->_label));
+      match(static_cast<int>(static_cast<const atn::AtomTransition*>(transition)->_label));
       break;
 
     case atn::Transition::RANGE:
@@ -189,7 +189,7 @@ void ParserInterpreter::visitState(atn::ATNState *p) {
       size_t ruleIndex = ruleStartState->ruleIndex;
       InterpreterRuleContext *newctx = createInterpreterRuleContext(_ctx, p->stateNumber, ruleIndex);
       if (ruleStartState->isLeftRecursiveRule) {
-        enterRecursionRule(newctx, ruleStartState->stateNumber, ruleIndex, static_cast<atn::RuleTransition*>(transition)->precedence);
+        enterRecursionRule(newctx, ruleStartState->stateNumber, ruleIndex, static_cast<const atn::RuleTransition*>(transition)->precedence);
       } else {
         enterRule(newctx, transition->target->stateNumber, ruleIndex);
       }
@@ -198,7 +198,7 @@ void ParserInterpreter::visitState(atn::ATNState *p) {
 
     case atn::Transition::PREDICATE:
     {
-      atn::PredicateTransition *predicateTransition = static_cast<atn::PredicateTransition*>(transition);
+      const atn::PredicateTransition *predicateTransition = static_cast<const atn::PredicateTransition*>(transition);
       if (!sempred(_ctx, predicateTransition->ruleIndex, predicateTransition->predIndex)) {
         throw FailedPredicateException(this);
       }
@@ -207,15 +207,15 @@ void ParserInterpreter::visitState(atn::ATNState *p) {
 
     case atn::Transition::ACTION:
     {
-      atn::ActionTransition *actionTransition = static_cast<atn::ActionTransition*>(transition);
+      const atn::ActionTransition *actionTransition = static_cast<const atn::ActionTransition*>(transition);
       action(_ctx, actionTransition->ruleIndex, actionTransition->actionIndex);
     }
       break;
 
     case atn::Transition::PRECEDENCE:
     {
-      if (!precpred(_ctx, static_cast<atn::PrecedencePredicateTransition*>(transition)->precedence)) {
-        throw FailedPredicateException(this, "precpred(_ctx, " + std::to_string(static_cast<atn::PrecedencePredicateTransition*>(transition)->precedence) +  ")");
+      if (!precpred(_ctx, static_cast<const atn::PrecedencePredicateTransition*>(transition)->precedence)) {
+        throw FailedPredicateException(this, "precpred(_ctx, " + std::to_string(static_cast<const atn::PrecedencePredicateTransition*>(transition)->precedence) +  ")");
       }
     }
       break;
@@ -259,7 +259,7 @@ void ParserInterpreter::visitRuleStopState(atn::ATNState *p) {
     exitRule();
   }
 
-  atn::RuleTransition *ruleTransition = static_cast<atn::RuleTransition*>(_atn.states[getState()]->transitions[0]);
+  const atn::RuleTransition *ruleTransition = static_cast<const atn::RuleTransition*>(_atn.states[getState()]->transitions[0].get());
   setState(ruleTransition->followState->stateNumber);
 }
 

--- a/runtime/Cpp/runtime/src/atn/ATN.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATN.cpp
@@ -146,7 +146,7 @@ misc::IntervalSet ATN::getExpectedTokens(size_t stateNumber, RuleContext *contex
   expected.remove(Token::EPSILON);
   while (ctx && ctx->invokingState != ATNState::INVALID_STATE_NUMBER && following.contains(Token::EPSILON)) {
     ATNState *invokingState = states.at(ctx->invokingState);
-    RuleTransition *rt = static_cast<RuleTransition*>(invokingState->transitions[0]);
+    const RuleTransition *rt = static_cast<const RuleTransition*>(invokingState->transitions[0].get());
     following = nextTokens(rt->followState);
     expected.addAll(following);
     expected.remove(Token::EPSILON);

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.h
@@ -5,7 +5,10 @@
 
 #pragma once
 
+#include <cassert>
+
 #include "antlr4-common.h"
+#include "atn/SemanticContext.h"
 
 namespace antlr4 {
 namespace atn {
@@ -22,32 +25,39 @@ namespace atn {
   public:
     struct Hasher
     {
+      size_t operator()(Ref<ATNConfig> const& k) const {
+        return k->hashCode();
+      }
+
       size_t operator()(ATNConfig const& k) const {
         return k.hashCode();
       }
     };
 
     struct Comparer {
+      bool operator()(Ref<ATNConfig> const& lhs, Ref<ATNConfig> const& rhs) const {
+        return (lhs == rhs) || (*lhs == *rhs);
+      }
+
       bool operator()(ATNConfig const& lhs, ATNConfig const& rhs) const {
         return (&lhs == &rhs) || (lhs == rhs);
       }
     };
 
-
     using Set = std::unordered_set<Ref<ATNConfig>, Hasher, Comparer>;
 
     /// The ATN state associated with this configuration.
-    ATNState * state;
+    ATNState *state = nullptr;
 
     /// What alt (or lexer rule) is predicted by this configuration.
-    const size_t alt;
+    const size_t alt = 0;
 
     /// The stack of invoking states leading to the rule/states associated
     /// with this config.  We track only those contexts pushed during
     /// execution of the ATN simulator.
     ///
     /// Can be shared between multiple ANTConfig instances.
-    Ref<PredictionContext> context;
+    Ref<const PredictionContext> context;
 
     /**
      * We cannot execute predicates dependent upon local context unless
@@ -72,20 +82,19 @@ namespace atn {
      * {@link ATNConfigSet#add(ATNConfig, DoubleKeyMap)} method are
      * <em>completely</em> unaffected by the change.</p>
      */
-    size_t reachesIntoOuterContext;
+    size_t reachesIntoOuterContext = 0;
 
     /// Can be shared between multiple ATNConfig instances.
-    Ref<SemanticContext> semanticContext;
+    Ref<const SemanticContext> semanticContext;
 
-    ATNConfig(ATNState *state, size_t alt, Ref<PredictionContext> context);
-    ATNConfig(ATNState *state, size_t alt, Ref<PredictionContext> context, Ref<SemanticContext> semanticContext);
+    ATNConfig(ATNState *state, size_t alt, Ref<const PredictionContext> context);
+    ATNConfig(ATNState *state, size_t alt, Ref<const PredictionContext> context, Ref<const SemanticContext> semanticContext);
 
-    ATNConfig(Ref<ATNConfig> const& c); // dup
-    ATNConfig(Ref<ATNConfig> const& c, ATNState *state);
-    ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<SemanticContext> semanticContext);
-    ATNConfig(Ref<ATNConfig> const& c, Ref<SemanticContext> semanticContext);
-    ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> context);
-    ATNConfig(Ref<ATNConfig> const& c, ATNState *state, Ref<PredictionContext> context, Ref<SemanticContext> semanticContext);
+    ATNConfig(ATNConfig const& other, Ref<const SemanticContext> semanticContext);
+    ATNConfig(ATNConfig const& other, ATNState *state);
+    ATNConfig(ATNConfig const& other, ATNState *state, Ref<const SemanticContext> semanticContext);
+    ATNConfig(ATNConfig const& other, ATNState *state, Ref<const PredictionContext> context);
+    ATNConfig(ATNConfig const& other, ATNState *state, Ref<const PredictionContext> context, Ref<const SemanticContext> semanticContext);
 
     ATNConfig(ATNConfig const&) = default;
 
@@ -114,12 +123,7 @@ namespace atn {
     std::string toString(bool showAlt) const;
 
   private:
-    /**
-     * This field stores the bit mask for implementing the
-     * {@link #isPrecedenceFilterSuppressed} property as a bit within the
-     * existing {@link #reachesIntoOuterContext} field.
-     */
-    static constexpr size_t SUPPRESS_PRECEDENCE_FILTER = 0x40000000;
+    ATNConfig(ATNState *state, size_t alt, Ref<const PredictionContext> context, size_t reachesIntoOuterContext, Ref<const SemanticContext> semanticContext);
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
@@ -5,8 +5,11 @@
 
 #pragma once
 
+#include <cassert>
+
 #include "support/BitSet.h"
 #include "atn/PredictionContext.h"
+#include "atn/ATNConfig.h"
 
 namespace antlr4 {
 namespace atn {
@@ -20,7 +23,7 @@ namespace atn {
 
     // TODO: these fields make me pretty uncomfortable but nice to pack up info together, saves recomputation
     // TODO: can we track conflicts as they are added to save scanning configs later?
-    size_t uniqueAlt;
+    size_t uniqueAlt = 0;
 
     /** Currently this is only used when we detect SLL conflict; this does
      *  not necessarily represent the ambiguous alternatives. In fact,
@@ -31,23 +34,25 @@ namespace atn {
 
     // Used in parser and lexer. In lexer, it indicates we hit a pred
     // while computing a closure operation.  Don't make a DFA state from this.
-    bool hasSemanticContext;
-    bool dipsIntoOuterContext;
+    bool hasSemanticContext = false;
+    bool dipsIntoOuterContext = false;
 
     /// Indicates that this configuration set is part of a full context
     /// LL prediction. It will be used to determine how to merge $. With SLL
     /// it's a wildcard whereas it is not for LL context merge.
-    const bool fullCtx;
+    const bool fullCtx = true;
 
     ATNConfigSet();
 
-    explicit ATNConfigSet(bool fullCtx);
+    ATNConfigSet(const ATNConfigSet &other);
 
-    explicit ATNConfigSet(const Ref<ATNConfigSet> &old);
+    ATNConfigSet(ATNConfigSet &&) = delete;
+
+    explicit ATNConfigSet(bool fullCtx);
 
     virtual ~ATNConfigSet() = default;
 
-    virtual bool add(const Ref<ATNConfig> &config);
+    bool add(const Ref<ATNConfig> &config);
 
     /// <summary>
     /// Adding a new config means merging contexts with existing configs for
@@ -59,9 +64,11 @@ namespace atn {
     /// This method updates <seealso cref="#dipsIntoOuterContext"/> and
     /// <seealso cref="#hasSemanticContext"/> when necessary.
     /// </summary>
-    virtual bool add(const Ref<ATNConfig> &config, PredictionContextMergeCache *mergeCache);
+    bool add(const Ref<ATNConfig> &config, PredictionContextMergeCache *mergeCache);
 
-    virtual std::vector<ATNState *> getStates() const;
+    bool addAll(const ATNConfigSet &other);
+
+    std::vector<ATNState *> getStates() const;
 
     /**
      * Gets the complete set of represented alternatives for the configuration
@@ -72,42 +79,76 @@ namespace atn {
      * @since 4.3
      */
     antlrcpp::BitSet getAlts() const;
-    virtual std::vector<Ref<SemanticContext>> getPredicates() const;
+    std::vector<Ref<const SemanticContext>> getPredicates() const;
 
-    virtual Ref<ATNConfig> get(size_t i) const;
+    const Ref<ATNConfig>& get(size_t i) const;
 
-    virtual void optimizeConfigs(ATNSimulator *interpreter);
+    void optimizeConfigs(ATNSimulator *interpreter);
 
-    bool addAll(const Ref<ATNConfigSet> &other);
+    size_t size() const;
+    bool isEmpty() const;
+    void clear();
+    bool isReadonly() const;
+    void setReadonly(bool readonly);
 
-    bool operator==(const ATNConfigSet &other) const;
     virtual size_t hashCode() const;
-    virtual size_t size() const;
-    virtual bool isEmpty() const;
-    virtual void clear();
-    virtual bool isReadonly() const;
-    virtual void setReadonly(bool readonly);
+
+    virtual bool equals(const ATNConfigSet &other) const;
+
     virtual std::string toString() const;
 
-  protected:
+  private:
+    struct ATNConfigHasher final {
+      const ATNConfigSet* atnConfigSet;
+
+      size_t operator()(const ATNConfig *other) const {
+        assert(other != nullptr);
+        return atnConfigSet->hashCode(*other);
+      }
+    };
+
+    struct ATNConfigComparer final {
+      const ATNConfigSet* atnConfigSet;
+
+      bool operator()(const ATNConfig *lhs, const ATNConfig *rhs) const {
+        assert(lhs != nullptr);
+        assert(rhs != nullptr);
+        return atnConfigSet->equals(*lhs, *rhs);
+      }
+    };
+
+    mutable std::atomic<size_t> _cachedHashCode = 0;
+
     /// Indicates that the set of configurations is read-only. Do not
     /// allow any code to manipulate the set; DFA states will point at
     /// the sets and they must not change. This does not protect the other
     /// fields; in particular, conflictingAlts is set after
     /// we've made this readonly.
-    bool _readonly;
+    bool _readonly = false;
 
-    virtual size_t getHash(const ATNConfig *c) const; // Hash differs depending on set type.
+    virtual size_t hashCode(const ATNConfig &atnConfig) const;
 
-  private:
-    mutable std::atomic<size_t> _cachedHashCode;
+    virtual bool equals(const ATNConfig &lhs, const ATNConfig &rhs) const;
 
     /// All configs but hashed by (s, i, _, pi) not including context. Wiped out
     /// when we go readonly as this set becomes a DFA state.
-    std::unordered_map<size_t, ATNConfig *> _configLookup;
-
-    void InitializeInstanceFields();
+    std::unordered_set<ATNConfig*, ATNConfigHasher, ATNConfigComparer> _configLookup;
   };
+
+  inline bool operator==(const ATNConfigSet &lhs, const ATNConfigSet &rhs) { return lhs.equals(rhs); }
+
+  inline bool operator!=(const ATNConfigSet &lhs, const ATNConfigSet &rhs) { return !operator==(lhs, rhs); }
 
 } // namespace atn
 } // namespace antlr4
+
+namespace std {
+
+template <>
+struct hash<::antlr4::atn::ATNConfigSet> {
+  size_t operator()(const ::antlr4::atn::ATNConfigSet &atnConfigSet) const {
+    return atnConfigSet.hashCode();
+  }
+};
+
+} // namespace std

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.h
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.h
@@ -7,6 +7,7 @@
 
 #include "atn/LexerAction.h"
 #include "atn/ATNDeserializationOptions.h"
+#include "atn/Transition.h"
 
 namespace antlr4 {
 namespace atn {
@@ -27,7 +28,7 @@ public:
   static void checkCondition(bool condition);
   static void checkCondition(bool condition, const std::string &message);
 
-  static Transition *edgeFactory(const ATN &atn, size_t type, size_t src, size_t trg, size_t arg1, size_t arg2,
+  static ConstTransitionPtr edgeFactory(const ATN &atn, size_t type, size_t src, size_t trg, size_t arg1, size_t arg2,
                                   size_t arg3, const std::vector<misc::IntervalSet> &sets);
 
   static ATNState *stateFactory(size_t type, size_t ruleIndex);

--- a/runtime/Cpp/runtime/src/atn/ATNSerializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNSerializer.cpp
@@ -106,10 +106,10 @@ std::vector<size_t> ATNSerializer::serialize() {
     }
 
     for (size_t i = 0; i < s->transitions.size(); i++) {
-      Transition *t = s->transitions[i];
+      const Transition *t = s->transitions[i].get();
       Transition::SerializationType edgeType = t->getSerializationType();
       if (edgeType == Transition::SET || edgeType == Transition::NOT_SET) {
-        SetTransition *st = static_cast<SetTransition *>(t);
+        const SetTransition *st = static_cast<const SetTransition *>(t);
         if (setIndices.find(st->set) == setIndices.end()) {
           sets.push_back(st->set);
           setIndices.insert({ st->set, (int)sets.size() - 1 });
@@ -193,7 +193,7 @@ std::vector<size_t> ATNSerializer::serialize() {
     }
 
     for (size_t i = 0; i < s->transitions.size(); i++) {
-      Transition *t = s->transitions[i];
+      const Transition *t = s->transitions[i].get();
 
       if (atn->states[t->target->stateNumber] == nullptr) {
         throw IllegalStateException("Cannot serialize a transition to a removed state.");
@@ -207,29 +207,29 @@ std::vector<size_t> ATNSerializer::serialize() {
       size_t arg3 = 0;
       switch (edgeType) {
         case Transition::RULE:
-          trg = (static_cast<RuleTransition *>(t))->followState->stateNumber;
-          arg1 = (static_cast<RuleTransition *>(t))->target->stateNumber;
-          arg2 = (static_cast<RuleTransition *>(t))->ruleIndex;
-          arg3 = (static_cast<RuleTransition *>(t))->precedence;
+          trg = (static_cast<const RuleTransition *>(t))->followState->stateNumber;
+          arg1 = (static_cast<const RuleTransition *>(t))->target->stateNumber;
+          arg2 = (static_cast<const RuleTransition *>(t))->ruleIndex;
+          arg3 = (static_cast<const RuleTransition *>(t))->precedence;
           break;
         case Transition::PRECEDENCE:
         {
-          PrecedencePredicateTransition *ppt =
-          static_cast<PrecedencePredicateTransition *>(t);
+          const PrecedencePredicateTransition *ppt =
+          static_cast<const PrecedencePredicateTransition *>(t);
           arg1 = ppt->precedence;
         }
           break;
         case Transition::PREDICATE:
         {
-          PredicateTransition *pt = static_cast<PredicateTransition *>(t);
+          const PredicateTransition *pt = static_cast<const PredicateTransition *>(t);
           arg1 = pt->ruleIndex;
           arg2 = pt->predIndex;
           arg3 = pt->isCtxDependent ? 1 : 0;
         }
           break;
         case Transition::RANGE:
-          arg1 = (static_cast<RangeTransition *>(t))->from;
-          arg2 = (static_cast<RangeTransition *>(t))->to;
+          arg1 = (static_cast<const RangeTransition *>(t))->from;
+          arg2 = (static_cast<const RangeTransition *>(t))->to;
           if (arg1 == Token::EOF) {
             arg1 = 0;
             arg3 = 1;
@@ -237,7 +237,7 @@ std::vector<size_t> ATNSerializer::serialize() {
 
           break;
         case Transition::ATOM:
-          arg1 = (static_cast<AtomTransition *>(t))->_label;
+          arg1 = (static_cast<const AtomTransition *>(t))->_label;
           if (arg1 == Token::EOF) {
             arg1 = 0;
             arg3 = 1;
@@ -246,7 +246,7 @@ std::vector<size_t> ATNSerializer::serialize() {
           break;
         case Transition::ACTION:
         {
-          ActionTransition *at = static_cast<ActionTransition *>(t);
+          const ActionTransition *at = static_cast<const ActionTransition *>(t);
           arg1 = at->ruleIndex;
           arg2 = at->actionIndex;
           if (arg2 == INVALID_INDEX) {
@@ -257,11 +257,11 @@ std::vector<size_t> ATNSerializer::serialize() {
         }
           break;
         case Transition::SET:
-          arg1 = setIndices[(static_cast<SetTransition *>(t))->set];
+          arg1 = setIndices[(static_cast<const SetTransition *>(t))->set];
           break;
 
         case Transition::NOT_SET:
-          arg1 = setIndices[(static_cast<SetTransition *>(t))->set];
+          arg1 = setIndices[(static_cast<const SetTransition *>(t))->set];
           break;
 
         default:

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
@@ -34,9 +34,9 @@ PredictionContextCache& ATNSimulator::getSharedContextCache() {
   return _sharedContextCache;
 }
 
-Ref<PredictionContext> ATNSimulator::getCachedContext(Ref<PredictionContext> const& context) {
+Ref<const PredictionContext> ATNSimulator::getCachedContext(Ref<const PredictionContext> const& context) {
   // This function must only be called with an active state lock, as we are going to change a shared structure.
-  std::map<Ref<PredictionContext>, Ref<PredictionContext>> visited;
+  std::map<Ref<const PredictionContext>, Ref<const PredictionContext>> visited;
   return PredictionContext::getCachedContext(context, _sharedContextCache, visited);
 }
 
@@ -53,7 +53,7 @@ void ATNSimulator::checkCondition(bool condition, const std::string &message) {
   ATNDeserializer::checkCondition(condition, message);
 }
 
-Transition *ATNSimulator::edgeFactory(const ATN &atn, int type, int src, int trg, int arg1, int arg2, int arg3,
+ConstTransitionPtr ATNSimulator::edgeFactory(const ATN &atn, int type, int src, int trg, int arg1, int arg2, int arg3,
                                       const std::vector<misc::IntervalSet> &sets) {
   return ATNDeserializer::edgeFactory(atn, type, src, trg, arg1, arg2, arg3, sets);
 }

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.h
@@ -37,7 +37,7 @@ namespace atn {
      */
     virtual void clearDFA();
     virtual PredictionContextCache& getSharedContextCache();
-    virtual Ref<PredictionContext> getCachedContext(Ref<PredictionContext> const& context);
+    virtual Ref<const PredictionContext> getCachedContext(Ref<const PredictionContext> const& context);
 
     /// @deprecated Use <seealso cref="ATNDeserializer#deserialize"/> instead.
     static ATN deserialize(const std::vector<uint16_t> &data);
@@ -49,7 +49,7 @@ namespace atn {
     static void checkCondition(bool condition, const std::string &message);
 
     /// @deprecated Use <seealso cref="ATNDeserializer#edgeFactory"/> instead.
-    static Transition *edgeFactory(const ATN &atn, int type, int src, int trg, int arg1, int arg2, int arg3,
+    static ConstTransitionPtr edgeFactory(const ATN &atn, int type, int src, int trg, int arg1, int arg2, int arg3,
                                    const std::vector<misc::IntervalSet> &sets);
 
     /// @deprecated Use <seealso cref="ATNDeserializer#stateFactory"/> instead.

--- a/runtime/Cpp/runtime/src/atn/ATNState.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNState.cpp
@@ -13,12 +13,6 @@
 using namespace antlr4::atn;
 using namespace antlrcpp;
 
-ATNState::~ATNState() {
-  for (auto *transition : transitions) {
-    delete transition;
-  }
-}
-
 const std::vector<std::string> ATNState::serializationNames = {
   "INVALID", "BASIC", "RULE_START", "BLOCK_START",
   "PLUS_BLOCK_START", "STAR_BLOCK_START", "TOKEN_START", "RULE_STOP",
@@ -29,7 +23,7 @@ size_t ATNState::hashCode() const {
   return stateNumber;
 }
 
-bool ATNState::operator==(const ATNState &other) const {
+bool ATNState::equals(const ATNState &other) const {
   return stateNumber == other.stateNumber;
 }
 
@@ -41,14 +35,13 @@ std::string ATNState::toString() const {
   return std::to_string(stateNumber);
 }
 
-void ATNState::addTransition(Transition *e) {
-  addTransition(transitions.size(), e);
+void ATNState::addTransition(ConstTransitionPtr e) {
+  addTransition(transitions.size(), std::move(e));
 }
 
-void ATNState::addTransition(size_t index, Transition *e) {
-  for (Transition *transition : transitions)
+void ATNState::addTransition(size_t index, ConstTransitionPtr e) {
+  for (const auto &transition : transitions)
     if (transition->target->stateNumber == e->target->stateNumber) {
-      delete e;
       return;
     }
 
@@ -59,11 +52,11 @@ void ATNState::addTransition(size_t index, Transition *e) {
     epsilonOnlyTransitions = false;
   }
 
-  transitions.insert(transitions.begin() + index, e);
+  transitions.insert(transitions.begin() + index, std::move(e));
 }
 
-Transition *ATNState::removeTransition(size_t index) {
-  Transition *result = transitions[index];
+ConstTransitionPtr ATNState::removeTransition(size_t index) {
+  ConstTransitionPtr result = std::move(transitions[index]);
   transitions.erase(transitions.begin() + index);
   return result;
 }

--- a/runtime/Cpp/runtime/src/atn/ATNState.h
+++ b/runtime/Cpp/runtime/src/atn/ATNState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "misc/IntervalSet.h"
+#include "atn/Transition.h"
 
 namespace antlr4 {
 namespace atn {
@@ -79,52 +80,58 @@ namespace atn {
   class ANTLR4CPP_PUBLIC ATN;
 #endif
 
+  using ATNStateType = size_t;
+
   class ANTLR4CPP_PUBLIC ATNState {
   public:
     static constexpr size_t INITIAL_NUM_TRANSITIONS = 4;
     static constexpr size_t INVALID_STATE_NUMBER = std::numeric_limits<size_t>::max();
 
+    static constexpr ATNStateType ATN_INVALID_TYPE = 0;
+    static constexpr ATNStateType BASIC = 1;
+    static constexpr ATNStateType RULE_START = 2;
+    static constexpr ATNStateType BLOCK_START = 3;
+    static constexpr ATNStateType PLUS_BLOCK_START = 4;
+    static constexpr ATNStateType STAR_BLOCK_START = 5;
+    static constexpr ATNStateType TOKEN_START = 6;
+    static constexpr ATNStateType RULE_STOP = 7;
+    static constexpr ATNStateType BLOCK_END = 8;
+    static constexpr ATNStateType STAR_LOOP_BACK = 9;
+    static constexpr ATNStateType STAR_LOOP_ENTRY = 10;
+    static constexpr ATNStateType PLUS_LOOP_BACK = 11;
+    static constexpr ATNStateType LOOP_END = 12;
+
     size_t stateNumber = INVALID_STATE_NUMBER;
     size_t ruleIndex = 0; // at runtime, we don't have Rule objects
     bool epsilonOnlyTransitions = false;
 
+    /// Track the transitions emanating from this ATN state.
+    std::vector<ConstTransitionPtr> transitions;
+
     ATNState() = default;
+
     ATNState(ATNState const&) = delete;
 
-    virtual ~ATNState();
+    ATNState(ATNState&&) = delete;
+
+    virtual ~ATNState() = default;
 
     ATNState& operator=(ATNState const&) = delete;
 
-    enum {
-      ATN_INVALID_TYPE = 0,
-      BASIC = 1,
-      RULE_START = 2,
-      BLOCK_START = 3,
-      PLUS_BLOCK_START = 4,
-      STAR_BLOCK_START = 5,
-      TOKEN_START = 6,
-      RULE_STOP = 7,
-      BLOCK_END = 8,
-      STAR_LOOP_BACK = 9,
-      STAR_LOOP_ENTRY = 10,
-      PLUS_LOOP_BACK = 11,
-      LOOP_END = 12
-    };
+    ATNState& operator=(ATNState&&) = delete;
 
     static const std::vector<std::string> serializationNames;
 
-    virtual size_t hashCode() const;
-    bool operator==(const ATNState &other) const;
+    void addTransition(ConstTransitionPtr e);
+    void addTransition(size_t index, ConstTransitionPtr e);
+    ConstTransitionPtr removeTransition(size_t index);
 
-    /// Track the transitions emanating from this ATN state.
-    std::vector<Transition*> transitions;
+    virtual size_t hashCode() const;
+    virtual bool equals(const ATNState &other) const;
 
     virtual bool isNonGreedyExitState() const;
     virtual std::string toString() const;
-    virtual void addTransition(Transition *e);
-    virtual void addTransition(size_t index, Transition *e);
-    virtual Transition* removeTransition(size_t index);
-    virtual size_t getStateType() = 0;
+    virtual ATNStateType getStateType() const = 0;
 
   private:
     /// Used to cache lookahead during parsing, not used during construction.
@@ -134,6 +141,10 @@ namespace atn {
 
     friend class ATN;
   };
+
+  inline bool operator==(const ATNState &lhs, const ATNState &rhs) { return lhs.equals(rhs); }
+
+  inline bool operator!=(const ATNState &lhs, const ATNState &rhs) { return !operator==(lhs, rhs); }
 
 } // namespace atn
 } // namespace antlr4

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
@@ -10,11 +10,11 @@
 
 using namespace antlr4::atn;
 
-ArrayPredictionContext::ArrayPredictionContext(Ref<SingletonPredictionContext> const& a)
+ArrayPredictionContext::ArrayPredictionContext(Ref<const SingletonPredictionContext> const& a)
   : ArrayPredictionContext({ a->parent }, { a->returnState }) {
 }
 
-ArrayPredictionContext::ArrayPredictionContext(std::vector<Ref<PredictionContext>> parents,
+ArrayPredictionContext::ArrayPredictionContext(std::vector<Ref<const PredictionContext>> parents,
                                                std::vector<size_t> returnStates)
   : PredictionContext(calculateHashCode(parents, returnStates)), parents(std::move(parents)), returnStates(std::move(returnStates)) {
     assert(this->parents.size() > 0);
@@ -30,7 +30,7 @@ size_t ArrayPredictionContext::size() const {
   return returnStates.size();
 }
 
-Ref<PredictionContext> ArrayPredictionContext::getParent(size_t index) const {
+Ref<const PredictionContext> ArrayPredictionContext::getParent(size_t index) const {
   return parents[index];
 }
 

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.h
@@ -20,18 +20,18 @@ namespace atn {
     /// returnState == EMPTY_RETURN_STATE.
     // Also here: we use a strong reference to our parents to avoid having them freed prematurely.
     //            See also SinglePredictionContext.
-    const std::vector<Ref<PredictionContext>> parents;
+    const std::vector<Ref<const PredictionContext>> parents;
 
     /// Sorted for merge, no duplicates; if present, EMPTY_RETURN_STATE is always last.
     const std::vector<size_t> returnStates;
 
-    explicit ArrayPredictionContext(Ref<SingletonPredictionContext> const &a);
+    explicit ArrayPredictionContext(Ref<const SingletonPredictionContext> const &a);
 
-    ArrayPredictionContext(std::vector<Ref<PredictionContext>> parents, std::vector<size_t> returnStates);
+    ArrayPredictionContext(std::vector<Ref<const PredictionContext>> parents, std::vector<size_t> returnStates);
 
     virtual bool isEmpty() const override;
     virtual size_t size() const override;
-    virtual Ref<PredictionContext> getParent(size_t index) const override;
+    virtual Ref<const PredictionContext> getParent(size_t index) const override;
     virtual size_t getReturnState(size_t index) const override;
     bool operator == (const PredictionContext &o) const override;
 

--- a/runtime/Cpp/runtime/src/atn/BasicBlockStartState.cpp
+++ b/runtime/Cpp/runtime/src/atn/BasicBlockStartState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t BasicBlockStartState::getStateType() {
+ATNStateType BasicBlockStartState::getStateType() const {
   return BLOCK_START;
 }

--- a/runtime/Cpp/runtime/src/atn/BasicBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/BasicBlockStartState.h
@@ -12,9 +12,8 @@ namespace antlr4 {
 namespace atn {
 
   class ANTLR4CPP_PUBLIC BasicBlockStartState final : public BlockStartState {
-
   public:
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
 
   };
 

--- a/runtime/Cpp/runtime/src/atn/BasicState.cpp
+++ b/runtime/Cpp/runtime/src/atn/BasicState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t BasicState::getStateType() {
+ATNStateType BasicState::getStateType() const {
   return BASIC;
 }

--- a/runtime/Cpp/runtime/src/atn/BasicState.h
+++ b/runtime/Cpp/runtime/src/atn/BasicState.h
@@ -11,9 +11,8 @@ namespace antlr4 {
 namespace atn {
 
   class ANTLR4CPP_PUBLIC BasicState final : public ATNState {
-
   public:
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
 
   };
 

--- a/runtime/Cpp/runtime/src/atn/BlockEndState.cpp
+++ b/runtime/Cpp/runtime/src/atn/BlockEndState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t BlockEndState::getStateType() {
+ATNStateType BlockEndState::getStateType() const {
   return BLOCK_END;
 }

--- a/runtime/Cpp/runtime/src/atn/BlockEndState.h
+++ b/runtime/Cpp/runtime/src/atn/BlockEndState.h
@@ -15,7 +15,7 @@ namespace atn {
   public:
     BlockStartState *startState = nullptr;
 
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/EmptyPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/EmptyPredictionContext.cpp
@@ -18,7 +18,7 @@ size_t EmptyPredictionContext::size() const {
   return 1;
 }
 
-Ref<PredictionContext> EmptyPredictionContext::getParent(size_t /*index*/) const {
+Ref<const PredictionContext> EmptyPredictionContext::getParent(size_t /*index*/) const {
   return nullptr;
 }
 

--- a/runtime/Cpp/runtime/src/atn/EmptyPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/EmptyPredictionContext.h
@@ -16,7 +16,7 @@ namespace atn {
 
     virtual bool isEmpty() const override;
     virtual size_t size() const override;
-    virtual Ref<PredictionContext> getParent(size_t index) const override;
+    virtual Ref<const PredictionContext> getParent(size_t index) const override;
     virtual size_t getReturnState(size_t index) const override;
     virtual std::string toString() const override;
 

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
@@ -16,38 +16,20 @@
 using namespace antlr4::atn;
 using namespace antlrcpp;
 
-LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> context)
-  : ATNConfig(state, alt, std::move(context), SemanticContext::NONE), _passedThroughNonGreedyDecision(false) {
-}
+LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<const PredictionContext> context)
+    : ATNConfig(state, alt, std::move(context)) {}
 
-LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> context,
-                               Ref<LexerActionExecutor> lexerActionExecutor)
-  : ATNConfig(state, alt, std::move(context), SemanticContext::NONE), _lexerActionExecutor(std::move(lexerActionExecutor)),
-    _passedThroughNonGreedyDecision(false) {
-}
+LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<const PredictionContext> context, Ref<LexerActionExecutor> lexerActionExecutor)
+    : ATNConfig(state, alt, std::move(context)), _lexerActionExecutor(std::move(lexerActionExecutor)) {}
 
-LexerATNConfig::LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state)
-  : ATNConfig(c, state, c->context, c->semanticContext), _lexerActionExecutor(c->_lexerActionExecutor),
-   _passedThroughNonGreedyDecision(checkNonGreedyDecision(c, state)) {
-}
+LexerATNConfig::LexerATNConfig(LexerATNConfig const& other, ATNState *state)
+    : ATNConfig(other, state), _lexerActionExecutor(other._lexerActionExecutor), _passedThroughNonGreedyDecision(checkNonGreedyDecision(other, state)) {}
 
-LexerATNConfig::LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<LexerActionExecutor> lexerActionExecutor)
-  : ATNConfig(c, state, c->context, c->semanticContext), _lexerActionExecutor(std::move(lexerActionExecutor)),
-    _passedThroughNonGreedyDecision(checkNonGreedyDecision(c, state)) {
-}
+LexerATNConfig::LexerATNConfig(LexerATNConfig const& other, ATNState *state, Ref<LexerActionExecutor> lexerActionExecutor)
+    : ATNConfig(other, state), _lexerActionExecutor(std::move(lexerActionExecutor)), _passedThroughNonGreedyDecision(checkNonGreedyDecision(other, state)) {}
 
-LexerATNConfig::LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<PredictionContext> context)
-  : ATNConfig(c, state, std::move(context), c->semanticContext), _lexerActionExecutor(c->_lexerActionExecutor),
-    _passedThroughNonGreedyDecision(checkNonGreedyDecision(c, state)) {
-}
-
-const Ref<LexerActionExecutor>& LexerATNConfig::getLexerActionExecutor() const {
-  return _lexerActionExecutor;
-}
-
-bool LexerATNConfig::hasPassedThroughNonGreedyDecision() const {
-  return _passedThroughNonGreedyDecision;
-}
+LexerATNConfig::LexerATNConfig(LexerATNConfig const& other, ATNState *state, Ref<const PredictionContext> context)
+    : ATNConfig(other, state, std::move(context)), _lexerActionExecutor(other._lexerActionExecutor), _passedThroughNonGreedyDecision(checkNonGreedyDecision(other, state)) {}
 
 size_t LexerATNConfig::hashCode() const {
   size_t hashCode = misc::MurmurHash::initialize(7);
@@ -78,7 +60,7 @@ bool LexerATNConfig::operator==(const LexerATNConfig& other) const
   return ATNConfig::operator==(other);
 }
 
-bool LexerATNConfig::checkNonGreedyDecision(Ref<LexerATNConfig> const& source, ATNState *target) {
-  return source->_passedThroughNonGreedyDecision ||
+bool LexerATNConfig::checkNonGreedyDecision(LexerATNConfig const& source, ATNState *target) {
+  return source._passedThroughNonGreedyDecision ||
     (is<DecisionState*>(target) && (static_cast<DecisionState*>(target))->nonGreedy);
 }

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
@@ -10,21 +10,21 @@
 namespace antlr4 {
 namespace atn {
 
-  class ANTLR4CPP_PUBLIC LexerATNConfig : public ATNConfig {
+  class ANTLR4CPP_PUBLIC LexerATNConfig final : public ATNConfig {
   public:
-    LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> context);
-    LexerATNConfig(ATNState *state, int alt, Ref<PredictionContext> context, Ref<LexerActionExecutor> lexerActionExecutor);
+    LexerATNConfig(ATNState *state, int alt, Ref<const PredictionContext> context);
+    LexerATNConfig(ATNState *state, int alt, Ref<const PredictionContext> context, Ref<LexerActionExecutor> lexerActionExecutor);
 
-    LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state);
-    LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<LexerActionExecutor> lexerActionExecutor);
-    LexerATNConfig(Ref<LexerATNConfig> const& c, ATNState *state, Ref<PredictionContext> context);
+    LexerATNConfig(LexerATNConfig const& other, ATNState *state);
+    LexerATNConfig(LexerATNConfig const& other, ATNState *state, Ref<LexerActionExecutor> lexerActionExecutor);
+    LexerATNConfig(LexerATNConfig const& other, ATNState *state, Ref<const PredictionContext> context);
 
     /**
      * Gets the {@link LexerActionExecutor} capable of executing the embedded
      * action(s) for the current configuration.
      */
-    const Ref<LexerActionExecutor>& getLexerActionExecutor() const;
-    bool hasPassedThroughNonGreedyDecision() const;
+    const Ref<LexerActionExecutor>& getLexerActionExecutor() const { return _lexerActionExecutor; }
+    bool hasPassedThroughNonGreedyDecision() const { return _passedThroughNonGreedyDecision; }
 
     virtual size_t hashCode() const override;
 
@@ -35,9 +35,9 @@ namespace atn {
      * This is the backing field for {@link #getLexerActionExecutor}.
      */
     const Ref<LexerActionExecutor> _lexerActionExecutor;
-    const bool _passedThroughNonGreedyDecision;
+    const bool _passedThroughNonGreedyDecision = false;
 
-    static bool checkNonGreedyDecision(Ref<LexerATNConfig> const& source, ATNState *target);
+    static bool checkNonGreedyDecision(LexerATNConfig const& source, ATNState *target);
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
@@ -138,7 +138,7 @@ namespace atn {
     virtual void accept(CharStream *input, const Ref<LexerActionExecutor> &lexerActionExecutor, size_t startIndex, size_t index,
                         size_t line, size_t charPos);
 
-    virtual ATNState *getReachableTarget(Transition *trans, size_t t);
+    virtual ATNState *getReachableTarget(const Transition *trans, size_t t);
 
     virtual std::unique_ptr<ATNConfigSet> computeStartState(CharStream *input, ATNState *p);
 
@@ -155,7 +155,7 @@ namespace atn {
                          bool currentAltReachedAcceptState, bool speculative, bool treatEofAsEpsilon);
 
     // side-effect: can alter configs.hasSemanticContext
-    virtual Ref<LexerATNConfig> getEpsilonTarget(CharStream *input, const Ref<LexerATNConfig> &config, Transition *t,
+    virtual Ref<LexerATNConfig> getEpsilonTarget(CharStream *input, const Ref<LexerATNConfig> &config, const Transition *t,
       ATNConfigSet *configs, bool speculative, bool treatEofAsEpsilon);
 
     /// <summary>

--- a/runtime/Cpp/runtime/src/atn/LoopEndState.cpp
+++ b/runtime/Cpp/runtime/src/atn/LoopEndState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t LoopEndState::getStateType() {
+ATNStateType LoopEndState::getStateType() const {
   return LOOP_END;
 }

--- a/runtime/Cpp/runtime/src/atn/LoopEndState.h
+++ b/runtime/Cpp/runtime/src/atn/LoopEndState.h
@@ -15,7 +15,7 @@ namespace atn {
   public:
     ATNState *loopBackState = nullptr;
 
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/OrderedATNConfigSet.cpp
+++ b/runtime/Cpp/runtime/src/atn/OrderedATNConfigSet.cpp
@@ -7,6 +7,10 @@
 
 using namespace antlr4::atn;
 
-size_t OrderedATNConfigSet::getHash(const ATNConfig *c) const {
-  return c->hashCode();
+size_t OrderedATNConfigSet::hashCode(const ATNConfig &atnConfig) const {
+  return atnConfig.hashCode();
+}
+
+bool OrderedATNConfigSet::equals(const ATNConfig &lhs, const ATNConfig &rhs) const {
+  return lhs == rhs;
 }

--- a/runtime/Cpp/runtime/src/atn/OrderedATNConfigSet.h
+++ b/runtime/Cpp/runtime/src/atn/OrderedATNConfigSet.h
@@ -11,9 +11,14 @@
 namespace antlr4 {
 namespace atn {
 
-  class ANTLR4CPP_PUBLIC OrderedATNConfigSet : public ATNConfigSet {
-  protected:
-    size_t getHash(const ATNConfig *c) const override;
+  class ANTLR4CPP_PUBLIC OrderedATNConfigSet final : public ATNConfigSet {
+  public:
+    OrderedATNConfigSet() = default;
+
+  private:
+    size_t hashCode(const ATNConfig &atnConfig) const override;
+
+    bool equals(const ATNConfig &lhs, const ATNConfig &rhs) const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
@@ -254,11 +254,11 @@ namespace atn {
     virtual void reset() override;
     virtual void clearDFA() override;
     virtual size_t adaptivePredict(TokenStream *input, size_t decision, ParserRuleContext *outerContext);
-    
+
     static const bool TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT;
 
     std::vector<dfa::DFA> &decisionToDFA;
-    
+
     /** Implements first-edge (loop entry) elimination as an optimization
      *  during closure operations.  See antlr/antlr4#1398.
      *
@@ -348,14 +348,14 @@ namespace atn {
     bool canDropLoopEntryEdgeInLeftRecursiveRule(ATNConfig *config) const;
     virtual std::string getRuleName(size_t index);
 
-    virtual Ref<ATNConfig> precedenceTransition(Ref<ATNConfig> const& config, PrecedencePredicateTransition *pt,
+    virtual Ref<ATNConfig> precedenceTransition(Ref<ATNConfig> const& config, const PrecedencePredicateTransition *pt,
                                                 bool collectPredicates, bool inContext, bool fullCtx);
 
     void setPredictionMode(PredictionMode newMode);
     PredictionMode getPredictionMode();
 
     Parser* getParser();
-    
+
     virtual std::string getTokenName(size_t t);
 
     virtual std::string getLookaheadName(TokenStream *input);
@@ -366,7 +366,7 @@ namespace atn {
     ///  "dead" code for a bit.
     /// </summary>
     virtual void dumpDeadEndConfigs(NoViableAltException &nvae);
-    
+
   protected:
     Parser *const parser;
 
@@ -386,7 +386,7 @@ namespace atn {
     size_t _startIndex;
     ParserRuleContext *_outerContext;
     dfa::DFA *_dfa; // Reference into the decisionToDFA vector.
-    
+
     /// <summary>
     /// Performs ATN simulation to compute a predicted alternative based
     ///  upon the remaining input, but also updates the DFA cache to avoid
@@ -646,13 +646,13 @@ namespace atn {
      */
     std::unique_ptr<ATNConfigSet> applyPrecedenceFilter(ATNConfigSet *configs);
 
-    virtual ATNState *getReachableTarget(Transition *trans, size_t ttype);
+    virtual ATNState *getReachableTarget(const Transition *trans, size_t ttype);
 
-    virtual std::vector<Ref<SemanticContext>> getPredsForAmbigAlts(const antlrcpp::BitSet &ambigAlts,
+    virtual std::vector<Ref<const SemanticContext>> getPredsForAmbigAlts(const antlrcpp::BitSet &ambigAlts,
                                                                    ATNConfigSet *configs, size_t nalts);
 
     virtual std::vector<dfa::DFAState::PredPrediction*> getPredicatePredictions(const antlrcpp::BitSet &ambigAlts,
-                                                                                std::vector<Ref<SemanticContext>> const& altToPred);
+                                                                                std::vector<Ref<const SemanticContext>> const& altToPred);
 
     /**
      * This method is used to improve the localization of error messages by
@@ -757,7 +757,7 @@ namespace atn {
      *
      * @since 4.3
      */
-    virtual bool evalSemanticContext(Ref<SemanticContext> const& pred, ParserRuleContext *parserCallStack,
+    virtual bool evalSemanticContext(Ref<const SemanticContext> const& pred, ParserRuleContext *parserCallStack,
                                      size_t alt, bool fullCtx);
 
     /* TODO: If we are doing predicates, there is no point in pursuing
@@ -771,19 +771,19 @@ namespace atn {
 
     virtual void closureCheckingStopState(Ref<ATNConfig> const& config, ATNConfigSet *configs, ATNConfig::Set &closureBusy,
                                           bool collectPredicates, bool fullCtx, int depth, bool treatEofAsEpsilon);
-    
+
     /// Do the actual work of walking epsilon edges.
     virtual void closure_(Ref<ATNConfig> const& config, ATNConfigSet *configs, ATNConfig::Set &closureBusy,
                           bool collectPredicates, bool fullCtx, int depth, bool treatEofAsEpsilon);
-    
-    virtual Ref<ATNConfig> getEpsilonTarget(Ref<ATNConfig> const& config, Transition *t, bool collectPredicates,
-                                            bool inContext, bool fullCtx, bool treatEofAsEpsilon);
-    virtual Ref<ATNConfig> actionTransition(Ref<ATNConfig> const& config, ActionTransition *t);
 
-    virtual Ref<ATNConfig> predTransition(Ref<ATNConfig> const& config, PredicateTransition *pt, bool collectPredicates,
+    virtual Ref<ATNConfig> getEpsilonTarget(Ref<ATNConfig> const& config, const Transition *t, bool collectPredicates,
+                                            bool inContext, bool fullCtx, bool treatEofAsEpsilon);
+    virtual Ref<ATNConfig> actionTransition(Ref<ATNConfig> const& config, const ActionTransition *t);
+
+    virtual Ref<ATNConfig> predTransition(Ref<ATNConfig> const& config, const PredicateTransition *pt, bool collectPredicates,
                                           bool inContext, bool fullCtx);
 
-    virtual Ref<ATNConfig> ruleTransition(Ref<ATNConfig> const& config, RuleTransition *t);
+    virtual Ref<ATNConfig> ruleTransition(Ref<ATNConfig> const& config, const RuleTransition *t);
 
     /**
      * Gets a {@link BitSet} containing the alternatives in {@code configs}

--- a/runtime/Cpp/runtime/src/atn/PlusBlockStartState.cpp
+++ b/runtime/Cpp/runtime/src/atn/PlusBlockStartState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t PlusBlockStartState::getStateType() {
+ATNStateType PlusBlockStartState::getStateType() const {
   return PLUS_BLOCK_START;
 }

--- a/runtime/Cpp/runtime/src/atn/PlusBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/PlusBlockStartState.h
@@ -18,7 +18,7 @@ namespace atn {
   public:
     PlusLoopbackState *loopBackState = nullptr;
 
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/PlusLoopbackState.cpp
+++ b/runtime/Cpp/runtime/src/atn/PlusLoopbackState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t PlusLoopbackState::getStateType() {
+ATNStateType PlusLoopbackState::getStateType() const {
   return PLUS_LOOP_BACK;
 }

--- a/runtime/Cpp/runtime/src/atn/PlusLoopbackState.h
+++ b/runtime/Cpp/runtime/src/atn/PlusLoopbackState.h
@@ -14,7 +14,7 @@ namespace atn {
   /// one to the loop back to start of the block and one to exit.
   class ANTLR4CPP_PUBLIC PlusLoopbackState final : public DecisionState {
   public:
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.cpp
@@ -11,7 +11,7 @@ using namespace antlr4;
 using namespace antlr4::atn;
 
 PredicateEvalInfo::PredicateEvalInfo(size_t decision, TokenStream *input, size_t startIndex, size_t stopIndex,
-  Ref<SemanticContext> semctx, bool evalResult, size_t predictedAlt, bool fullCtx)
+  Ref<const SemanticContext> semctx, bool evalResult, size_t predictedAlt, bool fullCtx)
   : DecisionEventInfo(decision, nullptr, input, startIndex, stopIndex, fullCtx),
     semctx(std::move(semctx)), predictedAlt(predictedAlt), evalResult(evalResult) {
 }

--- a/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.h
+++ b/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.h
@@ -20,7 +20,7 @@ namespace atn {
   class ANTLR4CPP_PUBLIC PredicateEvalInfo : public DecisionEventInfo {
   public:
     /// The semantic context which was evaluated.
-    const Ref<SemanticContext> semctx;
+    const Ref<const SemanticContext> semctx;
 
     /// <summary>
     /// The alternative number for the decision which is guarded by the semantic
@@ -55,7 +55,7 @@ namespace atn {
     /// <seealso cref= ParserATNSimulator#evalSemanticContext(SemanticContext, ParserRuleContext, int, boolean) </seealso>
     /// <seealso cref= SemanticContext#eval(Recognizer, RuleContext) </seealso>
     PredicateEvalInfo(size_t decision, TokenStream *input, size_t startIndex, size_t stopIndex,
-                      Ref<SemanticContext> semctx, bool evalResult, size_t predictedAlt, bool fullCtx);
+                      Ref<const SemanticContext> semctx, bool evalResult, size_t predictedAlt, bool fullCtx);
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
@@ -21,14 +21,14 @@ using namespace antlr4::atn;
 using namespace antlrcpp;
 
 std::atomic<size_t> PredictionContext::globalNodeCount(0);
-const Ref<PredictionContext> PredictionContext::EMPTY = std::make_shared<EmptyPredictionContext>();
+const Ref<const PredictionContext> PredictionContext::EMPTY = std::make_shared<EmptyPredictionContext>();
 
 //----------------- PredictionContext ----------------------------------------------------------------------------------
 
 PredictionContext::PredictionContext(size_t cachedHashCode) : id(globalNodeCount.fetch_add(1, std::memory_order_relaxed)), cachedHashCode(cachedHashCode)  {
 }
 
-Ref<PredictionContext> PredictionContext::fromRuleContext(const ATN &atn, RuleContext *outerContext) {
+Ref<const PredictionContext> PredictionContext::fromRuleContext(const ATN &atn, RuleContext *outerContext) {
   if (outerContext == nullptr) {
     return PredictionContext::EMPTY;
   }
@@ -40,10 +40,10 @@ Ref<PredictionContext> PredictionContext::fromRuleContext(const ATN &atn, RuleCo
   }
 
   // If we have a parent, convert it to a PredictionContext graph
-  Ref<PredictionContext> parent = PredictionContext::fromRuleContext(atn, dynamic_cast<RuleContext *>(outerContext->parent));
+  Ref<const PredictionContext> parent = PredictionContext::fromRuleContext(atn, dynamic_cast<RuleContext *>(outerContext->parent));
 
   ATNState *state = atn.states.at(outerContext->invokingState);
-  RuleTransition *transition = (RuleTransition *)state->transitions[0];
+  const RuleTransition *transition = dynamic_cast<const RuleTransition*>(state->transitions[0].get());
   return SingletonPredictionContext::create(parent, transition->followState->stateNumber);
 }
 
@@ -66,7 +66,7 @@ size_t PredictionContext::calculateEmptyHashCode() {
   return hash;
 }
 
-size_t PredictionContext::calculateHashCode(Ref<PredictionContext> parent, size_t returnState) {
+size_t PredictionContext::calculateHashCode(Ref<const PredictionContext> parent, size_t returnState) {
   size_t hash = MurmurHash::initialize(INITIAL_HASH);
   hash = MurmurHash::update(hash, parent);
   hash = MurmurHash::update(hash, returnState);
@@ -74,7 +74,7 @@ size_t PredictionContext::calculateHashCode(Ref<PredictionContext> parent, size_
   return hash;
 }
 
-size_t PredictionContext::calculateHashCode(const std::vector<Ref<PredictionContext>> &parents,
+size_t PredictionContext::calculateHashCode(const std::vector<Ref<const PredictionContext>> &parents,
                                             const std::vector<size_t> &returnStates) {
   size_t hash = MurmurHash::initialize(INITIAL_HASH);
 
@@ -89,8 +89,8 @@ size_t PredictionContext::calculateHashCode(const std::vector<Ref<PredictionCont
   return MurmurHash::finish(hash, parents.size() + returnStates.size());
 }
 
-Ref<PredictionContext> PredictionContext::merge(const Ref<PredictionContext> &a,
-  const Ref<PredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
+Ref<const PredictionContext> PredictionContext::merge(const Ref<const PredictionContext> &a,
+  const Ref<const PredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
   assert(a && b);
 
   // share same graph if both same
@@ -98,40 +98,40 @@ Ref<PredictionContext> PredictionContext::merge(const Ref<PredictionContext> &a,
     return a;
   }
 
-  if (is<SingletonPredictionContext>(a) && is<SingletonPredictionContext>(b)) {
-    return mergeSingletons(std::dynamic_pointer_cast<SingletonPredictionContext>(a),
-                           std::dynamic_pointer_cast<SingletonPredictionContext>(b), rootIsWildcard, mergeCache);
+  if (is<const SingletonPredictionContext>(a) && is<const SingletonPredictionContext>(b)) {
+    return mergeSingletons(std::dynamic_pointer_cast<const SingletonPredictionContext>(a),
+                           std::dynamic_pointer_cast<const SingletonPredictionContext>(b), rootIsWildcard, mergeCache);
   }
 
   // At least one of a or b is array.
   // If one is $ and rootIsWildcard, return $ as * wildcard.
   if (rootIsWildcard) {
-    if (is<EmptyPredictionContext>(a)) {
+    if (is<const EmptyPredictionContext>(a)) {
       return a;
     }
-    if (is<EmptyPredictionContext>(b)) {
+    if (is<const EmptyPredictionContext>(b)) {
       return b;
     }
   }
 
   // convert singleton so both are arrays to normalize
-  Ref<ArrayPredictionContext> left;
-  if (is<SingletonPredictionContext>(a)) {
-    left = std::make_shared<ArrayPredictionContext>(std::dynamic_pointer_cast<SingletonPredictionContext>(a));
+  Ref<const ArrayPredictionContext> left;
+  if (is<const SingletonPredictionContext>(a)) {
+    left = std::make_shared<ArrayPredictionContext>(std::dynamic_pointer_cast<const SingletonPredictionContext>(a));
   } else {
-    left = std::dynamic_pointer_cast<ArrayPredictionContext>(a);
+    left = std::dynamic_pointer_cast<const ArrayPredictionContext>(a);
   }
-  Ref<ArrayPredictionContext> right;
-  if (is<SingletonPredictionContext>(b)) {
-    right = std::make_shared<ArrayPredictionContext>(std::dynamic_pointer_cast<SingletonPredictionContext>(b));
+  Ref<const ArrayPredictionContext> right;
+  if (is<const SingletonPredictionContext>(b)) {
+    right = std::make_shared<ArrayPredictionContext>(std::dynamic_pointer_cast<const SingletonPredictionContext>(b));
   } else {
-    right = std::dynamic_pointer_cast<ArrayPredictionContext>(b);
+    right = std::dynamic_pointer_cast<const ArrayPredictionContext>(b);
   }
   return mergeArrays(left, right, rootIsWildcard, mergeCache);
 }
 
-Ref<PredictionContext> PredictionContext::mergeSingletons(const Ref<SingletonPredictionContext> &a,
-  const Ref<SingletonPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
+Ref<const PredictionContext> PredictionContext::mergeSingletons(const Ref<const SingletonPredictionContext> &a,
+  const Ref<const SingletonPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
 
   if (mergeCache != nullptr) { // Can be null if not given to the ATNState from which this call originates.
     auto existing = mergeCache->get(a, b);
@@ -144,7 +144,7 @@ Ref<PredictionContext> PredictionContext::mergeSingletons(const Ref<SingletonPre
     }
   }
 
-  Ref<PredictionContext> rootMerge = mergeRoot(a, b, rootIsWildcard);
+  Ref<const PredictionContext> rootMerge = mergeRoot(a, b, rootIsWildcard);
   if (rootMerge) {
     if (mergeCache != nullptr) {
       mergeCache->put(a, b, rootMerge);
@@ -152,10 +152,10 @@ Ref<PredictionContext> PredictionContext::mergeSingletons(const Ref<SingletonPre
     return rootMerge;
   }
 
-  Ref<PredictionContext> parentA = a->parent;
-  Ref<PredictionContext> parentB = b->parent;
+  Ref<const PredictionContext> parentA = a->parent;
+  Ref<const PredictionContext> parentB = b->parent;
   if (a->returnState == b->returnState) { // a == b
-    Ref<PredictionContext> parent = merge(parentA, parentB, rootIsWildcard, mergeCache);
+    Ref<const PredictionContext> parent = merge(parentA, parentB, rootIsWildcard, mergeCache);
 
     // If parent is same as existing a or b parent or reduced to a parent, return it.
     if (parent == parentA) { // ax + bx = ax, if a=b
@@ -169,7 +169,7 @@ Ref<PredictionContext> PredictionContext::mergeSingletons(const Ref<SingletonPre
     // merge parents x and y, giving array node with x,y then remainders
     // of those graphs.  dup a, a' points at merged array
     // new joined parent so create new singleton pointing to it, a'
-    Ref<PredictionContext> a_ = SingletonPredictionContext::create(parent, a->returnState);
+    Ref<const PredictionContext> a_ = SingletonPredictionContext::create(parent, a->returnState);
     if (mergeCache != nullptr) {
       mergeCache->put(a, b, a_);
     }
@@ -177,7 +177,7 @@ Ref<PredictionContext> PredictionContext::mergeSingletons(const Ref<SingletonPre
   } else {
     // a != b payloads differ
     // see if we can collapse parents due to $+x parents if local ctx
-    Ref<PredictionContext> singleParent;
+    Ref<const PredictionContext> singleParent;
     if (a == b || (*parentA == *parentB)) { // ax + bx = [a,b]x
       singleParent = parentA;
     }
@@ -187,8 +187,8 @@ Ref<PredictionContext> PredictionContext::mergeSingletons(const Ref<SingletonPre
         payloads[0] = b->returnState;
         payloads[1] = a->returnState;
       }
-      std::vector<Ref<PredictionContext>> parents = { singleParent, singleParent };
-      Ref<PredictionContext> a_ = std::make_shared<ArrayPredictionContext>(parents, payloads);
+      std::vector<Ref<const PredictionContext>> parents = { singleParent, singleParent };
+      Ref<const PredictionContext> a_ = std::make_shared<ArrayPredictionContext>(parents, payloads);
       if (mergeCache != nullptr) {
         mergeCache->put(a, b, a_);
       }
@@ -198,14 +198,14 @@ Ref<PredictionContext> PredictionContext::mergeSingletons(const Ref<SingletonPre
     // parents differ and can't merge them. Just pack together
     // into array; can't merge.
     // ax + by = [ax,by]
-    Ref<PredictionContext> a_;
+    Ref<const PredictionContext> a_;
     if (a->returnState > b->returnState) { // sort by payload
       std::vector<size_t> payloads = { b->returnState, a->returnState };
-      std::vector<Ref<PredictionContext>> parents = { b->parent, a->parent };
+      std::vector<Ref<const PredictionContext>> parents = { b->parent, a->parent };
       a_ = std::make_shared<ArrayPredictionContext>(parents, payloads);
     } else {
       std::vector<size_t> payloads = {a->returnState, b->returnState};
-      std::vector<Ref<PredictionContext>> parents = { a->parent, b->parent };
+      std::vector<Ref<const PredictionContext>> parents = { a->parent, b->parent };
       a_ = std::make_shared<ArrayPredictionContext>(parents, payloads);
     }
 
@@ -216,8 +216,8 @@ Ref<PredictionContext> PredictionContext::mergeSingletons(const Ref<SingletonPre
   }
 }
 
-Ref<PredictionContext> PredictionContext::mergeRoot(const Ref<SingletonPredictionContext> &a,
-  const Ref<SingletonPredictionContext> &b, bool rootIsWildcard) {
+Ref<const PredictionContext> PredictionContext::mergeRoot(const Ref<const SingletonPredictionContext> &a,
+  const Ref<const SingletonPredictionContext> &b, bool rootIsWildcard) {
   if (rootIsWildcard) {
     if (a == EMPTY) { // * + b = *
       return EMPTY;
@@ -231,22 +231,22 @@ Ref<PredictionContext> PredictionContext::mergeRoot(const Ref<SingletonPredictio
     }
     if (a == EMPTY) { // $ + x = [$,x]
       std::vector<size_t> payloads = { b->returnState, EMPTY_RETURN_STATE };
-      std::vector<Ref<PredictionContext>> parents = { b->parent, nullptr };
-      Ref<PredictionContext> joined = std::make_shared<ArrayPredictionContext>(parents, payloads);
+      std::vector<Ref<const PredictionContext>> parents = { b->parent, nullptr };
+      Ref<const PredictionContext> joined = std::make_shared<ArrayPredictionContext>(parents, payloads);
       return joined;
     }
     if (b == EMPTY) { // x + $ = [$,x] ($ is always first if present)
       std::vector<size_t> payloads = { a->returnState, EMPTY_RETURN_STATE };
-      std::vector<Ref<PredictionContext>> parents = { a->parent, nullptr };
-      Ref<PredictionContext> joined = std::make_shared<ArrayPredictionContext>(parents, payloads);
+      std::vector<Ref<const PredictionContext>> parents = { a->parent, nullptr };
+      Ref<const PredictionContext> joined = std::make_shared<ArrayPredictionContext>(parents, payloads);
       return joined;
     }
   }
   return nullptr;
 }
 
-Ref<PredictionContext> PredictionContext::mergeArrays(const Ref<ArrayPredictionContext> &a,
-  const Ref<ArrayPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
+Ref<const PredictionContext> PredictionContext::mergeArrays(const Ref<const ArrayPredictionContext> &a,
+  const Ref<const ArrayPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
 
   if (mergeCache != nullptr) {
     auto existing = mergeCache->get(a, b);
@@ -265,12 +265,12 @@ Ref<PredictionContext> PredictionContext::mergeArrays(const Ref<ArrayPredictionC
   size_t k = 0; // walks target M array
 
   std::vector<size_t> mergedReturnStates(a->returnStates.size() + b->returnStates.size());
-  std::vector<Ref<PredictionContext>> mergedParents(a->returnStates.size() + b->returnStates.size());
+  std::vector<Ref<const PredictionContext>> mergedParents(a->returnStates.size() + b->returnStates.size());
 
   // walk and merge to yield mergedParents, mergedReturnStates
   while (i < a->returnStates.size() && j < b->returnStates.size()) {
-    Ref<PredictionContext> a_parent = a->parents[i];
-    Ref<PredictionContext> b_parent = b->parents[j];
+    Ref<const PredictionContext> a_parent = a->parents[i];
+    Ref<const PredictionContext> b_parent = b->parents[j];
     if (a->returnStates[i] == b->returnStates[j]) {
       // same payload (stack tops are equal), must yield merged singleton
       size_t payload = a->returnStates[i];
@@ -282,7 +282,7 @@ Ref<PredictionContext> PredictionContext::mergeArrays(const Ref<ArrayPredictionC
         mergedReturnStates[k] = payload;
       }
       else { // ax+ay -> a'[x,y]
-        Ref<PredictionContext> mergedParent = merge(a_parent, b_parent, rootIsWildcard, mergeCache);
+        Ref<const PredictionContext> mergedParent = merge(a_parent, b_parent, rootIsWildcard, mergeCache);
         mergedParents[k] = mergedParent;
         mergedReturnStates[k] = payload;
       }
@@ -319,7 +319,7 @@ Ref<PredictionContext> PredictionContext::mergeArrays(const Ref<ArrayPredictionC
   // trim merged if we combined a few that had same stack tops
   if (k < mergedParents.size()) { // write index < last position; trim
     if (k == 1) { // for just one merged element, return singleton top
-      Ref<PredictionContext> a_ = SingletonPredictionContext::create(mergedParents[0], mergedReturnStates[0]);
+      Ref<const PredictionContext> a_ = SingletonPredictionContext::create(mergedParents[0], mergedReturnStates[0]);
       if (mergeCache != nullptr) {
         mergeCache->put(a, b, a_);
       }
@@ -329,7 +329,7 @@ Ref<PredictionContext> PredictionContext::mergeArrays(const Ref<ArrayPredictionC
     mergedReturnStates.resize(k);
   }
 
-  Ref<ArrayPredictionContext> M = std::make_shared<ArrayPredictionContext>(mergedParents, mergedReturnStates);
+  Ref<const ArrayPredictionContext> M = std::make_shared<ArrayPredictionContext>(mergedParents, mergedReturnStates);
 
   // if we created same array as a or b, return that instead
   // TODO: track whether this is possible above during merge sort for speed
@@ -358,11 +358,11 @@ Ref<PredictionContext> PredictionContext::mergeArrays(const Ref<ArrayPredictionC
   return M;
 }
 
-bool PredictionContext::combineCommonParents(std::vector<Ref<PredictionContext>> &parents) {
+bool PredictionContext::combineCommonParents(std::vector<Ref<const PredictionContext>> &parents) {
 
-  std::set<Ref<PredictionContext>> uniqueParents;
+  std::set<Ref<const PredictionContext>> uniqueParents;
   for (size_t p = 0; p < parents.size(); ++p) {
-    Ref<PredictionContext> parent = parents[p];
+    Ref<const PredictionContext> parent = parents[p];
     if (uniqueParents.find(parent) == uniqueParents.end()) { // don't replace
       uniqueParents.insert(parent);
     }
@@ -375,7 +375,7 @@ bool PredictionContext::combineCommonParents(std::vector<Ref<PredictionContext>>
   return true;
 }
 
-std::string PredictionContext::toDOTString(const Ref<PredictionContext> &context) {
+std::string PredictionContext::toDOTString(const Ref<const PredictionContext> &context) {
   if (context == nullptr) {
     return "";
   }
@@ -383,23 +383,23 @@ std::string PredictionContext::toDOTString(const Ref<PredictionContext> &context
   std::stringstream ss;
   ss << "digraph G {\n" << "rankdir=LR;\n";
 
-  std::vector<Ref<PredictionContext>> nodes = getAllContextNodes(context);
-  std::sort(nodes.begin(), nodes.end(), [](const Ref<PredictionContext> &o1, const Ref<PredictionContext> &o2) {
+  std::vector<Ref<const PredictionContext>> nodes = getAllContextNodes(context);
+  std::sort(nodes.begin(), nodes.end(), [](const Ref<const PredictionContext> &o1, const Ref<const PredictionContext> &o2) {
     return o1->id - o2->id;
   });
 
   for (const auto &current : nodes) {
-    if (is<SingletonPredictionContext>(current)) {
+    if (is<const SingletonPredictionContext>(current)) {
       std::string s = std::to_string(current->id);
       ss << "  s" << s;
       std::string returnState = std::to_string(current->getReturnState(0));
-      if (is<EmptyPredictionContext>(current)) {
+      if (is<const EmptyPredictionContext>(current)) {
         returnState = "$";
       }
       ss << " [label=\"" << returnState << "\"];\n";
       continue;
     }
-    Ref<ArrayPredictionContext> arr = std::static_pointer_cast<ArrayPredictionContext>(current);
+    Ref<const ArrayPredictionContext> arr = std::static_pointer_cast<const ArrayPredictionContext>(current);
     ss << "  s" << arr->id << " [shape=box, label=\"" << "[";
     bool first = true;
     for (auto inv : arr->returnStates) {
@@ -439,8 +439,8 @@ std::string PredictionContext::toDOTString(const Ref<PredictionContext> &context
 }
 
 // The "visited" map is just a temporary structure to control the retrieval process (which is recursive).
-Ref<PredictionContext> PredictionContext::getCachedContext(const Ref<PredictionContext> &context,
-  PredictionContextCache &contextCache, std::map<Ref<PredictionContext>, Ref<PredictionContext>> &visited) {
+Ref<const PredictionContext> PredictionContext::getCachedContext(const Ref<const PredictionContext> &context,
+  PredictionContextCache &contextCache, std::map<Ref<const PredictionContext>, Ref<const PredictionContext>> &visited) {
   if (context->isEmpty()) {
     return context;
   }
@@ -460,9 +460,9 @@ Ref<PredictionContext> PredictionContext::getCachedContext(const Ref<PredictionC
 
   bool changed = false;
 
-  std::vector<Ref<PredictionContext>> parents(context->size());
+  std::vector<Ref<const PredictionContext>> parents(context->size());
   for (size_t i = 0; i < parents.size(); i++) {
-    Ref<PredictionContext> parent = getCachedContext(context->getParent(i), contextCache, visited);
+    Ref<const PredictionContext> parent = getCachedContext(context->getParent(i), contextCache, visited);
     if (changed || parent != context->getParent(i)) {
       if (!changed) {
         parents.clear();
@@ -484,14 +484,14 @@ Ref<PredictionContext> PredictionContext::getCachedContext(const Ref<PredictionC
     return context;
   }
 
-  Ref<PredictionContext> updated;
+  Ref<const PredictionContext> updated;
   if (parents.empty()) {
     updated = EMPTY;
   } else if (parents.size() == 1) {
     updated = SingletonPredictionContext::create(parents[0], context->getReturnState(0));
     contextCache.insert(updated);
   } else {
-    updated = std::make_shared<ArrayPredictionContext>(parents, std::dynamic_pointer_cast<ArrayPredictionContext>(context)->returnStates);
+    updated = std::make_shared<ArrayPredictionContext>(parents, std::dynamic_pointer_cast<const ArrayPredictionContext>(context)->returnStates);
     contextCache.insert(updated);
   }
 
@@ -501,16 +501,16 @@ Ref<PredictionContext> PredictionContext::getCachedContext(const Ref<PredictionC
   return updated;
 }
 
-std::vector<Ref<PredictionContext>> PredictionContext::getAllContextNodes(const Ref<PredictionContext> &context) {
-  std::vector<Ref<PredictionContext>> nodes;
-  std::set<PredictionContext *> visited;
+std::vector<Ref<const PredictionContext>> PredictionContext::getAllContextNodes(const Ref<const PredictionContext> &context) {
+  std::vector<Ref<const PredictionContext>> nodes;
+  std::set<const PredictionContext *> visited;
   getAllContextNodes_(context, nodes, visited);
   return nodes;
 }
 
 
-void PredictionContext::getAllContextNodes_(const Ref<PredictionContext> &context, std::vector<Ref<PredictionContext>> &nodes,
-  std::set<PredictionContext *> &visited) {
+void PredictionContext::getAllContextNodes_(const Ref<const PredictionContext> &context, std::vector<Ref<const PredictionContext>> &nodes,
+  std::set<const PredictionContext *> &visited) {
 
   if (visited.find(context.get()) != visited.end()) {
     return; // Already done.
@@ -537,14 +537,14 @@ std::vector<std::string> PredictionContext::toStrings(Recognizer *recognizer, in
   return toStrings(recognizer, EMPTY, currentState);
 }
 
-std::vector<std::string> PredictionContext::toStrings(Recognizer *recognizer, const Ref<PredictionContext> &stop, int currentState) {
+std::vector<std::string> PredictionContext::toStrings(Recognizer *recognizer, const Ref<const PredictionContext> &stop, int currentState) {
 
   std::vector<std::string> result;
 
   for (size_t perm = 0; ; perm++) {
     size_t offset = 0;
     bool last = true;
-    PredictionContext *p = this;
+    const PredictionContext *p = this;
     size_t stateNumber = currentState;
 
     std::stringstream ss;
@@ -608,9 +608,9 @@ std::vector<std::string> PredictionContext::toStrings(Recognizer *recognizer, co
 
 //----------------- PredictionContextMergeCache ------------------------------------------------------------------------
 
-Ref<PredictionContext> PredictionContextMergeCache::put(Ref<PredictionContext> const& key1, Ref<PredictionContext> const& key2,
-                                                        Ref<PredictionContext> const& value) {
-  Ref<PredictionContext> previous;
+Ref<const PredictionContext> PredictionContextMergeCache::put(Ref<const PredictionContext> const& key1, Ref<const PredictionContext> const& key2,
+                                                        Ref<const PredictionContext> const& value) {
+  Ref<const PredictionContext> previous;
 
   auto iterator = _data.find(key1);
   if (iterator == _data.end())
@@ -625,7 +625,7 @@ Ref<PredictionContext> PredictionContextMergeCache::put(Ref<PredictionContext> c
   return previous;
 }
 
-Ref<PredictionContext> PredictionContextMergeCache::get(Ref<PredictionContext> const& key1, Ref<PredictionContext> const& key2) {
+Ref<const PredictionContext> PredictionContextMergeCache::get(Ref<const PredictionContext> const& key1, Ref<const PredictionContext> const& key2) {
   auto iterator = _data.find(key1);
   if (iterator == _data.end())
     return nullptr;

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.h
@@ -18,13 +18,13 @@ namespace atn {
   struct PredictionContextComparer;
   class PredictionContextMergeCache;
 
-  typedef std::unordered_set<Ref<PredictionContext>, PredictionContextHasher, PredictionContextComparer> PredictionContextCache;
+  typedef std::unordered_set<Ref<const PredictionContext>, PredictionContextHasher, PredictionContextComparer> PredictionContextCache;
 
   class ANTLR4CPP_PUBLIC PredictionContext {
   public:
     /// Represents $ in local context prediction, which means wildcard.
     /// *+x = *.
-    static const Ref<PredictionContext> EMPTY;
+    static const Ref<const PredictionContext> EMPTY;
 
     /// Represents $ in an array in full context mode, when $
     /// doesn't mean wildcard: $ + x = [$,x]. Here,
@@ -72,10 +72,10 @@ namespace atn {
 
     /// Convert a RuleContext tree to a PredictionContext graph.
     /// Return EMPTY if outerContext is empty.
-    static Ref<PredictionContext> fromRuleContext(const ATN &atn, RuleContext *outerContext);
+    static Ref<const PredictionContext> fromRuleContext(const ATN &atn, RuleContext *outerContext);
 
     virtual size_t size() const = 0;
-    virtual Ref<PredictionContext> getParent(size_t index) const = 0;
+    virtual Ref<const PredictionContext> getParent(size_t index) const = 0;
     virtual size_t getReturnState(size_t index) const = 0;
 
     virtual bool operator == (const PredictionContext &o) const = 0;
@@ -87,13 +87,13 @@ namespace atn {
 
   protected:
     static size_t calculateEmptyHashCode();
-    static size_t calculateHashCode(Ref<PredictionContext> parent, size_t returnState);
-    static size_t calculateHashCode(const std::vector<Ref<PredictionContext>> &parents,
+    static size_t calculateHashCode(Ref<const PredictionContext> parent, size_t returnState);
+    static size_t calculateHashCode(const std::vector<Ref<const PredictionContext>> &parents,
                                     const std::vector<size_t> &returnStates);
 
   public:
     // dispatch
-    static Ref<PredictionContext> merge(const Ref<PredictionContext> &a, const Ref<PredictionContext> &b,
+    static Ref<const PredictionContext> merge(const Ref<const PredictionContext> &a, const Ref<const PredictionContext> &b,
                                         bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
 
     /// <summary>
@@ -130,8 +130,8 @@ namespace atn {
     /// <param name="rootIsWildcard"> {@code true} if this is a local-context merge,
     /// otherwise false to indicate a full-context merge </param>
     /// <param name="mergeCache"> </param>
-    static Ref<PredictionContext> mergeSingletons(const Ref<SingletonPredictionContext> &a,
-      const Ref<SingletonPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
+    static Ref<const PredictionContext> mergeSingletons(const Ref<const SingletonPredictionContext> &a,
+      const Ref<const SingletonPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
 
     /**
      * Handle case where at least one of {@code a} or {@code b} is
@@ -171,8 +171,8 @@ namespace atn {
      * @param rootIsWildcard {@code true} if this is a local-context merge,
      * otherwise false to indicate a full-context merge
      */
-    static Ref<PredictionContext> mergeRoot(const Ref<SingletonPredictionContext> &a,
-      const Ref<SingletonPredictionContext> &b, bool rootIsWildcard);
+    static Ref<const PredictionContext> mergeRoot(const Ref<const SingletonPredictionContext> &a,
+      const Ref<const SingletonPredictionContext> &b, bool rootIsWildcard);
 
     /**
      * Merge two {@link ArrayPredictionContext} instances.
@@ -193,41 +193,41 @@ namespace atn {
      * {@link SingletonPredictionContext}.<br>
      * <embed src="images/ArrayMerge_EqualTop.svg" type="image/svg+xml"/></p>
      */
-    static Ref<PredictionContext> mergeArrays(const Ref<ArrayPredictionContext> &a,
-      const Ref<ArrayPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
+    static Ref<const PredictionContext> mergeArrays(const Ref<const ArrayPredictionContext> &a,
+      const Ref<const ArrayPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
 
   protected:
     /// Make pass over all M parents; merge any equal() ones.
     /// @returns true if the list has been changed (i.e. duplicates where found).
-    static bool combineCommonParents(std::vector<Ref<PredictionContext>> &parents);
+    static bool combineCommonParents(std::vector<Ref<const PredictionContext>> &parents);
 
   public:
-    static std::string toDOTString(const Ref<PredictionContext> &context);
+    static std::string toDOTString(const Ref<const PredictionContext> &context);
 
-    static Ref<PredictionContext> getCachedContext(const Ref<PredictionContext> &context,
+    static Ref<const PredictionContext> getCachedContext(const Ref<const PredictionContext> &context,
       PredictionContextCache &contextCache,
-      std::map<Ref<PredictionContext>, Ref<PredictionContext>> &visited);
+      std::map<Ref<const PredictionContext>, Ref<const PredictionContext>> &visited);
 
     // ter's recursive version of Sam's getAllNodes()
-    static std::vector<Ref<PredictionContext>> getAllContextNodes(const Ref<PredictionContext> &context);
-    static void getAllContextNodes_(const Ref<PredictionContext> &context,
-      std::vector<Ref<PredictionContext>> &nodes, std::set<PredictionContext *> &visited);
+    static std::vector<Ref<const PredictionContext>> getAllContextNodes(const Ref<const PredictionContext> &context);
+    static void getAllContextNodes_(const Ref<const PredictionContext> &context,
+      std::vector<Ref<const PredictionContext>> &nodes, std::set<const PredictionContext *> &visited);
 
     virtual std::string toString() const;
     virtual std::string toString(Recognizer *recog) const;
 
     std::vector<std::string> toStrings(Recognizer *recognizer, int currentState);
-    std::vector<std::string> toStrings(Recognizer *recognizer, const Ref<PredictionContext> &stop, int currentState);
+    std::vector<std::string> toStrings(Recognizer *recognizer, const Ref<const PredictionContext> &stop, int currentState);
   };
 
   struct PredictionContextHasher {
-    size_t operator () (const Ref<PredictionContext> &k) const {
+    size_t operator () (const Ref<const PredictionContext> &k) const {
       return k->hashCode();
     }
   };
 
   struct PredictionContextComparer {
-    bool operator () (const Ref<PredictionContext> &lhs, const Ref<PredictionContext> &rhs) const
+    bool operator () (const Ref<const PredictionContext> &lhs, const Ref<const PredictionContext> &rhs) const
     {
       if (lhs == rhs) // Object identity.
         return true;
@@ -237,17 +237,17 @@ namespace atn {
 
   class PredictionContextMergeCache {
   public:
-    Ref<PredictionContext> put(Ref<PredictionContext> const& key1, Ref<PredictionContext> const& key2,
-                               Ref<PredictionContext> const& value);
-    Ref<PredictionContext> get(Ref<PredictionContext> const& key1, Ref<PredictionContext> const& key2);
+    Ref<const PredictionContext> put(Ref<const PredictionContext> const& key1, Ref<const PredictionContext> const& key2,
+                               Ref<const PredictionContext> const& value);
+    Ref<const PredictionContext> get(Ref<const PredictionContext> const& key1, Ref<const PredictionContext> const& key2);
 
     void clear();
     std::string toString() const;
     size_t count() const;
 
   private:
-    std::unordered_map<Ref<PredictionContext>,
-      std::unordered_map<Ref<PredictionContext>, Ref<PredictionContext>, PredictionContextHasher, PredictionContextComparer>,
+    std::unordered_map<Ref<const PredictionContext>,
+      std::unordered_map<Ref<const PredictionContext>, Ref<const PredictionContext>, PredictionContextHasher, PredictionContextComparer>,
       PredictionContextHasher, PredictionContextComparer> _data;
 
   };

--- a/runtime/Cpp/runtime/src/atn/PredictionMode.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionMode.cpp
@@ -62,7 +62,7 @@ bool PredictionModeClass::hasSLLConflictTerminatingPrediction(PredictionMode mod
     // dup configs, tossing out semantic predicates
     ATNConfigSet dup(true);
     for (auto &config : configs->configs) {
-      Ref<ATNConfig> c = std::make_shared<ATNConfig>(config, SemanticContext::NONE);
+      Ref<ATNConfig> c = std::make_shared<ATNConfig>(*config, SemanticContext::NONE);
       dup.add(c);
     }
     std::vector<antlrcpp::BitSet> altsets = getConflictingAltSubsets(&dup);

--- a/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
@@ -112,10 +112,10 @@ std::unique_ptr<ATNConfigSet> ProfilingATNSimulator::computeReachSet(ATNConfigSe
   return reachConfigs;
 }
 
-bool ProfilingATNSimulator::evalSemanticContext(Ref<SemanticContext> const& pred, ParserRuleContext *parserCallStack,
+bool ProfilingATNSimulator::evalSemanticContext(Ref<const SemanticContext> const& pred, ParserRuleContext *parserCallStack,
                                                 size_t alt, bool fullCtx) {
   bool result = ParserATNSimulator::evalSemanticContext(pred, parserCallStack, alt, fullCtx);
-  if (!(std::dynamic_pointer_cast<SemanticContext::PrecedencePredicate>(pred) != nullptr)) {
+  if (!(std::dynamic_pointer_cast<const SemanticContext::PrecedencePredicate>(pred) != nullptr)) {
     bool fullContext = _llStopIndex >= 0;
     int stopIndex = fullContext ? _llStopIndex : _sllStopIndex;
     _decisions[_currentDecision].predicateEvals.push_back(

--- a/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.h
@@ -46,7 +46,7 @@ namespace atn {
     virtual dfa::DFAState* getExistingTargetState(dfa::DFAState *previousD, size_t t) override;
     virtual dfa::DFAState* computeTargetState(dfa::DFA &dfa, dfa::DFAState *previousD, size_t t) override;
     virtual std::unique_ptr<ATNConfigSet> computeReachSet(ATNConfigSet *closure, size_t t, bool fullCtx) override;
-    virtual bool evalSemanticContext(Ref<SemanticContext> const& pred, ParserRuleContext *parserCallStack,
+    virtual bool evalSemanticContext(Ref<const SemanticContext> const& pred, ParserRuleContext *parserCallStack,
                                      size_t alt, bool fullCtx) override;
     virtual void reportAttemptingFullContext(dfa::DFA &dfa, const antlrcpp::BitSet &conflictingAlts, ATNConfigSet *configs,
                                              size_t startIndex, size_t stopIndex) override;

--- a/runtime/Cpp/runtime/src/atn/RuleStartState.cpp
+++ b/runtime/Cpp/runtime/src/atn/RuleStartState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t RuleStartState::getStateType() {
+ATNStateType RuleStartState::getStateType() const {
   return RULE_START;
 }

--- a/runtime/Cpp/runtime/src/atn/RuleStartState.h
+++ b/runtime/Cpp/runtime/src/atn/RuleStartState.h
@@ -15,7 +15,7 @@ namespace atn {
     RuleStopState *stopState = nullptr;
     bool isLeftRecursiveRule = false;
 
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
 
   };
 

--- a/runtime/Cpp/runtime/src/atn/RuleStopState.cpp
+++ b/runtime/Cpp/runtime/src/atn/RuleStopState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t RuleStopState::getStateType() {
+ATNStateType RuleStopState::getStateType() const {
   return RULE_STOP;
 }

--- a/runtime/Cpp/runtime/src/atn/RuleStopState.h
+++ b/runtime/Cpp/runtime/src/atn/RuleStopState.h
@@ -16,7 +16,7 @@ namespace atn {
   /// error handling.
   class ANTLR4CPP_PUBLIC RuleStopState final : public ATNState {
   public:
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
 
   };
 

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.h
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.h
@@ -21,13 +21,13 @@ namespace atn {
   public:
     struct Hasher
     {
-      size_t operator()(Ref<SemanticContext> const& k) const {
+      size_t operator()(Ref<const SemanticContext> const& k) const {
         return k->hashCode();
       }
     };
 
     struct Comparer {
-      bool operator()(Ref<SemanticContext> const& lhs, Ref<SemanticContext> const& rhs) const {
+      bool operator()(Ref<const SemanticContext> const& lhs, Ref<const SemanticContext> const& rhs) const {
         if (lhs == rhs)
           return true;
         return (lhs->hashCode() == rhs->hashCode()) && (*lhs == *rhs);
@@ -35,13 +35,13 @@ namespace atn {
     };
 
 
-    using Set = std::unordered_set<Ref<SemanticContext>, Hasher, Comparer>;
+    using Set = std::unordered_set<Ref<const SemanticContext>, Hasher, Comparer>;
 
     /**
      * The default {@link SemanticContext}, which is semantically equivalent to
      * a predicate of the form {@code {true}?}.
      */
-    static const Ref<SemanticContext> NONE;
+    static const Ref<const SemanticContext> NONE;
 
     virtual ~SemanticContext() = default;
 
@@ -63,7 +63,7 @@ namespace atn {
     /// prediction, so we passed in the outer context here in case of context
     /// dependent predicate evaluation.
     /// </summary>
-    virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) = 0;
+    virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) const = 0;
 
     /**
      * Evaluate the precedence predicates for the context and reduce the result.
@@ -83,12 +83,12 @@ namespace atn {
      * semantic context after precedence predicates are evaluated.</li>
      * </ul>
      */
-    virtual Ref<SemanticContext> evalPrecedence(Recognizer *parser, RuleContext *parserCallStack);
+    virtual Ref<const SemanticContext> evalPrecedence(Recognizer *parser, RuleContext *parserCallStack) const;
 
-    static Ref<SemanticContext> And(Ref<SemanticContext> const& a, Ref<SemanticContext> const& b);
+    static Ref<const SemanticContext> And(Ref<const SemanticContext> const& a, Ref<const SemanticContext> const& b);
 
     /// See also: ParserATNSimulator::getPredsForAmbigAlts.
-    static Ref<SemanticContext> Or(Ref<SemanticContext> const& a, Ref<SemanticContext> const& b);
+    static Ref<const SemanticContext> Or(Ref<const SemanticContext> const& a, Ref<const SemanticContext> const& b);
 
     class Predicate;
     class PrecedencePredicate;
@@ -97,7 +97,7 @@ namespace atn {
     class OR;
 
   private:
-    static std::vector<Ref<PrecedencePredicate>> filterPrecedencePredicates(const Set &collection);
+    static std::vector<Ref<const PrecedencePredicate>> filterPrecedencePredicates(const Set &collection);
   };
 
   class ANTLR4CPP_PUBLIC SemanticContext::Predicate : public SemanticContext {
@@ -112,7 +112,7 @@ namespace atn {
   public:
     Predicate(size_t ruleIndex, size_t predIndex, bool isCtxDependent);
 
-    virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) override;
+    virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) const override;
     virtual size_t hashCode() const override;
     virtual bool operator == (const SemanticContext &other) const override;
     virtual std::string toString() const override;
@@ -128,8 +128,8 @@ namespace atn {
   public:
     explicit PrecedencePredicate(int precedence);
 
-    virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) override;
-    virtual Ref<SemanticContext> evalPrecedence(Recognizer *parser, RuleContext *parserCallStack) override;
+    virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) const override;
+    virtual Ref<const SemanticContext> evalPrecedence(Recognizer *parser, RuleContext *parserCallStack) const override;
     virtual int compareTo(PrecedencePredicate *o);
     virtual size_t hashCode() const override;
     virtual bool operator == (const SemanticContext &other) const override;
@@ -153,7 +153,7 @@ namespace atn {
      * @since 4.3
      */
 
-    virtual const std::vector<Ref<SemanticContext>>& getOperands() const = 0;
+    virtual const std::vector<Ref<const SemanticContext>>& getOperands() const = 0;
   };
 
   /**
@@ -162,11 +162,11 @@ namespace atn {
    */
   class ANTLR4CPP_PUBLIC SemanticContext::AND : public SemanticContext::Operator {
   public:
-    std::vector<Ref<SemanticContext>> opnds;
+    std::vector<Ref<const SemanticContext>> opnds;
 
-    AND(Ref<SemanticContext> const& a, Ref<SemanticContext> const& b) ;
+    AND(Ref<const SemanticContext> const& a, Ref<const SemanticContext> const& b) ;
 
-    virtual const std::vector<Ref<SemanticContext>>& getOperands() const override;
+    virtual const std::vector<Ref<const SemanticContext>>& getOperands() const override;
     virtual bool operator==(const SemanticContext &other) const override;
     virtual size_t hashCode() const override;
 
@@ -174,8 +174,8 @@ namespace atn {
      * The evaluation of predicates by this context is short-circuiting, but
      * unordered.</p>
      */
-    virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) override;
-    virtual Ref<SemanticContext> evalPrecedence(Recognizer *parser, RuleContext *parserCallStack) override;
+    virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) const override;
+    virtual Ref<const SemanticContext> evalPrecedence(Recognizer *parser, RuleContext *parserCallStack) const override;
     virtual std::string toString() const override;
   };
 
@@ -185,11 +185,11 @@ namespace atn {
    */
   class ANTLR4CPP_PUBLIC SemanticContext::OR : public SemanticContext::Operator {
   public:
-    std::vector<Ref<SemanticContext>> opnds;
+    std::vector<Ref<const SemanticContext>> opnds;
 
-    OR(Ref<SemanticContext> const& a, Ref<SemanticContext> const& b);
+    OR(Ref<const SemanticContext> const& a, Ref<const SemanticContext> const& b);
 
-    virtual const std::vector<Ref<SemanticContext>>& getOperands() const override;
+    virtual const std::vector<Ref<const SemanticContext>>& getOperands() const override;
     virtual bool operator==(const SemanticContext &other) const override;
     virtual size_t hashCode() const override;
 
@@ -197,8 +197,8 @@ namespace atn {
      * The evaluation of predicates by this context is short-circuiting, but
      * unordered.
      */
-    virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) override;
-    virtual Ref<SemanticContext> evalPrecedence(Recognizer *parser, RuleContext *parserCallStack) override;
+    virtual bool eval(Recognizer *parser, RuleContext *parserCallStack) const override;
+    virtual Ref<const SemanticContext> evalPrecedence(Recognizer *parser, RuleContext *parserCallStack) const override;
     virtual std::string toString() const override;
   };
 
@@ -212,7 +212,7 @@ namespace std {
 
   template <> struct hash<SemanticContext>
   {
-    size_t operator () (SemanticContext &x) const
+    size_t operator () (const SemanticContext &x) const
     {
       return x.hashCode();
     }

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
@@ -9,17 +9,17 @@
 
 using namespace antlr4::atn;
 
-SingletonPredictionContext::SingletonPredictionContext(Ref<PredictionContext> parent, size_t returnState)
+SingletonPredictionContext::SingletonPredictionContext(Ref<const PredictionContext> parent, size_t returnState)
   : PredictionContext(parent ? calculateHashCode(parent, returnState) : calculateEmptyHashCode()),
     parent(std::move(parent)), returnState(returnState) {
   assert(returnState != ATNState::INVALID_STATE_NUMBER);
 }
 
-Ref<SingletonPredictionContext> SingletonPredictionContext::create(Ref<PredictionContext> parent, size_t returnState) {
+Ref<const SingletonPredictionContext> SingletonPredictionContext::create(Ref<const PredictionContext> parent, size_t returnState) {
 
   if (returnState == EMPTY_RETURN_STATE && parent) {
     // someone can pass in the bits of an array ctx that mean $
-    return std::dynamic_pointer_cast<SingletonPredictionContext>(EMPTY);
+    return std::dynamic_pointer_cast<const SingletonPredictionContext>(EMPTY);
   }
   return std::make_shared<SingletonPredictionContext>(std::move(parent), returnState);
 }
@@ -28,7 +28,7 @@ size_t SingletonPredictionContext::size() const {
   return 1;
 }
 
-Ref<PredictionContext> SingletonPredictionContext::getParent(size_t index) const {
+Ref<const PredictionContext> SingletonPredictionContext::getParent(size_t index) const {
   assert(index == 0);
   ((void)(index)); // Make Release build happy.
   return parent;

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.h
@@ -17,16 +17,16 @@ namespace atn {
     // owning ATNState is released. In order to avoid having this context released as well (leaving all other contexts
     // which got this one as parent with a null reference) we use a shared_ptr here instead, to keep those left alone
     // parent contexts alive.
-    const Ref<PredictionContext> parent;
+    const Ref<const PredictionContext> parent;
     const size_t returnState;
 
-    SingletonPredictionContext(Ref<PredictionContext> parent, size_t returnState);
+    SingletonPredictionContext(Ref<const PredictionContext> parent, size_t returnState);
     virtual ~SingletonPredictionContext() = default;
 
-    static Ref<SingletonPredictionContext> create(Ref<PredictionContext> parent, size_t returnState);
+    static Ref<const SingletonPredictionContext> create(Ref<const PredictionContext> parent, size_t returnState);
 
     virtual size_t size() const override;
-    virtual Ref<PredictionContext> getParent(size_t index) const override;
+    virtual Ref<const PredictionContext> getParent(size_t index) const override;
     virtual size_t getReturnState(size_t index) const override;
     virtual bool operator == (const PredictionContext &o) const override;
     virtual std::string toString() const override;

--- a/runtime/Cpp/runtime/src/atn/StarBlockStartState.cpp
+++ b/runtime/Cpp/runtime/src/atn/StarBlockStartState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t StarBlockStartState::getStateType() {
+ATNStateType StarBlockStartState::getStateType() const {
   return STAR_BLOCK_START;
 }

--- a/runtime/Cpp/runtime/src/atn/StarBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/StarBlockStartState.h
@@ -13,7 +13,7 @@ namespace atn {
   /// The block that begins a closure loop.
   class ANTLR4CPP_PUBLIC StarBlockStartState final : public BlockStartState {
   public:
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/StarLoopEntryState.cpp
+++ b/runtime/Cpp/runtime/src/atn/StarLoopEntryState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t StarLoopEntryState::getStateType() {
+ATNStateType StarLoopEntryState::getStateType() const {
   return STAR_LOOP_ENTRY;
 }

--- a/runtime/Cpp/runtime/src/atn/StarLoopEntryState.h
+++ b/runtime/Cpp/runtime/src/atn/StarLoopEntryState.h
@@ -26,7 +26,7 @@ namespace atn {
 
     StarLoopbackState *loopBackState = nullptr;
 
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/StarLoopbackState.cpp
+++ b/runtime/Cpp/runtime/src/atn/StarLoopbackState.cpp
@@ -14,6 +14,6 @@ StarLoopEntryState *StarLoopbackState::getLoopEntryState() const {
   return dynamic_cast<StarLoopEntryState *>(transitions[0]->target);
 }
 
-size_t StarLoopbackState::getStateType() {
+ATNStateType StarLoopbackState::getStateType() const {
   return STAR_LOOP_BACK;
 }

--- a/runtime/Cpp/runtime/src/atn/StarLoopbackState.h
+++ b/runtime/Cpp/runtime/src/atn/StarLoopbackState.h
@@ -14,7 +14,7 @@ namespace atn {
   public:
     StarLoopEntryState *getLoopEntryState() const;
 
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/TokensStartState.cpp
+++ b/runtime/Cpp/runtime/src/atn/TokensStartState.cpp
@@ -7,6 +7,6 @@
 
 using namespace antlr4::atn;
 
-size_t TokensStartState::getStateType() {
+ATNStateType TokensStartState::getStateType() const {
   return TOKEN_START;
 }

--- a/runtime/Cpp/runtime/src/atn/TokensStartState.h
+++ b/runtime/Cpp/runtime/src/atn/TokensStartState.h
@@ -13,7 +13,7 @@ namespace atn {
   /// The Tokens rule start state linking to each lexer rule start state.
   class ANTLR4CPP_PUBLIC TokensStartState final : public DecisionState {
   public:
-    virtual size_t getStateType() override;
+    virtual ATNStateType getStateType() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/Transition.h
+++ b/runtime/Cpp/runtime/src/atn/Transition.h
@@ -72,5 +72,7 @@ namespace atn {
     Transition& operator=(Transition const&) = delete;
   };
 
+  using ConstTransitionPtr = std::unique_ptr<const Transition>;
+
 } // namespace atn
 } // namespace antlr4

--- a/runtime/Cpp/runtime/src/dfa/DFAState.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.cpp
@@ -13,7 +13,7 @@
 using namespace antlr4::dfa;
 using namespace antlr4::atn;
 
-DFAState::PredPrediction::PredPrediction(Ref<SemanticContext> pred, int alt) : pred(std::move(pred)), alt(alt) {}
+DFAState::PredPrediction::PredPrediction(Ref<const SemanticContext> pred, int alt) : pred(std::move(pred)), alt(alt) {}
 
 std::string DFAState::PredPrediction::toString() const {
   return std::string("(") + pred->toString() + ", " + std::to_string(alt) + ")";

--- a/runtime/Cpp/runtime/src/dfa/DFAState.h
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.h
@@ -39,10 +39,10 @@ namespace dfa {
   public:
     class PredPrediction final {
     public:
-      Ref<atn::SemanticContext> pred; // never null; at least SemanticContext.NONE
+      Ref<const atn::SemanticContext> pred; // never null; at least SemanticContext.NONE
       int alt;
 
-      PredPrediction(Ref<atn::SemanticContext> pred, int alt);
+      PredPrediction(Ref<const atn::SemanticContext> pred, int alt);
 
       std::string toString() const;
     };

--- a/runtime/Cpp/runtime/src/support/Arrays.h
+++ b/runtime/Cpp/runtime/src/support/Arrays.h
@@ -32,8 +32,13 @@ namespace antlrcpp {
         return false;
 
       for (size_t i = 0; i < a.size(); ++i) {
+        if (!a[i] && !b[i])
+          continue;
+        if (!a[i] || !b[i])
+          return false;
         if (a[i] == b[i])
           continue;
+
         if (!(*a[i] == *b[i]))
           return false;
       }
@@ -43,6 +48,26 @@ namespace antlrcpp {
 
     template <typename T>
     static bool equals(const std::vector<Ref<T>> &a, const std::vector<Ref<T>> &b) {
+      if (a.size() != b.size())
+        return false;
+
+      for (size_t i = 0; i < a.size(); ++i) {
+        if (!a[i] && !b[i])
+          continue;
+        if (!a[i] || !b[i])
+          return false;
+        if (a[i] == b[i])
+          continue;
+
+        if (!(*a[i] == *b[i]))
+          return false;
+      }
+
+      return true;
+    }
+
+    template <typename T>
+    static bool equals(const std::vector<std::unique_ptr<T>> &a, const std::vector<std::unique_ptr<T>> &b) {
       if (a.size() != b.size())
         return false;
 
@@ -77,6 +102,20 @@ namespace antlrcpp {
 
     template <typename T>
     static std::string toString(const std::vector<Ref<T>> &source) {
+      std::string result = "[";
+      bool firstEntry = true;
+      for (auto &value : source) {
+        result += value->toString();
+        if (firstEntry) {
+          result += ", ";
+          firstEntry = false;
+        }
+      }
+      return result + "]";
+    }
+
+    template <typename T>
+    static std::string toString(const std::vector<std::unique_ptr<T>> &source) {
       std::string result = "[";
       bool firstEntry = true;
       for (auto &value : source) {


### PR DESCRIPTION
This is a safe but large change that fixes const correctness in various places in the ATN and DFA. Historically things were passed around as `std::shared_ptr<T>` which allowed `T` to be modified even if it never was. This change fixes it so that most things are passed around as `std::shared_ptr<const T>`. This makes thread saftey analysis easier when simply reading.

I also replaced `const std::shared_ptr<T>&` with `const T&` in places where `std::shared_ptr` was not being copied and thus extending the lifetime of `T`.