### PR TITLE
perf: Add default implementation for Visit in ParseTreeVisitor. 

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -326,3 +326,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/12/16, Ketler13, Oleksandr Martyshchenko, oleksandr.martyshchenko@gmail.com
 2021/12/25, Tinker1024, Tinker1024, tinker@huawei.com
 2021/12/31, Biswa96, Biswapriyo Nath, nathbappai@gmail.com
+2022/03/07, chenquan, chenquan, chenquan.dev@gmail.com

--- a/runtime/Go/antlr/tree.go
+++ b/runtime/Go/antlr/tree.go
@@ -64,7 +64,7 @@ type BaseParseTreeVisitor struct{}
 
 var _ ParseTreeVisitor = &BaseParseTreeVisitor{}
 
-func (v *BaseParseTreeVisitor) Visit(tree ParseTree) interface{}            { return nil }
+func (v *BaseParseTreeVisitor) Visit(tree ParseTree) interface{}            { return tree.Accept(v) }
 func (v *BaseParseTreeVisitor) VisitChildren(node RuleNode) interface{}     { return nil }
 func (v *BaseParseTreeVisitor) VisitTerminal(node TerminalNode) interface{} { return nil }
 func (v *BaseParseTreeVisitor) VisitErrorNode(node ErrorNode) interface{}   { return nil }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

Reference: https://github.com/antlr/antlr4/blob/ad29539cd2e94b2599e0281515f6cbb420d29f38/runtime/Java/src/org/antlr/v4/runtime/tree/AbstractParseTreeVisitor.java#L18