### PR TITLE
[C++] Cleanup ATNDeserializer and remove related deprecated methods from ATNSimulator

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.h
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.h
@@ -5,41 +5,32 @@
 
 #pragma once
 
-#include "atn/LexerAction.h"
 #include "atn/ATNDeserializationOptions.h"
+#include "atn/LexerAction.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {
 namespace atn {
 
-class ANTLR4CPP_PUBLIC ATNDeserializer {
-public:
-  static constexpr size_t SERIALIZED_VERSION = 4;
+  class ANTLR4CPP_PUBLIC ATNDeserializer final {
+  public:
+    static constexpr size_t SERIALIZED_VERSION = 4;
 
-  ATNDeserializer();
+    ATNDeserializer();
 
-  explicit ATNDeserializer(const ATNDeserializationOptions& dso);
+    explicit ATNDeserializer(ATNDeserializationOptions deserializationOptions);
 
-  virtual ~ATNDeserializer();
+    ATN deserialize(const std::vector<uint16_t> &input) const;
+    void verifyATN(const ATN &atn) const;
 
-  virtual ATN deserialize(const std::vector<uint16_t> &input);
-  virtual void verifyATN(const ATN &atn);
+    static ConstTransitionPtr edgeFactory(const ATN &atn, size_t type, size_t src, size_t trg, size_t arg1, size_t arg2,
+                                          size_t arg3, const std::vector<misc::IntervalSet> &sets);
 
-  static void checkCondition(bool condition);
-  static void checkCondition(bool condition, const std::string &message);
+    static ATNState* stateFactory(size_t type, size_t ruleIndex);
 
-  static ConstTransitionPtr edgeFactory(const ATN &atn, size_t type, size_t src, size_t trg, size_t arg1, size_t arg2,
-                                  size_t arg3, const std::vector<misc::IntervalSet> &sets);
-
-  static ATNState *stateFactory(size_t type, size_t ruleIndex);
-
-protected:
-  void markPrecedenceDecisions(const ATN &atn) const;
-  Ref<LexerAction> lexerActionFactory(LexerActionType type, int data1, int data2) const;
-
-private:
-  const ATNDeserializationOptions _deserializationOptions;
-};
+  private:
+    const ATNDeserializationOptions _deserializationOptions;
+  };
 
 } // namespace atn
 } // namespace antlr4

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
@@ -3,28 +3,24 @@
  * can be found in the LICENSE.txt file in the project root.
  */
 
-#include "atn/ATNType.h"
-#include "atn/ATNConfigSet.h"
-#include "dfa/DFAState.h"
-#include "atn/ATNDeserializer.h"
-#include "atn/EmptyPredictionContext.h"
-
 #include "atn/ATNSimulator.h"
+
+#include "atn/ATNConfigSet.h"
+#include "atn/ATNDeserializer.h"
+#include "atn/ATNType.h"
+#include "atn/EmptyPredictionContext.h"
+#include "dfa/DFAState.h"
 
 using namespace antlr4;
 using namespace antlr4::dfa;
 using namespace antlr4::atn;
 
-const Ref<DFAState> ATNSimulator::ERROR = std::make_shared<DFAState>(INT32_MAX);
+const Ref<DFAState> ATNSimulator::ERROR = std::make_shared<DFAState>(std::numeric_limits<int>::max());
 std::shared_mutex ATNSimulator::_stateLock;
 std::shared_mutex ATNSimulator::_edgeLock;
 
 ATNSimulator::ATNSimulator(const ATN &atn, PredictionContextCache &sharedContextCache)
-: atn(atn), _sharedContextCache(sharedContextCache) {
-}
-
-ATNSimulator::~ATNSimulator() {
-}
+    : atn(atn), _sharedContextCache(sharedContextCache) {}
 
 void ATNSimulator::clearDFA() {
   throw UnsupportedOperationException("This ATN simulator does not support clearing the DFA.");
@@ -38,26 +34,4 @@ Ref<const PredictionContext> ATNSimulator::getCachedContext(Ref<const Prediction
   // This function must only be called with an active state lock, as we are going to change a shared structure.
   std::map<Ref<const PredictionContext>, Ref<const PredictionContext>> visited;
   return PredictionContext::getCachedContext(context, _sharedContextCache, visited);
-}
-
-ATN ATNSimulator::deserialize(const std::vector<uint16_t> &data) {
-  ATNDeserializer deserializer;
-  return deserializer.deserialize(data);
-}
-
-void ATNSimulator::checkCondition(bool condition) {
-  ATNDeserializer::checkCondition(condition);
-}
-
-void ATNSimulator::checkCondition(bool condition, const std::string &message) {
-  ATNDeserializer::checkCondition(condition, message);
-}
-
-ConstTransitionPtr ATNSimulator::edgeFactory(const ATN &atn, int type, int src, int trg, int arg1, int arg2, int arg3,
-                                      const std::vector<misc::IntervalSet> &sets) {
-  return ATNDeserializer::edgeFactory(atn, type, src, trg, arg1, arg2, arg3, sets);
-}
-
-ATNState *ATNSimulator::stateFactory(int type, int ruleIndex) {
-  return ATNDeserializer::stateFactory(type, ruleIndex);
 }

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.h
@@ -6,9 +6,9 @@
 #pragma once
 
 #include "atn/ATN.h"
+#include "atn/PredictionContext.h"
 #include "misc/IntervalSet.h"
 #include "support/CPPUtils.h"
-#include "atn/PredictionContext.h"
 
 namespace antlr4 {
 namespace atn {
@@ -20,7 +20,8 @@ namespace atn {
     const ATN &atn;
 
     ATNSimulator(const ATN &atn, PredictionContextCache &sharedContextCache);
-    virtual ~ATNSimulator();
+
+    virtual ~ATNSimulator() = default;
 
     virtual void reset() = 0;
 
@@ -38,22 +39,6 @@ namespace atn {
     virtual void clearDFA();
     virtual PredictionContextCache& getSharedContextCache();
     virtual Ref<const PredictionContext> getCachedContext(Ref<const PredictionContext> const& context);
-
-    /// @deprecated Use <seealso cref="ATNDeserializer#deserialize"/> instead.
-    static ATN deserialize(const std::vector<uint16_t> &data);
-
-    /// @deprecated Use <seealso cref="ATNDeserializer#checkCondition(boolean)"/> instead.
-    static void checkCondition(bool condition);
-
-    /// @deprecated Use <seealso cref="ATNDeserializer#checkCondition(boolean, String)"/> instead.
-    static void checkCondition(bool condition, const std::string &message);
-
-    /// @deprecated Use <seealso cref="ATNDeserializer#edgeFactory"/> instead.
-    static ConstTransitionPtr edgeFactory(const ATN &atn, int type, int src, int trg, int arg1, int arg2, int arg3,
-                                   const std::vector<misc::IntervalSet> &sets);
-
-    /// @deprecated Use <seealso cref="ATNDeserializer#stateFactory"/> instead.
-    static ATNState *stateFactory(int type, int ruleIndex);
 
   protected:
     static std::shared_mutex _stateLock; // Lock for DFA states.


### PR DESCRIPTION
Simple cleanup of `ATNDeserializer` that removes virtual methods, since they cannot really be overridden anyway, moves private methods to the source file, and removes related deprecated methods from ATNSimulator since nobody should be using those. 