### PR TITLE
Fix PHP codegen to support int ATN serialization

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
@@ -297,7 +297,7 @@ namespace<if(file.genPackage)> <file.genPackage><endif> {
 			return self::RULE_NAMES;
 		}
 
-		public function getSerializedATN() : string
+		public function getSerializedATN() : array
 		{
 			return self::SERIALIZED_ATN;
 		}
@@ -1173,7 +1173,7 @@ namespace<if(lexerFile.genPackage)> <lexerFile.genPackage><endif> {
 			return self::RULE_NAMES;
 		}
 
-		public function getSerializedATN() : string
+		public function getSerializedATN() : array
 		{
 			return self::SERIALIZED_ATN;
 		}
@@ -1210,7 +1210,7 @@ namespace<if(lexerFile.genPackage)> <lexerFile.genPackage><endif> {
 
 SerializedATN(model) ::= <<
 private const SERIALIZED_ATN =
-	"<model.serialized; wrap={" .<\n>    "}>";
+	[<model.serialized: {s | <s>}; separator=", ", wrap={<\n>    }>];
 >>
 
 /**

--- a/tool/src/org/antlr/v4/codegen/target/PHPTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/PHPTarget.java
@@ -96,7 +96,7 @@ public class PHPTarget extends Target {
 
 	@Override
 	public boolean isATNSerializedAsInts() {
-		return false;
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
Fix PHP codegen to support int ATN serialization.

Complements https://github.com/antlr/antlr-php-runtime/pull/23.