### PR TITLE
Update editorconfig for c++

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,10 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 ij_java_else_on_new_line = true
+
+[*.{h,cpp}]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2

--- a/contributors.txt
+++ b/contributors.txt
@@ -327,3 +327,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/12/25, Tinker1024, Tinker1024, tinker@huawei.com
 2021/12/31, Biswa96, Biswapriyo Nath, nathbappai@gmail.com
 2022/03/07, chenquan, chenquan, chenquan.dev@gmail.com
+2022/03/15, hzeller, Henner Zeller, h.zeller@acm.org


### PR DESCRIPTION
Make it easier to contribute: Add c++ configuration for .editorconfig.
Using the observed style with 2 indentation spaces.

Also adding myself to contributors.txt (both `h.zeller@acm.org` or `hzeller@google.com` would work; choosing one of them)