### PR TITLE
Fix bail error strategy nil interface panic

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -319,3 +319,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/10/10, tools4origins, Erwan Guyomarc'h, contact@erwan-guyomarch.fr
 2021/10/19, jcking, Justin King, jcking@google.com
 2021/10/31, skef, Skef Iterum, github@skef.org
+2022/02/10, mattwiller, Matt Willer, matt.r.willer@gmail.com

--- a/runtime/Go/antlr/error_strategy.go
+++ b/runtime/Go/antlr/error_strategy.go
@@ -738,7 +738,11 @@ func (b *BailErrorStrategy) Recover(recognizer Parser, e RecognitionException) {
 	context := recognizer.GetParserRuleContext()
 	for context != nil {
 		context.SetException(e)
-		context = context.GetParent().(ParserRuleContext)
+		if parent, ok := context.GetParent().(ParserRuleContext); ok {
+			context = parent
+		} else {
+			context = nil
+		}
 	}
 	panic(NewParseCancellationException()) // TODO we don't emit e properly
 }


### PR DESCRIPTION
I had experienced a nil interface conversion panic in the bail error strategy, which appeared simple to fix.  Please let me know if a test is needed, but I thought this trivial change might be okay without.