### PR TITLE
Don't decode utf16 in ATN deserialization for Go; it's just a bunch of uint16

### DIFF
--- a/runtime/Go/antlr/atn_deserializer.go
+++ b/runtime/Go/antlr/atn_deserializer.go
@@ -7,7 +7,6 @@ package antlr
 import (
 	"fmt"
 	"strconv"
-	"unicode/utf16"
 )
 
 var SerializedVersion = 4
@@ -24,7 +23,7 @@ type BlockStartStateIntPair struct {
 
 type ATNDeserializer struct {
 	deserializationOptions *ATNDeserializationOptions
-	data                   []rune
+	data                   []uint16
 	pos                    int
 }
 
@@ -47,7 +46,7 @@ func stringInSlice(a string, list []string) int {
 }
 
 func (a *ATNDeserializer) DeserializeFromUInt16(data []uint16) *ATN {
-	a.data = utf16.Decode(data)
+	a.data = data
 	a.pos = 0
 	a.checkVersion()
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->