### PR TITLE
[C++] Lazily deserialize ATN in generated code

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
@@ -92,8 +92,11 @@ protected:
 public:
   virtual std::unique_ptr\<antlr4::Token> nextToken() override {
     if (dynamic_cast\<PositionAdjustingLexerATNSimulator *>(_interpreter) == nullptr) {
+      const auto &atn = _interpreter->atn;
+      auto &decisionToDFA = dynamic_cast\<antlr4::atn::LexerATNSimulator*>(_interpreter)->_decisionToDFA;
+      auto &sharedContextCache = dynamic_cast\<antlr4::atn::LexerATNSimulator*>(_interpreter)->getSharedContextCache();
       delete _interpreter;
-      _interpreter = new PositionAdjustingLexerATNSimulator(this, *_atn, *_decisionToDFA, _sharedContextCache);
+      _interpreter = new PositionAdjustingLexerATNSimulator(this, atn, decisionToDFA, sharedContextCache);
     }
 
     return antlr4::Lexer::nextToken();

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.cpp
@@ -7,102 +7,60 @@
 
 using namespace antlr4;
 
+namespace {
 
-XPathLexer::XPathLexer(CharStream *input) : Lexer(input) {
-  _interpreter = new atn::LexerATNSimulator(this, *_atn, *_decisionToDFA, _sharedContextCache);
-}
+struct XPathLexerStaticData final {
+  XPathLexerStaticData(std::vector<std::string> ruleNames,
+                        std::vector<std::string> channelNames,
+                        std::vector<std::string> modeNames,
+                        std::vector<std::string> literalNames,
+                        std::vector<std::string> symbolicNames)
+      : ruleNames(std::move(ruleNames)), channelNames(std::move(channelNames)),
+        modeNames(std::move(modeNames)), literalNames(std::move(literalNames)),
+        symbolicNames(std::move(symbolicNames)),
+        vocabulary(this->literalNames, this->symbolicNames) {}
 
-XPathLexer::~XPathLexer() {
-  delete _interpreter;
-}
+  XPathLexerStaticData(const XPathLexerStaticData&) = delete;
+  XPathLexerStaticData(XPathLexerStaticData&&) = delete;
+  XPathLexerStaticData& operator=(const XPathLexerStaticData&) = delete;
+  XPathLexerStaticData& operator=(XPathLexerStaticData&&) = delete;
 
-std::string XPathLexer::getGrammarFileName() const {
-  return "XPathLexer.g4";
-}
-
-const std::vector<std::string>& XPathLexer::getRuleNames() const {
-  return _ruleNames;
-}
-
-const std::vector<std::string>& XPathLexer::getChannelNames() const {
-  return _channelNames;
-}
-
-const std::vector<std::string>& XPathLexer::getModeNames() const {
-  return _modeNames;
-}
-
-dfa::Vocabulary& XPathLexer::getVocabulary() const {
-  return _vocabulary;
-}
-
-const std::vector<uint16_t>& XPathLexer::getSerializedATN() const {
-  return _serializedATN;
-}
-
-const atn::ATN& XPathLexer::getATN() const {
-  return *_atn;
-}
-
-
-void XPathLexer::action(RuleContext *context, size_t ruleIndex, size_t actionIndex) {
-  switch (ruleIndex) {
-    case 4: IDAction(antlrcpp::downCast<antlr4::RuleContext *>(context), actionIndex); break;
-
-  default:
-    break;
-  }
-}
-
-void XPathLexer::IDAction(antlr4::RuleContext *context, size_t actionIndex) {
-  switch (actionIndex) {
-    case 0:
-    				if (isupper(getText()[0]))
-    				  setType(TOKEN_REF);
-    				else
-    				  setType(RULE_REF);
-    				 break;
-
-  default:
-    break;
-  }
-}
-
-
-
-// Static vars and initialization.
-std::vector<dfa::DFA>* XPathLexer::_decisionToDFA = nullptr;
-atn::PredictionContextCache XPathLexer::_sharedContextCache;
-
-// We own the ATN which in turn owns the ATN states.
-atn::ATN* XPathLexer::_atn = nullptr;
-std::vector<uint16_t> XPathLexer::_serializedATN;
-
-std::vector<std::string> XPathLexer::_ruleNames = {
-  "ANYWHERE", "ROOT", "WILDCARD", "BANG", "ID", "NameChar", "NameStartChar",
-  "STRING"
+  std::vector<antlr4::dfa::DFA> decisionToDFA;
+  antlr4::atn::PredictionContextCache sharedContextCache;
+  const std::vector<std::string> ruleNames;
+  const std::vector<std::string> channelNames;
+  const std::vector<std::string> modeNames;
+  const std::vector<std::string> literalNames;
+  const std::vector<std::string> symbolicNames;
+  const antlr4::dfa::Vocabulary vocabulary;
+  std::vector<uint16_t> serializedATN;
+  std::unique_ptr<antlr4::atn::ATN> atn;
 };
 
-std::vector<std::string> XPathLexer::_channelNames = {
-  "DEFAULT_TOKEN_CHANNEL", "HIDDEN"
-};
+std::once_flag XPathLexer_onceFlag;
+XPathLexerStaticData *XPathLexerstaticData = nullptr;
 
-std::vector<std::string> XPathLexer::_modeNames = {
-  "DEFAULT_MODE"
-};
-
-std::vector<std::string> XPathLexer::_literalNames = {
-  "", "", "", "'//'", "'/'", "'*'", "'!'"
-};
-
-std::vector<std::string> XPathLexer::_symbolicNames = {
-  "", "TOKEN_REF", "RULE_REF", "ANYWHERE", "ROOT", "WILDCARD", "BANG", "ID",
-  "STRING"
-};
-
-dfa::Vocabulary XPathLexer::_vocabulary(_literalNames, _symbolicNames);
-
-XPathLexer::Initializer::Initializer() {
+void XPathLexer_initialize() {
+  assert(XPathLexerstaticData == nullptr);
+  auto staticData = std::make_unique<XPathLexerStaticData>(
+    std::vector<std::string>{
+      "ANYWHERE", "ROOT", "WILDCARD", "BANG", "ID", "NameChar", "NameStartChar",
+      "STRING"
+    },
+    std::vector<std::string>{
+      "DEFAULT_TOKEN_CHANNEL", "HIDDEN"
+    },
+    std::vector<std::string>{
+      "DEFAULT_MODE"
+    },
+    std::vector<std::string>{
+      "", "", "", "'//'", "'/'", "'*'", "'!'"
+    },
+    std::vector<std::string>{
+      "", "TOKEN_REF", "RULE_REF", "ANYWHERE", "ROOT", "WILDCARD", "BANG", "ID",
+      "STRING"
+    }
+  );
   static const uint16_t serializedATNSegment0[] = {
     0x4, 0x0, 0x8, 0x32, 0x6, 0xffff, 0x2, 0x0, 0x7, 0x0, 0x2, 0x1, 0x7,
        0x1, 0x2, 0x2, 0x7, 0x2, 0x2, 0x3, 0x7, 0x3, 0x2, 0x4, 0x7, 0x4,
@@ -144,19 +102,86 @@ XPathLexer::Initializer::Initializer() {
        0x1, 0x0, 0x0, 0x0, 0x4, 0x0, 0x1e, 0x25, 0x2d, 0x1, 0x1, 0x4, 0x0,
   };
 
-  _serializedATN.insert(_serializedATN.end(), serializedATNSegment0,
+  size_t serializedATNSize = 0;
+  serializedATNSize += sizeof(serializedATNSegment0) / sizeof(serializedATNSegment0[0]);
+  staticData->serializedATN.reserve(serializedATNSize);
+
+  staticData->serializedATN.insert(staticData->serializedATN.end(), serializedATNSegment0,
     serializedATNSegment0 + sizeof(serializedATNSegment0) / sizeof(serializedATNSegment0[0]));
 
-
   atn::ATNDeserializer deserializer;
-  _atn = deserializer.deserialize(_serializedATN).release();
+  staticData->atn = deserializer.deserialize(staticData->serializedATN);
 
-  size_t count = _atn->getNumberOfDecisions();
-  _decisionToDFA = new std::vector<dfa::DFA>();
-  _decisionToDFA->reserve(count);
+  size_t count = staticData->atn->getNumberOfDecisions();
+  staticData->decisionToDFA.reserve(count);
   for (size_t i = 0; i < count; i++) {
-    _decisionToDFA->emplace_back(_atn->getDecisionState(i), i);
+    staticData->decisionToDFA.emplace_back(staticData->atn->getDecisionState(i), i);
+  }
+  XPathLexerstaticData = staticData.release();
+}
+
+}
+
+XPathLexer::XPathLexer(CharStream *input) : Lexer(input) {
+  XPathLexer::initialize();
+  _interpreter = new atn::LexerATNSimulator(this, *XPathLexerstaticData->atn, XPathLexerstaticData->decisionToDFA, XPathLexerstaticData->sharedContextCache);
+}
+
+XPathLexer::~XPathLexer() {
+  delete _interpreter;
+}
+
+std::string XPathLexer::getGrammarFileName() const {
+  return "XPathLexer.g4";
+}
+
+const std::vector<std::string>& XPathLexer::getRuleNames() const {
+  return XPathLexerstaticData->ruleNames;
+}
+
+const std::vector<std::string>& XPathLexer::getChannelNames() const {
+  return XPathLexerstaticData->channelNames;
+}
+
+const std::vector<std::string>& XPathLexer::getModeNames() const {
+  return XPathLexerstaticData->modeNames;
+}
+
+const dfa::Vocabulary& XPathLexer::getVocabulary() const {
+  return XPathLexerstaticData->vocabulary;
+}
+
+const std::vector<uint16_t>& XPathLexer::getSerializedATN() const {
+  return XPathLexerstaticData->serializedATN;
+}
+
+const atn::ATN& XPathLexer::getATN() const {
+  return *XPathLexerstaticData->atn;
+}
+
+void XPathLexer::action(RuleContext *context, size_t ruleIndex, size_t actionIndex) {
+  switch (ruleIndex) {
+    case 4: IDAction(antlrcpp::downCast<antlr4::RuleContext *>(context), actionIndex); break;
+
+  default:
+    break;
   }
 }
 
-XPathLexer::Initializer XPathLexer::_init;
+void XPathLexer::IDAction(antlr4::RuleContext *context, size_t actionIndex) {
+  switch (actionIndex) {
+    case 0:
+    				if (isupper(getText()[0]))
+    				  setType(TOKEN_REF);
+    				else
+    				  setType(RULE_REF);
+    				 break;
+
+  default:
+    break;
+  }
+}
+
+void XPathLexer::initialize() {
+  std::call_once(XPathLexer_onceFlag, XPathLexer_initialize);
+}

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.h
@@ -7,8 +7,6 @@
 #include "antlr4-runtime.h"
 
 
-
-
 class  XPathLexer : public antlr4::Lexer {
 public:
   enum {
@@ -17,41 +15,33 @@ public:
   };
 
   explicit XPathLexer(antlr4::CharStream *input);
-  ~XPathLexer();
+
+  ~XPathLexer() override;
 
   virtual std::string getGrammarFileName() const override;
+
   virtual const std::vector<std::string>& getRuleNames() const override;
 
   virtual const std::vector<std::string>& getChannelNames() const override;
+
   virtual const std::vector<std::string>& getModeNames() const override;
-  virtual antlr4::dfa::Vocabulary& getVocabulary() const override;
+
+  virtual const antlr4::dfa::Vocabulary& getVocabulary() const override;
 
   virtual const std::vector<uint16_t>& getSerializedATN() const override;
+
   virtual const antlr4::atn::ATN& getATN() const override;
 
   virtual void action(antlr4::RuleContext *context, size_t ruleIndex, size_t actionIndex) override;
+
+  // By default the static state used to implement the lexer is lazily initialized during the first
+  // call to the constructor. You can call this function if you wish to initialize the static state
+  // ahead of time.
+  static void initialize();
 private:
-  static std::vector<antlr4::dfa::DFA> *_decisionToDFA;
-  static antlr4::atn::PredictionContextCache _sharedContextCache;
-  static std::vector<std::string> _ruleNames;
-  static std::vector<std::string> _channelNames;
-  static std::vector<std::string> _modeNames;
-
-  static std::vector<std::string> _literalNames;
-  static std::vector<std::string> _symbolicNames;
-  static antlr4::dfa::Vocabulary _vocabulary;
-  static antlr4::atn::ATN *_atn;
-  static std::vector<uint16_t> _serializedATN;
-
-
   // Individual action functions triggered by action() above.
   void IDAction(antlr4::RuleContext *context, size_t actionIndex);
 
   // Individual semantic predicate functions triggered by sempred() above.
-
-  struct Initializer {
-    Initializer();
-  };
-  static Initializer _init;
 };
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -64,38 +64,38 @@ public:
 <endif>
 
   explicit <lexer.name>(antlr4::CharStream *input);
-  ~<lexer.name>();
+
+  ~<lexer.name>() override;
 
   <namedActions.members>
-  virtual std::string getGrammarFileName() const override;
-  virtual const std::vector\<std::string>& getRuleNames() const override;
 
-  virtual const std::vector\<std::string>& getChannelNames() const override;
-  virtual const std::vector\<std::string>& getModeNames() const override;
-  virtual antlr4::dfa::Vocabulary& getVocabulary() const override;
+  std::string getGrammarFileName() const override;
+
+  const std::vector\<std::string>& getRuleNames() const override;
+
+  const std::vector\<std::string>& getChannelNames() const override;
+
+  const std::vector\<std::string>& getModeNames() const override;
+
+  const antlr4::dfa::Vocabulary& getVocabulary() const override;
 
   virtual const std::vector\<uint16_t>& getSerializedATN() const override;
   virtual const antlr4::atn::ATN& getATN() const override;
 
   <if (actionFuncs)>
-  virtual void action(antlr4::RuleContext *context, size_t ruleIndex, size_t actionIndex) override;
+  void action(antlr4::RuleContext *context, size_t ruleIndex, size_t actionIndex) override;
   <endif>
+
   <if (sempredFuncs)>
-  virtual bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
+  bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
   <endif>
+
+  // By default the static state used to implement the lexer is lazily initialized during the first
+  // call to the constructor. You can call this function if you wish to initialize the static state
+  // ahead of time.
+  static void initialize();
 
 private:
-  static std::vector\<antlr4::dfa::DFA> *_decisionToDFA;
-  static antlr4::atn::PredictionContextCache _sharedContextCache;
-  static std::vector\<std::string> _ruleNames;
-  static std::vector\<std::string> _channelNames;
-  static std::vector\<std::string> _modeNames;
-
-  static std::vector\<std::string> _literalNames;
-  static std::vector\<std::string> _symbolicNames;
-  static antlr4::dfa::Vocabulary _vocabulary;
-  <atn>
-
   <namedActions.declarations>
 
   // Individual action functions triggered by action() above.
@@ -104,16 +104,75 @@ private:
   // Individual semantic predicate functions triggered by sempred() above.
   <sempredFuncs.values; separator="\n">
 
-  struct Initializer {
-    Initializer();
-  };
-  static Initializer _init;
+  <atn>
 };
 >>
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass = {Lexer}) ::= <<
+
+using namespace antlr4;
+
+namespace {
+
+struct <lexer.name>StaticData final {
+  <lexer.name>StaticData(std::vector\<std::string> ruleNames,
+                          std::vector\<std::string> channelNames,
+                          std::vector\<std::string> modeNames,
+                          std::vector\<std::string> literalNames,
+                          std::vector\<std::string> symbolicNames)
+      : ruleNames(std::move(ruleNames)), channelNames(std::move(channelNames)),
+        modeNames(std::move(modeNames)), literalNames(std::move(literalNames)),
+        symbolicNames(std::move(symbolicNames)),
+        vocabulary(this->literalNames, this->symbolicNames) {}
+
+  <lexer.name>StaticData(const <lexer.name>StaticData&) = delete;
+  <lexer.name>StaticData(<lexer.name>StaticData&&) = delete;
+  <lexer.name>StaticData& operator=(const <lexer.name>StaticData&) = delete;
+  <lexer.name>StaticData& operator=(<lexer.name>StaticData&&) = delete;
+
+  std::vector\<antlr4::dfa::DFA> decisionToDFA;
+  antlr4::atn::PredictionContextCache sharedContextCache;
+  const std::vector\<std::string> ruleNames;
+  const std::vector\<std::string> channelNames;
+  const std::vector\<std::string> modeNames;
+  const std::vector\<std::string> literalNames;
+  const std::vector\<std::string> symbolicNames;
+  const antlr4::dfa::Vocabulary vocabulary;
+  std::vector\<uint16_t> serializedATN;
+  std::unique_ptr\<antlr4::atn::ATN> atn;
+};
+
+std::once_flag <lexer.name>_onceFlag;
+<lexer.name>StaticData *<lexer.name>staticData = nullptr;
+
+void <lexer.name>_initialize() {
+  assert(<lexer.name>staticData == nullptr);
+  auto staticData = std::make_unique\<<lexer.name>StaticData>(
+    std::vector\<std::string>{
+      <lexer.ruleNames: {r | "<r>"}; separator = ", ", wrap, anchor>
+    },
+    std::vector\<std::string>{
+      "DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channels)>, <lexer.channels: {c | "<c>"}; separator = ", ", wrap, anchor><endif>
+    },
+    std::vector\<std::string>{
+      <lexer.modes: {m | "<m>"}; separator = ", ", wrap, anchor>
+    },
+    std::vector\<std::string>{
+      <lexer.literalNames: {t | <t>}; null = "\"\"", separator = ", ", wrap, anchor>
+    },
+    std::vector\<std::string>{
+      <lexer.symbolicNames: {t | <t>}; null = "\"\"", separator = ", ", wrap, anchor>
+    }
+  );
+  <atn>
+  <lexer.name>staticData = staticData.release();
+}
+
+}
+
 <lexer.name>::<lexer.name>(CharStream *input) : <superClass>(input) {
-  _interpreter = new atn::LexerATNSimulator(this, *_atn, *_decisionToDFA, _sharedContextCache);
+  <lexer.name>::initialize();
+  _interpreter = new atn::LexerATNSimulator(this, *<lexer.name>staticData->atn, <lexer.name>staticData->decisionToDFA, <lexer.name>staticData->sharedContextCache);
 }
 
 <lexer.name>::~<lexer.name>() {
@@ -125,27 +184,27 @@ std::string <lexer.name>::getGrammarFileName() const {
 }
 
 const std::vector\<std::string>& <lexer.name>::getRuleNames() const {
-  return _ruleNames;
+  return <lexer.name>staticData->ruleNames;
 }
 
 const std::vector\<std::string>& <lexer.name>::getChannelNames() const {
-  return _channelNames;
+  return <lexer.name>staticData->channelNames;
 }
 
 const std::vector\<std::string>& <lexer.name>::getModeNames() const {
-  return _modeNames;
+  return <lexer.name>staticData->modeNames;
 }
 
-dfa::Vocabulary& <lexer.name>::getVocabulary() const {
-  return _vocabulary;
+const dfa::Vocabulary& <lexer.name>::getVocabulary() const {
+  return <lexer.name>staticData->vocabulary;
 }
 
 const std::vector\<uint16_t>& <lexer.name>::getSerializedATN() const {
-  return _serializedATN;
+  return <lexer.name>staticData->serializedATN;
 }
 
 const atn::ATN& <lexer.name>::getATN() const {
-  return *_atn;
+  return *<lexer.name>staticData->atn;
 }
 
 <namedActions.definitions>
@@ -177,41 +236,9 @@ bool <lexer.name>::sempred(RuleContext *context, size_t ruleIndex, size_t predic
 
 <sempredFuncs.values; separator="\n">
 
-// Static vars and initialization.
-std::vector\<dfa::DFA>* <lexer.name>::_decisionToDFA = nullptr;
-atn::PredictionContextCache <lexer.name>::_sharedContextCache;
-
-// We own the ATN which in turn owns the ATN states.
-atn::ATN* <lexer.name>::_atn = nullptr;
-std::vector\<uint16_t> <lexer.name>::_serializedATN;
-
-std::vector\<std::string> <lexer.name>::_ruleNames = {
-  <lexer.ruleNames: {r | "<r>"}; separator = ", ", wrap, anchor>
-};
-
-std::vector\<std::string> <lexer.name>::_channelNames = {
-  "DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channelNames)>, <lexer.channelNames: {c | "<c>"}; separator = ", ", wrap, anchor><endif>
-};
-
-std::vector\<std::string> <lexer.name>::_modeNames = {
-  <lexer.modes: {m | "<m>"}; separator = ", ", wrap, anchor>
-};
-
-std::vector\<std::string> <lexer.name>::_literalNames = {
-  <lexer.literalNames: {t | <t>}; null = "\"\"", separator = ", ", wrap, anchor>
-};
-
-std::vector\<std::string> <lexer.name>::_symbolicNames = {
-  <lexer.symbolicNames: {t | <t>}; null = "\"\"", separator = ", ", wrap, anchor>
-};
-
-dfa::Vocabulary <lexer.name>::_vocabulary(_literalNames, _symbolicNames);
-
-<lexer.name>::Initializer::Initializer() {
-  <atn>
+void <lexer.name>::initialize() {
+  std::call_once(<lexer.name>_onceFlag, <lexer.name>_initialize);
 }
-
-<lexer.name>::Initializer <lexer.name>::_init;
 >>
 
 RuleActionFunctionHeader(r, actions) ::= <<
@@ -269,12 +296,18 @@ public:
 <endif>
 
   explicit <parser.name>(antlr4::TokenStream *input);
-  ~<parser.name>();
 
-  virtual std::string getGrammarFileName() const override;
-  virtual const antlr4::atn::ATN& getATN() const override { return *_atn; };
-  virtual const std::vector\<std::string>& getRuleNames() const override;
-  virtual antlr4::dfa::Vocabulary& getVocabulary() const override;
+  ~<parser.name>() override;
+
+  std::string getGrammarFileName() const override;
+
+  const antlr4::atn::ATN& getATN() const override;
+
+  const std::vector\<std::string>& getRuleNames() const override;
+
+  const antlr4::dfa::Vocabulary& getVocabulary() const override;
+
+  const std::vector\<uint16_t>& getSerializedATN() const override;
 
   <namedActions.members>
 
@@ -283,38 +316,83 @@ public:
   <funcs; separator = "\n">
 
   <if (sempredFuncs)>
-  virtual bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
+  bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
+
   <sempredFuncs.values; separator = "\n">
   <endif>
 
+  // By default the static state used to implement the parser is lazily initialized during the first
+  // call to the constructor. You can call this function if you wish to initialize the static state
+  // ahead of time.
+  static void initialize();
+
 private:
-  static std::vector\<antlr4::dfa::DFA> *_decisionToDFA;
-  static antlr4::atn::PredictionContextCache _sharedContextCache;
-  static std::vector\<std::string> _ruleNames;
-
-  static std::vector\<std::string> _literalNames;
-  static std::vector\<std::string> _symbolicNames;
-  static antlr4::dfa::Vocabulary _vocabulary;
-  <atn>
-
   <namedActions.declarations>
-
-  struct Initializer {
-    Initializer();
-  };
-  static Initializer _init;
 };
 >>
 
 Parser(parser, funcs, atn, sempredFuncs, superClass = {Parser}) ::= <<
+
 using namespace antlr4;
 
+namespace {
+
+struct <parser.name>StaticData final {
+  <parser.name>StaticData(std::vector\<std::string> ruleNames,
+                        std::vector\<std::string> literalNames,
+                        std::vector\<std::string> symbolicNames)
+      : ruleNames(std::move(ruleNames)), literalNames(std::move(literalNames)),
+        symbolicNames(std::move(symbolicNames)),
+        vocabulary(this->literalNames, this->symbolicNames) {}
+
+  <parser.name>StaticData(const <parser.name>StaticData&) = delete;
+  <parser.name>StaticData(<parser.name>StaticData&&) = delete;
+  <parser.name>StaticData& operator=(const <parser.name>StaticData&) = delete;
+  <parser.name>StaticData& operator=(<parser.name>StaticData&&) = delete;
+
+  std::vector\<antlr4::dfa::DFA> decisionToDFA;
+  antlr4::atn::PredictionContextCache sharedContextCache;
+  const std::vector\<std::string> ruleNames;
+  const std::vector\<std::string> literalNames;
+  const std::vector\<std::string> symbolicNames;
+  const antlr4::dfa::Vocabulary vocabulary;
+  std::vector\<uint16_t> serializedATN;
+  std::unique_ptr\<antlr4::atn::ATN> atn;
+};
+
+std::once_flag <parser.name>_onceFlag;
+<parser.name>StaticData *<parser.name>staticData = nullptr;
+
+void <parser.name>_initialize() {
+  assert(<parser.name>staticData == nullptr);
+  auto staticData = std::make_unique\<<parser.name>StaticData>(
+    std::vector\<std::string>{
+      <parser.ruleNames: {r | "<r>"}; separator = ", ", wrap, anchor>
+    },
+    std::vector\<std::string>{
+      <parser.literalNames: {t | <t>}; null = "\"\"", separator = ", ", wrap, anchor>
+    },
+    std::vector\<std::string>{
+      <parser.symbolicNames: {t | <t>}; null = "\"\"", separator = ", ", wrap, anchor>
+    }
+  );
+  <atn>
+  <parser.name>staticData = staticData.release();
+}
+
+}
+
 <parser.name>::<parser.name>(TokenStream *input) : <superClass>(input) {
-  _interpreter = new atn::ParserATNSimulator(this, *_atn, *_decisionToDFA, _sharedContextCache);
+  <parser.name>::initialize();
+  _interpreter = new atn::ParserATNSimulator(this, *<parser.name>staticData->atn, <parser.name>staticData->decisionToDFA, <parser.name>staticData->sharedContextCache);
 }
 
 <parser.name>::~<parser.name>() {
   delete _interpreter;
+}
+
+const atn::ATN& <parser.name>::getATN() const {
+  return *<parser.name>staticData->atn;
 }
 
 std::string <parser.name>::getGrammarFileName() const {
@@ -322,11 +400,15 @@ std::string <parser.name>::getGrammarFileName() const {
 }
 
 const std::vector\<std::string>& <parser.name>::getRuleNames() const {
-  return _ruleNames;
+  return <parser.name>staticData->ruleNames;
 }
 
-dfa::Vocabulary& <parser.name>::getVocabulary() const {
-  return _vocabulary;
+const dfa::Vocabulary& <parser.name>::getVocabulary() const {
+  return <parser.name>staticData->vocabulary;
+}
+
+const std::vector\<uint16_t>& <parser.name>::getSerializedATN() const {
+  return <parser.name>staticData->serializedATN;
 }
 
 <namedActions.definitions>
@@ -347,57 +429,29 @@ bool <parser.name>::sempred(RuleContext *context, size_t ruleIndex, size_t predi
 
 <sempredFuncs.values; separator="\n"><endif>
 
-// Static vars and initialization.
-std::vector\<dfa::DFA>* <parser.name>::_decisionToDFA = nullptr;
-atn::PredictionContextCache <parser.name>::_sharedContextCache;
-
-// We own the ATN which in turn owns the ATN states.
-atn::ATN* <parser.name>::_atn = nullptr;
-std::vector\<uint16_t> <parser.name>::_serializedATN;
-
-std::vector\<std::string> <parser.name>::_ruleNames = {
-  <parser.ruleNames: {r | "<r>"}; separator = ", ", wrap, anchor>
-};
-
-std::vector\<std::string> <parser.name>::_literalNames = {
-  <parser.literalNames: {t | <t>}; null = "\"\"", separator = ", ", wrap, anchor>
-};
-
-std::vector\<std::string> <parser.name>::_symbolicNames = {
-  <parser.symbolicNames: {t | <t>}; null = "\"\"", separator = ", ", wrap, anchor>
-};
-
-dfa::Vocabulary <parser.name>::_vocabulary(_literalNames, _symbolicNames);
-
-<parser.name>::Initializer::Initializer() {
-  <atn>
+void <parser.name>::initialize() {
+  std::call_once(<parser.name>_onceFlag, <parser.name>_initialize);
 }
-
-<parser.name>::Initializer <parser.name>::_init;
 >>
 
 SerializedATNHeader(model) ::= <<
-static antlr4::atn::ATN *_atn;
-static std::vector\<uint16_t> _serializedATN;
 >>
 
-// Constructs the serialized ATN and writes init code for static member vars.
 SerializedATN(model) ::= <<
 static const uint16_t serializedATNSegment[] = {
 	<model.serialized: {s | <s>}; separator=",", wrap>
 };
-
-_serializedATN.insert(_serializedATN.end(), serializedATNSegment,
+staticData->serializedATN.reserve(sizeof(serializedATNSegment) / sizeof(serializedATNSegment[0]));
+staticData->serializedATN.insert(staticData->serializedATN.end(), serializedATNSegment,
   serializedATNSegment + sizeof(serializedATNSegment) / sizeof(serializedATNSegment[0]));
 
-atn::ATNDeserializer deserializer;
-_atn = deserializer.deserialize(_serializedATN).release();
+antlr4::atn::ATNDeserializer deserializer;
+staticData->atn = deserializer.deserialize(staticData->serializedATN);
 
-size_t count = _atn->getNumberOfDecisions();
-_decisionToDFA = new std::vector\<dfa::DFA>();
-_decisionToDFA->reserve(count);
+const size_t count = staticData->atn->getNumberOfDecisions();
+staticData->decisionToDFA.reserve(count);
 for (size_t i = 0; i \< count; i++) { <! Rework class ATN to allow standard iterations. !>
-  _decisionToDFA->emplace_back(_atn->getDecisionState(i), i);
+  staticData->decisionToDFA.emplace_back(staticData->atn->getDecisionState(i), i);
 }
 >>
 


### PR DESCRIPTION
Currently ATN is deserialized during program initialization before `main` is invoked. This has a cost that all programs must pay regardless of whether the lexer/parser is even used. This change shifts initialize to be just-in-time using `std::once_flag` and `std::call_once`. This additionally resolves concerns around potential future issues with regards to static initialization order. Static initialization order between separate compliation units is undefined in C++. By switching to `std::once_flag` which has constant initialization, we avoid the problem entirely.