### PR TITLE
[Java] Preserve serialized ATN version 3 compatibility

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDeserializer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNDeserializer.java
@@ -20,10 +20,10 @@ import java.util.Locale;
  * @author Sam Harwell
  */
 public class ATNDeserializer {
-	public static final int SERIALIZED_VERSION;
-	static {
-		SERIALIZED_VERSION = 4;
-	}
+
+  static final int LEGACY_SERIALIZED_VERSION = 3;
+
+	public static final int SERIALIZED_VERSION = 4;
 
 	interface UnicodeDeserializer {
 		// Wrapper for readInt() or readInt32()
@@ -90,6 +90,12 @@ public class ATNDeserializer {
 
 		int p = 0;
 		int version = toInt(data[p++]);
+    if (version == LEGACY_SERIALIZED_VERSION) {
+      // Preserve backwards compatibility for version 3. We simply skip over the UUID and assume all
+      // features were supported.
+      p += 8;
+      version = SERIALIZED_VERSION;
+    }
 		if (version != SERIALIZED_VERSION) {
 			String reason = String.format(Locale.getDefault(), "Could not deserialize ATN with version %d (expected %d).", version, SERIALIZED_VERSION);
 			throw new UnsupportedOperationException(new InvalidClassException(ATN.class.getName(), reason));


### PR DESCRIPTION
Java is a bit special in that it is the only language where it is normal for pre-compiled code to be distributed. This makes it difficult to hard cut to a new serialized ATN version. There are a bunch of libraries which break unexpectedly, including some Android libraries. This patch preserves backwards compatibility for ATN serialized version 3, by simply skipping the UUID and assuming all features were supported.