### PR TITLE
[C++] Refactor PredictionContext and yet more performance improvements

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
@@ -46,7 +46,7 @@ namespace atn {
 
     ATNConfigSet(const ATNConfigSet &other);
 
-    ATNConfigSet(ATNConfigSet &&) = delete;
+    ATNConfigSet(ATNConfigSet&&) = delete;
 
     explicit ATNConfigSet(bool fullCtx);
 
@@ -68,7 +68,7 @@ namespace atn {
 
     bool addAll(const ATNConfigSet &other);
 
-    std::vector<ATNState *> getStates() const;
+    std::vector<ATNState*> getStates() const;
 
     /**
      * Gets the complete set of represented alternatives for the configuration

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
@@ -23,12 +23,11 @@ void ATNSimulator::clearDFA() {
   throw UnsupportedOperationException("This ATN simulator does not support clearing the DFA.");
 }
 
-PredictionContextCache& ATNSimulator::getSharedContextCache() {
+PredictionContextCache& ATNSimulator::getSharedContextCache() const {
   return _sharedContextCache;
 }
 
-Ref<const PredictionContext> ATNSimulator::getCachedContext(Ref<const PredictionContext> const& context) {
+Ref<const PredictionContext> ATNSimulator::getCachedContext(const Ref<const PredictionContext> &context) {
   // This function must only be called with an active state lock, as we are going to change a shared structure.
-  std::map<Ref<const PredictionContext>, Ref<const PredictionContext>> visited;
-  return PredictionContext::getCachedContext(context, _sharedContextCache, visited);
+  return PredictionContext::getCachedContext(context, getSharedContextCache());
 }

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.h
@@ -37,8 +37,9 @@ namespace atn {
      * @since 4.3
      */
     virtual void clearDFA();
-    virtual PredictionContextCache& getSharedContextCache();
-    virtual Ref<const PredictionContext> getCachedContext(Ref<const PredictionContext> const& context);
+
+    PredictionContextCache& getSharedContextCache() const;
+    Ref<const PredictionContext> getCachedContext(const Ref<const PredictionContext> &context);
 
   protected:
     /// <summary>

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
@@ -3,22 +3,39 @@
  * can be found in the LICENSE.txt file in the project root.
  */
 
-#include "support/Arrays.h"
-#include "atn/SingletonPredictionContext.h"
-
 #include "atn/ArrayPredictionContext.h"
 
-using namespace antlr4::atn;
+#include <cstring>
 
-ArrayPredictionContext::ArrayPredictionContext(Ref<const SingletonPredictionContext> const& a)
-  : ArrayPredictionContext({ a->parent }, { a->returnState }) {
+#include "atn/SingletonPredictionContext.h"
+#include "misc/MurmurHash.h"
+#include "support/Casts.h"
+
+using namespace antlr4::atn;
+using namespace antlr4::misc;
+using namespace antlrcpp;
+
+namespace {
+
+  bool cachedHashCodeEqual(size_t lhs, size_t rhs) {
+    return lhs == rhs || lhs == 0 || rhs == 0;
+  }
+
+  bool predictionContextEqual(const Ref<const PredictionContext> &lhs, const Ref<const PredictionContext> &rhs) {
+    return *lhs == *rhs;
+  }
+
 }
+
+ArrayPredictionContext::ArrayPredictionContext(const SingletonPredictionContext &predictionContext)
+    : ArrayPredictionContext({ predictionContext.parent }, { predictionContext.returnState }) {}
 
 ArrayPredictionContext::ArrayPredictionContext(std::vector<Ref<const PredictionContext>> parents,
                                                std::vector<size_t> returnStates)
-  : PredictionContext(PredictionContextType::ARRAY, calculateHashCode(parents, returnStates)), parents(std::move(parents)), returnStates(std::move(returnStates)) {
-    assert(this->parents.size() > 0);
-    assert(this->returnStates.size() > 0);
+    : PredictionContext(PredictionContextType::ARRAY), parents(std::move(parents)), returnStates(std::move(returnStates)) {
+  assert(this->parents.size() > 0);
+  assert(this->returnStates.size() > 0);
+  assert(this->parents.size() == this->returnStates.size());
 }
 
 bool ArrayPredictionContext::isEmpty() const {
@@ -30,7 +47,7 @@ size_t ArrayPredictionContext::size() const {
   return returnStates.size();
 }
 
-Ref<const PredictionContext> ArrayPredictionContext::getParent(size_t index) const {
+const Ref<const PredictionContext>& ArrayPredictionContext::getParent(size_t index) const {
   return parents[index];
 }
 
@@ -38,21 +55,31 @@ size_t ArrayPredictionContext::getReturnState(size_t index) const {
   return returnStates[index];
 }
 
-bool ArrayPredictionContext::operator == (PredictionContext const& o) const {
-  if (this == &o) {
+size_t ArrayPredictionContext::hashCodeImpl() const {
+  size_t hash = MurmurHash::initialize();
+  hash = MurmurHash::update(hash, static_cast<size_t>(getContextType()));
+  for (const auto &parent : parents) {
+    hash = MurmurHash::update(hash, parent);
+  }
+  for (const auto &returnState : returnStates) {
+    hash = MurmurHash::update(hash, returnState);
+  }
+  return MurmurHash::finish(hash, 1 + parents.size() + returnStates.size());
+}
+
+bool ArrayPredictionContext::equals(const PredictionContext &other) const {
+  if (this == std::addressof(other)) {
     return true;
   }
-  if (o.getContextType() != PredictionContextType::ARRAY) {
+  if (getContextType() != other.getContextType()) {
     return false;
   }
-
-  const ArrayPredictionContext *other = static_cast<const ArrayPredictionContext*>(&o);
-  if (hashCode() != other->hashCode()) {
-    return false; // can't be same if hash is different
-  }
-
-  return antlrcpp::Arrays::equals(returnStates, other->returnStates) &&
-    antlrcpp::Arrays::equals(parents, other->parents);
+  const auto &array = downCast<const ArrayPredictionContext&>(other);
+  return returnStates.size() == array.returnStates.size() &&
+         parents.size() == array.parents.size() &&
+         cachedHashCodeEqual(cachedHashCode(), array.cachedHashCode()) &&
+         std::memcmp(returnStates.data(), array.returnStates.data(), returnStates.size() * sizeof(decltype(returnStates)::value_type)) == 0 &&
+         std::equal(parents.begin(), parents.end(), array.parents.begin(), predictionContextEqual);
 }
 
 std::string ArrayPredictionContext::toString() const {

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.h
@@ -24,22 +24,26 @@ namespace atn {
     /// returnState == EMPTY_RETURN_STATE.
     // Also here: we use a strong reference to our parents to avoid having them freed prematurely.
     //            See also SinglePredictionContext.
-    const std::vector<Ref<const PredictionContext>> parents;
+    std::vector<Ref<const PredictionContext>> parents;
 
     /// Sorted for merge, no duplicates; if present, EMPTY_RETURN_STATE is always last.
-    const std::vector<size_t> returnStates;
+    std::vector<size_t> returnStates;
 
-    explicit ArrayPredictionContext(Ref<const SingletonPredictionContext> const &a);
+    explicit ArrayPredictionContext(const SingletonPredictionContext &predictionContext);
 
     ArrayPredictionContext(std::vector<Ref<const PredictionContext>> parents, std::vector<size_t> returnStates);
 
-    virtual bool isEmpty() const override;
-    virtual size_t size() const override;
-    virtual Ref<const PredictionContext> getParent(size_t index) const override;
-    virtual size_t getReturnState(size_t index) const override;
-    bool operator == (const PredictionContext &o) const override;
+    ArrayPredictionContext(ArrayPredictionContext&&) = default;
 
-    virtual std::string toString() const override;
+    bool isEmpty() const override;
+    size_t size() const override;
+    const Ref<const PredictionContext>& getParent(size_t index) const override;
+    size_t getReturnState(size_t index) const override;
+    bool equals(const PredictionContext &other) const override;
+    std::string toString() const override;
+
+  protected:
+    size_t hashCodeImpl() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
@@ -18,16 +18,115 @@
 using namespace antlr4;
 using namespace antlr4::misc;
 using namespace antlr4::atn;
-
 using namespace antlrcpp;
 
-std::atomic<size_t> PredictionContext::globalNodeCount(0);
+namespace {
+
+  void combineCommonParents(std::vector<Ref<const PredictionContext>> &parents) {
+    std::unordered_set<Ref<const PredictionContext>> uniqueParents;
+    uniqueParents.reserve(parents.size());
+    for (const auto &parent : parents) {
+      uniqueParents.insert(parent);
+    }
+    for (auto &parent : parents) {
+      parent = *uniqueParents.find(parent);
+    }
+  }
+
+  Ref<const PredictionContext> getCachedContextImpl(const Ref<const PredictionContext> &context,
+                                                    PredictionContextCache &contextCache,
+                                                    std::unordered_map<Ref<const PredictionContext>, Ref<const PredictionContext>> &visited) {
+    if (context->isEmpty()) {
+      return context;
+    }
+
+    {
+      auto iterator = visited.find(context);
+      if (iterator != visited.end()) {
+        return iterator->second; // Not necessarly the same as context.
+      }
+    }
+
+    auto cached = contextCache.get(context);
+    if (cached) {
+      visited[context] = cached;
+      return cached;
+    }
+
+    bool changed = false;
+
+    std::vector<Ref<const PredictionContext>> parents(context->size());
+    for (size_t i = 0; i < parents.size(); i++) {
+      auto parent = getCachedContextImpl(context->getParent(i), contextCache, visited);
+      if (changed || parent != context->getParent(i)) {
+        if (!changed) {
+          parents.clear();
+          for (size_t j = 0; j < context->size(); j++) {
+            parents.push_back(context->getParent(j));
+          }
+
+          changed = true;
+        }
+
+        parents[i] = std::move(parent);
+      }
+    }
+
+    if (!changed) {
+      visited[context] = context;
+      contextCache.put(context);
+      return context;
+    }
+
+    Ref<const PredictionContext> updated;
+    if (parents.empty()) {
+      updated = PredictionContext::EMPTY;
+    } else if (parents.size() == 1) {
+      updated = SingletonPredictionContext::create(std::move(parents[0]), context->getReturnState(0));
+      contextCache.put(updated);
+    } else {
+      updated = std::make_shared<ArrayPredictionContext>(std::move(parents), downCast<const ArrayPredictionContext*>(context.get())->returnStates);
+      contextCache.put(updated);
+    }
+
+    visited[updated] = updated;
+    visited[context] = updated;
+
+    return updated;
+  }
+
+  void getAllContextNodesImpl(const Ref<const PredictionContext> &context, std::vector<Ref<const PredictionContext>> &nodes,
+                              std::unordered_set<const PredictionContext*> &visited) {
+
+    if (visited.find(context.get()) != visited.end()) {
+      return; // Already done.
+    }
+
+    visited.insert(context.get());
+    nodes.push_back(context);
+
+    for (size_t i = 0; i < context->size(); i++) {
+      getAllContextNodesImpl(context->getParent(i), nodes, visited);
+    }
+  }
+
+  size_t insertOrAssignNodeId(std::unordered_map<const PredictionContext*, size_t> &nodeIds, size_t &nodeId, const PredictionContext *node) {
+    auto existing = nodeIds.find(node);
+    if (existing != nodeIds.end()) {
+      return existing->second;
+    }
+    return nodeIds.insert({node, nodeId++}).first->second;
+  }
+
+}
+
 const Ref<const PredictionContext> PredictionContext::EMPTY = std::make_shared<SingletonPredictionContext>(nullptr, PredictionContext::EMPTY_RETURN_STATE);
 
 //----------------- PredictionContext ----------------------------------------------------------------------------------
 
-PredictionContext::PredictionContext(PredictionContextType contextType, size_t cachedHashCode) : id(globalNodeCount.fetch_add(1, std::memory_order_relaxed)), cachedHashCode(cachedHashCode), _contextType(contextType)  {
-}
+PredictionContext::PredictionContext(PredictionContextType contextType) : _contextType(contextType), _hashCode(0) {}
+
+PredictionContext::PredictionContext(PredictionContext&& other) : _contextType(other._contextType), _hashCode(other._hashCode.exchange(0, std::memory_order_relaxed)) {}
 
 Ref<const PredictionContext> PredictionContext::fromRuleContext(const ATN &atn, RuleContext *outerContext) {
   if (outerContext == nullptr) {
@@ -41,15 +140,9 @@ Ref<const PredictionContext> PredictionContext::fromRuleContext(const ATN &atn, 
   }
 
   // If we have a parent, convert it to a PredictionContext graph
-  Ref<const PredictionContext> parent = PredictionContext::fromRuleContext(atn, dynamic_cast<RuleContext *>(outerContext->parent));
-
-  ATNState *state = atn.states.at(outerContext->invokingState);
-  const RuleTransition *transition = downCast<const RuleTransition*>(state->transitions[0].get());
-  return SingletonPredictionContext::create(parent, transition->followState->stateNumber);
-}
-
-bool PredictionContext::isEmpty() const {
-  return this == EMPTY.get();
+  auto parent = PredictionContext::fromRuleContext(atn, RuleContext::is(outerContext->parent) ? downCast<RuleContext*>(outerContext->parent) : nullptr);
+  const auto *transition = downCast<const RuleTransition*>(atn.states[outerContext->invokingState]->transitions[0].get());
+  return SingletonPredictionContext::create(std::move(parent), transition->followState->stateNumber);
 }
 
 bool PredictionContext::hasEmptyPath() const {
@@ -58,40 +151,19 @@ bool PredictionContext::hasEmptyPath() const {
 }
 
 size_t PredictionContext::hashCode() const {
-  return cachedHashCode;
-}
-
-size_t PredictionContext::calculateEmptyHashCode() {
-  size_t hash = MurmurHash::initialize(INITIAL_HASH);
-  hash = MurmurHash::finish(hash, 0);
+  auto hash = cachedHashCode();
+  if (hash == 0) {
+    hash = hashCodeImpl();
+    if (hash == 0) {
+      hash = std::numeric_limits<size_t>::max();
+    }
+    _hashCode.store(hash, std::memory_order_relaxed);
+  }
   return hash;
 }
 
-size_t PredictionContext::calculateHashCode(Ref<const PredictionContext> parent, size_t returnState) {
-  size_t hash = MurmurHash::initialize(INITIAL_HASH);
-  hash = MurmurHash::update(hash, parent);
-  hash = MurmurHash::update(hash, returnState);
-  hash = MurmurHash::finish(hash, 2);
-  return hash;
-}
-
-size_t PredictionContext::calculateHashCode(const std::vector<Ref<const PredictionContext>> &parents,
-                                            const std::vector<size_t> &returnStates) {
-  size_t hash = MurmurHash::initialize(INITIAL_HASH);
-
-  for (const auto &parent : parents) {
-    hash = MurmurHash::update(hash, parent);
-  }
-
-  for (const auto &returnState : returnStates) {
-    hash = MurmurHash::update(hash, returnState);
-  }
-
-  return MurmurHash::finish(hash, parents.size() + returnStates.size());
-}
-
-Ref<const PredictionContext> PredictionContext::merge(const Ref<const PredictionContext> &a,
-  const Ref<const PredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
+Ref<const PredictionContext> PredictionContext::merge(Ref<const PredictionContext> a, Ref<const PredictionContext> b,
+                                                      bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
   assert(a && b);
 
   // share same graph if both same
@@ -103,8 +175,8 @@ Ref<const PredictionContext> PredictionContext::merge(const Ref<const Prediction
   const auto bType = b->getContextType();
 
   if (aType == PredictionContextType::SINGLETON && bType == PredictionContextType::SINGLETON) {
-    return mergeSingletons(std::static_pointer_cast<const SingletonPredictionContext>(a),
-                           std::static_pointer_cast<const SingletonPredictionContext>(b), rootIsWildcard, mergeCache);
+    return mergeSingletons(std::static_pointer_cast<const SingletonPredictionContext>(std::move(a)),
+                           std::static_pointer_cast<const SingletonPredictionContext>(std::move(b)), rootIsWildcard, mergeCache);
   }
 
   // At least one of a or b is array.
@@ -121,23 +193,23 @@ Ref<const PredictionContext> PredictionContext::merge(const Ref<const Prediction
   // convert singleton so both are arrays to normalize
   Ref<const ArrayPredictionContext> left;
   if (aType == PredictionContextType::SINGLETON) {
-    left = std::make_shared<ArrayPredictionContext>(std::static_pointer_cast<const SingletonPredictionContext>(a));
+    left = std::make_shared<ArrayPredictionContext>(downCast<const SingletonPredictionContext&>(*a));
   } else {
-    left = std::static_pointer_cast<const ArrayPredictionContext>(a);
+    left = std::static_pointer_cast<const ArrayPredictionContext>(std::move(a));
   }
   Ref<const ArrayPredictionContext> right;
   if (bType == PredictionContextType::SINGLETON) {
-    right = std::make_shared<ArrayPredictionContext>(std::static_pointer_cast<const SingletonPredictionContext>(b));
+    right = std::make_shared<ArrayPredictionContext>(downCast<const SingletonPredictionContext&>(*b));
   } else {
-    right = std::static_pointer_cast<const ArrayPredictionContext>(b);
+    right = std::static_pointer_cast<const ArrayPredictionContext>(std::move(b));
   }
-  return mergeArrays(left, right, rootIsWildcard, mergeCache);
+  return mergeArrays(std::move(left), std::move(right), rootIsWildcard, mergeCache);
 }
 
-Ref<const PredictionContext> PredictionContext::mergeSingletons(const Ref<const SingletonPredictionContext> &a,
-  const Ref<const SingletonPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
+Ref<const PredictionContext> PredictionContext::mergeSingletons(Ref<const SingletonPredictionContext> a, Ref<const SingletonPredictionContext> b,
+                                                                bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
 
-  if (mergeCache != nullptr) { // Can be null if not given to the ATNState from which this call originates.
+  if (mergeCache) {
     auto existing = mergeCache->get(a, b);
     if (existing) {
       return existing;
@@ -148,18 +220,18 @@ Ref<const PredictionContext> PredictionContext::mergeSingletons(const Ref<const 
     }
   }
 
-  Ref<const PredictionContext> rootMerge = mergeRoot(a, b, rootIsWildcard);
+  auto rootMerge = mergeRoot(a, b, rootIsWildcard);
   if (rootMerge) {
-    if (mergeCache != nullptr) {
-      mergeCache->put(a, b, rootMerge);
+    if (mergeCache) {
+      return mergeCache->put(a, b, rootMerge);
     }
     return rootMerge;
   }
 
-  Ref<const PredictionContext> parentA = a->parent;
-  Ref<const PredictionContext> parentB = b->parent;
+  auto parentA = a->parent;
+  auto parentB = b->parent;
   if (a->returnState == b->returnState) { // a == b
-    Ref<const PredictionContext> parent = merge(parentA, parentB, rootIsWildcard, mergeCache);
+    auto parent = merge(parentA, parentB, rootIsWildcard, mergeCache);
 
     // If parent is same as existing a or b parent or reduced to a parent, return it.
     if (parent == parentA) { // ax + bx = ax, if a=b
@@ -173,55 +245,55 @@ Ref<const PredictionContext> PredictionContext::mergeSingletons(const Ref<const 
     // merge parents x and y, giving array node with x,y then remainders
     // of those graphs.  dup a, a' points at merged array
     // new joined parent so create new singleton pointing to it, a'
-    Ref<const PredictionContext> a_ = SingletonPredictionContext::create(parent, a->returnState);
-    if (mergeCache != nullptr) {
-      mergeCache->put(a, b, a_);
+    auto c = SingletonPredictionContext::create(std::move(parent), a->returnState);
+    if (mergeCache) {
+      return mergeCache->put(a, b, std::move(c));
     }
-    return a_;
-  } else {
-    // a != b payloads differ
-    // see if we can collapse parents due to $+x parents if local ctx
-    Ref<const PredictionContext> singleParent;
-    if (a == b || (*parentA == *parentB)) { // ax + bx = [a,b]x
-      singleParent = parentA;
-    }
-    if (singleParent) { // parents are same, sort payloads and use same parent
-      std::vector<size_t> payloads = { a->returnState, b->returnState };
-      if (a->returnState > b->returnState) {
-        payloads[0] = b->returnState;
-        payloads[1] = a->returnState;
-      }
-      std::vector<Ref<const PredictionContext>> parents = { singleParent, singleParent };
-      Ref<const PredictionContext> a_ = std::make_shared<ArrayPredictionContext>(std::move(parents), std::move(payloads));
-      if (mergeCache != nullptr) {
-        mergeCache->put(a, b, a_);
-      }
-      return a_;
-    }
-
-    // parents differ and can't merge them. Just pack together
-    // into array; can't merge.
-    // ax + by = [ax,by]
-    Ref<const PredictionContext> a_;
-    if (a->returnState > b->returnState) { // sort by payload
-      std::vector<size_t> payloads = { b->returnState, a->returnState };
-      std::vector<Ref<const PredictionContext>> parents = { b->parent, a->parent };
-      a_ = std::make_shared<ArrayPredictionContext>(std::move(parents), std::move(payloads));
-    } else {
-      std::vector<size_t> payloads = {a->returnState, b->returnState};
-      std::vector<Ref<const PredictionContext>> parents = { a->parent, b->parent };
-      a_ = std::make_shared<ArrayPredictionContext>(std::move(parents), std::move(payloads));
-    }
-
-    if (mergeCache != nullptr) {
-      mergeCache->put(a, b, a_);
-    }
-    return a_;
+    return c;
   }
+  // a != b payloads differ
+  // see if we can collapse parents due to $+x parents if local ctx
+  Ref<const PredictionContext> singleParent;
+  if (a == b || (*parentA == *parentB)) { // ax + bx = [a,b]x
+    singleParent = parentA;
+  }
+  if (singleParent) { // parents are same, sort payloads and use same parent
+    std::vector<size_t> payloads = { a->returnState, b->returnState };
+    if (a->returnState > b->returnState) {
+      payloads[0] = b->returnState;
+      payloads[1] = a->returnState;
+    }
+    std::vector<Ref<const PredictionContext>> parents = { singleParent, singleParent };
+    auto c = std::make_shared<ArrayPredictionContext>(std::move(parents), std::move(payloads));
+    if (mergeCache) {
+      return mergeCache->put(a, b, std::move(c));
+    }
+    return c;
+  }
+
+  // parents differ and can't merge them. Just pack together
+  // into array; can't merge.
+  // ax + by = [ax,by]
+  if (a->returnState > b->returnState) { // sort by payload
+    std::vector<size_t> payloads = { b->returnState, a->returnState };
+    std::vector<Ref<const PredictionContext>> parents = { b->parent, a->parent };
+    auto c = std::make_shared<ArrayPredictionContext>(std::move(parents), std::move(payloads));
+    if (mergeCache) {
+      return mergeCache->put(a, b, std::move(c));
+    }
+    return c;
+  }
+  std::vector<size_t> payloads = {a->returnState, b->returnState};
+  std::vector<Ref<const PredictionContext>> parents = { a->parent, b->parent };
+  auto c = std::make_shared<ArrayPredictionContext>(std::move(parents), std::move(payloads));
+  if (mergeCache) {
+    return mergeCache->put(a, b, std::move(c));
+  }
+  return c;
 }
 
-Ref<const PredictionContext> PredictionContext::mergeRoot(const Ref<const SingletonPredictionContext> &a,
-  const Ref<const SingletonPredictionContext> &b, bool rootIsWildcard) {
+Ref<const PredictionContext> PredictionContext::mergeRoot(Ref<const SingletonPredictionContext> a, Ref<const SingletonPredictionContext> b,
+                                                          bool rootIsWildcard) {
   if (rootIsWildcard) {
     if (a == EMPTY) { // * + b = *
       return EMPTY;
@@ -236,23 +308,21 @@ Ref<const PredictionContext> PredictionContext::mergeRoot(const Ref<const Single
     if (a == EMPTY) { // $ + x = [$,x]
       std::vector<size_t> payloads = { b->returnState, EMPTY_RETURN_STATE };
       std::vector<Ref<const PredictionContext>> parents = { b->parent, nullptr };
-      Ref<const PredictionContext> joined = std::make_shared<ArrayPredictionContext>(std::move(parents), std::move(payloads));
-      return joined;
+      return std::make_shared<ArrayPredictionContext>(std::move(parents), std::move(payloads));
     }
     if (b == EMPTY) { // x + $ = [$,x] ($ is always first if present)
       std::vector<size_t> payloads = { a->returnState, EMPTY_RETURN_STATE };
       std::vector<Ref<const PredictionContext>> parents = { a->parent, nullptr };
-      Ref<const PredictionContext> joined = std::make_shared<ArrayPredictionContext>(std::move(parents), std::move(payloads));
-      return joined;
+      return std::make_shared<ArrayPredictionContext>(std::move(parents), std::move(payloads));
     }
   }
   return nullptr;
 }
 
-Ref<const PredictionContext> PredictionContext::mergeArrays(const Ref<const ArrayPredictionContext> &a,
-  const Ref<const ArrayPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
+Ref<const PredictionContext> PredictionContext::mergeArrays(Ref<const ArrayPredictionContext> a, Ref<const ArrayPredictionContext> b,
+                                                            bool rootIsWildcard, PredictionContextMergeCache *mergeCache) {
 
-  if (mergeCache != nullptr) {
+  if (mergeCache) {
     auto existing = mergeCache->get(a, b);
     if (existing) {
       return existing;
@@ -273,32 +343,29 @@ Ref<const PredictionContext> PredictionContext::mergeArrays(const Ref<const Arra
 
   // walk and merge to yield mergedParents, mergedReturnStates
   while (i < a->returnStates.size() && j < b->returnStates.size()) {
-    Ref<const PredictionContext> a_parent = a->parents[i];
-    Ref<const PredictionContext> b_parent = b->parents[j];
+    auto parentA = a->parents[i];
+    auto parentB = b->parents[j];
     if (a->returnStates[i] == b->returnStates[j]) {
       // same payload (stack tops are equal), must yield merged singleton
       size_t payload = a->returnStates[i];
       // $+$ = $
-      bool both$ = payload == EMPTY_RETURN_STATE && !a_parent && !b_parent;
-      bool ax_ax = (a_parent && b_parent) && *a_parent == *b_parent; // ax+ax -> ax
+      bool both$ = payload == EMPTY_RETURN_STATE && !parentA && !parentB;
+      bool ax_ax = (parentA && parentB) && *parentA == *parentB; // ax+ax -> ax
       if (both$ || ax_ax) {
-        mergedParents[k] = a_parent; // choose left
+        mergedParents[k] = std::move(parentA); // choose left
         mergedReturnStates[k] = payload;
-      }
-      else { // ax+ay -> a'[x,y]
-        Ref<const PredictionContext> mergedParent = merge(a_parent, b_parent, rootIsWildcard, mergeCache);
-        mergedParents[k] = mergedParent;
+      } else { // ax+ay -> a'[x,y]
+        mergedParents[k] = merge(std::move(parentA), std::move(parentB), rootIsWildcard, mergeCache);
         mergedReturnStates[k] = payload;
       }
       i++; // hop over left one as usual
       j++; // but also skip one in right side since we merge
     } else if (a->returnStates[i] < b->returnStates[j]) { // copy a[i] to M
-      mergedParents[k] = a_parent;
+      mergedParents[k] = std::move(parentA);
       mergedReturnStates[k] = a->returnStates[i];
       i++;
-    }
-    else { // b > a, copy b[j] to M
-      mergedParents[k] = b_parent;
+    } else { // b > a, copy b[j] to M
+      mergedParents[k] = std::move(parentB);
       mergedReturnStates[k] = b->returnStates[j];
       j++;
     }
@@ -307,13 +374,13 @@ Ref<const PredictionContext> PredictionContext::mergeArrays(const Ref<const Arra
 
   // copy over any payloads remaining in either array
   if (i < a->returnStates.size()) {
-    for (std::vector<int>::size_type p = i; p < a->returnStates.size(); p++) {
+    for (auto p = i; p < a->returnStates.size(); p++) {
       mergedParents[k] = a->parents[p];
       mergedReturnStates[k] = a->returnStates[p];
       k++;
     }
   } else {
-    for (std::vector<int>::size_type p = j; p < b->returnStates.size(); p++) {
+    for (auto p = j; p < b->returnStates.size(); p++) {
       mergedParents[k] = b->parents[p];
       mergedReturnStates[k] = b->returnStates[p];
       k++;
@@ -323,60 +390,39 @@ Ref<const PredictionContext> PredictionContext::mergeArrays(const Ref<const Arra
   // trim merged if we combined a few that had same stack tops
   if (k < mergedParents.size()) { // write index < last position; trim
     if (k == 1) { // for just one merged element, return singleton top
-      Ref<const PredictionContext> a_ = SingletonPredictionContext::create(mergedParents[0], mergedReturnStates[0]);
-      if (mergeCache != nullptr) {
-        mergeCache->put(a, b, a_);
+      auto c = SingletonPredictionContext::create(std::move(mergedParents[0]), mergedReturnStates[0]);
+      if (mergeCache) {
+        return mergeCache->put(a, b, std::move(c));
       }
-      return a_;
+      return c;
     }
     mergedParents.resize(k);
     mergedReturnStates.resize(k);
   }
 
-  Ref<const ArrayPredictionContext> M = std::make_shared<ArrayPredictionContext>(mergedParents, mergedReturnStates);
+  ArrayPredictionContext m(std::move(mergedParents), std::move(mergedReturnStates));
 
   // if we created same array as a or b, return that instead
   // TODO: track whether this is possible above during merge sort for speed
-  if (*M == *a) {
-    if (mergeCache != nullptr) {
-      mergeCache->put(a, b, a);
+  if (m == *a) {
+    if (mergeCache) {
+      return mergeCache->put(a, b, a);
     }
     return a;
   }
-  if (*M == *b) {
-    if (mergeCache != nullptr) {
-      mergeCache->put(a, b, b);
+  if (m == *b) {
+    if (mergeCache) {
+      return mergeCache->put(a, b, b);
     }
     return b;
   }
 
-  // ml: this part differs from Java code. We have to recreate the context as the parents array is copied on creation.
-  if (combineCommonParents(mergedParents)) {
-    mergedReturnStates.resize(mergedParents.size());
-    M = std::make_shared<ArrayPredictionContext>(mergedParents, mergedReturnStates);
+  combineCommonParents(m.parents);
+  auto c = std::make_shared<ArrayPredictionContext>(std::move(m));
+  if (mergeCache) {
+    return mergeCache->put(a, b, std::move(c));
   }
-
-  if (mergeCache != nullptr) {
-    mergeCache->put(a, b, M);
-  }
-  return M;
-}
-
-bool PredictionContext::combineCommonParents(std::vector<Ref<const PredictionContext>> &parents) {
-
-  std::set<Ref<const PredictionContext>> uniqueParents;
-  for (size_t p = 0; p < parents.size(); ++p) {
-    Ref<const PredictionContext> parent = parents[p];
-    if (uniqueParents.find(parent) == uniqueParents.end()) { // don't replace
-      uniqueParents.insert(parent);
-    }
-  }
-
-  for (size_t p = 0; p < parents.size(); ++p) {
-    parents[p] = *uniqueParents.find(parents[p]);
-  }
-
-  return true;
+  return c;
 }
 
 std::string PredictionContext::toDOTString(const Ref<const PredictionContext> &context) {
@@ -388,13 +434,12 @@ std::string PredictionContext::toDOTString(const Ref<const PredictionContext> &c
   ss << "digraph G {\n" << "rankdir=LR;\n";
 
   std::vector<Ref<const PredictionContext>> nodes = getAllContextNodes(context);
-  std::sort(nodes.begin(), nodes.end(), [](const Ref<const PredictionContext> &o1, const Ref<const PredictionContext> &o2) {
-    return o1->id - o2->id;
-  });
+  std::unordered_map<const PredictionContext*, size_t> nodeIds;
+  size_t nodeId = 0;
 
   for (const auto &current : nodes) {
     if (current->getContextType() == PredictionContextType::SINGLETON) {
-      std::string s = std::to_string(current->id);
+      std::string s = std::to_string(insertOrAssignNodeId(nodeIds, nodeId, current.get()));
       ss << "  s" << s;
       std::string returnState = std::to_string(current->getReturnState(0));
       if (current == PredictionContext::EMPTY) {
@@ -404,7 +449,7 @@ std::string PredictionContext::toDOTString(const Ref<const PredictionContext> &c
       continue;
     }
     Ref<const ArrayPredictionContext> arr = std::static_pointer_cast<const ArrayPredictionContext>(current);
-    ss << "  s" << arr->id << " [shape=box, label=\"" << "[";
+    ss << "  s" << insertOrAssignNodeId(nodeIds, nodeId, arr.get()) << " [shape=box, label=\"" << "[";
     bool first = true;
     for (auto inv : arr->returnStates) {
       if (!first) {
@@ -429,7 +474,7 @@ std::string PredictionContext::toDOTString(const Ref<const PredictionContext> &c
       if (!current->getParent(i)) {
         continue;
       }
-      ss << "  s" << current->id << "->" << "s" << current->getParent(i)->id;
+      ss << "  s" << insertOrAssignNodeId(nodeIds, nodeId, current.get()) << "->" << "s" << insertOrAssignNodeId(nodeIds, nodeId, current->getParent(i).get());
       if (current->size() > 1) {
         ss << " [label=\"parent[" << i << "]\"];\n";
       } else {
@@ -444,104 +489,23 @@ std::string PredictionContext::toDOTString(const Ref<const PredictionContext> &c
 
 // The "visited" map is just a temporary structure to control the retrieval process (which is recursive).
 Ref<const PredictionContext> PredictionContext::getCachedContext(const Ref<const PredictionContext> &context,
-  PredictionContextCache &contextCache, std::map<Ref<const PredictionContext>, Ref<const PredictionContext>> &visited) {
-  if (context->isEmpty()) {
-    return context;
-  }
-
-  {
-    auto iterator = visited.find(context);
-    if (iterator != visited.end())
-      return iterator->second; // Not necessarly the same as context.
-  }
-
-  auto iterator = contextCache.find(context);
-  if (iterator != contextCache.end()) {
-    visited[context] = *iterator;
-
-    return *iterator;
-  }
-
-  bool changed = false;
-
-  std::vector<Ref<const PredictionContext>> parents(context->size());
-  for (size_t i = 0; i < parents.size(); i++) {
-    Ref<const PredictionContext> parent = getCachedContext(context->getParent(i), contextCache, visited);
-    if (changed || parent != context->getParent(i)) {
-      if (!changed) {
-        parents.clear();
-        for (size_t j = 0; j < context->size(); j++) {
-          parents.push_back(context->getParent(j));
-        }
-
-        changed = true;
-      }
-
-      parents[i] = parent;
-    }
-  }
-
-  if (!changed) {
-    contextCache.insert(context);
-    visited[context] = context;
-
-    return context;
-  }
-
-  Ref<const PredictionContext> updated;
-  if (parents.empty()) {
-    updated = EMPTY;
-  } else if (parents.size() == 1) {
-    updated = SingletonPredictionContext::create(parents[0], context->getReturnState(0));
-    contextCache.insert(updated);
-  } else {
-    updated = std::make_shared<ArrayPredictionContext>(parents, std::dynamic_pointer_cast<const ArrayPredictionContext>(context)->returnStates);
-    contextCache.insert(updated);
-  }
-
-  visited[updated] = updated;
-  visited[context] = updated;
-
-  return updated;
+                                                                 PredictionContextCache &contextCache) {
+  std::unordered_map<Ref<const PredictionContext>, Ref<const PredictionContext>> visited;
+  return getCachedContextImpl(context, contextCache, visited);
 }
 
 std::vector<Ref<const PredictionContext>> PredictionContext::getAllContextNodes(const Ref<const PredictionContext> &context) {
   std::vector<Ref<const PredictionContext>> nodes;
-  std::set<const PredictionContext *> visited;
-  getAllContextNodes_(context, nodes, visited);
+  std::unordered_set<const PredictionContext*> visited;
+  getAllContextNodesImpl(context, nodes, visited);
   return nodes;
 }
 
-
-void PredictionContext::getAllContextNodes_(const Ref<const PredictionContext> &context, std::vector<Ref<const PredictionContext>> &nodes,
-  std::set<const PredictionContext *> &visited) {
-
-  if (visited.find(context.get()) != visited.end()) {
-    return; // Already done.
-  }
-
-  visited.insert(context.get());
-  nodes.push_back(context);
-
-  for (size_t i = 0; i < context->size(); i++) {
-    getAllContextNodes_(context->getParent(i), nodes, visited);
-  }
-}
-
-std::string PredictionContext::toString() const {
-
-  return antlrcpp::toString(this);
-}
-
-std::string PredictionContext::toString(Recognizer * /*recog*/) const {
-  return toString();
-}
-
-std::vector<std::string> PredictionContext::toStrings(Recognizer *recognizer, int currentState) {
+std::vector<std::string> PredictionContext::toStrings(Recognizer *recognizer, int currentState) const {
   return toStrings(recognizer, EMPTY, currentState);
 }
 
-std::vector<std::string> PredictionContext::toStrings(Recognizer *recognizer, const Ref<const PredictionContext> &stop, int currentState) {
+std::vector<std::string> PredictionContext::toStrings(Recognizer *recognizer, const Ref<const PredictionContext> &stop, int currentState) const {
 
   std::vector<std::string> result;
 
@@ -610,33 +574,49 @@ std::vector<std::string> PredictionContext::toStrings(Recognizer *recognizer, co
   return result;
 }
 
-//----------------- PredictionContextMergeCache ------------------------------------------------------------------------
+//----------------- PredictionContextCache ------------------------------------------------------------------------
 
-Ref<const PredictionContext> PredictionContextMergeCache::put(Ref<const PredictionContext> const& key1, Ref<const PredictionContext> const& key2,
-                                                        Ref<const PredictionContext> const& value) {
-  Ref<const PredictionContext> previous;
+void PredictionContextCache::put(const Ref<const PredictionContext> &value) {
+  assert(value);
 
-  auto iterator = _data.find(key1);
-  if (iterator == _data.end())
-    _data[key1][key2] = value;
-  else {
-    auto iterator2 = iterator->second.find(key2);
-    if (iterator2 != iterator->second.end())
-      previous = iterator2->second;
-    iterator->second[key2] = value;
-  }
-
-  return previous;
+  _data.insert(value);
 }
 
-Ref<const PredictionContext> PredictionContextMergeCache::get(Ref<const PredictionContext> const& key1, Ref<const PredictionContext> const& key2) {
-  auto iterator = _data.find(key1);
-  if (iterator == _data.end())
-    return nullptr;
+Ref<const PredictionContext> PredictionContextCache::get(const Ref<const PredictionContext> &value) const {
+  assert(value);
 
-  auto iterator2 = iterator->second.find(key2);
-  if (iterator2 == iterator->second.end())
+  auto iterator = _data.find(value);
+  if (iterator == _data.end()) {
     return nullptr;
+  }
+  return *iterator;
+}
+
+//----------------- PredictionContextMergeCache ------------------------------------------------------------------------
+
+Ref<const PredictionContext> PredictionContextMergeCache::put(const Ref<const PredictionContext> &key1,
+                                                              const Ref<const PredictionContext> &key2,
+                                                              Ref<const PredictionContext> value) {
+  assert(key1);
+  assert(key2);
+
+  return _data.try_emplace(key1).first->second.insert_or_assign(key2, std::move(value)).first->second;
+}
+
+Ref<const PredictionContext> PredictionContextMergeCache::get(const Ref<const PredictionContext> &key1,
+                                                              const Ref<const PredictionContext> &key2) const {
+  assert(key1);
+  assert(key2);
+
+  auto iterator1 = _data.find(key1);
+  if (iterator1 == _data.end()) {
+    return nullptr;
+  }
+
+  auto iterator2 = iterator1->second.find(key2);
+  if (iterator2 == iterator1->second.end()) {
+    return nullptr;
+  }
 
   return iterator2->second;
 }
@@ -644,20 +624,3 @@ Ref<const PredictionContext> PredictionContextMergeCache::get(Ref<const Predicti
 void PredictionContextMergeCache::clear() {
   _data.clear();
 }
-
-std::string PredictionContextMergeCache::toString() const {
-  std::string result;
-  for (const auto &pair : _data)
-    for (const auto &pair2 : pair.second)
-      result += pair2.second->toString() + "\n";
-
-  return result;
-}
-
-size_t PredictionContextMergeCache::count() const {
-  size_t result = 0;
-  for (const auto &entry : _data)
-    result += entry.second.size();
-  return result;
-}
-

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.h
@@ -15,11 +15,8 @@
 namespace antlr4 {
 namespace atn {
 
-  struct PredictionContextHasher;
-  struct PredictionContextComparer;
+  class PredictionContextCache;
   class PredictionContextMergeCache;
-
-  typedef std::unordered_set<Ref<const PredictionContext>, PredictionContextHasher, PredictionContextComparer> PredictionContextCache;
 
   class ANTLR4CPP_PUBLIC PredictionContext {
   public:
@@ -35,68 +32,9 @@ namespace atn {
     //     conflict with real return states.
     static constexpr size_t EMPTY_RETURN_STATE = std::numeric_limits<size_t>::max() - 9;
 
-  private:
-    static constexpr size_t INITIAL_HASH = 1;
-
-  public:
-    static std::atomic<size_t> globalNodeCount;
-    const size_t id;
-
-    /// <summary>
-    /// Stores the computed hash code of this <seealso cref="PredictionContext"/>. The hash
-    /// code is computed in parts to match the following reference algorithm.
-    ///
-    /// <pre>
-    ///  private int referenceHashCode() {
-    ///      int hash = <seealso cref="MurmurHash#initialize"/>(<seealso cref="#INITIAL_HASH"/>);
-    ///
-    ///      for (int i = 0; i < <seealso cref="#size()"/>; i++) {
-    ///          hash = <seealso cref="MurmurHash#update"/>(hash, <seealso cref="#getParent"/>(i));
-    ///      }
-    ///
-    ///      for (int i = 0; i < <seealso cref="#size()"/>; i++) {
-    ///          hash = <seealso cref="MurmurHash#update"/>(hash, <seealso cref="#getReturnState"/>(i));
-    ///      }
-    ///
-    ///      hash = <seealso cref="MurmurHash#finish"/>(hash, 2 * <seealso cref="#size()"/>);
-    ///      return hash;
-    ///  }
-    /// </pre>
-    /// </summary>
-    const size_t cachedHashCode;
-
-  public:
-    virtual ~PredictionContext() = default;
-
-    PredictionContextType getContextType() const { return _contextType; }
-
-    /// Convert a RuleContext tree to a PredictionContext graph.
-    /// Return EMPTY if outerContext is empty.
-    static Ref<const PredictionContext> fromRuleContext(const ATN &atn, RuleContext *outerContext);
-
-    virtual size_t size() const = 0;
-    virtual Ref<const PredictionContext> getParent(size_t index) const = 0;
-    virtual size_t getReturnState(size_t index) const = 0;
-
-    virtual bool operator == (const PredictionContext &o) const = 0;
-
-    /// This means only the EMPTY (wildcard? not sure) context is in set.
-    virtual bool isEmpty() const;
-    virtual bool hasEmptyPath() const;
-    virtual size_t hashCode() const;
-
-  protected:
-    PredictionContext(PredictionContextType contextType, size_t cachedHashCode);
-
-    static size_t calculateEmptyHashCode();
-    static size_t calculateHashCode(Ref<const PredictionContext> parent, size_t returnState);
-    static size_t calculateHashCode(const std::vector<Ref<const PredictionContext>> &parents,
-                                    const std::vector<size_t> &returnStates);
-
-  public:
     // dispatch
-    static Ref<const PredictionContext> merge(const Ref<const PredictionContext> &a, const Ref<const PredictionContext> &b,
-                                        bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
+    static Ref<const PredictionContext> merge(Ref<const PredictionContext> a, Ref<const PredictionContext> b,
+                                              bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
 
     /// <summary>
     /// Merge two <seealso cref="SingletonPredictionContext"/> instances.
@@ -132,8 +70,8 @@ namespace atn {
     /// <param name="rootIsWildcard"> {@code true} if this is a local-context merge,
     /// otherwise false to indicate a full-context merge </param>
     /// <param name="mergeCache"> </param>
-    static Ref<const PredictionContext> mergeSingletons(const Ref<const SingletonPredictionContext> &a,
-      const Ref<const SingletonPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
+    static Ref<const PredictionContext> mergeSingletons(Ref<const SingletonPredictionContext> a, Ref<const SingletonPredictionContext> b,
+                                                        bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
 
     /**
      * Handle case where at least one of {@code a} or {@code b} is
@@ -173,8 +111,8 @@ namespace atn {
      * @param rootIsWildcard {@code true} if this is a local-context merge,
      * otherwise false to indicate a full-context merge
      */
-    static Ref<const PredictionContext> mergeRoot(const Ref<const SingletonPredictionContext> &a,
-      const Ref<const SingletonPredictionContext> &b, bool rootIsWildcard);
+    static Ref<const PredictionContext> mergeRoot(Ref<const SingletonPredictionContext> a, Ref<const SingletonPredictionContext> b,
+                                                  bool rootIsWildcard);
 
     /**
      * Merge two {@link ArrayPredictionContext} instances.
@@ -195,68 +133,132 @@ namespace atn {
      * {@link SingletonPredictionContext}.<br>
      * <embed src="images/ArrayMerge_EqualTop.svg" type="image/svg+xml"/></p>
      */
-    static Ref<const PredictionContext> mergeArrays(const Ref<const ArrayPredictionContext> &a,
-      const Ref<const ArrayPredictionContext> &b, bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
+    static Ref<const PredictionContext> mergeArrays(Ref<const ArrayPredictionContext> a, Ref<const ArrayPredictionContext> b,
+                                                    bool rootIsWildcard, PredictionContextMergeCache *mergeCache);
 
-  protected:
-    /// Make pass over all M parents; merge any equal() ones.
-    /// @returns true if the list has been changed (i.e. duplicates where found).
-    static bool combineCommonParents(std::vector<Ref<const PredictionContext>> &parents);
-
-  public:
     static std::string toDOTString(const Ref<const PredictionContext> &context);
 
     static Ref<const PredictionContext> getCachedContext(const Ref<const PredictionContext> &context,
-      PredictionContextCache &contextCache,
-      std::map<Ref<const PredictionContext>, Ref<const PredictionContext>> &visited);
+                                                         PredictionContextCache &contextCache);
 
     // ter's recursive version of Sam's getAllNodes()
     static std::vector<Ref<const PredictionContext>> getAllContextNodes(const Ref<const PredictionContext> &context);
-    static void getAllContextNodes_(const Ref<const PredictionContext> &context,
-      std::vector<Ref<const PredictionContext>> &nodes, std::set<const PredictionContext *> &visited);
 
-    virtual std::string toString() const;
-    virtual std::string toString(Recognizer *recog) const;
+    PredictionContext(const PredictionContext&) = delete;
 
-    std::vector<std::string> toStrings(Recognizer *recognizer, int currentState);
-    std::vector<std::string> toStrings(Recognizer *recognizer, const Ref<const PredictionContext> &stop, int currentState);
+    virtual ~PredictionContext() = default;
+
+    PredictionContext& operator=(const PredictionContext&) = delete;
+    PredictionContext& operator=(PredictionContext&&) = delete;
+
+    PredictionContextType getContextType() const { return _contextType; }
+
+    /// Convert a RuleContext tree to a PredictionContext graph.
+    /// Return EMPTY if outerContext is empty.
+    static Ref<const PredictionContext> fromRuleContext(const ATN &atn, RuleContext *outerContext);
+
+    virtual size_t size() const = 0;
+    virtual const Ref<const PredictionContext>& getParent(size_t index) const = 0;
+    virtual size_t getReturnState(size_t index) const = 0;
+
+    /// This means only the EMPTY (wildcard? not sure) context is in set.
+    virtual bool isEmpty() const = 0;
+    bool hasEmptyPath() const;
+
+    size_t hashCode() const;
+
+    virtual bool equals(const PredictionContext &other) const = 0;
+
+    virtual std::string toString() const = 0;
+
+    std::vector<std::string> toStrings(Recognizer *recognizer, int currentState) const;
+    std::vector<std::string> toStrings(Recognizer *recognizer, const Ref<const PredictionContext> &stop, int currentState) const;
+
+  protected:
+    explicit PredictionContext(PredictionContextType contextType);
+
+    PredictionContext(PredictionContext&& other);
+
+    virtual size_t hashCodeImpl() const = 0;
+
+    size_t cachedHashCode() const { return _hashCode.load(std::memory_order_relaxed); }
 
   private:
-    PredictionContextType _contextType;
+    const PredictionContextType _contextType;
+    mutable std::atomic<size_t> _hashCode;
   };
 
-  struct PredictionContextHasher {
-    size_t operator () (const Ref<const PredictionContext> &k) const {
-      return k->hashCode();
-    }
-  };
+  inline bool operator==(const PredictionContext &lhs, const PredictionContext &rhs) {
+    return lhs.equals(rhs);
+  }
 
-  struct PredictionContextComparer {
-    bool operator () (const Ref<const PredictionContext> &lhs, const Ref<const PredictionContext> &rhs) const
-    {
-      if (lhs == rhs) // Object identity.
-        return true;
-      return (lhs->hashCode() == rhs->hashCode()) && (*lhs == *rhs);
-    }
-  };
+  inline bool operator!=(const PredictionContext &lhs, const PredictionContext &rhs) {
+    return !operator==(lhs, rhs);
+  }
 
-  class PredictionContextMergeCache {
+  class ANTLR4CPP_PUBLIC PredictionContextCache final {
   public:
-    Ref<const PredictionContext> put(Ref<const PredictionContext> const& key1, Ref<const PredictionContext> const& key2,
-                               Ref<const PredictionContext> const& value);
-    Ref<const PredictionContext> get(Ref<const PredictionContext> const& key1, Ref<const PredictionContext> const& key2);
+    void put(const Ref<const PredictionContext> &value);
+
+    Ref<const PredictionContext> get(const Ref<const PredictionContext> &value) const;
+
+  private:
+    struct PredictionContextHasher final {
+      size_t operator()(const Ref<const PredictionContext> &predictionContext) const {
+        return predictionContext->hashCode();
+      }
+    };
+
+    struct PredictionContextComparer final {
+      bool operator()(const Ref<const PredictionContext> &lhs, const Ref<const PredictionContext> &rhs) const {
+        return *lhs == *rhs;
+      }
+    };
+
+    std::unordered_set<Ref<const PredictionContext>, PredictionContextHasher, PredictionContextComparer> _data;
+  };
+
+  class ANTLR4CPP_PUBLIC PredictionContextMergeCache final {
+  public:
+    Ref<const PredictionContext> put(const Ref<const PredictionContext> &key1,
+                                     const Ref<const PredictionContext> &key2,
+                                     Ref<const PredictionContext> value);
+
+    Ref<const PredictionContext> get(const Ref<const PredictionContext> &key1,
+                                     const Ref<const PredictionContext> &key2) const;
 
     void clear();
-    std::string toString() const;
-    size_t count() const;
 
   private:
+    struct PredictionContextHasher final {
+      size_t operator()(const Ref<const PredictionContext> &predictionContext) const {
+        return predictionContext->hashCode();
+      }
+    };
+
+    struct PredictionContextComparer final {
+      bool operator()(const Ref<const PredictionContext> &lhs, const Ref<const PredictionContext> &rhs) const {
+        return *lhs == *rhs;
+      }
+    };
+
     std::unordered_map<Ref<const PredictionContext>,
-      std::unordered_map<Ref<const PredictionContext>, Ref<const PredictionContext>, PredictionContextHasher, PredictionContextComparer>,
+      std::unordered_map<Ref<const PredictionContext>, Ref<const PredictionContext>,
+        PredictionContextHasher, PredictionContextComparer>,
       PredictionContextHasher, PredictionContextComparer> _data;
 
   };
 
-} // namespace atn
-} // namespace antlr4
+}  // namespace atn
+}  // namespace antlr4
 
+namespace std {
+
+  template <>
+  struct hash<::antlr4::atn::PredictionContext> {
+    size_t operator()(const ::antlr4::atn::PredictionContext &predictionContext) const {
+      return predictionContext.hashCode();
+    }
+  };
+
+}  // namespace std

--- a/runtime/Cpp/runtime/src/atn/PredictionMode.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionMode.cpp
@@ -73,8 +73,8 @@ bool PredictionModeClass::hasSLLConflictTerminatingPrediction(PredictionMode mod
 }
 
 bool PredictionModeClass::hasConfigInRuleStopState(ATNConfigSet *configs) {
-  for (auto &c : configs->configs) {
-    if (is<RuleStopState *>(c->state)) {
+  for (const auto &config : configs->configs) {
+    if (RuleStopState::is(config->state)) {
       return true;
     }
   }
@@ -83,8 +83,8 @@ bool PredictionModeClass::hasConfigInRuleStopState(ATNConfigSet *configs) {
 }
 
 bool PredictionModeClass::allConfigsInRuleStopStates(ATNConfigSet *configs) {
-  for (auto &config : configs->configs) {
-    if (!is<RuleStopState*>(config->state)) {
+  for (const auto &config : configs->configs) {
+    if (!RuleStopState::is(config->state)) {
       return false;
     }
   }
@@ -142,7 +142,7 @@ size_t PredictionModeClass::getUniqueAlt(const std::vector<antlrcpp::BitSet>& al
 
 antlrcpp::BitSet PredictionModeClass::getAlts(const std::vector<antlrcpp::BitSet>& altsets) {
   antlrcpp::BitSet all;
-  for (antlrcpp::BitSet alts : altsets) {
+  for (const auto &alts : altsets) {
     all |= alts;
   }
 
@@ -151,43 +151,44 @@ antlrcpp::BitSet PredictionModeClass::getAlts(const std::vector<antlrcpp::BitSet
 
 antlrcpp::BitSet PredictionModeClass::getAlts(ATNConfigSet *configs) {
   antlrcpp::BitSet alts;
-  for (auto &config : configs->configs) {
+  for (const auto &config : configs->configs) {
     alts.set(config->alt);
   }
   return alts;
 }
 
 std::vector<antlrcpp::BitSet> PredictionModeClass::getConflictingAltSubsets(ATNConfigSet *configs) {
-  std::unordered_map<ATNConfig *, antlrcpp::BitSet, AltAndContextConfigHasher, AltAndContextConfigComparer> configToAlts;
+  std::unordered_map<ATNConfig*, antlrcpp::BitSet, AltAndContextConfigHasher, AltAndContextConfigComparer> configToAlts;
   for (auto &config : configs->configs) {
     configToAlts[config.get()].set(config->alt);
   }
   std::vector<antlrcpp::BitSet> values;
-  for (auto it : configToAlts) {
-    values.push_back(it.second);
+  values.reserve(configToAlts.size());
+  for (const auto &pair : configToAlts) {
+    values.push_back(pair.second);
   }
   return values;
 }
 
-std::map<ATNState*, antlrcpp::BitSet> PredictionModeClass::getStateToAltMap(ATNConfigSet *configs) {
-  std::map<ATNState*, antlrcpp::BitSet> m;
-  for (auto &c : configs->configs) {
+std::unordered_map<ATNState*, antlrcpp::BitSet> PredictionModeClass::getStateToAltMap(ATNConfigSet *configs) {
+  std::unordered_map<ATNState*, antlrcpp::BitSet> m;
+  for (const auto &c : configs->configs) {
     m[c->state].set(c->alt);
   }
   return m;
 }
 
 bool PredictionModeClass::hasStateAssociatedWithOneAlt(ATNConfigSet *configs) {
-  std::map<ATNState*, antlrcpp::BitSet> x = getStateToAltMap(configs);
-  for (std::map<ATNState*, antlrcpp::BitSet>::iterator it = x.begin(); it != x.end(); it++){
-    if (it->second.count() == 1) return true;
+  auto x = getStateToAltMap(configs);
+  for (const auto &pair : x){
+    if (pair.second.count() == 1) return true;
   }
   return false;
 }
 
 size_t PredictionModeClass::getSingleViableAlt(const std::vector<antlrcpp::BitSet>& altsets) {
   antlrcpp::BitSet viableAlts;
-  for (antlrcpp::BitSet alts : altsets) {
+  for (const auto &alts : altsets) {
     size_t minAlt = alts.nextSetBit(0);
 
     viableAlts.set(minAlt);

--- a/runtime/Cpp/runtime/src/atn/PredictionMode.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionMode.h
@@ -425,7 +425,7 @@ namespace atn {
     /// cref="ATNConfig#alt alt"/>
     /// </pre>
     /// </summary>
-    static std::map<ATNState*, antlrcpp::BitSet> getStateToAltMap(ATNConfigSet *configs);
+    static std::unordered_map<ATNState*, antlrcpp::BitSet> getStateToAltMap(ATNConfigSet *configs);
 
     static bool hasStateAssociatedWithOneAlt(ATNConfigSet *configs);
 

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.h
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.h
@@ -221,8 +221,6 @@ namespace atn {
 }  // namespace atn
 }  // namespace antlr4
 
-// Hash function for SemanticContext, used in the MurmurHash::update function
-
 namespace std {
 
   template <>

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
@@ -5,17 +5,27 @@
 
 #include "atn/SingletonPredictionContext.h"
 
+#include "support/Casts.h"
+#include "misc/MurmurHash.h"
+
 using namespace antlr4::atn;
+using namespace antlrcpp;
+
+namespace {
+
+  bool cachedHashCodeEqual(size_t lhs, size_t rhs) {
+    return lhs == rhs || lhs == 0 || rhs == 0;
+  }
+
+}
 
 SingletonPredictionContext::SingletonPredictionContext(Ref<const PredictionContext> parent, size_t returnState)
-  : PredictionContext(PredictionContextType::SINGLETON, parent ? calculateHashCode(parent, returnState) : calculateEmptyHashCode()),
-    parent(std::move(parent)), returnState(returnState) {
+    : PredictionContext(PredictionContextType::SINGLETON), parent(std::move(parent)), returnState(returnState) {
   assert(returnState != ATNState::INVALID_STATE_NUMBER);
 }
 
 Ref<const SingletonPredictionContext> SingletonPredictionContext::create(Ref<const PredictionContext> parent, size_t returnState) {
-
-  if (returnState == EMPTY_RETURN_STATE && parent) {
+  if (returnState == EMPTY_RETURN_STATE && parent == nullptr) {
     // someone can pass in the bits of an array ctx that mean $
     return std::dynamic_pointer_cast<const SingletonPredictionContext>(EMPTY);
   }
@@ -30,41 +40,37 @@ size_t SingletonPredictionContext::size() const {
   return 1;
 }
 
-Ref<const PredictionContext> SingletonPredictionContext::getParent(size_t index) const {
+const Ref<const PredictionContext>& SingletonPredictionContext::getParent(size_t index) const {
   assert(index == 0);
-  ((void)(index)); // Make Release build happy.
+  static_cast<void>(index);
   return parent;
 }
 
 size_t SingletonPredictionContext::getReturnState(size_t index) const {
   assert(index == 0);
-  ((void)(index)); // Make Release build happy.
+  static_cast<void>(index);
   return returnState;
 }
 
-bool SingletonPredictionContext::operator == (const PredictionContext &o) const {
-  if (this == &o) {
+size_t SingletonPredictionContext::hashCodeImpl() const {
+  size_t hash = misc::MurmurHash::initialize();
+  hash = misc::MurmurHash::update(hash, static_cast<size_t>(getContextType()));
+  hash = misc::MurmurHash::update(hash, parent);
+  hash = misc::MurmurHash::update(hash, returnState);
+  return misc::MurmurHash::finish(hash, 3);
+}
+
+bool SingletonPredictionContext::equals(const PredictionContext &other) const {
+  if (this == std::addressof(other)) {
     return true;
   }
-
-  if (o.getContextType() != PredictionContextType::SINGLETON) {
+  if (getContextType() != other.getContextType()) {
     return false;
   }
-
-  const SingletonPredictionContext *other = static_cast<const SingletonPredictionContext*>(&o);
-  if (this->hashCode() != other->hashCode()) {
-    return false; // can't be same if hash is different
-  }
-
-  if (returnState != other->returnState)
-    return false;
-
-  if (!parent && !other->parent)
-    return true;
-  if (!parent || !other->parent)
-    return false;
-
-   return parent == other->parent || *parent == *other->parent;
+  const auto &singleton = downCast<const SingletonPredictionContext&>(other);
+  return returnState == singleton.returnState &&
+         cachedHashCodeEqual(cachedHashCode(), singleton.cachedHashCode()) &&
+         (parent == singleton.parent || (parent != nullptr && singleton.parent != nullptr && *parent == *singleton.parent));
 }
 
 std::string SingletonPredictionContext::toString() const {

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.h
@@ -16,6 +16,8 @@ namespace atn {
 
     static bool is(const PredictionContext *predictionContext) { return predictionContext != nullptr && is(*predictionContext); }
 
+    static Ref<const SingletonPredictionContext> create(Ref<const PredictionContext> parent, size_t returnState);
+
     // Usually a parent is linked via a weak ptr. Not so here as we have kinda reverse reference chain.
     // There are no child contexts stored here and often the parent context is left dangling when it's
     // owning ATNState is released. In order to avoid having this context released as well (leaving all other contexts
@@ -26,14 +28,15 @@ namespace atn {
 
     SingletonPredictionContext(Ref<const PredictionContext> parent, size_t returnState);
 
-    static Ref<const SingletonPredictionContext> create(Ref<const PredictionContext> parent, size_t returnState);
+    bool isEmpty() const override;
+    size_t size() const override;
+    const Ref<const PredictionContext>& getParent(size_t index) const override;
+    size_t getReturnState(size_t index) const override;
+    bool equals(const PredictionContext &other) const override;
+    std::string toString() const override;
 
-    virtual bool isEmpty() const override;
-    virtual size_t size() const override;
-    virtual Ref<const PredictionContext> getParent(size_t index) const override;
-    virtual size_t getReturnState(size_t index) const override;
-    virtual bool operator == (const PredictionContext &o) const override;
-    virtual std::string toString() const override;
+  protected:
+    size_t hashCodeImpl() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
@@ -265,18 +265,13 @@ bool IntervalSet::contains(size_t el) const {
 }
 
 bool IntervalSet::contains(ssize_t el) const {
-  if (_intervals.empty())
+  if (_intervals.empty() || el < _intervals.front().a || el > _intervals.back().b) {
     return false;
-
-  if (el < _intervals[0].a) // list is sorted and el is before first interval; not here
-    return false;
-
-  for (const auto &interval : _intervals) {
-    if (el >= interval.a && el <= interval.b) {
-      return true; // found in this interval
-    }
   }
-  return false;
+
+  return std::binary_search(_intervals.begin(), _intervals.end(), Interval(el, el), [](const Interval &lhs, const Interval &rhs) {
+    return lhs.b < rhs.a;
+  });
 }
 
 bool IntervalSet::isEmpty() const {
@@ -306,7 +301,7 @@ ssize_t IntervalSet::getMinElement() const {
     return Token::INVALID_TYPE;
   }
 
-  return _intervals[0].a;
+  return _intervals.front().a;
 }
 
 std::vector<Interval> const& IntervalSet::getIntervals() const {


### PR DESCRIPTION
Refactor PredictionContext, remove some `dynamic_cast`, and avoid copying `std::shared_ptr` when possible