### PR TITLE
[Go] Cleanup and fix ATN deserialization verification

### DIFF
--- a/runtime/Go/antlr/atn_deserialization_options.go
+++ b/runtime/Go/antlr/atn_deserialization_options.go
@@ -4,7 +4,9 @@
 
 package antlr
 
-var ATNDeserializationOptionsdefaultOptions = &ATNDeserializationOptions{true, false, false}
+import "errors"
+
+var defaultATNDeserializationOptions = ATNDeserializationOptions{true, true, false}
 
 type ATNDeserializationOptions struct {
 	readOnly                      bool
@@ -12,14 +14,48 @@ type ATNDeserializationOptions struct {
 	generateRuleBypassTransitions bool
 }
 
-func NewATNDeserializationOptions(CopyFrom *ATNDeserializationOptions) *ATNDeserializationOptions {
-	o := new(ATNDeserializationOptions)
+func (opts *ATNDeserializationOptions) ReadOnly() bool {
+	return opts.readOnly
+}
 
-	if CopyFrom != nil {
-		o.readOnly = CopyFrom.readOnly
-		o.verifyATN = CopyFrom.verifyATN
-		o.generateRuleBypassTransitions = CopyFrom.generateRuleBypassTransitions
+func (opts *ATNDeserializationOptions) SetReadOnly(readOnly bool) {
+	if opts.readOnly {
+		panic(errors.New("Cannot mutate read only ATNDeserializationOptions"))
 	}
+	opts.readOnly = readOnly
+}
 
+func (opts *ATNDeserializationOptions) VerifyATN() bool {
+	return opts.verifyATN
+}
+
+func (opts *ATNDeserializationOptions) SetVerifyATN(verifyATN bool) {
+	if opts.readOnly {
+		panic(errors.New("Cannot mutate read only ATNDeserializationOptions"))
+	}
+	opts.verifyATN = verifyATN
+}
+
+func (opts *ATNDeserializationOptions) GenerateRuleBypassTransitions() bool {
+	return opts.generateRuleBypassTransitions
+}
+
+func (opts *ATNDeserializationOptions) SetGenerateRuleBypassTransitions(generateRuleBypassTransitions bool) {
+	if opts.readOnly {
+		panic(errors.New("Cannot mutate read only ATNDeserializationOptions"))
+	}
+	opts.generateRuleBypassTransitions = generateRuleBypassTransitions
+}
+
+func DefaultATNDeserializationOptions() *ATNDeserializationOptions {
+	return NewATNDeserializationOptions(&defaultATNDeserializationOptions)
+}
+
+func NewATNDeserializationOptions(other *ATNDeserializationOptions) *ATNDeserializationOptions {
+	o := new(ATNDeserializationOptions)
+	if other != nil {
+		*o = *other
+		o.readOnly = false
+	}
 	return o
 }

--- a/runtime/Go/antlr/atn_deserializer.go
+++ b/runtime/Go/antlr/atn_deserializer.go
@@ -9,30 +9,30 @@ import (
 	"strconv"
 )
 
-var SerializedVersion = 4
+const serializedVersion = 4
 
-type LoopEndStateIntPair struct {
+type loopEndStateIntPair struct {
 	item0 *LoopEndState
 	item1 int
 }
 
-type BlockStartStateIntPair struct {
+type blockStartStateIntPair struct {
 	item0 BlockStartState
 	item1 int
 }
 
 type ATNDeserializer struct {
-	deserializationOptions *ATNDeserializationOptions
-	data                   []uint16
-	pos                    int
+	options *ATNDeserializationOptions
+	data    []uint16
+	pos     int
 }
 
 func NewATNDeserializer(options *ATNDeserializationOptions) *ATNDeserializer {
 	if options == nil {
-		options = ATNDeserializationOptionsdefaultOptions
+		options = &defaultATNDeserializationOptions
 	}
 
-	return &ATNDeserializer{deserializationOptions: options}
+	return &ATNDeserializer{options: options}
 }
 
 func stringInSlice(a string, list []string) int {
@@ -56,10 +56,8 @@ func (a *ATNDeserializer) DeserializeFromUInt16(data []uint16) *ATN {
 	a.readRules(atn)
 	a.readModes(atn)
 
-	sets := make([]*IntervalSet, 0)
-
 	// First, deserialize sets with 16-bit arguments <= U+FFFF.
-	sets = a.readSets(atn, sets, a.readInt)
+	sets := a.readSets(atn, nil, a.readInt)
 	// Next, deserialize sets with 32-bit arguments <= U+10FFFF.
 	sets = a.readSets(atn, sets, a.readInt32)
 
@@ -69,7 +67,7 @@ func (a *ATNDeserializer) DeserializeFromUInt16(data []uint16) *ATN {
 	a.markPrecedenceDecisions(atn)
 	a.verifyATN(atn)
 
-	if a.deserializationOptions.generateRuleBypassTransitions && atn.grammarType == ATNTypeParser {
+	if a.options.GenerateRuleBypassTransitions() && atn.grammarType == ATNTypeParser {
 		a.generateRuleBypassTransitions(atn)
 		// Re-verify after modification
 		a.verifyATN(atn)
@@ -82,8 +80,8 @@ func (a *ATNDeserializer) DeserializeFromUInt16(data []uint16) *ATN {
 func (a *ATNDeserializer) checkVersion() {
 	version := a.readInt()
 
-	if version != SerializedVersion {
-		panic("Could not deserialize ATN with version " + strconv.Itoa(version) + " (expected " + strconv.Itoa(SerializedVersion) + ").")
+	if version != serializedVersion {
+		panic("Could not deserialize ATN with version " + strconv.Itoa(version) + " (expected " + strconv.Itoa(serializedVersion) + ").")
 	}
 }
 
@@ -95,10 +93,14 @@ func (a *ATNDeserializer) readATN() *ATN {
 }
 
 func (a *ATNDeserializer) readStates(atn *ATN) {
-	loopBackStateNumbers := make([]LoopEndStateIntPair, 0)
-	endStateNumbers := make([]BlockStartStateIntPair, 0)
-
 	nstates := a.readInt()
+
+	// Allocate worst case size.
+	loopBackStateNumbers := make([]loopEndStateIntPair, 0, nstates)
+	endStateNumbers := make([]blockStartStateIntPair, 0, nstates)
+
+	// Preallocate states slice.
+	atn.states = make([]ATNState, 0, nstates)
 
 	for i := 0; i < nstates; i++ {
 		stype := a.readInt()
@@ -106,7 +108,6 @@ func (a *ATNDeserializer) readStates(atn *ATN) {
 		// Ignore bad types of states
 		if stype == ATNStateInvalidType {
 			atn.addState(nil)
-
 			continue
 		}
 
@@ -121,11 +122,11 @@ func (a *ATNDeserializer) readStates(atn *ATN) {
 		if stype == ATNStateLoopEnd {
 			loopBackStateNumber := a.readInt()
 
-			loopBackStateNumbers = append(loopBackStateNumbers, LoopEndStateIntPair{s.(*LoopEndState), loopBackStateNumber})
+			loopBackStateNumbers = append(loopBackStateNumbers, loopEndStateIntPair{s.(*LoopEndState), loopBackStateNumber})
 		} else if s2, ok := s.(BlockStartState); ok {
 			endStateNumber := a.readInt()
 
-			endStateNumbers = append(endStateNumbers, BlockStartStateIntPair{s2, endStateNumber})
+			endStateNumbers = append(endStateNumbers, blockStartStateIntPair{s2, endStateNumber})
 		}
 
 		atn.addState(s)
@@ -133,20 +134,15 @@ func (a *ATNDeserializer) readStates(atn *ATN) {
 
 	// Delay the assignment of loop back and end states until we know all the state
 	// instances have been initialized
-	for j := 0; j < len(loopBackStateNumbers); j++ {
-		pair := loopBackStateNumbers[j]
-
+	for _, pair := range loopBackStateNumbers {
 		pair.item0.loopBackState = atn.states[pair.item1]
 	}
 
-	for j := 0; j < len(endStateNumbers); j++ {
-		pair := endStateNumbers[j]
-
+	for _, pair := range endStateNumbers {
 		pair.item0.setEndState(atn.states[pair.item1].(*BlockEndState))
 	}
 
 	numNonGreedyStates := a.readInt()
-
 	for j := 0; j < numNonGreedyStates; j++ {
 		stateNumber := a.readInt()
 
@@ -154,7 +150,6 @@ func (a *ATNDeserializer) readStates(atn *ATN) {
 	}
 
 	numPrecedenceStates := a.readInt()
-
 	for j := 0; j < numPrecedenceStates; j++ {
 		stateNumber := a.readInt()
 
@@ -166,12 +161,12 @@ func (a *ATNDeserializer) readRules(atn *ATN) {
 	nrules := a.readInt()
 
 	if atn.grammarType == ATNTypeLexer {
-		atn.ruleToTokenType = make([]int, nrules) // TODO: initIntArray(nrules, 0)
+		atn.ruleToTokenType = make([]int, nrules)
 	}
 
-	atn.ruleToStartState = make([]*RuleStartState, nrules) // TODO: initIntArray(nrules, 0)
+	atn.ruleToStartState = make([]*RuleStartState, nrules)
 
-	for i := 0; i < nrules; i++ {
+	for i := range atn.ruleToStartState {
 		s := a.readInt()
 		startState := atn.states[s].(*RuleStartState)
 
@@ -188,11 +183,9 @@ func (a *ATNDeserializer) readRules(atn *ATN) {
 		}
 	}
 
-	atn.ruleToStopState = make([]*RuleStopState, nrules) //initIntArray(nrules, 0)
+	atn.ruleToStopState = make([]*RuleStopState, nrules)
 
-	for i := 0; i < len(atn.states); i++ {
-		state := atn.states[i]
-
+	for _, state := range atn.states {
 		if s2, ok := state.(*RuleStopState); ok {
 			atn.ruleToStopState[s2.ruleIndex] = s2
 			atn.ruleToStartState[s2.ruleIndex].stopState = s2
@@ -202,16 +195,24 @@ func (a *ATNDeserializer) readRules(atn *ATN) {
 
 func (a *ATNDeserializer) readModes(atn *ATN) {
 	nmodes := a.readInt()
+	atn.modeToStartState = make([]*TokensStartState, nmodes)
 
-	for i := 0; i < nmodes; i++ {
+	for i := range atn.modeToStartState {
 		s := a.readInt()
 
-		atn.modeToStartState = append(atn.modeToStartState, atn.states[s].(*TokensStartState))
+		atn.modeToStartState[i] = atn.states[s].(*TokensStartState)
 	}
 }
 
 func (a *ATNDeserializer) readSets(atn *ATN, sets []*IntervalSet, readUnicode func() int) []*IntervalSet {
 	m := a.readInt()
+
+	// Preallocate the needed capacity.
+	if cap(sets)-len(sets) < m {
+		isets := make([]*IntervalSet, len(sets), len(sets)+m)
+		copy(isets, sets)
+		sets = isets
+	}
 
 	for i := 0; i < m; i++ {
 		iset := NewIntervalSet()
@@ -255,11 +256,9 @@ func (a *ATNDeserializer) readEdges(atn *ATN, sets []*IntervalSet) {
 	}
 
 	// Edges for rule stop states can be derived, so they are not serialized
-	for i := 0; i < len(atn.states); i++ {
-		state := atn.states[i]
-
-		for j := 0; j < len(state.GetTransitions()); j++ {
-			var t, ok = state.GetTransitions()[j].(*RuleTransition)
+	for _, state := range atn.states {
+		for _, t := range state.GetTransitions() {
+			var rt, ok = t.(*RuleTransition)
 
 			if !ok {
 				continue
@@ -267,48 +266,42 @@ func (a *ATNDeserializer) readEdges(atn *ATN, sets []*IntervalSet) {
 
 			outermostPrecedenceReturn := -1
 
-			if atn.ruleToStartState[t.getTarget().GetRuleIndex()].isPrecedenceRule {
-				if t.precedence == 0 {
-					outermostPrecedenceReturn = t.getTarget().GetRuleIndex()
+			if atn.ruleToStartState[rt.getTarget().GetRuleIndex()].isPrecedenceRule {
+				if rt.precedence == 0 {
+					outermostPrecedenceReturn = rt.getTarget().GetRuleIndex()
 				}
 			}
 
-			trans := NewEpsilonTransition(t.followState, outermostPrecedenceReturn)
+			trans := NewEpsilonTransition(rt.followState, outermostPrecedenceReturn)
 
-			atn.ruleToStopState[t.getTarget().GetRuleIndex()].AddTransition(trans, -1)
+			atn.ruleToStopState[rt.getTarget().GetRuleIndex()].AddTransition(trans, -1)
 		}
 	}
 
-	for i := 0; i < len(atn.states); i++ {
-		state := atn.states[i]
-
-		if s2, ok := state.(*BaseBlockStartState); ok {
+	for _, state := range atn.states {
+		if s2, ok := state.(BlockStartState); ok {
 			// We need to know the end state to set its start state
-			if s2.endState == nil {
+			if s2.getEndState() == nil {
 				panic("IllegalState")
 			}
 
 			// Block end states can only be associated to a single block start state
-			if s2.endState.startState != nil {
+			if s2.getEndState().startState != nil {
 				panic("IllegalState")
 			}
 
-			s2.endState.startState = state
+			s2.getEndState().startState = state
 		}
 
 		if s2, ok := state.(*PlusLoopbackState); ok {
-			for j := 0; j < len(s2.GetTransitions()); j++ {
-				target := s2.GetTransitions()[j].getTarget()
-
-				if t2, ok := target.(*PlusBlockStartState); ok {
+			for _, t := range s2.GetTransitions() {
+				if t2, ok := t.getTarget().(*PlusBlockStartState); ok {
 					t2.loopBackState = state
 				}
 			}
 		} else if s2, ok := state.(*StarLoopbackState); ok {
-			for j := 0; j < len(s2.GetTransitions()); j++ {
-				target := s2.GetTransitions()[j].getTarget()
-
-				if t2, ok := target.(*StarLoopEntryState); ok {
+			for _, t := range s2.GetTransitions() {
+				if t2, ok := t.getTarget().(*StarLoopEntryState); ok {
 					t2.loopBackState = state
 				}
 			}
@@ -332,9 +325,9 @@ func (a *ATNDeserializer) readLexerActions(atn *ATN) {
 	if atn.grammarType == ATNTypeLexer {
 		count := a.readInt()
 
-		atn.lexerActions = make([]LexerAction, count) // initIntArray(count, nil)
+		atn.lexerActions = make([]LexerAction, count)
 
-		for i := 0; i < count; i++ {
+		for i := range atn.lexerActions {
 			actionType := a.readInt()
 			data1 := a.readInt()
 
@@ -348,9 +341,7 @@ func (a *ATNDeserializer) readLexerActions(atn *ATN) {
 				data2 = -1
 			}
 
-			lexerAction := a.lexerActionFactory(actionType, data1, data2)
-
-			atn.lexerActions[i] = lexerAction
+			atn.lexerActions[i] = a.lexerActionFactory(actionType, data1, data2)
 		}
 	}
 }
@@ -498,14 +489,12 @@ func (a *ATNDeserializer) markPrecedenceDecisions(atn *ATN) {
 }
 
 func (a *ATNDeserializer) verifyATN(atn *ATN) {
-	if !a.deserializationOptions.verifyATN {
+	if !a.options.VerifyATN() {
 		return
 	}
 
 	// Verify assumptions
-	for i := 0; i < len(atn.states); i++ {
-		state := atn.states[i]
-
+	for _, state := range atn.states {
 		if state == nil {
 			continue
 		}
@@ -520,18 +509,18 @@ func (a *ATNDeserializer) verifyATN(atn *ATN) {
 			a.checkCondition(s2.loopBackState != nil, "")
 			a.checkCondition(len(s2.GetTransitions()) == 2, "")
 
-			switch s2 := state.(type) {
+			switch s2.transitions[0].getTarget().(type) {
 			case *StarBlockStartState:
-				var _, ok2 = s2.GetTransitions()[1].getTarget().(*LoopEndState)
+				_, ok := s2.transitions[1].getTarget().(*LoopEndState)
 
-				a.checkCondition(ok2, "")
+				a.checkCondition(ok, "")
 				a.checkCondition(!s2.nonGreedy, "")
 
 			case *LoopEndState:
-				var s3, ok2 = s2.GetTransitions()[1].getTarget().(*StarBlockStartState)
+				var _, ok = s2.transitions[1].getTarget().(*StarBlockStartState)
 
-				a.checkCondition(ok2, "")
-				a.checkCondition(s3.nonGreedy, "")
+				a.checkCondition(ok, "")
+				a.checkCondition(s2.nonGreedy, "")
 
 			default:
 				panic("IllegalState")
@@ -540,9 +529,9 @@ func (a *ATNDeserializer) verifyATN(atn *ATN) {
 		case *StarLoopbackState:
 			a.checkCondition(len(state.GetTransitions()) == 1, "")
 
-			var _, ok2 = state.GetTransitions()[0].getTarget().(*StarLoopEntryState)
+			var _, ok = state.GetTransitions()[0].getTarget().(*StarLoopEntryState)
 
-			a.checkCondition(ok2, "")
+			a.checkCondition(ok, "")
 
 		case *LoopEndState:
 			a.checkCondition(s2.loopBackState != nil, "")
@@ -550,8 +539,8 @@ func (a *ATNDeserializer) verifyATN(atn *ATN) {
 		case *RuleStartState:
 			a.checkCondition(s2.stopState != nil, "")
 
-		case *BaseBlockStartState:
-			a.checkCondition(s2.endState != nil, "")
+		case BlockStartState:
+			a.checkCondition(s2.getEndState() != nil, "")
 
 		case *BlockEndState:
 			a.checkCondition(s2.startState != nil, "")


### PR DESCRIPTION
Updates `ATNDeserializationOptions`, makes some things private, fixes ATN deserialization, and enables verification by default.

Currently ATN deserialization is incorrect, but it is not clear what the incorrect behavior would surface as.