### PR TITLE
JavaScript: Change string to int array for serialized ATN

### DIFF
--- a/runtime/JavaScript/src/antlr4/atn/ATNDeserializer.js
+++ b/runtime/JavaScript/src/antlr4/atn/ATNDeserializer.js
@@ -74,7 +74,7 @@ class ATNDeserializer {
     }
 
     deserialize(data) {
-        this.data = data.split("").map(c => c.charCodeAt(0));
+        this.data = data
         this.pos = 0;
         this.checkVersion();
         const atn = this.readATN();

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -837,9 +837,7 @@ export default class <lexer.name> extends <if(superClass)><superClass><else>antl
 >>
 
 SerializedATN(model) ::= <<
-<! only one segment, can be inlined !>
-
-const serializedATN = ["<model.serialized; wrap={",<\n>    "}>"].join("");
+const serializedATN = [<model.serialized: {s | <s>}; separator=",", wrap>];
 
 >>
 

--- a/tool/src/org/antlr/v4/codegen/target/JavaScriptTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/JavaScriptTarget.java
@@ -94,6 +94,6 @@ public class JavaScriptTarget extends Target {
 
 	@Override
 	public boolean isATNSerializedAsInts() {
-		return false;
+		return true;
 	}
 }


### PR DESCRIPTION
@KvanTTT @ericvergnaud @jcking And now JavaScript uses an int array not a string! woot!  Soon we will worry less about large ATN.