### PR TITLE
[Java] Used LinkedHashSet to preserve insertion order in SemanticContext

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/SemanticContext.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/SemanticContext.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -206,7 +206,7 @@ public abstract class SemanticContext {
 		public final SemanticContext[] opnds;
 
 		public AND(SemanticContext a, SemanticContext b) {
-			Set<SemanticContext> operands = new HashSet<SemanticContext>();
+			Set<SemanticContext> operands = new LinkedHashSet<SemanticContext>();
 			if ( a instanceof AND ) operands.addAll(Arrays.asList(((AND)a).opnds));
 			else operands.add(a);
 			if ( b instanceof AND ) operands.addAll(Arrays.asList(((AND)b).opnds));
@@ -303,7 +303,7 @@ public abstract class SemanticContext {
 		public final SemanticContext[] opnds;
 
 		public OR(SemanticContext a, SemanticContext b) {
-			Set<SemanticContext> operands = new HashSet<SemanticContext>();
+			Set<SemanticContext> operands = new LinkedHashSet<SemanticContext>();
 			if ( a instanceof OR ) operands.addAll(Arrays.asList(((OR)a).opnds));
 			else operands.add(a);
 			if ( b instanceof OR ) operands.addAll(Arrays.asList(((OR)b).opnds));


### PR DESCRIPTION
Currently SemanticContext equality and hashing assume a well defined iteration order for `HashSet`. `HashSet` does not actually guarantee this, so we need to switch to `LinkedHashSet` which guarantees insertion order.