### PR TITLE
[C++] Add ANTLR4CPP_PUBLIC attributes to various symbols

### DIFF
--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -31,20 +31,8 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlrcpp;
 
-LexerATNSimulator::SimState::~SimState() {
-}
-
 void LexerATNSimulator::SimState::reset() {
-  index = INVALID_INDEX;
-  line = 0;
-  charPos = INVALID_INDEX;
-  dfaState = nullptr; // Don't delete. It's just a reference.
-}
-
-void LexerATNSimulator::SimState::InitializeInstanceFields() {
-  index = INVALID_INDEX;
-  line = 0;
-  charPos = INVALID_INDEX;
+  *this = SimState();
 }
 
 LexerATNSimulator::LexerATNSimulator(const ATN &atn, std::vector<dfa::DFA> &decisionToDFA,

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
@@ -17,27 +17,14 @@ namespace atn {
   /// "dup" of ParserInterpreter
   class ANTLR4CPP_PUBLIC LexerATNSimulator : public ATNSimulator {
   protected:
-    class SimState {
-    public:
-      virtual ~SimState();
+    struct ANTLR4CPP_PUBLIC SimState final {
+      size_t index = INVALID_INDEX;
+      size_t line = 0;
+      size_t charPos = INVALID_INDEX;
+      dfa::DFAState *dfaState = nullptr;
 
-    protected:
-      size_t index;
-      size_t line;
-      size_t charPos;
-      dfa::DFAState *dfaState;
-      virtual void reset();
-      friend class LexerATNSimulator;
-
-    private:
-      void InitializeInstanceFields();
-
-    public:
-      SimState() {
-        InitializeInstanceFields();
-      }
+      void reset();
     };
-
 
   public:
     static constexpr size_t MIN_DFA_EDGE = 0;

--- a/runtime/Cpp/runtime/src/dfa/DFAState.h
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.h
@@ -37,7 +37,7 @@ namespace dfa {
   /// </summary>
   class ANTLR4CPP_PUBLIC DFAState final {
   public:
-    class PredPrediction final {
+    class ANTLR4CPP_PUBLIC PredPrediction final {
     public:
       Ref<const atn::SemanticContext> pred; // never null; at least SemanticContext.NONE
       int alt;

--- a/runtime/Cpp/runtime/src/support/CPPUtils.h
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.h
@@ -5,20 +5,18 @@
 
 #pragma once
 
-#include <shared_mutex>
-
 #include "antlr4-common.h"
 
 namespace antlrcpp {
 
-  std::string join(const std::vector<std::string> &strings, const std::string &separator);
-  std::map<std::string, size_t> toMap(const std::vector<std::string> &keys);
-  std::string escapeWhitespace(std::string str, bool escapeSpaces);
-  std::string toHexString(const int t);
-  std::string arrayToString(const std::vector<std::string> &data);
-  std::string replaceString(const std::string &s, const std::string &from, const std::string &to);
-  std::vector<std::string> split(const std::string &s, const std::string &sep, int count);
-  std::string indent(const std::string &s, const std::string &indentation, bool includingFirst = true);
+  ANTLR4CPP_PUBLIC std::string join(const std::vector<std::string> &strings, const std::string &separator);
+  ANTLR4CPP_PUBLIC std::map<std::string, size_t> toMap(const std::vector<std::string> &keys);
+  ANTLR4CPP_PUBLIC std::string escapeWhitespace(std::string str, bool escapeSpaces);
+  ANTLR4CPP_PUBLIC std::string toHexString(const int t);
+  ANTLR4CPP_PUBLIC std::string arrayToString(const std::vector<std::string> &data);
+  ANTLR4CPP_PUBLIC std::string replaceString(const std::string &s, const std::string &from, const std::string &to);
+  ANTLR4CPP_PUBLIC std::vector<std::string> split(const std::string &s, const std::string &sep, int count);
+  ANTLR4CPP_PUBLIC std::string indent(const std::string &s, const std::string &indentation, bool includingFirst = true);
 
   // Using RAII + a lambda to implement a "finally" replacement.
   template <typename OnEnd>
@@ -62,6 +60,6 @@ namespace antlrcpp {
   }
 
   // Get the error text from an exception pointer or the current exception.
-  std::string what(std::exception_ptr eptr = std::current_exception());
+  ANTLR4CPP_PUBLIC std::string what(std::exception_ptr eptr = std::current_exception());
 
 } // namespace antlrcpp

--- a/runtime/Cpp/runtime/src/support/StringUtils.h
+++ b/runtime/Cpp/runtime/src/support/StringUtils.h
@@ -9,8 +9,8 @@
 
 namespace antlrcpp {
 
-  std::string escapeWhitespace(std::string_view in);
+  ANTLR4CPP_PUBLIC std::string escapeWhitespace(std::string_view in);
 
-  std::string& escapeWhitespace(std::string& out, std::string_view in);
+  ANTLR4CPP_PUBLIC std::string& escapeWhitespace(std::string& out, std::string_view in);
 
 }

--- a/runtime/Cpp/runtime/src/support/Unicode.h
+++ b/runtime/Cpp/runtime/src/support/Unicode.h
@@ -5,9 +5,11 @@
 
 #pragma once
 
+#include "antlr4-common.h"
+
 namespace antlrcpp {
 
-  class Unicode final {
+  class ANTLR4CPP_PUBLIC Unicode final {
   public:
     static constexpr char32_t REPLACEMENT_CHARACTER = 0xfffd;
 
@@ -17,10 +19,10 @@ namespace antlrcpp {
 
   private:
     Unicode() = delete;
-
     Unicode(const Unicode&) = delete;
-
+    Unicode(Unicode&&) = delete;
     Unicode& operator=(const Unicode&) = delete;
+    Unicode& operator=(Unicode&&) = delete;
   };
 
 }

--- a/runtime/Cpp/runtime/src/support/Utf8.h
+++ b/runtime/Cpp/runtime/src/support/Utf8.h
@@ -10,9 +10,11 @@
 #include <string_view>
 #include <tuple>
 
+#include "antlr4-common.h"
+
 namespace antlrcpp {
 
-  class Utf8 final {
+  class ANTLR4CPP_PUBLIC Utf8 final {
   public:
     // Decodes the next code point, returning the decoded code point and the number
     // of code units (a.k.a. bytes) consumed. In the event that an invalid code unit
@@ -43,10 +45,10 @@ namespace antlrcpp {
 
   private:
     Utf8() = delete;
-
     Utf8(const Utf8&) = delete;
-
+    Utf8(Utf8&&) = delete;
     Utf8& operator=(const Utf8&) = delete;
+    Utf8& operator=(Utf8&&) = delete;
   };
 
 }


### PR DESCRIPTION
As the name suggests, add `ANTLR4CPP_PUBLIC` to various symbols. I additionally cleaned up `SimState` while I was there, as it cannot be virtual since it is used by value as a member. So using a struct is more simple.

Addresses #3577 