### PR TITLE
Increase ATN states size limit, simplify ATN serialization

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/BaseRuntimeTest.java
@@ -366,9 +366,10 @@ public abstract class BaseRuntimeTest {
 		}
 
 		if (group.equals("LexerExec")) {
-			descriptors.add(GeneratedLexerDescriptors.getLineSeparatorLfTest(targetName));
-			descriptors.add(GeneratedLexerDescriptors.getLineSeparatorCrLfTest(targetName));
+			descriptors.add(GeneratedLexerDescriptors.getLineSeparatorLfDescriptor(targetName));
+			descriptors.add(GeneratedLexerDescriptors.getLineSeparatorCrLfDescriptor(targetName));
 			descriptors.add(GeneratedLexerDescriptors.getLargeLexerDescriptor(targetName));
+			descriptors.add(GeneratedLexerDescriptors.getAtnStatesSizeMoreThan65535Descriptor(targetName));
 		}
 
 		return descriptors.toArray(new RuntimeTestDescriptor[0]);

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/GeneratedLexerDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/GeneratedLexerDescriptors.java
@@ -1,7 +1,9 @@
 package org.antlr.v4.test.runtime;
 
+import java.util.Collections;
+
 public class GeneratedLexerDescriptors {
-	static RuntimeTestDescriptor getLineSeparatorLfTest(String targetName) {
+	static RuntimeTestDescriptor getLineSeparatorLfDescriptor(String targetName) {
 		UniversalRuntimeTestDescriptor result = new UniversalRuntimeTestDescriptor();
 		result.name = "LineSeparatorLf";
 		result.targetName = targetName;
@@ -20,7 +22,7 @@ public class GeneratedLexerDescriptors {
 		return result;
 	}
 
-	static RuntimeTestDescriptor getLineSeparatorCrLfTest(String targetName) {
+	static RuntimeTestDescriptor getLineSeparatorCrLfDescriptor(String targetName) {
 		UniversalRuntimeTestDescriptor result = new UniversalRuntimeTestDescriptor();
 		result.name = "LineSeparatorCrLf";
 		result.targetName = targetName;
@@ -63,6 +65,52 @@ public class GeneratedLexerDescriptors {
 		result.input = "KW400";
 		result.output = "[@0,0:4='KW400',<402>,1:0]\n" +
 				"[@1,5:4='<EOF>',<-1>,1:5]\n";
+		return result;
+	}
+
+	static RuntimeTestDescriptor getAtnStatesSizeMoreThan65535Descriptor(String targetName) {
+		UniversalRuntimeTestDescriptor result = new UniversalRuntimeTestDescriptor();
+		result.name = "AtnStatesSizeMoreThan65535";
+		result.notes = "Regression for https://github.com/antlr/antlr4/issues/1863";
+		result.targetName = targetName;
+		result.testType = "Lexer";
+
+		final int tokensCount = 1024;
+		final String suffix = String.join("", Collections.nCopies(70, "_"));
+
+		String grammarName = "L";
+		StringBuilder grammar = new StringBuilder();
+		grammar.append("lexer grammar ").append(grammarName).append(";\n");
+		grammar.append('\n');
+		StringBuilder input = new StringBuilder();
+		StringBuilder output = new StringBuilder();
+		int startOffset;
+		int stopOffset = -2;
+		for (int i = 0; i < tokensCount; i++) {
+			String value = "T_" + i + suffix;
+			grammar.append(value).append(": '").append(value).append("';\n");
+			input.append(value).append('\n');
+
+			startOffset = stopOffset + 2;
+			stopOffset += value.length() + 1;
+
+			output.append("[@").append(i).append(',').append(startOffset).append(':').append(stopOffset)
+					.append("='").append(value).append("',<").append(i + 1).append(">,").append(i + 1)
+					.append(":0]\n");
+		}
+
+		grammar.append("\n");
+		grammar.append("WS: [ \\t\\r\\n]+ -> skip;\n");
+
+		startOffset = stopOffset + 2;
+		stopOffset = startOffset - 1;
+		output.append("[@").append(tokensCount).append(',').append(startOffset).append(':').append(stopOffset)
+				.append("='<EOF>',<-1>,").append(tokensCount + 1).append(":0]\n");
+
+		result.grammar = grammar.toString();
+		result.grammarName = grammarName;
+		result.input = input.toString();
+		result.output = output.toString();
 		return result;
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataReader.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataReader.java
@@ -1,0 +1,45 @@
+package org.antlr.v4.runtime.atn;
+
+public class ATNDataReader {
+	private final static int JavaOptimizeOffset2 = 0xFFFF - ATNDataWriter.JavaOptimizeOffset + 1;
+
+	private final char[] data;
+	private int p;
+
+	public ATNDataReader(char[] data) {
+		this.data = data;
+	}
+
+	public int readUInt32() {
+		return readUInt16() | (readUInt16() << 16);
+	}
+
+	public int readUInt16() {
+		return readUInt16(true);
+	}
+
+	public int readUInt16(boolean normalize) {
+		int result = data[p++];
+		// Each char value in data is shifted by +2 at the entry to this method.
+		// This is an encoding optimization targeting the serialized values 0
+		// and -1 (serialized to 0xFFFF), each of which are very common in the
+		// serialized form of the ATN. In the modified UTF-8 that Java uses for
+		// compiled string literals, these two character values have multi-byte
+		// forms. By shifting each value by +2, they become characters 2 and 1
+		// prior to writing the string, each of which have single-byte
+		// representations. Since the shift occurs in the tool during ATN
+		// serialization, each target is responsible for adjusting the values
+		// during deserialization.
+		//
+		// As a special case, note that the first element of data is not
+		// adjusted because it contains the major version number of the
+		// serialized ATN, which was fixed at 3 at the time the value shifting
+		// was implemented.
+		if (normalize) {
+			return result >= ATNDataWriter.JavaOptimizeOffset
+					? result - ATNDataWriter.JavaOptimizeOffset
+					: result + JavaOptimizeOffset2;
+		}
+		return result;
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataReader.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataReader.java
@@ -10,7 +10,21 @@ public class ATNDataReader {
 		this.data = data;
 	}
 
-	public int readUInt32() {
+	public int read() {
+		int value = readUInt16();
+		if (value == 0xFFFF) {
+			return -1;
+		}
+
+		int mask = value >> ATNDataWriter.MaskBits & 0b11;
+		return mask == 0
+				? value
+				: mask == 0b01
+				? (readUInt16() << ATNDataWriter.MaskBits) | (value & ((1 << ATNDataWriter.MaskBits) - 1))
+				: readInt32();
+	}
+
+	public int readInt32() {
 		return readUInt16() | (readUInt16() << 16);
 	}
 

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataWriter.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataWriter.java
@@ -1,0 +1,36 @@
+package org.antlr.v4.runtime.atn;
+
+import org.antlr.v4.runtime.misc.IntegerList;
+
+public class ATNDataWriter {
+	public static final int JavaOptimizeOffset = 2;
+
+	private final IntegerList data;
+	private final String language;
+	private final boolean isJava;
+
+	public ATNDataWriter(IntegerList data, String language) {
+		this.data = data;
+		this.language = language;
+		this.isJava = language.equals("Java");
+	}
+
+	public void writeUInt32(int value) {
+		writeUInt16((char)value);
+		writeUInt16((char)(value >> 16));
+	}
+
+	public void writeUInt16(int value) {
+		writeUInt16(value, true);
+	}
+
+	public void writeUInt16(int value, boolean optimize) {
+		if (value < Character.MIN_VALUE || value > Character.MAX_VALUE) {
+			throw new UnsupportedOperationException("Serialized ATN data element "+
+					data.size() + " element " + value + " out of range "+
+					(int)Character.MIN_VALUE + ".." + (int)Character.MAX_VALUE);
+		}
+
+		data.add(isJava && optimize ? (value + JavaOptimizeOffset) & 0xFFFF : value);
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataWriter.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDataWriter.java
@@ -3,19 +3,49 @@ package org.antlr.v4.runtime.atn;
 import org.antlr.v4.runtime.misc.IntegerList;
 
 public class ATNDataWriter {
+	public static final int MaskBits = 14;
 	public static final int JavaOptimizeOffset = 2;
 
 	private final IntegerList data;
-	private final String language;
 	private final boolean isJava;
 
 	public ATNDataWriter(IntegerList data, String language) {
 		this.data = data;
-		this.language = language;
 		this.isJava = language.equals("Java");
 	}
 
-	public void writeUInt32(int value) {
+	/* Write int of full range [Integer.MIN_VALUE..Integer.MAX_VALUE] in compact format
+		| encoding                                                    | count | type         |
+		| ----------------------------------------------------------- | ----- | ------------ |
+		| 00xx xxxx xxxx xxxx                                         | 1     | int (14 bit) |
+		| 01xx xxxx xxxx xxxx xxxx xxxx xxxx xxxx                     | 2     | int (30 bit) |
+		| 1000 0000 0000 0000 xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx | 3     | int (32 bit) |
+		| 1111 1111 1111 1111                                         | 1     | -1 (0xFFFF)  |
+	 */
+	public int write(int value) {
+		if (value == -1) {
+			writeUInt16(0xFFFF);
+			return 1;
+		}
+
+		if (value >= 0) {
+			if (value < 1 << MaskBits) {
+				writeUInt16(value);
+				return 1;
+			}
+			else if (value < 1 << (MaskBits + 16)) {
+				writeUInt16(value & ((1 << MaskBits) - 1) | 0b01 << MaskBits);
+				writeUInt16(value >>> MaskBits);
+				return 2;
+			}
+		}
+
+		writeUInt16(0b10 << MaskBits);
+		writeInt32(value);
+		return 3;
+	}
+
+	public void writeInt32(int value) {
 		writeUInt16((char)value);
 		writeUInt16((char)(value >> 16));
 	}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSerializer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSerializer.java
@@ -22,16 +22,18 @@ import java.util.Locale;
 import java.util.Map;
 
 public class ATNSerializer {
-	public ATN atn;
-	private List<String> tokenNames;
-
-	private interface CodePointSerializer {
-		void serializeCodePoint(IntegerList data, int cp);
+	enum UnicodeSerializeMode {
+		UNICODE_BMP,
+		UNICODE_SMP
 	}
+
+	public final ATN atn;
+	private final List<String> tokenNames;
 
 	public ATNSerializer(ATN atn) {
 		assert atn.grammarType != null;
 		this.atn = atn;
+		this.tokenNames = null;
 	}
 
 	public ATNSerializer(ATN atn, List<String> tokenNames) {
@@ -67,11 +69,13 @@ public class ATNSerializer {
 	 */
 	public IntegerList serialize(String language) {
 		IntegerList data = new IntegerList();
-		data.add(ATNDeserializer.SERIALIZED_VERSION);
+		ATNDataWriter writer = new ATNDataWriter(data, language);
+
+		writer.writeUInt16(ATNDeserializer.SERIALIZED_VERSION, false);
 
 		// convert grammar type to ATN const to avoid dependence on ANTLRParser
-		data.add(atn.grammarType.ordinal());
-		data.add(atn.maxTokenType);
+		writer.writeUInt16(atn.grammarType.ordinal());
+		writer.writeUInt16(atn.maxTokenType);
 		int nedges = 0;
 
 		// Note that we use a LinkedHashMap as a set to
@@ -82,10 +86,10 @@ public class ATNSerializer {
 		// dump states, count edges and collect sets while doing so
 		IntegerList nonGreedyStates = new IntegerList();
 		IntegerList precedenceStates = new IntegerList();
-		data.add(atn.states.size());
+		writer.writeUInt16(atn.states.size());
 		for (ATNState s : atn.states) {
 			if ( s==null ) { // might be optimized away
-				data.add(ATNState.INVALID_TYPE);
+				writer.writeUInt16(ATNState.INVALID_TYPE);
 				continue;
 			}
 
@@ -98,20 +102,15 @@ public class ATNSerializer {
 				precedenceStates.add(s.stateNumber);
 			}
 
-			data.add(stateType);
+			writer.writeUInt16(stateType);
 
-			if (s.ruleIndex == -1) {
-				data.add(Character.MAX_VALUE);
-			}
-			else {
-				data.add(s.ruleIndex);
-			}
+			writer.writeUInt16(s.ruleIndex == -1 ? Character.MAX_VALUE : s.ruleIndex);
 
 			if ( s.getStateType() == ATNState.LOOP_END ) {
-				data.add(((LoopEndState)s).loopBackState.stateNumber);
+				writer.writeUInt16(((LoopEndState)s).loopBackState.stateNumber);
 			}
 			else if ( s instanceof BlockStartState ) {
-				data.add(((BlockStartState)s).endState.stateNumber);
+				writer.writeUInt16(((BlockStartState)s).endState.stateNumber);
 			}
 
 			if (s.getStateType() != ATNState.RULE_STOP) {
@@ -130,67 +129,42 @@ public class ATNSerializer {
 		}
 
 		// non-greedy states
-		data.add(nonGreedyStates.size());
+		writer.writeUInt16(nonGreedyStates.size());
 		for (int i = 0; i < nonGreedyStates.size(); i++) {
-			data.add(nonGreedyStates.get(i));
+			writer.writeUInt16(nonGreedyStates.get(i));
 		}
 
 		// precedence states
-		data.add(precedenceStates.size());
+		writer.writeUInt16(precedenceStates.size());
 		for (int i = 0; i < precedenceStates.size(); i++) {
-			data.add(precedenceStates.get(i));
+			writer.writeUInt16(precedenceStates.get(i));
 		}
 
 		int nrules = atn.ruleToStartState.length;
-		data.add(nrules);
+		writer.writeUInt16(nrules);
 		for (int r=0; r<nrules; r++) {
 			ATNState ruleStartState = atn.ruleToStartState[r];
-			data.add(ruleStartState.stateNumber);
+			writer.writeUInt16(ruleStartState.stateNumber);
 			if (atn.grammarType == ATNType.LEXER) {
-				if (atn.ruleToTokenType[r] == Token.EOF) {
-					data.add(Character.MAX_VALUE);
-				}
-				else {
-					data.add(atn.ruleToTokenType[r]);
-				}
+				writer.writeUInt16(atn.ruleToTokenType[r] == Token.EOF ? Character.MAX_VALUE : atn.ruleToTokenType[r]);
 			}
 		}
 
 		int nmodes = atn.modeToStartState.size();
-		data.add(nmodes);
+		writer.writeUInt16(nmodes);
 		if ( nmodes>0 ) {
 			for (ATNState modeStartState : atn.modeToStartState) {
-				data.add(modeStartState.stateNumber);
+				writer.writeUInt16(modeStartState.stateNumber);
 			}
 		}
 		List<IntervalSet> bmpSets = new ArrayList<>();
 		List<IntervalSet> smpSets = new ArrayList<>();
 		for (IntervalSet set : sets.keySet()) {
-			if (!set.isNil() && set.getMaxElement() <= Character.MAX_VALUE) {
-				bmpSets.add(set);
-			}
-			else {
-				smpSets.add(set);
-			}
+			List<IntervalSet> localSets = !set.isNil() && set.getMaxElement() <= Character.MAX_VALUE ? bmpSets : smpSets;
+			localSets.add(set);
 		}
-		serializeSets(
-			data,
-			bmpSets,
-			new CodePointSerializer() {
-				@Override
-				public void serializeCodePoint(IntegerList data, int cp) {
-					data.add(cp);
-				}
-			});
-		serializeSets(
-			data,
-			smpSets,
-			new CodePointSerializer() {
-				@Override
-				public void serializeCodePoint(IntegerList data, int cp) {
-					serializeInt(data, cp);
-				}
-			});
+		serializeSets(writer, bmpSets, UnicodeSerializeMode.UNICODE_BMP);
+		serializeSets(writer, smpSets, UnicodeSerializeMode.UNICODE_SMP);
 		Map<IntervalSet, Integer> setIndices = new HashMap<>();
 		int setIndex = 0;
 		for (IntervalSet bmpSet : bmpSets) {
@@ -200,7 +174,7 @@ public class ATNSerializer {
 			setIndices.put(smpSet, setIndex++);
 		}
 
-		data.add(nedges);
+		writer.writeUInt16(nedges);
 		for (ATNState s : atn.states) {
 			if ( s==null ) {
 				// might be optimized away
@@ -227,7 +201,7 @@ public class ATNSerializer {
 				switch ( edgeType ) {
 					case Transition.RULE :
 						trg = ((RuleTransition)t).followState.stateNumber;
-						arg1 = ((RuleTransition)t).target.stateNumber;
+						arg1 = t.target.stateNumber;
 						arg2 = ((RuleTransition)t).ruleIndex;
 						arg3 = ((RuleTransition)t).precedence;
 						break;
@@ -269,8 +243,6 @@ public class ATNSerializer {
 						arg3 = at.isCtxDependent ? 1 : 0 ;
 						break;
 					case Transition.SET :
-						arg1 = setIndices.get(((SetTransition)t).set);
-						break;
 					case Transition.NOT_SET :
 						arg1 = setIndices.get(((SetTransition)t).set);
 						break;
@@ -278,73 +250,65 @@ public class ATNSerializer {
 						break;
 				}
 
-				data.add(src);
-				data.add(trg);
-				data.add(edgeType);
-				data.add(arg1);
-				data.add(arg2);
-				data.add(arg3);
+				writer.writeUInt16(src);
+				writer.writeUInt16(trg);
+				writer.writeUInt16(edgeType);
+				writer.writeUInt16(arg1);
+				writer.writeUInt16(arg2);
+				writer.writeUInt16(arg3);
 			}
 		}
 
 		int ndecisions = atn.decisionToState.size();
-		data.add(ndecisions);
+		writer.writeUInt16(ndecisions);
 		for (DecisionState decStartState : atn.decisionToState) {
-			data.add(decStartState.stateNumber);
+			writer.writeUInt16(decStartState.stateNumber);
 		}
 
 		//
 		// LEXER ACTIONS
 		//
 		if (atn.grammarType == ATNType.LEXER) {
-			data.add(atn.lexerActions.length);
+			writer.writeUInt16(atn.lexerActions.length);
 			for (LexerAction action : atn.lexerActions) {
-				data.add(action.getActionType().ordinal());
+				writer.writeUInt16(action.getActionType().ordinal());
 				switch (action.getActionType()) {
 				case CHANNEL:
 					int channel = ((LexerChannelAction)action).getChannel();
-					data.add(channel != -1 ? channel : 0xFFFF);
-					data.add(0);
+					writer.writeUInt16(channel != -1 ? channel : 0xFFFF);
+					writer.writeUInt16(0);
 					break;
 
 				case CUSTOM:
 					int ruleIndex = ((LexerCustomAction)action).getRuleIndex();
 					int actionIndex = ((LexerCustomAction)action).getActionIndex();
-					data.add(ruleIndex != -1 ? ruleIndex : 0xFFFF);
-					data.add(actionIndex != -1 ? actionIndex : 0xFFFF);
+					writer.writeUInt16(ruleIndex != -1 ? ruleIndex : 0xFFFF);
+					writer.writeUInt16(actionIndex != -1 ? actionIndex : 0xFFFF);
 					break;
 
 				case MODE:
 					int mode = ((LexerModeAction)action).getMode();
-					data.add(mode != -1 ? mode : 0xFFFF);
-					data.add(0);
+					writer.writeUInt16(mode != -1 ? mode : 0xFFFF);
+					writer.writeUInt16(0);
 					break;
 
 				case MORE:
-					data.add(0);
-					data.add(0);
-					break;
-
 				case POP_MODE:
-					data.add(0);
-					data.add(0);
+				case SKIP:
+					writer.writeUInt16(0);
+					writer.writeUInt16(0);
 					break;
 
 				case PUSH_MODE:
 					mode = ((LexerPushModeAction)action).getMode();
-					data.add(mode != -1 ? mode : 0xFFFF);
-					data.add(0);
-					break;
-
-				case SKIP:
-					data.add(0);
-					data.add(0);
+					writer.writeUInt16(mode != -1 ? mode : 0xFFFF);
+					writer.writeUInt16(0);
 					break;
 
 				case TYPE:
 					int type = ((LexerTypeAction)action).getType();
-					data.add(type != -1 ? type : 0xFFFF);
-					data.add(0);
+					writer.writeUInt16(type != -1 ? type : 0xFFFF);
+					writer.writeUInt16(0);
 					break;
 
 				default:
@@ -354,90 +318,75 @@ public class ATNSerializer {
 			}
 		}
 
-		boolean isJava = language.equals("Java");
-		for (int i = 1; i < data.size(); i++) {
-			int value = data.get(i);
-			if (value < Character.MIN_VALUE || value > Character.MAX_VALUE) {
-				throw new UnsupportedOperationException("Serialized ATN data element " +
-						value + " element " + i + " out of range " + (int) Character.MIN_VALUE + ".." + (int) Character.MAX_VALUE);
-			}
-
-			data.set(i, isJava ? (value + 2) & 0xFFFF : value);
-		}
-
 		return data;
 	}
 
-	private static void serializeSets(
-			IntegerList data,
-			Collection<IntervalSet> sets,
-			CodePointSerializer codePointSerializer)
-	{
+	private static void serializeSets(ATNDataWriter writer, Collection<IntervalSet> sets, UnicodeSerializeMode mode) {
 		int nSets = sets.size();
-		data.add(nSets);
+		writer.writeUInt16(nSets);
 
 		for (IntervalSet set : sets) {
 			boolean containsEof = set.contains(Token.EOF);
+			int size = set.getIntervals().size();
 			if (containsEof && set.getIntervals().get(0).b == Token.EOF) {
-				data.add(set.getIntervals().size() - 1);
+				size--;
 			}
-			else {
-				data.add(set.getIntervals().size());
-			}
+			writer.writeUInt16(size);
 
-			data.add(containsEof ? 1 : 0);
+			writer.writeUInt16(containsEof ? 1 : 0);
 			for (Interval I : set.getIntervals()) {
+				int firstValue;
 				if (I.a == Token.EOF) {
 					if (I.b == Token.EOF) {
 						continue;
 					}
 					else {
-						codePointSerializer.serializeCodePoint(data, 0);
+						firstValue = 0;
 					}
 				}
 				else {
-					codePointSerializer.serializeCodePoint(data, I.a);
+					firstValue = I.a;
 				}
 
-				codePointSerializer.serializeCodePoint(data, I.b);
+				if (mode == UnicodeSerializeMode.UNICODE_BMP) {
+					writer.writeUInt16(firstValue);
+					writer.writeUInt16(I.b);
+				} else {
+					writer.writeUInt32(firstValue);
+					writer.writeUInt32(I.b);
+				}
 			}
 		}
 	}
 
 	public String decode(char[] data) {
-		data = data.clone();
-		// don't adjust the first value since that's the version number
-		for (int i = 1; i < data.length; i++) {
-			data[i] = (char)(data[i] - 2);
-		}
-
+		ATNDataReader reader = new ATNDataReader(data);
 		StringBuilder buf = new StringBuilder();
-		int p = 0;
-		int version = ATNDeserializer.toInt(data[p++]);
+		int version = reader.readUInt16(false);
 		if (version != ATNDeserializer.SERIALIZED_VERSION) {
 			String reason = String.format("Could not deserialize ATN with version %d (expected %d).", version, ATNDeserializer.SERIALIZED_VERSION);
 			throw new UnsupportedOperationException(new InvalidClassException(ATN.class.getName(), reason));
 		}
 
-		p++; // skip grammarType
-		int maxType = ATNDeserializer.toInt(data[p++]);
+		reader.readUInt16(); // skip grammarType
+		int maxType = reader.readUInt16();
 		buf.append("max type ").append(maxType).append("\n");
-		int nstates = ATNDeserializer.toInt(data[p++]);
+		int nstates = reader.readUInt16();
 		for (int i=0; i<nstates; i++) {
-			int stype = ATNDeserializer.toInt(data[p++]);
+			int stype = reader.readUInt16();
             if ( stype==ATNState.INVALID_TYPE ) continue; // ignore bad type of states
-			int ruleIndex = ATNDeserializer.toInt(data[p++]);
+			int ruleIndex = reader.readUInt16();
 			if (ruleIndex == Character.MAX_VALUE) {
 				ruleIndex = -1;
 			}
 
 			String arg = "";
 			if ( stype == ATNState.LOOP_END ) {
-				int loopBackStateNumber = ATNDeserializer.toInt(data[p++]);
+				int loopBackStateNumber = reader.readUInt16();
 				arg = " "+loopBackStateNumber;
 			}
 			else if ( stype == ATNState.PLUS_BLOCK_START || stype == ATNState.STAR_BLOCK_START || stype == ATNState.BLOCK_START ) {
-				int endStateNumber = ATNDeserializer.toInt(data[p++]);
+				int endStateNumber = reader.readUInt16();
 				arg = " "+endStateNumber;
 			}
 			buf.append(i).append(":")
@@ -450,52 +399,47 @@ public class ATNSerializer {
 		// and testing scenarios, so the form you see here was kept for
 		// improved maintainability.
 		// start
-		int numNonGreedyStates = ATNDeserializer.toInt(data[p++]);
+		int numNonGreedyStates = reader.readUInt16();
 		for (int i = 0; i < numNonGreedyStates; i++) {
-			int stateNumber = ATNDeserializer.toInt(data[p++]);
+			reader.readUInt16(); // Skip stateNumber
 		}
-		int numPrecedenceStates = ATNDeserializer.toInt(data[p++]);
+		int numPrecedenceStates = reader.readUInt16();
 		for (int i = 0; i < numPrecedenceStates; i++) {
-			int stateNumber = ATNDeserializer.toInt(data[p++]);
+			reader.readUInt16(); // Skip stateNumber
 		}
 		// finish
-		int nrules = ATNDeserializer.toInt(data[p++]);
+		int nrules = reader.readUInt16();
 		for (int i=0; i<nrules; i++) {
-			int s = ATNDeserializer.toInt(data[p++]);
-            if (atn.grammarType == ATNType.LEXER) {
-                int arg1 = ATNDeserializer.toInt(data[p++]);
-                buf.append("rule ").append(i).append(":").append(s).append(" ").append(arg1).append('\n');
-            }
-            else {
-                buf.append("rule ").append(i).append(":").append(s).append('\n');
-            }
+			int s = reader.readUInt16();
+			buf.append("rule ").append(i).append(":").append(s);
+			if (atn.grammarType == ATNType.LEXER) {
+				buf.append(" ").append(reader.readUInt16());
+			}
+			buf.append('\n');
 		}
-		int nmodes = ATNDeserializer.toInt(data[p++]);
+		int nmodes = reader.readUInt16();
 		for (int i=0; i<nmodes; i++) {
-			int s = ATNDeserializer.toInt(data[p++]);
+			int s = reader.readUInt16();
 			buf.append("mode ").append(i).append(":").append(s).append('\n');
 		}
-		int numBMPSets = ATNDeserializer.toInt(data[p++]);
-		p = appendSets(buf, data, p, numBMPSets, 0, ATNDeserializer.getUnicodeDeserializer(ATNDeserializer.UnicodeDeserializingMode.UNICODE_BMP));
-		int numSMPSets = ATNDeserializer.toInt(data[p++]);
-		p = appendSets(buf, data, p, numSMPSets, numBMPSets, ATNDeserializer.getUnicodeDeserializer(ATNDeserializer.UnicodeDeserializingMode.UNICODE_SMP));
-		int nedges = ATNDeserializer.toInt(data[p++]);
+		int offset = appendSets(buf, reader, 0, UnicodeSerializeMode.UNICODE_BMP);
+		appendSets(buf, reader, offset, UnicodeSerializeMode.UNICODE_SMP);
+		int nedges = reader.readUInt16();
 		for (int i=0; i<nedges; i++) {
-			int src = ATNDeserializer.toInt(data[p]);
-			int trg = ATNDeserializer.toInt(data[p + 1]);
-			int ttype = ATNDeserializer.toInt(data[p + 2]);
-			int arg1 = ATNDeserializer.toInt(data[p + 3]);
-			int arg2 = ATNDeserializer.toInt(data[p + 4]);
-			int arg3 = ATNDeserializer.toInt(data[p + 5]);
+			int src = reader.readUInt16();
+			int trg = reader.readUInt16();
+			int ttype = reader.readUInt16();
+			int arg1 = reader.readUInt16();
+			int arg2 = reader.readUInt16();
+			int arg3 = reader.readUInt16();
 			buf.append(src).append("->").append(trg)
 				.append(" ").append(Transition.serializationNames.get(ttype))
 				.append(" ").append(arg1).append(",").append(arg2).append(",").append(arg3)
 				.append("\n");
-			p += 6;
 		}
-		int ndecisions = ATNDeserializer.toInt(data[p++]);
+		int ndecisions = reader.readUInt16();
 		for (int i=0; i<ndecisions; i++) {
-			int s = ATNDeserializer.toInt(data[p++]);
+			int s = reader.readUInt16();
 			buf.append(i).append(":").append(s).append("\n");
 		}
 		if (atn.grammarType == ATNType.LEXER) {
@@ -504,21 +448,22 @@ public class ATNSerializer {
 			// the serialization format. The "dead" code is only used in debugging
 			// and testing scenarios, so the form you see here was kept for
 			// improved maintainability.
-			int lexerActionCount = ATNDeserializer.toInt(data[p++]);
+			int lexerActionCount = reader.readUInt16();
 			for (int i = 0; i < lexerActionCount; i++) {
-				LexerActionType actionType = LexerActionType.values()[ATNDeserializer.toInt(data[p++])];
-				int data1 = ATNDeserializer.toInt(data[p++]);
-				int data2 = ATNDeserializer.toInt(data[p++]);
+				reader.readUInt16(); // Skip actionType
+				reader.readUInt16();
+				reader.readUInt16();
 			}
 		}
 		return buf.toString();
 	}
 
-	private int appendSets(StringBuilder buf, char[] data, int p, int nsets, int setIndexOffset, ATNDeserializer.UnicodeDeserializer unicodeDeserializer) {
+	private int appendSets(StringBuilder buf, ATNDataReader dataReader, int setIndexOffset, UnicodeSerializeMode mode) {
+		int nsets = dataReader.readUInt16();
 		for (int i=0; i<nsets; i++) {
-			int nintervals = ATNDeserializer.toInt(data[p++]);
-			buf.append(i+setIndexOffset).append(":");
-			boolean containsEof = data[p++] != 0;
+			int nintervals = dataReader.readUInt16();
+			buf.append(i + setIndexOffset).append(":");
+			boolean containsEof = dataReader.readUInt16() != 0;
 			if (containsEof) {
 				buf.append(getTokenName(Token.EOF));
 			}
@@ -528,15 +473,19 @@ public class ATNSerializer {
 					buf.append(", ");
 				}
 
-				int a = unicodeDeserializer.readUnicode(data, p);
-				p += unicodeDeserializer.size();
-				int b = unicodeDeserializer.readUnicode(data, p);
-				p += unicodeDeserializer.size();
+				int a, b;
+				if (mode == UnicodeSerializeMode.UNICODE_BMP) {
+					a = dataReader.readUInt16();
+					b = dataReader.readUInt16();
+				} else {
+					a = dataReader.readUInt32();
+					b = dataReader.readUInt32();
+				}
 				buf.append(getTokenName(a)).append("..").append(getTokenName(b));
 			}
 			buf.append("\n");
 		}
-		return p;
+		return nsets;
 	}
 
 	public String getTokenName(int t) {
@@ -561,15 +510,13 @@ public class ATNSerializer {
 			case '\'':
 				return "'\\''";
 			default:
-				if ( Character.UnicodeBlock.of((char)t)==Character.UnicodeBlock.BASIC_LATIN &&
-					 !Character.isISOControl((char)t) ) {
-					return '\''+Character.toString((char)t)+'\'';
+				char c = (char)t;
+				if (Character.UnicodeBlock.of(c)==Character.UnicodeBlock.BASIC_LATIN && !Character.isISOControl(c)) {
+					return '\'' + Character.toString(c) + '\'';
 				}
 				// turn on the bit above max "\uFFFF" value so that we pad with zeros
 				// then only take last 4 digits
-				String hex = Integer.toHexString(t|0x10000).toUpperCase().substring(1,5);
-				String unicodeStr = "'\\u"+hex+"'";
-				return unicodeStr;
+				return String.format("'\\u%04X'", t);
 			}
 		}
 
@@ -580,21 +527,11 @@ public class ATNSerializer {
 		return String.valueOf(t);
 	}
 
-	/** Used by Java target to encode short/int array as chars in string. */
-	public static String getSerializedAsString(ATN atn, String language) {
-		return new String(getSerializedAsChars(atn, language));
-	}
-
 	public static IntegerList getSerialized(ATN atn, String language) {
 		return new ATNSerializer(atn).serialize(language);
 	}
 
 	public static char[] getSerializedAsChars(ATN atn, String language) {
 		return Utils.toCharArray(getSerialized(atn, language));
-	}
-
-	private void serializeInt(IntegerList data, int value) {
-		data.add((char)value);
-		data.add((char)(value >> 16));
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
@@ -78,11 +78,8 @@ public abstract class ATNSimulator {
 		if ( sharedContextCache==null ) return context;
 
 		synchronized (sharedContextCache) {
-			IdentityHashMap<PredictionContext, PredictionContext> visited =
-				new IdentityHashMap<PredictionContext, PredictionContext>();
-			return PredictionContext.getCachedContext(context,
-													  sharedContextCache,
-													  visited);
+			IdentityHashMap<PredictionContext, PredictionContext> visited = new IdentityHashMap<>();
+			return PredictionContext.getCachedContext(context, sharedContextCache, visited);
 		}
 	}
 
@@ -108,22 +105,6 @@ public abstract class ATNSimulator {
 	@Deprecated
 	public static void checkCondition(boolean condition, String message) {
 		new ATNDeserializer().checkCondition(condition, message);
-	}
-
-	/**
-	 * @deprecated Use {@link ATNDeserializer#toInt} instead.
-	 */
-	@Deprecated
-	public static int toInt(char c) {
-		return ATNDeserializer.toInt(c);
-	}
-
-	/**
-	 * @deprecated Use {@link ATNDeserializer#toInt32} instead.
-	 */
-	@Deprecated
-	public static int toInt32(char[] data, int offset) {
-		return ATNDeserializer.toInt32(data, offset);
 	}
 
 	/**

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
@@ -7,10 +7,8 @@
 package org.antlr.v4.runtime.atn;
 
 import org.antlr.v4.runtime.dfa.DFAState;
-import org.antlr.v4.runtime.misc.IntervalSet;
 
 import java.util.IdentityHashMap;
-import java.util.List;
 
 public abstract class ATNSimulator {
 	/** Must distinguish between missing edge and edge we know leads nowhere */
@@ -105,19 +103,6 @@ public abstract class ATNSimulator {
 	@Deprecated
 	public static void checkCondition(boolean condition, String message) {
 		new ATNDeserializer().checkCondition(condition, message);
-	}
-
-	/**
-	 * @deprecated Use {@link ATNDeserializer#edgeFactory} instead.
-	 */
-	@Deprecated
-
-	public static Transition edgeFactory(ATN atn,
-										 int type, int src, int trg,
-										 int arg1, int arg2, int arg3,
-										 List<IntervalSet> sets)
-	{
-		return new ATNDeserializer().edgeFactory(atn, type, src, trg, arg1, arg2, arg3, sets);
 	}
 
 	/**

--- a/runtime/Java/src/org/antlr/v4/runtime/misc/IntegerList.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/IntegerList.java
@@ -17,11 +17,10 @@ import java.util.*;
  */
 public class IntegerList {
 
-	private static int[] EMPTY_DATA = new int[0];
+	private static final int[] EMPTY_DATA = new int[0];
 
 	private static final int INITIAL_SIZE = 4;
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
-
 
 	private int[] _data;
 
@@ -36,12 +35,7 @@ public class IntegerList {
 			throw new IllegalArgumentException();
 		}
 
-		if (capacity == 0) {
-			_data = EMPTY_DATA;
-		}
-		else {
-			_data = new int[capacity];
-		}
+		_data = capacity == 0 ? EMPTY_DATA : new int[capacity];
 	}
 
 	public IntegerList(IntegerList list) {
@@ -258,13 +252,7 @@ public class IntegerList {
 			throw new OutOfMemoryError();
 		}
 
-		int newLength;
-		if (_data.length == 0) {
-			newLength = INITIAL_SIZE;
-		}
-		else {
-			newLength = _data.length;
-		}
+		int newLength = _data.length == 0 ? INITIAL_SIZE : _data.length;
 
 		while (newLength < capacity) {
 			newLength = newLength * 2;

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestATNDeserialization.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestATNDeserialization.java
@@ -6,9 +6,8 @@
 
 package org.antlr.v4.test.tool;
 
-import org.antlr.v4.runtime.atn.ATN;
-import org.antlr.v4.runtime.atn.ATNDeserializer;
-import org.antlr.v4.runtime.atn.ATNSerializer;
+import org.antlr.v4.runtime.atn.*;
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.runtime.misc.Utils;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.LexerGrammar;
@@ -18,6 +17,7 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class TestATNDeserialization extends BaseJavaToolTest {
 	@Before
@@ -158,6 +158,52 @@ public class TestATNDeserialization extends BaseJavaToolTest {
 			"mode M2;\n" +
 			"C : 'c';\n");
 		checkDeserializationIsStable(lg);
+	}
+
+	@Test public void testATNDataWriterReaderCompact() {
+		IntegerList integerList = new IntegerList();
+		ATNDataWriter writer = new ATNDataWriter(integerList, "Java");
+		assertEquals(1, writer.write(0));
+		assertEquals(1, writer.write(-1));
+		assertEquals(1, writer.write(42));
+		assertEquals(2, writer.write(1 << 14));
+		assertEquals(2, writer.write(0xFFFF));
+		assertEquals(3, writer.write(Integer.MAX_VALUE));
+		assertEquals(3, writer.write(Integer.MIN_VALUE));
+		assertEquals(13, integerList.size());
+
+		char[] charArray = Utils.toCharArray(integerList);
+		ATNDataReader reader = new ATNDataReader(charArray);
+		assertEquals(0, reader.read());
+		assertEquals(-1, reader.read());
+		assertEquals(42, reader.read());
+		assertEquals(1 << 14, reader.read());
+		assertEquals(0xFFFF, reader.read());
+		assertEquals(Integer.MAX_VALUE, reader.read());
+		assertEquals(Integer.MIN_VALUE, reader.read());
+	}
+
+	@Test public void testATNDataWriterReaderRaw() {
+		IntegerList integerList = new IntegerList();
+		ATNDataWriter writer = new ATNDataWriter(integerList, "Java");
+		writer.writeInt32(0);
+		writer.writeInt32(-1);
+		writer.writeInt32(42);
+		writer.writeInt32(1 << 14);
+		writer.writeInt32(0xFFFF);
+		writer.writeInt32(Integer.MAX_VALUE);
+		writer.writeInt32(Integer.MIN_VALUE);
+		assertEquals(7 * 2, integerList.size());
+
+		char[] charArray = Utils.toCharArray(integerList);
+		ATNDataReader reader = new ATNDataReader(charArray);
+		assertEquals(0, reader.readInt32());
+		assertEquals(-1, reader.readInt32());
+		assertEquals(42, reader.readInt32());
+		assertEquals(1 << 14, reader.readInt32());
+		assertEquals(0xFFFF, reader.readInt32());
+		assertEquals(Integer.MAX_VALUE, reader.readInt32());
+		assertEquals(Integer.MIN_VALUE, reader.readInt32());
 	}
 
 	protected void checkDeserializationIsStable(Grammar g) {

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestATNSerialization.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestATNSerialization.java
@@ -921,12 +921,12 @@ public class TestATNSerialization extends BaseJavaToolTest {
 				"5:BASIC 0\n" +
 				"rule 0:1 1\n" +
 				"mode 0:0\n" +
-				"0:'a'..'b'\n" +
-				"1:'e'..'e', 'p'..'t'\n" +
+				"0:'e'..'e', 'p'..'t'\n" +
+				"1:'a'..'b'\n" +
 				"0->1 EPSILON 0,0,0\n" +
 				"1->3 EPSILON 0,0,0\n" +
-				"3->4 NOT_SET 0,0,0\n" +
-				"4->5 NOT_SET 1,0,0\n" +
+				"3->4 NOT_SET 1,0,0\n" +
+				"4->5 NOT_SET 0,0,0\n" +
 				"5->2 EPSILON 0,0,0\n" +
 				"0:0\n";
 		ATN atn = createATN(lg, true);


### PR DESCRIPTION
I'm returning to the increasing of ATN states size and I've also simplified serialization (related to Unicode encoding).

ATN states size can be > 65535, up to 2^31-1:

* fixes #1863
* fixes #2732
* fixes #3338

Take a look at C# code: it contains small changes because it already has `Read` and `Write` methods (as well as other runtimes except for Java).

If Java and C# are ok, I'll complete other runtimes.

Writing, Reading methods have comprehensive tests: `testATNDataWriterReaderCompact`, `testATNDataWriterReaderRaw`.