### PR TITLE
Fix for #3441 and #3443 -- expose Reset() and String() methods.

### DIFF
--- a/runtime/Go/antlr/lexer.go
+++ b/runtime/Go/antlr/lexer.go
@@ -118,7 +118,7 @@ const (
 	LexerMaxCharValue        = 0x10FFFF
 )
 
-func (b *BaseLexer) reset() {
+func (b *BaseLexer) Reset() {
 	// wack Lexer state variables
 	if b.input != nil {
 		b.input.Seek(0) // rewind the input
@@ -282,7 +282,7 @@ func (b *BaseLexer) inputStream() CharStream {
 func (b *BaseLexer) SetInputStream(input CharStream) {
 	b.input = nil
 	b.tokenFactorySourcePair = &TokenSourceCharStreamPair{b, b.input}
-	b.reset()
+	b.Reset()
 	b.input = input
 	b.tokenFactorySourcePair = &TokenSourceCharStreamPair{b, b.input}
 }

--- a/runtime/Go/antlr/testing_api_test.go
+++ b/runtime/Go/antlr/testing_api_test.go
@@ -1,0 +1,35 @@
+// Run via "go test"
+
+package antlr
+
+import (
+	"testing"
+)
+
+func next(t *testing.T, lexer *LexerB, want string) {
+    var token = lexer.NextToken()
+    var got = token.String()
+    if got != want {
+        t.Errorf("got %q, wanted %q", got, want)
+    }
+}
+
+func TestString(t *testing.T){
+    str := NewInputStream("a b c 1 2 3")
+    lexer := NewLexerB(str)
+    next(t, lexer, "[@-1,0:0='a',<1>,1:0]")
+    next(t, lexer, "[@-1,1:1=' ',<7>,1:1]")
+    next(t, lexer, "[@-1,2:2='b',<1>,1:2]")
+    next(t, lexer, "[@-1,3:3=' ',<7>,1:3]")
+    next(t, lexer, "[@-1,4:4='c',<1>,1:4]")
+    next(t, lexer, "[@-1,5:5=' ',<7>,1:5]")
+    next(t, lexer, "[@-1,6:6='1',<2>,1:6]")
+    next(t, lexer, "[@-1,7:7=' ',<7>,1:7]")
+    next(t, lexer, "[@-1,8:8='2',<2>,1:8]")
+    next(t, lexer, "[@-1,9:9=' ',<7>,1:9]")
+    next(t, lexer, "[@-1,10:10='3',<2>,1:10]")
+    next(t, lexer, "[@-1,11:10='<EOF>',<-1>,1:11]")
+}
+
+
+

--- a/runtime/Go/antlr/token.go
+++ b/runtime/Go/antlr/token.go
@@ -35,6 +35,7 @@ type Token interface {
 
 	GetTokenSource() TokenSource
 	GetInputStream() CharStream
+	String() string
 }
 
 type BaseToken struct {


### PR DESCRIPTION
This is a fix for the missing API method String() in the [Token](https://github.com/antlr/antlr4/blob/2be5a44ba10760303fc8600b2816fce8e74fdaf5/runtime/Go/antlr/token.go#L21), and Reset() in the [Lexer](https://github.com/antlr/antlr4/blob/2be5a44ba10760303fc8600b2816fce8e74fdaf5/runtime/Go/antlr/lexer.go#L18).

Go requires any exported data or functions to be capitalized. These functions are required for this code to print out the token stream:

        j := 0
        for {
            t := lexer.NextToken()
            fmt.Print(j)
            fmt.Print(" ")
            // missing fmt.Println(t.String())
            fmt.Println(t.GetText())
            if t.GetTokenType() == antlr.TokenEOF {
                break
            }
            j = j + 1
        }
        // missing lexer.Reset()

IToken.ToString() in C# and Token.toString() in Java are available because whatever implementation is used, it is derived from `object`. Thus, in C#, you can do `t.ToString()` or Java, `t.toString()`. Yet, `t.String()` in Go causes a compilation error.

[Reset() in C#](https://github.com/antlr/antlr4/blob/2be5a44ba10760303fc8600b2816fce8e74fdaf5/runtime/CSharp/src/Lexer.cs#L112) and [reset() in Java](https://github.com/antlr/antlr4/blob/2be5a44ba10760303fc8600b2816fce8e74fdaf5/runtime/Java/src/org/antlr/v4/runtime/Lexer.java#L88) are explicitly listed `public` in the interface. Thus, in C#, you can do `lexer.Reset();`, and Java, `lexer.reset();`. Yet,  `lexer.Reset()` or `lexer.reset()` in Go results in a compilation error.
