### PR TITLE
Fix for #3510

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -762,9 +762,9 @@ LexerSkipCommand()  ::= "Skip();"
 LexerMoreCommand()  ::= "More();"
 LexerPopModeCommand() ::= "PopMode();"
 
-LexerTypeCommand(arg, grammar)      ::= "_type = <tokenType.(arg)>;"
-LexerChannelCommand(arg, grammar)   ::= "_channel = <channelName.(arg)>;"
-LexerModeCommand(arg, grammar)      ::= "_mode = <modeName.(arg)>;"
+LexerTypeCommand(arg, grammar)      ::= "Type = <tokenType.(arg)>;"
+LexerChannelCommand(arg, grammar)   ::= "Channel = <channelName.(arg)>;"
+LexerModeCommand(arg, grammar)      ::= "CurrentMode = <modeName.(arg)>;"
 LexerPushModeCommand(arg, grammar)  ::= "PushMode(<modeName.(arg)>);"
 
 ActionText(t) ::= "<t.text>"


### PR DESCRIPTION
This is a fix for #3510. The problem is that "-> Channel(HIDDEN)" in the lexer is output to the generated lexer as "_channel = HIDDEN". This cannot work because the Antlr CSharp runtime sets the accessibility of the various fields ("_channel", "_type", "_mode") to private, and provides instead get and set properties. Since it already is using the method PushMode, and I don't want to change the runtime, this change uses property set instead.