### PR TITLE
[Go] Do not export Array2DHashSet which is an implementation detail

### DIFF
--- a/runtime/Go/antlr/atn_config_set.go
+++ b/runtime/Go/antlr/atn_config_set.go
@@ -104,7 +104,7 @@ func (b *BaseATNConfigSet) Alts() *BitSet {
 func NewBaseATNConfigSet(fullCtx bool) *BaseATNConfigSet {
 	return &BaseATNConfigSet{
 		cachedHash:   -1,
-		configLookup: NewArray2DHashSetWithCap(hashATNConfig, equalATNConfigs, 16, 2),
+		configLookup: newArray2DHashSetWithCap(hashATNConfig, equalATNConfigs, 16, 2),
 		fullCtx:      fullCtx,
 	}
 }
@@ -155,7 +155,7 @@ func (b *BaseATNConfigSet) Add(config ATNConfig, mergeCache *DoubleDict) bool {
 }
 
 func (b *BaseATNConfigSet) GetStates() Set {
-	states := NewArray2DHashSet(nil, nil)
+	states := newArray2DHashSet(nil, nil)
 
 	for i := 0; i < len(b.configs); i++ {
 		states.Add(b.configs[i].GetState())
@@ -283,7 +283,7 @@ func (b *BaseATNConfigSet) Clear() {
 
 	b.configs = make([]ATNConfig, 0)
 	b.cachedHash = -1
-	b.configLookup = NewArray2DHashSet(nil, equalATNConfigs)
+	b.configLookup = newArray2DHashSet(nil, equalATNConfigs)
 }
 
 func (b *BaseATNConfigSet) FullContext() bool {
@@ -365,7 +365,7 @@ type OrderedATNConfigSet struct {
 func NewOrderedATNConfigSet() *OrderedATNConfigSet {
 	b := NewBaseATNConfigSet(false)
 
-	b.configLookup = NewArray2DHashSet(nil, nil)
+	b.configLookup = newArray2DHashSet(nil, nil)
 
 	return &OrderedATNConfigSet{BaseATNConfigSet: b}
 }

--- a/runtime/Go/antlr/dfa_state.go
+++ b/runtime/Go/antlr/dfa_state.go
@@ -91,7 +91,7 @@ func NewDFAState(stateNumber int, configs ATNConfigSet) *DFAState {
 
 // GetAltSet gets the set of all alts mentioned by all ATN configurations in d.
 func (d *DFAState) GetAltSet() Set {
-	alts := NewArray2DHashSet(nil, nil)
+	alts := newArray2DHashSet(nil, nil)
 
 	if d.configs != nil {
 		for _, c := range d.configs.GetItems() {

--- a/runtime/Go/antlr/ll1_analyzer.go
+++ b/runtime/Go/antlr/ll1_analyzer.go
@@ -38,7 +38,7 @@ func (la *LL1Analyzer) getDecisionLookahead(s ATNState) []*IntervalSet {
 	look := make([]*IntervalSet, count)
 	for alt := 0; alt < count; alt++ {
 		look[alt] = NewIntervalSet()
-		lookBusy := NewArray2DHashSet(nil, nil)
+		lookBusy := newArray2DHashSet(nil, nil)
 		seeThruPreds := false // fail to get lookahead upon pred
 		la.look1(s.GetTransitions()[alt].getTarget(), nil, BasePredictionContextEMPTY, look[alt], lookBusy, NewBitSet(), seeThruPreds, false)
 		// Wipe out lookahead for la alternative if we found nothing
@@ -75,7 +75,7 @@ func (la *LL1Analyzer) Look(s, stopState ATNState, ctx RuleContext) *IntervalSet
 	if ctx != nil {
 		lookContext = predictionContextFromRuleContext(s.GetATN(), ctx)
 	}
-	la.look1(s, stopState, lookContext, r, NewArray2DHashSet(nil, nil), NewBitSet(), seeThruPreds, true)
+	la.look1(s, stopState, lookContext, r, newArray2DHashSet(nil, nil), NewBitSet(), seeThruPreds, true)
 	return r
 }
 

--- a/runtime/Go/antlr/parser_atn_simulator.go
+++ b/runtime/Go/antlr/parser_atn_simulator.go
@@ -570,7 +570,7 @@ func (p *ParserATNSimulator) computeReachSet(closure ATNConfigSet, t int, fullCt
 	//
 	if reach == nil {
 		reach = NewBaseATNConfigSet(fullCtx)
-		closureBusy := NewArray2DHashSet(nil, nil)
+		closureBusy := newArray2DHashSet(nil, nil)
 		treatEOFAsEpsilon := t == TokenEOF
 		amount := len(intermediate.configs)
 		for k := 0; k < amount; k++ {
@@ -665,7 +665,7 @@ func (p *ParserATNSimulator) computeStartState(a ATNState, ctx RuleContext, full
 	for i := 0; i < len(a.GetTransitions()); i++ {
 		target := a.GetTransitions()[i].getTarget()
 		c := NewBaseATNConfig6(target, i+1, initialContext)
-		closureBusy := NewArray2DHashSet(nil, nil)
+		closureBusy := newArray2DHashSet(nil, nil)
 		p.closure(c, configs, closureBusy, true, fullCtx, false)
 	}
 	return configs

--- a/runtime/Go/antlr/semantic_context.go
+++ b/runtime/Go/antlr/semantic_context.go
@@ -193,7 +193,7 @@ type AND struct {
 
 func NewAND(a, b SemanticContext) *AND {
 
-	operands := NewArray2DHashSet(nil, nil)
+	operands := newArray2DHashSet(nil, nil)
 	if aa, ok := a.(*AND); ok {
 		for _, o := range aa.opnds {
 			operands.Add(o)
@@ -345,7 +345,7 @@ type OR struct {
 
 func NewOR(a, b SemanticContext) *OR {
 
-	operands := NewArray2DHashSet(nil, nil)
+	operands := newArray2DHashSet(nil, nil)
 	if aa, ok := a.(*OR); ok {
 		for _, o := range aa.opnds {
 			operands.Add(o)

--- a/runtime/Go/antlr/utils_set.go
+++ b/runtime/Go/antlr/utils_set.go
@@ -8,7 +8,7 @@ const (
 	_loadFactor           = 0.75
 )
 
-var _ Set = (*Array2DHashSet)(nil)
+var _ Set = (*array2DHashSet)(nil)
 
 type Set interface {
 	Add(value interface{}) (added interface{})
@@ -19,7 +19,7 @@ type Set interface {
 	Each(f func(interface{}) bool)
 }
 
-type Array2DHashSet struct {
+type array2DHashSet struct {
 	buckets          [][]interface{}
 	hashcodeFunction func(interface{}) int
 	equalsFunction   func(interface{}, interface{}) bool
@@ -31,7 +31,7 @@ type Array2DHashSet struct {
 	initialBucketCapacity int
 }
 
-func (as *Array2DHashSet) Each(f func(interface{}) bool) {
+func (as *array2DHashSet) Each(f func(interface{}) bool) {
 	if as.Len() < 1 {
 		return
 	}
@@ -48,7 +48,7 @@ func (as *Array2DHashSet) Each(f func(interface{}) bool) {
 	}
 }
 
-func (as *Array2DHashSet) Values() []interface{} {
+func (as *array2DHashSet) Values() []interface{} {
 	if as.Len() < 1 {
 		return nil
 	}
@@ -61,18 +61,18 @@ func (as *Array2DHashSet) Values() []interface{} {
 	return values
 }
 
-func (as *Array2DHashSet) Contains(value interface{}) bool {
+func (as *array2DHashSet) Contains(value interface{}) bool {
 	return as.Get(value) != nil
 }
 
-func (as *Array2DHashSet) Add(value interface{}) interface{} {
+func (as *array2DHashSet) Add(value interface{}) interface{} {
 	if as.n > as.threshold {
 		as.expand()
 	}
 	return as.innerAdd(value)
 }
 
-func (as *Array2DHashSet) expand() {
+func (as *array2DHashSet) expand() {
 	old := as.buckets
 
 	as.currentPrime += 4
@@ -120,11 +120,11 @@ func (as *Array2DHashSet) expand() {
 	}
 }
 
-func (as *Array2DHashSet) Len() int {
+func (as *array2DHashSet) Len() int {
 	return as.n
 }
 
-func (as *Array2DHashSet) Get(o interface{}) interface{} {
+func (as *array2DHashSet) Get(o interface{}) interface{} {
 	if o == nil {
 		return nil
 	}
@@ -147,7 +147,7 @@ func (as *Array2DHashSet) Get(o interface{}) interface{} {
 	return nil
 }
 
-func (as *Array2DHashSet) innerAdd(o interface{}) interface{} {
+func (as *array2DHashSet) innerAdd(o interface{}) interface{} {
 	b := as.getBuckets(o)
 
 	bucket := as.buckets[b]
@@ -187,25 +187,25 @@ func (as *Array2DHashSet) innerAdd(o interface{}) interface{} {
 	return o
 }
 
-func (as *Array2DHashSet) getBuckets(value interface{}) int {
+func (as *array2DHashSet) getBuckets(value interface{}) int {
 	hash := as.hashcodeFunction(value)
 	return hash & (len(as.buckets) - 1)
 }
 
-func (as *Array2DHashSet) createBuckets(cap int) [][]interface{} {
+func (as *array2DHashSet) createBuckets(cap int) [][]interface{} {
 	return make([][]interface{}, cap)
 }
 
-func (as *Array2DHashSet) createBucket(cap int) []interface{} {
+func (as *array2DHashSet) createBucket(cap int) []interface{} {
 	return make([]interface{}, cap)
 }
 
-func NewArray2DHashSetWithCap(
+func newArray2DHashSetWithCap(
 	hashcodeFunction func(interface{}) int,
 	equalsFunction func(interface{}, interface{}) bool,
 	initCap int,
 	initBucketCap int,
-) *Array2DHashSet {
+) *array2DHashSet {
 	if hashcodeFunction == nil {
 		hashcodeFunction = standardHashFunction
 	}
@@ -214,7 +214,7 @@ func NewArray2DHashSetWithCap(
 		equalsFunction = standardEqualsFunction
 	}
 
-	ret := &Array2DHashSet{
+	ret := &array2DHashSet{
 		hashcodeFunction: hashcodeFunction,
 		equalsFunction:   equalsFunction,
 
@@ -229,9 +229,9 @@ func NewArray2DHashSetWithCap(
 	return ret
 }
 
-func NewArray2DHashSet(
+func newArray2DHashSet(
 	hashcodeFunction func(interface{}) int,
 	equalsFunction func(interface{}, interface{}) bool,
-) *Array2DHashSet {
-	return NewArray2DHashSetWithCap(hashcodeFunction, equalsFunction, _initalCapacity, _initalBucketCapacity)
+) *array2DHashSet {
+	return newArray2DHashSetWithCap(hashcodeFunction, equalsFunction, _initalCapacity, _initalBucketCapacity)
 }


### PR DESCRIPTION
`Array2DHashSet` is an implementation detail that is not directly exposed by any other interfaces or structures. It should be considered an implementation detail and not exported.