### PR TITLE
[C++] Fix generated Lexer static data constructor

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -115,7 +115,7 @@ using namespace antlr4;
 namespace {
 
 struct <lexer.name; format = "cap">StaticData final {
-  <lexer.name>StaticData(std::vector\<std::string> ruleNames,
+  <lexer.name; format = "cap">StaticData(std::vector\<std::string> ruleNames,
                           std::vector\<std::string> channelNames,
                           std::vector\<std::string> modeNames,
                           std::vector\<std::string> literalNames,


### PR DESCRIPTION
I missed one from my previous pull request.