### PR TITLE
[C++] Remove unused LexerATNSimulator::match_calls

### DIFF
--- a/runtime/CSharp/src/Atn/LexerATNSimulator.cs
+++ b/runtime/CSharp/src/Atn/LexerATNSimulator.cs
@@ -45,8 +45,6 @@ namespace Antlr4.Runtime.Atn
 
 		readonly SimState prevAccept = new SimState();
 
-		public static int match_calls = 0;
-
 		public LexerATNSimulator(ATN atn, DFA[] decisionToDFA,
 								 PredictionContextCache sharedContextCache)
 			: this(null, atn, decisionToDFA, sharedContextCache)
@@ -74,7 +72,6 @@ namespace Antlr4.Runtime.Atn
 
 		public int Match(ICharStream input, int mode)
 		{
-			match_calls++;
 			this.mode = mode;
 			int mark = input.Mark();
 			try

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -47,9 +47,6 @@ void LexerATNSimulator::SimState::InitializeInstanceFields() {
   charPos = INVALID_INDEX;
 }
 
-std::atomic<int> LexerATNSimulator::match_calls(0);
-
-
 LexerATNSimulator::LexerATNSimulator(const ATN &atn, std::vector<dfa::DFA> &decisionToDFA,
                                      PredictionContextCache &sharedContextCache)
   : LexerATNSimulator(nullptr, atn, decisionToDFA, sharedContextCache) {
@@ -69,7 +66,6 @@ void LexerATNSimulator::copyState(LexerATNSimulator *simulator) {
 }
 
 size_t LexerATNSimulator::match(CharStream *input, size_t mode) {
-  match_calls.fetch_add(1, std::memory_order_relaxed);
   _mode = mode;
   ssize_t mark = input->mark();
 

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
@@ -84,8 +84,6 @@ namespace atn {
     SimState _prevAccept;
 
   public:
-    static std::atomic<int> match_calls;
-
     LexerATNSimulator(const ATN &atn, std::vector<dfa::DFA> &decisionToDFA, PredictionContextCache &sharedContextCache);
     LexerATNSimulator(Lexer *recog, const ATN &atn, std::vector<dfa::DFA> &decisionToDFA, PredictionContextCache &sharedContextCache);
     virtual ~LexerATNSimulator() = default;

--- a/runtime/JavaScript/src/antlr4/atn/LexerATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/LexerATNSimulator.js
@@ -85,7 +85,6 @@ class LexerATNSimulator extends ATNSimulator {
 	}
 
 	match(input, mode) {
-		this.match_calls += 1;
 		this.mode = mode;
 		const mark = input.mark();
 		try {
@@ -644,7 +643,5 @@ LexerATNSimulator.dfa_debug = false;
 
 LexerATNSimulator.MIN_DFA_EDGE = 0;
 LexerATNSimulator.MAX_DFA_EDGE = 127; // forces unicode to stay in ATN
-
-LexerATNSimulator.match_calls = 0;
 
 module.exports = LexerATNSimulator;

--- a/runtime/Python2/src/antlr4/atn/LexerATNSimulator.py
+++ b/runtime/Python2/src/antlr4/atn/LexerATNSimulator.py
@@ -53,8 +53,6 @@ class LexerATNSimulator(ATNSimulator):
 
     ERROR = None
 
-    match_calls = 0
-
     def __init__(self, recog, atn, decisionToDFA, sharedContextCache):
         super(LexerATNSimulator, self).__init__(atn, sharedContextCache)
         self.decisionToDFA = decisionToDFA
@@ -81,7 +79,6 @@ class LexerATNSimulator(ATNSimulator):
         self.startIndex = simulator.startIndex
 
     def match(self, input , mode):
-        self.match_calls += 1
         self.mode = mode
         mark = input.mark()
         try:

--- a/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/LexerATNSimulator.swift
@@ -1,14 +1,14 @@
-/// 
+///
 /// Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
 /// Use of this file is governed by the BSD 3-clause license that
 /// can be found in the LICENSE.txt file in the project root.
-/// 
+///
 
 
 
-/// 
+///
 /// "dup" of ParserInterpreter
-/// 
+///
 
 open class LexerATNSimulator: ATNSimulator {
     public static let debug = false
@@ -17,7 +17,7 @@ open class LexerATNSimulator: ATNSimulator {
     public static let MIN_DFA_EDGE = 0
     public static let MAX_DFA_EDGE = 127  // forces unicode to stay in ATN
 
-    /// 
+    ///
     /// When we hit an accept state in either the DFA or the ATN, we
     /// have to notify the character stream to start buffering characters
     /// via _org.antlr.v4.runtime.IntStream#mark_ and record the current state. The current sim state
@@ -25,14 +25,14 @@ open class LexerATNSimulator: ATNSimulator {
     /// and current character position in that line. Note that the Lexer is
     /// tracking the starting line and characterization of the token. These
     /// variables track the "state" of the simulator when it hits an accept state.
-    /// 
+    ///
     /// We track these variables separately for the DFA and ATN simulation
     /// because the DFA simulation often has to fail over to the ATN
     /// simulation. If the ATN simulation fails, we need the DFA to fall
     /// back to its previously accepted state, if any. If the ATN succeeds,
     /// then the ATN does the accept and the DFA simulator that invoked it
     /// can simply return the predicted token type.
-    /// 
+    ///
 
     internal class SimState {
         internal var index: Int = -1
@@ -51,35 +51,33 @@ open class LexerATNSimulator: ATNSimulator {
 
     internal weak var recog: Lexer?
 
-    /// 
+    ///
     /// The current token's starting index into the character stream.
     /// Shared across DFA to ATN simulation in case the ATN fails and the
     /// DFA did not have a previous accept state. In this case, we use the
     /// ATN-generated exception object.
-    /// 
+    ///
     internal var startIndex = -1
 
-    /// 
+    ///
     /// line number 1..n within the input
-    /// 
+    ///
     public var line = 1
 
-    /// 
+    ///
     /// The index of the character relative to the beginning of the line 0..n-1
-    /// 
+    ///
     public var charPositionInLine = 0
 
     public private(set) final var decisionToDFA: [DFA]
-    
+
     internal var mode = Lexer.DEFAULT_MODE
 
-    /// 
+    ///
     /// Used during DFA/ATN exec to record the most recent accept configuration info
-    /// 
+    ///
 
     internal final var prevAccept = SimState()
-
-    public static var match_calls = 0
 
     public convenience init(_ atn: ATN, _ decisionToDFA: [DFA],
         _ sharedContextCache: PredictionContextCache) {
@@ -103,8 +101,6 @@ open class LexerATNSimulator: ATNSimulator {
     }
 
     open func match(_ input: CharStream, _ mode: Int) throws -> Int {
-        LexerATNSimulator.match_calls += 1
-
         self.mode = mode
         let mark = input.mark()
         defer {
@@ -237,17 +233,17 @@ open class LexerATNSimulator: ATNSimulator {
         return try failOrAccept(prevAccept, input, s.configs, t)
     }
 
-    /// 
+    ///
     /// Get an existing target state for an edge in the DFA. If the target state
     /// for the edge has not yet been computed or is otherwise not available,
     /// this method returns `null`.
-    /// 
+    ///
     /// - parameter s: The current DFA state
     /// - parameter t: The next input symbol
     /// - returns: The existing target DFA state for the given input symbol
     /// `t`, or `null` if the target state for this edge is not
     /// already cached
-    /// 
+    ///
 
     internal func getExistingTargetState(_ s: DFAState, _ t: Int) -> DFAState? {
         if s.edges == nil || t < LexerATNSimulator.MIN_DFA_EDGE || t > LexerATNSimulator.MAX_DFA_EDGE {
@@ -262,18 +258,18 @@ open class LexerATNSimulator: ATNSimulator {
         return target
     }
 
-    /// 
+    ///
     /// Compute a target state for an edge in the DFA, and attempt to add the
     /// computed state and corresponding edge to the DFA.
-    /// 
+    ///
     /// - parameter input: The input stream
     /// - parameter s: The current DFA state
     /// - parameter t: The next input symbol
-    /// 
+    ///
     /// - returns: The computed target DFA state for the given input symbol
     /// `t`. If `t` does not lead to a valid DFA state, this method
     /// returns _#ERROR_.
-    /// 
+    ///
 
     internal func computeTargetState(_ input: CharStream, _ s: DFAState, _ t: Int) throws -> DFAState {
         let reach = ATNConfigSet(true, isOrdered: true)
@@ -315,11 +311,11 @@ open class LexerATNSimulator: ATNSimulator {
             }
     }
 
-    /// 
+    ///
     /// Given a starting configuration set, figure out all ATN configurations
     /// we can reach upon input `t`. Parameter `reach` is a return
     /// parameter.
-    /// 
+    ///
     internal func getReachableConfigSet(_ input: CharStream, _ closureConfig: ATNConfigSet, _ reach: ATNConfigSet, _ t: Int) throws {
         // this is used to skip processing for configs which have a lower priority
         // than a config that already reached an accept state for the same rule
@@ -404,16 +400,16 @@ open class LexerATNSimulator: ATNSimulator {
             return configs
     }
 
-    /// 
+    ///
     /// Since the alternatives within any lexer decision are ordered by
     /// preference, this method stops pursuing the closure as soon as an accept
     /// state is reached. After the first accept state is reached by depth-first
     /// search from `config`, all other (potentially reachable) states for
     /// this rule would have a lower priority.
-    /// 
+    ///
     /// - returns: `true` if an accept state is reached, otherwise
     /// `false`.
-    /// 
+    ///
     @discardableResult
     final func closure(_ input: CharStream, _ config: LexerATNConfig, _ configs: ATNConfigSet, _ currentAltReachedAcceptState: Bool, _ speculative: Bool, _ treatEofAsEpsilon: Bool) throws -> Bool {
         var currentAltReachedAcceptState = currentAltReachedAcceptState
@@ -495,7 +491,7 @@ open class LexerATNSimulator: ATNSimulator {
 
 
             case Transition.PREDICATE:
-                /// 
+                ///
                 /// Track traversing semantic predicates. If we traverse,
                 /// we cannot add a DFA state for this "reach" computation
                 /// because the DFA would not test the predicate again in the
@@ -505,15 +501,15 @@ open class LexerATNSimulator: ATNSimulator {
                 /// semantically it's not used that often. One of the key elements to
                 /// this predicate mechanism is not adding DFA states that see
                 /// predicates immediately afterwards in the ATN. For example,
-                /// 
+                ///
                 /// a : ID {p1}? | ID {p2}? ;
-                /// 
+                ///
                 /// should create the start state for rule 'a' (to save start state
                 /// competition), but should not create target of ID state. The
                 /// collection of ATN states the following ID references includes
                 /// states reached by traversing predicates. Since this is when we
                 /// test them, we cannot cash the DFA state target of ID.
-                /// 
+                ///
                 let pt = t as! PredicateTransition
                 if LexerATNSimulator.debug {
                     print("EVAL rule \(pt.ruleIndex):\(pt.predIndex)")
@@ -569,9 +565,9 @@ open class LexerATNSimulator: ATNSimulator {
             return c
     }
 
-    /// 
+    ///
     /// Evaluate a predicate specified in the lexer.
-    /// 
+    ///
     /// If `speculative` is `true`, this method was called before
     /// _#consume_ for the matched character. This method should call
     /// _#consume_ before evaluating the predicate to ensure position
@@ -580,16 +576,16 @@ open class LexerATNSimulator: ATNSimulator {
     /// lexer state. This method should restore `input` and the simulator
     /// to the original state before returning (i.e. undo the actions made by the
     /// call to _#consume_.
-    /// 
+    ///
     /// - parameter input: The input stream.
     /// - parameter ruleIndex: The rule containing the predicate.
     /// - parameter predIndex: The index of the predicate within the rule.
     /// - parameter speculative: `true` if the current index in `input` is
     /// one character before the predicate's location.
-    /// 
+    ///
     /// - returns: `true` if the specified predicate evaluates to
     /// `true`.
-    /// 
+    ///
     final func evaluatePredicate(_ input: CharStream, _ ruleIndex: Int, _ predIndex: Int, _ speculative: Bool) throws -> Bool {
         // assume true if no recognizer was provided
         guard let recog = recog else {
@@ -631,18 +627,18 @@ open class LexerATNSimulator: ATNSimulator {
     private final func addDFAEdge(_ from: DFAState,
         _ t: Int,
         _ q: ATNConfigSet) -> DFAState {
-            /// 
+            ///
             /// leading to this call, ATNConfigSet.hasSemanticContext is used as a
             /// marker indicating dynamic predicate evaluation makes this edge
             /// dependent on the specific input sequence, so the static edge in the
             /// DFA should be omitted. The target DFAState is still created since
             /// execATN has the ability to resynchronize with the DFA state cache
             /// following the predicate evaluation step.
-            /// 
+            ///
             /// TJP notes: next time through the DFA, we see a pred again and eval.
             /// If that gets us to a previously created (but dangling) DFA
             /// state, we can continue in pure DFA mode from there.
-            /// 
+            ///
             let suppressEdge = q.hasSemanticContext
             q.hasSemanticContext = false
             let to = addDFAState(q)
@@ -674,18 +670,18 @@ open class LexerATNSimulator: ATNSimulator {
         }
     }
 
-    /// 
+    ///
     /// Add a new DFA state if there isn't one with this set of
     /// configurations already. This method also detects the first
     /// configuration containing an ATN rule stop state. Later, when
     /// traversing the DFA, we will know which rule to accept.
-    /// 
+    ///
 
     final func addDFAState(_ configs: ATNConfigSet) -> DFAState {
-        /// 
+        ///
         /// the lexer evaluates predicates on-the-fly; by this point configs
         /// should not contain any configurations with unevaluated predicates.
-        /// 
+        ///
         assert(!configs.hasSemanticContext, "Expected: !configs.hasSemanticContext")
 
         let proposed = DFAState(configs)
@@ -717,9 +713,9 @@ open class LexerATNSimulator: ATNSimulator {
         return decisionToDFA[mode]
     }
 
-    /// 
+    ///
     /// Get the text matched so far for the current token.
-    /// 
+    ///
 
     public func getText(_ input: CharStream) -> String {
         // index is first lookahead char, don't include.


### PR DESCRIPTION
The variable appears to be unused and atomic operations are not exactly free.