### PR TITLE
[C++] Improve multithreaded performance, fix TSAN error, and fix profiling ATN simulator setup

### DIFF
--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -589,12 +589,12 @@ std::string Parser::getSourceName() {
 }
 
 atn::ParseInfo Parser::getParseInfo() const {
-  atn::ProfilingATNSimulator *interp = getInterpreter<atn::ProfilingATNSimulator>();
-  return atn::ParseInfo(interp);
+  atn::ParserATNSimulator *simulator = getInterpreter<atn::ParserATNSimulator>();
+  return atn::ParseInfo(dynamic_cast<atn::ProfilingATNSimulator*>(simulator));
 }
 
 void Parser::setProfile(bool profile) {
-  atn::ParserATNSimulator *interp = getInterpreter<atn::ProfilingATNSimulator>();
+  atn::ParserATNSimulator *interp = getInterpreter<atn::ParserATNSimulator>();
   atn::PredictionMode saveMode = interp != nullptr ? interp->getPredictionMode() : atn::PredictionMode::LL;
   if (profile) {
     if (!is<atn::ProfilingATNSimulator *>(interp)) {


### PR DESCRIPTION
Various small improvements.

- Improve multithreaded performance by using `insert` instead of `find` then `insert`. This reduces the amount of time spent in critical sections. 
- Fix extremely rare race condition that I introduced as I unlocked then dereferenced an iterator.
- Fix parser profiling setup. Currently calling `setProfile` more than once would crash in debug builds.