### PR TITLE
Update go-target.md

### DIFF
--- a/doc/go-target.md
+++ b/doc/go-target.md
@@ -13,7 +13,7 @@ Each target language for ANTLR has a runtime package for running parser generate
 Get the runtime and install it on your GOPATH:
 
 ```bash
-go get github.com/antlr/antlr4/runtime/Go/antlr
+go get github.com/antlr/antlr4/runtime/Go/antlr@master
 ```
 
 #### 3. Set the release tag (optional)


### PR DESCRIPTION
Because the dev branch is now the default, `@master` must be added to the end of the go get, so that the deserialize ATN does not give a version error, while version 4.10 comes out.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->