### PR TITLE
[C++] Cleanup DFA, DFAState, LexerAction, and yet more performance improvements

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ATN.h
+++ b/runtime/Cpp/runtime/src/atn/ATN.h
@@ -68,7 +68,7 @@ namespace atn {
 
     /// For lexer ATNs, this is an array of {@link LexerAction} objects which may
     /// be referenced by action transitions in the ATN.
-    std::vector<Ref<LexerAction>> lexerActions;
+    std::vector<Ref<const LexerAction>> lexerActions;
 
     std::vector<TokensStartState *> modeToStartState;
 

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
@@ -101,7 +101,7 @@ namespace {
     }
   }
 
-  Ref<LexerAction> lexerActionFactory(LexerActionType type, int data1, int data2) {
+  Ref<const LexerAction> lexerActionFactory(LexerActionType type, int data1, int data2) {
     switch (type) {
       case LexerActionType::CHANNEL:
         return std::make_shared<LexerChannelAction>(data1);

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
@@ -20,13 +20,13 @@ using namespace antlrcpp;
 LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<const PredictionContext> context)
     : ATNConfig(state, alt, std::move(context)) {}
 
-LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<const PredictionContext> context, Ref<LexerActionExecutor> lexerActionExecutor)
+LexerATNConfig::LexerATNConfig(ATNState *state, int alt, Ref<const PredictionContext> context, Ref<const LexerActionExecutor> lexerActionExecutor)
     : ATNConfig(state, alt, std::move(context)), _lexerActionExecutor(std::move(lexerActionExecutor)) {}
 
 LexerATNConfig::LexerATNConfig(LexerATNConfig const& other, ATNState *state)
     : ATNConfig(other, state), _lexerActionExecutor(other._lexerActionExecutor), _passedThroughNonGreedyDecision(checkNonGreedyDecision(other, state)) {}
 
-LexerATNConfig::LexerATNConfig(LexerATNConfig const& other, ATNState *state, Ref<LexerActionExecutor> lexerActionExecutor)
+LexerATNConfig::LexerATNConfig(LexerATNConfig const& other, ATNState *state, Ref<const LexerActionExecutor> lexerActionExecutor)
     : ATNConfig(other, state), _lexerActionExecutor(std::move(lexerActionExecutor)), _passedThroughNonGreedyDecision(checkNonGreedyDecision(other, state)) {}
 
 LexerATNConfig::LexerATNConfig(LexerATNConfig const& other, ATNState *state, Ref<const PredictionContext> context)

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
@@ -13,17 +13,17 @@ namespace atn {
   class ANTLR4CPP_PUBLIC LexerATNConfig final : public ATNConfig {
   public:
     LexerATNConfig(ATNState *state, int alt, Ref<const PredictionContext> context);
-    LexerATNConfig(ATNState *state, int alt, Ref<const PredictionContext> context, Ref<LexerActionExecutor> lexerActionExecutor);
+    LexerATNConfig(ATNState *state, int alt, Ref<const PredictionContext> context, Ref<const LexerActionExecutor> lexerActionExecutor);
 
     LexerATNConfig(LexerATNConfig const& other, ATNState *state);
-    LexerATNConfig(LexerATNConfig const& other, ATNState *state, Ref<LexerActionExecutor> lexerActionExecutor);
+    LexerATNConfig(LexerATNConfig const& other, ATNState *state, Ref<const LexerActionExecutor> lexerActionExecutor);
     LexerATNConfig(LexerATNConfig const& other, ATNState *state, Ref<const PredictionContext> context);
 
     /**
      * Gets the {@link LexerActionExecutor} capable of executing the embedded
      * action(s) for the current configuration.
      */
-    const Ref<LexerActionExecutor>& getLexerActionExecutor() const { return _lexerActionExecutor; }
+    const Ref<const LexerActionExecutor>& getLexerActionExecutor() const { return _lexerActionExecutor; }
     bool hasPassedThroughNonGreedyDecision() const { return _passedThroughNonGreedyDecision; }
 
     virtual size_t hashCode() const override;
@@ -34,7 +34,7 @@ namespace atn {
     /**
      * This is the backing field for {@link #getLexerActionExecutor}.
      */
-    const Ref<LexerActionExecutor> _lexerActionExecutor;
+    const Ref<const LexerActionExecutor> _lexerActionExecutor;
     const bool _passedThroughNonGreedyDecision = false;
 
     static bool checkNonGreedyDecision(LexerATNConfig const& source, ATNState *target);

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
@@ -120,7 +120,7 @@ namespace atn {
     void getReachableConfigSet(CharStream *input, ATNConfigSet *closure_, // closure_ as we have a closure() already
                                ATNConfigSet *reach, size_t t);
 
-    virtual void accept(CharStream *input, const Ref<LexerActionExecutor> &lexerActionExecutor, size_t startIndex, size_t index,
+    virtual void accept(CharStream *input, const Ref<const LexerActionExecutor> &lexerActionExecutor, size_t startIndex, size_t index,
                         size_t line, size_t charPos);
 
     virtual ATNState *getReachableTarget(const Transition *trans, size_t t);

--- a/runtime/Cpp/runtime/src/atn/LexerAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerAction.cpp
@@ -1,6 +1,15 @@
-/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
- * Use of this file is governed by the BSD 3-clause license that
- * can be found in the LICENSE.txt file in the project root.
- */
-
 #include "LexerAction.h"
+
+using namespace antlr4::atn;
+
+size_t LexerAction::hashCode() const {
+  auto hash = cachedHashCode();
+  if (hash == 0) {
+    hash = hashCodeImpl();
+    if (hash == 0) {
+      hash = std::numeric_limits<size_t>::max();
+    }
+    _hashCode.store(hash, std::memory_order_relaxed);
+  }
+  return hash;
+}

--- a/runtime/Cpp/runtime/src/atn/LexerAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerAction.h
@@ -27,6 +27,10 @@ namespace atn {
     /// Gets the serialization type of the lexer action.
     /// </summary>
     /// <returns> The serialization type of the lexer action. </returns>
+    ///
+    /// IMPORTANT: Unlike Java, this returns LexerActionType::INDEXED_CUSTOM for instances of
+    /// LexerIndexedCustomAction. If you need the wrapped action type, use
+    /// LexerIndexedCustomAction::getAction()->getActionType().
     LexerActionType getActionType() const { return _actionType; }
 
     /// <summary>
@@ -42,7 +46,7 @@ namespace atn {
     /// <returns> {@code true} if the lexer action semantics can be affected by the
     /// position of the input <seealso cref="CharStream"/> at the time it is executed;
     /// otherwise, {@code false}. </returns>
-    virtual bool isPositionDependent() const = 0;
+    bool isPositionDependent() const { return _positionDependent; }
 
     /// <summary>
     /// Execute the lexer action in the context of the specified <seealso cref="Lexer"/>.
@@ -51,22 +55,46 @@ namespace atn {
     /// positioned correctly prior to calling this method.</para>
     /// </summary>
     /// <param name="lexer"> The lexer instance. </param>
-    virtual void execute(Lexer *lexer) = 0;
+    virtual void execute(Lexer *lexer) const = 0;
 
-    virtual size_t hashCode() const = 0;
-    virtual bool operator == (const LexerAction &obj) const = 0;
-    virtual bool operator != (const LexerAction &obj) const {
-      return !(*this == obj);
-    }
+    size_t hashCode() const;
+
+    virtual bool equals(const LexerAction &other) const = 0;
 
     virtual std::string toString() const = 0;
 
   protected:
-    explicit LexerAction(LexerActionType actionType) : _actionType(actionType) {}
+    LexerAction(LexerActionType actionType, bool positionDependent)
+        : _actionType(actionType), _hashCode(0), _positionDependent(positionDependent) {}
+
+    virtual size_t hashCodeImpl() const = 0;
+
+    size_t cachedHashCode() const { return _hashCode.load(std::memory_order_relaxed); }
 
   private:
     const LexerActionType _actionType;
+    mutable std::atomic<size_t> _hashCode;
+    const bool _positionDependent;
   };
 
-} // namespace atn
-} // namespace antlr4
+  inline bool operator==(const LexerAction &lhs, const LexerAction &rhs) {
+    return lhs.equals(rhs);
+  }
+
+  inline bool operator!=(const LexerAction &lhs, const LexerAction &rhs) {
+    return !operator==(lhs, rhs);
+  }
+
+}  // namespace atn
+}  // namespace antlr4
+
+namespace std {
+
+  template <>
+  struct hash<::antlr4::atn::LexerAction> {
+    size_t operator()(const ::antlr4::atn::LexerAction &lexerAction) const {
+      return lexerAction.hashCode();
+    }
+  };
+
+}  // namespace std

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
@@ -7,6 +7,7 @@
 #include "atn/LexerIndexedCustomAction.h"
 #include "support/CPPUtils.h"
 #include "support/Arrays.h"
+#include "support/Casts.h"
 
 #include "atn/LexerActionExecutor.h"
 
@@ -15,45 +16,54 @@ using namespace antlr4::atn;
 using namespace antlr4::misc;
 using namespace antlrcpp;
 
-LexerActionExecutor::LexerActionExecutor(std::vector<Ref<LexerAction>> lexerActions)
-  : _lexerActions(std::move(lexerActions)), _hashCode(generateHashCode()) {
-}
+namespace {
 
-Ref<LexerActionExecutor> LexerActionExecutor::append(Ref<LexerActionExecutor> const& lexerActionExecutor,
-                                                     Ref<LexerAction> lexerAction) {
-  if (lexerActionExecutor == nullptr) {
-    return std::make_shared<LexerActionExecutor>(std::vector<Ref<LexerAction>> { std::move(lexerAction) });
+  bool cachedHashCodeEqual(size_t lhs, size_t rhs) {
+    return lhs == rhs || lhs == 0 || rhs == 0;
   }
 
-  std::vector<Ref<LexerAction>> lexerActions = lexerActionExecutor->_lexerActions; // Make a copy.
+  bool lexerActionEqual(const Ref<const LexerAction> &lhs, const Ref<const LexerAction> &rhs) {
+    return *lhs == *rhs;
+  }
+
+}
+
+LexerActionExecutor::LexerActionExecutor(std::vector<Ref<const LexerAction>> lexerActions)
+    : _lexerActions(std::move(lexerActions)), _hashCode(0) {}
+
+Ref<const LexerActionExecutor> LexerActionExecutor::append(const Ref<const LexerActionExecutor> &lexerActionExecutor,
+                                                           Ref<const LexerAction> lexerAction) {
+  if (lexerActionExecutor == nullptr) {
+    return std::make_shared<LexerActionExecutor>(std::vector<Ref<const LexerAction>>{ std::move(lexerAction) });
+  }
+  std::vector<Ref<const LexerAction>> lexerActions;
+  lexerActions.reserve(lexerActionExecutor->_lexerActions.size() + 1);
+  lexerActions.insert(lexerActions.begin(), lexerActionExecutor->_lexerActions.begin(), lexerActionExecutor->_lexerActions.end());
   lexerActions.push_back(std::move(lexerAction));
   return std::make_shared<LexerActionExecutor>(std::move(lexerActions));
 }
 
-Ref<LexerActionExecutor> LexerActionExecutor::fixOffsetBeforeMatch(int offset) {
-  std::vector<Ref<LexerAction>> updatedLexerActions;
+Ref<const LexerActionExecutor> LexerActionExecutor::fixOffsetBeforeMatch(int offset) const {
+  std::vector<Ref<const LexerAction>> updatedLexerActions;
   for (size_t i = 0; i < _lexerActions.size(); i++) {
-    if (_lexerActions[i]->isPositionDependent() && !is<LexerIndexedCustomAction>(_lexerActions[i])) {
+    if (_lexerActions[i]->isPositionDependent() && !LexerIndexedCustomAction::is(*_lexerActions[i])) {
       if (updatedLexerActions.empty()) {
         updatedLexerActions = _lexerActions; // Make a copy.
       }
-
       updatedLexerActions[i] = std::make_shared<LexerIndexedCustomAction>(offset, _lexerActions[i]);
     }
   }
-
   if (updatedLexerActions.empty()) {
     return shared_from_this();
   }
-
   return std::make_shared<LexerActionExecutor>(std::move(updatedLexerActions));
 }
 
-const std::vector<Ref<LexerAction>>& LexerActionExecutor::getLexerActions() const {
+const std::vector<Ref<const LexerAction>>& LexerActionExecutor::getLexerActions() const {
   return _lexerActions;
 }
 
-void LexerActionExecutor::execute(Lexer *lexer, CharStream *input, size_t startIndex) {
+void LexerActionExecutor::execute(Lexer *lexer, CharStream *input, size_t startIndex) const {
   bool requiresSeek = false;
   size_t stopIndex = input->index();
 
@@ -62,43 +72,40 @@ void LexerActionExecutor::execute(Lexer *lexer, CharStream *input, size_t startI
       input->seek(stopIndex);
     }
   });
-  for (auto lexerAction : _lexerActions) {
-    if (is<LexerIndexedCustomAction>(lexerAction)) {
-      int offset = (std::static_pointer_cast<LexerIndexedCustomAction>(lexerAction))->getOffset();
+  for (const auto &lexerAction : _lexerActions) {
+    if (LexerIndexedCustomAction::is(*lexerAction)) {
+      int offset = downCast<const LexerIndexedCustomAction&>(*lexerAction).getOffset();
       input->seek(startIndex + offset);
-      lexerAction = std::static_pointer_cast<LexerIndexedCustomAction>(lexerAction)->getAction();
       requiresSeek = (startIndex + offset) != stopIndex;
     } else if (lexerAction->isPositionDependent()) {
       input->seek(stopIndex);
       requiresSeek = false;
     }
-
     lexerAction->execute(lexer);
   }
 }
 
 size_t LexerActionExecutor::hashCode() const {
-  return _hashCode;
+  auto hash = _hashCode.load(std::memory_order_relaxed);
+  if (hash == 0) {
+    hash = MurmurHash::initialize();
+    for (const auto &lexerAction : _lexerActions) {
+      hash = MurmurHash::update(hash, lexerAction);
+    }
+    hash = MurmurHash::finish(hash, _lexerActions.size());
+    if (hash == 0) {
+      hash = std::numeric_limits<size_t>::max();
+    }
+    _hashCode.store(hash, std::memory_order_relaxed);
+  }
+  return hash;
 }
 
-bool LexerActionExecutor::operator==(const LexerActionExecutor &obj) const {
-  if (&obj == this) {
+bool LexerActionExecutor::equals(const LexerActionExecutor &other) const {
+  if (this == std::addressof(other)) {
     return true;
   }
-
-  return _hashCode == obj._hashCode && Arrays::equals(_lexerActions, obj._lexerActions);
-}
-
-bool LexerActionExecutor::operator!=(const LexerActionExecutor &obj) const {
-  return !operator==(obj);
-}
-
-size_t LexerActionExecutor::generateHashCode() const {
-  size_t hash = MurmurHash::initialize();
-  for (const auto &lexerAction : _lexerActions) {
-    hash = MurmurHash::update(hash, lexerAction);
-  }
-  hash = MurmurHash::finish(hash, _lexerActions.size());
-
-  return hash;
+  return cachedHashCodeEqual(_hashCode.load(std::memory_order_relaxed), other._hashCode.load(std::memory_order_relaxed)) &&
+         _lexerActions.size() == other._lexerActions.size() &&
+         std::equal(_lexerActions.begin(), _lexerActions.end(), other._lexerActions.begin(), lexerActionEqual);
 }

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
@@ -17,14 +17,12 @@ namespace atn {
   /// <para>The executor tracks position information for position-dependent lexer actions
   /// efficiently, ensuring that actions appearing only at the end of the rule do
   /// not cause bloating of the <seealso cref="DFA"/> created for the lexer.</para>
-  class ANTLR4CPP_PUBLIC LexerActionExecutor : public std::enable_shared_from_this<LexerActionExecutor> {
+  class ANTLR4CPP_PUBLIC LexerActionExecutor final : public std::enable_shared_from_this<LexerActionExecutor> {
   public:
     /// <summary>
     /// Constructs an executor for a sequence of <seealso cref="LexerAction"/> actions. </summary>
     /// <param name="lexerActions"> The lexer actions to execute. </param>
-    explicit LexerActionExecutor(std::vector<Ref<LexerAction>> lexerActions);
-
-    virtual ~LexerActionExecutor() = default;
+    explicit LexerActionExecutor(std::vector<Ref<const LexerAction>> lexerActions);
 
     /// <summary>
     /// Creates a <seealso cref="LexerActionExecutor"/> which executes the actions for
@@ -40,8 +38,8 @@ namespace atn {
     /// </param>
     /// <returns> A <seealso cref="LexerActionExecutor"/> for executing the combine actions
     /// of {@code lexerActionExecutor} and {@code lexerAction}. </returns>
-    static Ref<LexerActionExecutor> append(Ref<LexerActionExecutor> const& lexerActionExecutor,
-                                           Ref<LexerAction> lexerAction);
+    static Ref<const LexerActionExecutor> append(const Ref<const LexerActionExecutor> &lexerActionExecutor,
+                                                 Ref<const LexerAction> lexerAction);
 
     /// <summary>
     /// Creates a <seealso cref="LexerActionExecutor"/> which encodes the current offset
@@ -71,12 +69,12 @@ namespace atn {
     /// </param>
     /// <returns> A <seealso cref="LexerActionExecutor"/> which stores input stream offsets
     /// for all position-dependent lexer actions. </returns>
-    virtual Ref<LexerActionExecutor> fixOffsetBeforeMatch(int offset);
+    Ref<const LexerActionExecutor> fixOffsetBeforeMatch(int offset) const;
 
     /// <summary>
     /// Gets the lexer actions to be executed by this executor. </summary>
     /// <returns> The lexer actions to be executed by this executor. </returns>
-    virtual const std::vector<Ref<LexerAction>>& getLexerActions() const;
+    const std::vector<Ref<const LexerAction>>& getLexerActions() const;
 
     /// <summary>
     /// Execute the actions encapsulated by this executor within the context of a
@@ -96,21 +94,35 @@ namespace atn {
     /// <param name="startIndex"> The token start index. This value may be passed to
     /// <seealso cref="IntStream#seek"/> to set the {@code input} position to the beginning
     /// of the token. </param>
-    virtual void execute(Lexer *lexer, CharStream *input, size_t startIndex);
+    void execute(Lexer *lexer, CharStream *input, size_t startIndex) const;
 
-    virtual size_t hashCode() const;
-    virtual bool operator==(const LexerActionExecutor &obj) const;
-    virtual bool operator!=(const LexerActionExecutor &obj) const;
+    size_t hashCode() const;
+
+    bool equals(const LexerActionExecutor &other) const;
 
   private:
-    const std::vector<Ref<LexerAction>> _lexerActions;
-
-    /// Caches the result of <seealso cref="#hashCode"/> since the hash code is an element
-    /// of the performance-critical <seealso cref="LexerATNConfig#hashCode"/> operation.
-    const size_t _hashCode;
-
-    size_t generateHashCode() const;
+    const std::vector<Ref<const LexerAction>> _lexerActions;
+    mutable std::atomic<size_t> _hashCode;
   };
 
-} // namespace atn
-} // namespace antlr4
+  inline bool operator==(const LexerActionExecutor &lhs, const LexerActionExecutor &rhs) {
+    return lhs.equals(rhs);
+  }
+
+  inline bool operator!=(const LexerActionExecutor &lhs, const LexerActionExecutor &rhs) {
+    return !operator==(lhs, rhs);
+  }
+
+}  // namespace atn
+}  // namespace antlr4
+
+namespace std {
+
+  template <>
+  struct hash<::antlr4::atn::LexerActionExecutor> {
+    size_t operator()(const ::antlr4::atn::LexerActionExecutor &lexerActionExecutor) const {
+      return lexerActionExecutor.hashCode();
+    }
+  };
+
+}  // namespace std

--- a/runtime/Cpp/runtime/src/atn/LexerActionType.h
+++ b/runtime/Cpp/runtime/src/atn/LexerActionType.h
@@ -20,7 +20,7 @@ namespace atn {
     /// <summary>
     /// The type of a <seealso cref="LexerChannelAction"/> action.
     /// </summary>
-    CHANNEL,
+    CHANNEL = 0,
     /// <summary>
     /// The type of a <seealso cref="LexerCustomAction"/> action.
     /// </summary>
@@ -49,6 +49,8 @@ namespace atn {
     /// The type of a <seealso cref="LexerTypeAction"/> action.
     /// </summary>
     TYPE,
+
+    INDEXED_CUSTOM,
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerChannelAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerChannelAction.cpp
@@ -5,47 +5,39 @@
 
 #include "misc/MurmurHash.h"
 #include "Lexer.h"
+#include "support/Casts.h"
 
 #include "atn/LexerChannelAction.h"
 
 using namespace antlr4::atn;
 using namespace antlr4::misc;
+using namespace antlrcpp;
 
-LexerChannelAction::LexerChannelAction(int channel) : LexerAction(LexerActionType::CHANNEL), _channel(channel) {
+LexerChannelAction::LexerChannelAction(int channel)
+    : LexerAction(LexerActionType::CHANNEL, false), _channel(channel) {}
+
+void LexerChannelAction::execute(Lexer *lexer) const {
+  lexer->setChannel(getChannel());
 }
 
-int LexerChannelAction::getChannel() const {
-  return _channel;
-}
-
-bool LexerChannelAction::isPositionDependent() const {
-  return false;
-}
-
-void LexerChannelAction::execute(Lexer *lexer) {
-  lexer->setChannel(_channel);
-}
-
-size_t LexerChannelAction::hashCode() const {
+size_t LexerChannelAction::hashCodeImpl() const {
   size_t hash = MurmurHash::initialize();
   hash = MurmurHash::update(hash, static_cast<size_t>(getActionType()));
-  hash = MurmurHash::update(hash, _channel);
+  hash = MurmurHash::update(hash, getChannel());
   return MurmurHash::finish(hash, 2);
 }
 
-bool LexerChannelAction::operator==(const LexerAction &obj) const {
-  if (&obj == this) {
+bool LexerChannelAction::equals(const LexerAction &other) const {
+  if (this == std::addressof(other)) {
     return true;
   }
-
-  const LexerChannelAction *action = dynamic_cast<const LexerChannelAction *>(&obj);
-  if (action == nullptr) {
+  if (getActionType() != other.getActionType()) {
     return false;
   }
-
-  return _channel == action->_channel;
+  const auto &lexerAction = downCast<const LexerChannelAction&>(other);
+  return getChannel() == lexerAction.getChannel();
 }
 
 std::string LexerChannelAction::toString() const {
-  return "channel(" + std::to_string(_channel) + ")";
+  return "channel(" + std::to_string(getChannel()) + ")";
 }

--- a/runtime/Cpp/runtime/src/atn/LexerChannelAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerChannelAction.h
@@ -35,12 +35,7 @@ namespace atn {
     /// Gets the channel to use for the <seealso cref="Token"/> created by the lexer.
     /// </summary>
     /// <returns> The channel to use for the <seealso cref="Token"/> created by the lexer. </returns>
-    int getChannel() const;
-
-    /// <summary>
-    /// {@inheritDoc} </summary>
-    /// <returns> This method returns {@code false}. </returns>
-    virtual bool isPositionDependent() const override;
+    int getChannel() const { return _channel; }
 
     /// <summary>
     /// {@inheritDoc}
@@ -48,11 +43,13 @@ namespace atn {
     /// <para>This action is implemented by calling <seealso cref="Lexer#setChannel"/> with the
     /// value provided by <seealso cref="#getChannel"/>.</para>
     /// </summary>
-    virtual void execute(Lexer *lexer) override;
+    void execute(Lexer *lexer) const override;
 
-    virtual size_t hashCode() const override;
-    virtual bool operator==(const LexerAction &obj) const override;
-    virtual std::string toString() const override;
+    bool equals(const LexerAction &other) const override;
+    std::string toString() const override;
+
+  protected:
+    size_t hashCodeImpl() const override;
 
   private:
     const int _channel;

--- a/runtime/Cpp/runtime/src/atn/LexerCustomAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerCustomAction.cpp
@@ -4,55 +4,42 @@
  */
 
 #include "misc/MurmurHash.h"
-#include "support/CPPUtils.h"
 #include "Lexer.h"
+#include "support/Casts.h"
 
 #include "atn/LexerCustomAction.h"
 
 using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
+using namespace antlrcpp;
 
-LexerCustomAction::LexerCustomAction(size_t ruleIndex, size_t actionIndex) : LexerAction(LexerActionType::CUSTOM), _ruleIndex(ruleIndex), _actionIndex(actionIndex) {
+LexerCustomAction::LexerCustomAction(size_t ruleIndex, size_t actionIndex)
+    : LexerAction(LexerActionType::CUSTOM, true), _ruleIndex(ruleIndex), _actionIndex(actionIndex) {}
+
+void LexerCustomAction::execute(Lexer *lexer) const {
+  lexer->action(nullptr, getRuleIndex(), getActionIndex());
 }
 
-size_t LexerCustomAction::getRuleIndex() const {
-  return _ruleIndex;
-}
-
-size_t LexerCustomAction::getActionIndex() const {
-  return _actionIndex;
-}
-
-bool LexerCustomAction::isPositionDependent() const {
-  return true;
-}
-
-void LexerCustomAction::execute(Lexer *lexer) {
-  lexer->action(nullptr, _ruleIndex, _actionIndex);
-}
-
-size_t LexerCustomAction::hashCode() const {
+size_t LexerCustomAction::hashCodeImpl() const {
   size_t hash = MurmurHash::initialize();
   hash = MurmurHash::update(hash, static_cast<size_t>(getActionType()));
-  hash = MurmurHash::update(hash, _ruleIndex);
-  hash = MurmurHash::update(hash, _actionIndex);
+  hash = MurmurHash::update(hash, getRuleIndex());
+  hash = MurmurHash::update(hash, getActionIndex());
   return MurmurHash::finish(hash, 3);
 }
 
-bool LexerCustomAction::operator == (const LexerAction &obj) const {
-  if (&obj == this) {
+bool LexerCustomAction::equals(const LexerAction &other) const {
+  if (this == std::addressof(other)) {
     return true;
   }
-
-  const LexerCustomAction *action = dynamic_cast<const LexerCustomAction *>(&obj);
-  if (action == nullptr) {
+  if (getActionType() != other.getActionType()) {
     return false;
   }
-
-  return _ruleIndex == action->_ruleIndex && _actionIndex == action->_actionIndex;
+  const auto &lexerAction = downCast<const LexerCustomAction&>(other);
+  return getRuleIndex() == lexerAction.getRuleIndex() && getActionIndex() == lexerAction.getActionIndex();
 }
 
 std::string LexerCustomAction::toString() const {
-  return antlrcpp::toString(this);
+  return "custom(" + std::to_string(getRuleIndex()) + ", " + std::to_string(getActionIndex()) + ")";
 }

--- a/runtime/Cpp/runtime/src/atn/LexerCustomAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerCustomAction.h
@@ -44,25 +44,13 @@ namespace atn {
     /// Gets the rule index to use for calls to <seealso cref="Recognizer#action"/>.
     /// </summary>
     /// <returns> The rule index for the custom action. </returns>
-    size_t getRuleIndex() const;
+    size_t getRuleIndex() const { return _ruleIndex; }
 
     /// <summary>
     /// Gets the action index to use for calls to <seealso cref="Recognizer#action"/>.
     /// </summary>
     /// <returns> The action index for the custom action. </returns>
-    size_t getActionIndex() const;
-
-    /// <summary>
-    /// Gets whether the lexer action is position-dependent. Position-dependent
-    /// actions may have different semantics depending on the <seealso cref="CharStream"/>
-    /// index at the time the action is executed.
-    ///
-    /// <para>Custom actions are position-dependent since they may represent a
-    /// user-defined embedded action which makes calls to methods like
-    /// <seealso cref="Lexer#getText"/>.</para>
-    /// </summary>
-    /// <returns> This method returns {@code true}. </returns>
-    virtual bool isPositionDependent() const override;
+    size_t getActionIndex() const { return _actionIndex; }
 
     /// <summary>
     /// {@inheritDoc}
@@ -70,11 +58,13 @@ namespace atn {
     /// <para>Custom actions are implemented by calling <seealso cref="Lexer#action"/> with the
     /// appropriate rule and action indexes.</para>
     /// </summary>
-    virtual void execute(Lexer *lexer) override;
+    void execute(Lexer *lexer) const override;
 
-    virtual size_t hashCode() const override;
-    virtual bool operator == (const LexerAction &obj) const override;
-    virtual std::string toString() const override;
+    bool equals(const LexerAction &other) const override;
+    std::string toString() const override;
+
+  protected:
+    size_t hashCodeImpl() const override;
 
   private:
     const size_t _ruleIndex;

--- a/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.cpp
@@ -6,54 +6,52 @@
 #include "misc/MurmurHash.h"
 #include "Lexer.h"
 #include "support/CPPUtils.h"
+#include "support/Casts.h"
 
 #include "atn/LexerIndexedCustomAction.h"
 
 using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
+using namespace antlrcpp;
 
-LexerIndexedCustomAction::LexerIndexedCustomAction(int offset, Ref<LexerAction> action)
-  : LexerAction(action->getActionType()), _offset(offset), _action(std::move(action)) {
+namespace {
+
+  bool cachedHashCodeEqual(size_t lhs, size_t rhs) {
+    return lhs == rhs || lhs == 0 || rhs == 0;
+  }
+
 }
 
-int LexerIndexedCustomAction::getOffset() const {
-  return _offset;
-}
+LexerIndexedCustomAction::LexerIndexedCustomAction(int offset, Ref<const LexerAction> action)
+    : LexerAction(LexerActionType::INDEXED_CUSTOM, true), _action(std::move(action)), _offset(offset) {}
 
-Ref<LexerAction> LexerIndexedCustomAction::getAction() const {
-  return _action;
-}
-
-bool LexerIndexedCustomAction::isPositionDependent() const {
-  return true;
-}
-
-void LexerIndexedCustomAction::execute(Lexer *lexer) {
+void LexerIndexedCustomAction::execute(Lexer *lexer) const {
   // assume the input stream position was properly set by the calling code
-  _action->execute(lexer);
+  getAction()->execute(lexer);
 }
 
-size_t LexerIndexedCustomAction::hashCode() const {
+size_t LexerIndexedCustomAction::hashCodeImpl() const {
   size_t hash = MurmurHash::initialize();
-  hash = MurmurHash::update(hash, _offset);
-  hash = MurmurHash::update(hash, _action);
-  return MurmurHash::finish(hash, 2);
+  hash = MurmurHash::update(hash, static_cast<size_t>(getActionType()));
+  hash = MurmurHash::update(hash, getOffset());
+  hash = MurmurHash::update(hash, getAction());
+  return MurmurHash::finish(hash, 3);
 }
 
-bool LexerIndexedCustomAction::operator==(const LexerAction &obj) const {
-  if (&obj == this) {
+bool LexerIndexedCustomAction::equals(const LexerAction &other) const {
+  if (this == std::addressof(other)) {
     return true;
   }
-
-  const LexerIndexedCustomAction *action = dynamic_cast<const LexerIndexedCustomAction *>(&obj);
-  if (action == nullptr) {
+  if (getActionType() != other.getActionType()) {
     return false;
   }
-
-  return _offset == action->_offset && *_action == *action->_action;
+  const auto &lexerAction = downCast<const LexerIndexedCustomAction&>(other);
+  return getOffset() == lexerAction.getOffset() &&
+         cachedHashCodeEqual(cachedHashCode(), lexerAction.cachedHashCode()) &&
+         *getAction() == *lexerAction.getAction();
 }
 
 std::string LexerIndexedCustomAction::toString() const {
-  return antlrcpp::toString(this);
+  return "indexedCustom(" + std::to_string(getOffset()) + ", " + getAction()->toString() + ")";
 }

--- a/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.h
@@ -26,6 +26,10 @@ namespace atn {
   /// </summary>
   class ANTLR4CPP_PUBLIC LexerIndexedCustomAction final : public LexerAction {
   public:
+    static bool is(const LexerAction &lexerAction) { return lexerAction.getActionType() == LexerActionType::INDEXED_CUSTOM; }
+
+    static bool is(const LexerAction *lexerAction) { return lexerAction != nullptr && is(*lexerAction); }
+
     /// <summary>
     /// Constructs a new indexed custom action by associating a character offset
     /// with a <seealso cref="LexerAction"/>.
@@ -38,7 +42,7 @@ namespace atn {
     /// executed. </param>
     /// <param name="action"> The lexer action to execute at a particular offset in the
     /// input <seealso cref="CharStream"/>. </param>
-    LexerIndexedCustomAction(int offset, Ref<LexerAction> action);
+    LexerIndexedCustomAction(int offset, Ref<const LexerAction> action);
 
     /// <summary>
     /// Gets the location in the input <seealso cref="CharStream"/> at which the lexer
@@ -47,27 +51,24 @@ namespace atn {
     /// </summary>
     /// <returns> The location in the input <seealso cref="CharStream"/> at which the lexer
     /// action should be executed. </returns>
-    int getOffset() const;
+    int getOffset() const { return _offset; }
 
     /// <summary>
     /// Gets the lexer action to execute.
     /// </summary>
     /// <returns> A <seealso cref="LexerAction"/> object which executes the lexer action. </returns>
-    Ref<LexerAction> getAction() const;
+    const Ref<const LexerAction>& getAction() const { return _action; }
 
-    /// <summary>
-    /// {@inheritDoc} </summary>
-    /// <returns> This method returns {@code true}. </returns>
-    virtual bool isPositionDependent() const override;
+    void execute(Lexer *lexer) const override;
+    bool equals(const LexerAction &other) const override;
+    std::string toString() const override;
 
-    virtual void execute(Lexer *lexer) override;
-    virtual size_t hashCode() const override;
-    virtual bool operator==(const LexerAction &obj) const override;
-    virtual std::string toString() const override;
+  protected:
+    size_t hashCodeImpl() const override;
 
   private:
+    const Ref<const LexerAction> _action;
     const int _offset;
-    const Ref<LexerAction> _action;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerModeAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerModeAction.cpp
@@ -5,48 +5,39 @@
 
 #include "misc/MurmurHash.h"
 #include "Lexer.h"
+#include "support/Casts.h"
 
 #include "atn/LexerModeAction.h"
 
 using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
+using namespace antlrcpp;
 
-LexerModeAction::LexerModeAction(int mode) : LexerAction(LexerActionType::MODE), _mode(mode) {
+LexerModeAction::LexerModeAction(int mode) : LexerAction(LexerActionType::MODE, false), _mode(mode) {}
+
+void LexerModeAction::execute(Lexer *lexer) const {
+  lexer->setMode(getMode());
 }
 
-int LexerModeAction::getMode() const {
-  return _mode;
-}
-
-bool LexerModeAction::isPositionDependent() const {
-  return false;
-}
-
-void LexerModeAction::execute(Lexer *lexer) {
-  lexer->setMode(_mode);
-}
-
-size_t LexerModeAction::hashCode() const {
+size_t LexerModeAction::hashCodeImpl() const {
   size_t hash = MurmurHash::initialize();
   hash = MurmurHash::update(hash, static_cast<size_t>(getActionType()));
-  hash = MurmurHash::update(hash, _mode);
+  hash = MurmurHash::update(hash, getMode());
   return MurmurHash::finish(hash, 2);
 }
 
-bool LexerModeAction::operator==(const LexerAction &obj) const {
-  if (&obj == this) {
+bool LexerModeAction::equals(const LexerAction &other) const {
+  if (this == std::addressof(other)) {
     return true;
   }
-
-  const LexerModeAction *action = dynamic_cast<const LexerModeAction *>(&obj);
-  if (action == nullptr) {
+  if (getActionType() != other.getActionType()) {
     return false;
   }
-
-  return _mode == action->_mode;
+  const auto &lexerAction = downCast<const LexerModeAction&>(other);
+  return getMode() == lexerAction.getMode();
 }
 
 std::string LexerModeAction::toString() const {
-  return "mode(" + std::to_string(_mode) + ")";
+  return "mode(" + std::to_string(getMode()) + ")";
 }

--- a/runtime/Cpp/runtime/src/atn/LexerModeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerModeAction.h
@@ -33,12 +33,7 @@ namespace atn {
     /// Get the lexer mode this action should transition the lexer to.
     /// </summary>
     /// <returns> The lexer mode for this {@code mode} command. </returns>
-    int getMode() const;
-
-    /// <summary>
-    /// {@inheritDoc} </summary>
-    /// <returns> This method returns {@code false}. </returns>
-    virtual bool isPositionDependent() const override;
+    int getMode() const { return _mode; }
 
     /// <summary>
     /// {@inheritDoc}
@@ -46,11 +41,13 @@ namespace atn {
     /// <para>This action is implemented by calling <seealso cref="Lexer#mode"/> with the
     /// value provided by <seealso cref="#getMode"/>.</para>
     /// </summary>
-    virtual void execute(Lexer *lexer) override;
+    void execute(Lexer *lexer) const override;
 
-    virtual size_t hashCode() const override;
-    virtual bool operator == (const LexerAction &obj) const override;
-    virtual std::string toString() const override;
+    bool equals(const LexerAction &obj) const override;
+    std::string toString() const override;
+
+  protected:
+    size_t hashCodeImpl() const override;
 
   private:
     const int _mode;

--- a/runtime/Cpp/runtime/src/atn/LexerMoreAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerMoreAction.cpp
@@ -12,27 +12,23 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
 
-const Ref<LexerMoreAction>& LexerMoreAction::getInstance() {
-  static Ref<LexerMoreAction> instance(new LexerMoreAction());
+const Ref<const LexerMoreAction>& LexerMoreAction::getInstance() {
+  static const Ref<const LexerMoreAction> instance(new LexerMoreAction());
   return instance;
 }
 
-bool LexerMoreAction::isPositionDependent() const {
-  return false;
-}
-
-void LexerMoreAction::execute(Lexer *lexer) {
+void LexerMoreAction::execute(Lexer *lexer) const {
   lexer->more();
 }
 
-size_t LexerMoreAction::hashCode() const {
+size_t LexerMoreAction::hashCodeImpl() const {
   size_t hash = MurmurHash::initialize();
   hash = MurmurHash::update(hash, static_cast<size_t>(getActionType()));
   return MurmurHash::finish(hash, 1);
 }
 
-bool LexerMoreAction::operator==(const LexerAction &obj) const {
-  return &obj == this;
+bool LexerMoreAction::equals(const LexerAction &other) const {
+  return this == std::addressof(other);
 }
 
 std::string LexerMoreAction::toString() const {

--- a/runtime/Cpp/runtime/src/atn/LexerMoreAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerMoreAction.h
@@ -29,27 +29,24 @@ namespace atn {
     /// <summary>
     /// Provides a singleton instance of this parameterless lexer action.
     /// </summary>
-    static const Ref<LexerMoreAction>& getInstance();
-
-    /// <summary>
-    /// {@inheritDoc} </summary>
-    /// <returns> This method returns {@code false}. </returns>
-    virtual bool isPositionDependent() const override;
+    static const Ref<const LexerMoreAction>& getInstance();
 
     /// <summary>
     /// {@inheritDoc}
     ///
     /// <para>This action is implemented by calling <seealso cref="Lexer#more"/>.</para>
     /// </summary>
-    virtual void execute(Lexer *lexer) override;
+    void execute(Lexer *lexer) const override;
 
-    virtual size_t hashCode() const override;
-    virtual bool operator==(const LexerAction &obj) const override;
-    virtual std::string toString() const override;
+    bool equals(const LexerAction &obj) const override;
+    std::string toString() const override;
+
+  protected:
+    size_t hashCodeImpl() const override;
 
   private:
     /// Constructs the singleton instance of the lexer {@code more} command.
-    LexerMoreAction() : LexerAction(LexerActionType::MORE) {}
+    LexerMoreAction() : LexerAction(LexerActionType::MORE, false) {}
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerPopModeAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerPopModeAction.cpp
@@ -12,27 +12,23 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
 
-const Ref<LexerPopModeAction>& LexerPopModeAction::getInstance() {
-  static Ref<LexerPopModeAction> instance(new LexerPopModeAction());
+const Ref<const LexerPopModeAction>& LexerPopModeAction::getInstance() {
+  static const Ref<const LexerPopModeAction> instance(new LexerPopModeAction());
   return instance;
 }
 
-bool LexerPopModeAction::isPositionDependent() const {
-  return false;
-}
-
-void LexerPopModeAction::execute(Lexer *lexer) {
+void LexerPopModeAction::execute(Lexer *lexer) const {
   lexer->popMode();
 }
 
-size_t LexerPopModeAction::hashCode() const {
+size_t LexerPopModeAction::hashCodeImpl() const {
   size_t hash = MurmurHash::initialize();
   hash = MurmurHash::update(hash, static_cast<size_t>(getActionType()));
   return MurmurHash::finish(hash, 1);
 }
 
-bool LexerPopModeAction::operator==(const LexerAction &obj) const {
-  return &obj == this;
+bool LexerPopModeAction::equals(const LexerAction &other) const {
+  return this == std::addressof(other);
 }
 
 std::string LexerPopModeAction::toString() const {

--- a/runtime/Cpp/runtime/src/atn/LexerPopModeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerPopModeAction.h
@@ -29,27 +29,24 @@ namespace atn {
     /// <summary>
     /// Provides a singleton instance of this parameterless lexer action.
     /// </summary>
-    static const Ref<LexerPopModeAction>& getInstance();
-
-    /// <summary>
-    /// {@inheritDoc} </summary>
-    /// <returns> This method returns {@code false}. </returns>
-    virtual bool isPositionDependent() const override;
+    static const Ref<const LexerPopModeAction>& getInstance();
 
     /// <summary>
     /// {@inheritDoc}
     ///
     /// <para>This action is implemented by calling <seealso cref="Lexer#popMode"/>.</para>
     /// </summary>
-    virtual void execute(Lexer *lexer) override;
+    void execute(Lexer *lexer) const override;
 
-    virtual size_t hashCode() const override;
-    virtual bool operator==(const LexerAction &obj) const override;
-    virtual std::string toString() const override;
+    bool equals(const LexerAction &other) const override;
+    std::string toString() const override;
+
+  protected:
+    size_t hashCodeImpl() const override;
 
   private:
     /// Constructs the singleton instance of the lexer {@code popMode} command.
-    LexerPopModeAction() : LexerAction(LexerActionType::POP_MODE) {}
+    LexerPopModeAction() : LexerAction(LexerActionType::POP_MODE, false) {}
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerPushModeAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerPushModeAction.cpp
@@ -5,48 +5,39 @@
 
 #include "misc/MurmurHash.h"
 #include "Lexer.h"
+#include "support/Casts.h"
 
 #include "atn/LexerPushModeAction.h"
 
 using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
+using namespace antlrcpp;
 
-LexerPushModeAction::LexerPushModeAction(int mode) : LexerAction(LexerActionType::PUSH_MODE), _mode(mode) {
+LexerPushModeAction::LexerPushModeAction(int mode) : LexerAction(LexerActionType::PUSH_MODE, false), _mode(mode) {}
+
+void LexerPushModeAction::execute(Lexer *lexer) const {
+  lexer->pushMode(getMode());
 }
 
-int LexerPushModeAction::getMode() const {
-  return _mode;
-}
-
-bool LexerPushModeAction::isPositionDependent() const {
-  return false;
-}
-
-void LexerPushModeAction::execute(Lexer *lexer) {
-  lexer->pushMode(_mode);
-}
-
-size_t LexerPushModeAction::hashCode() const {
+size_t LexerPushModeAction::hashCodeImpl() const {
   size_t hash = MurmurHash::initialize();
   hash = MurmurHash::update(hash, static_cast<size_t>(getActionType()));
-  hash = MurmurHash::update(hash, _mode);
+  hash = MurmurHash::update(hash, getMode());
   return MurmurHash::finish(hash, 2);
 }
 
-bool LexerPushModeAction::operator==(const LexerAction &obj) const {
-  if (&obj == this) {
+bool LexerPushModeAction::equals(const LexerAction &other) const {
+  if (this == std::addressof(other)) {
     return true;
   }
-
-  const LexerPushModeAction *action = dynamic_cast<const LexerPushModeAction *>(&obj);
-  if (action == nullptr) {
+  if (getActionType() != other.getActionType()) {
     return false;
   }
-
-  return _mode == action->_mode;
+  const auto &lexerAction = downCast<const LexerPushModeAction&>(other);
+  return getMode() == lexerAction.getMode();
 }
 
 std::string LexerPushModeAction::toString() const {
-  return "pushMode(" + std::to_string(_mode) + ")";
+  return "pushMode(" + std::to_string(getMode()) + ")";
 }

--- a/runtime/Cpp/runtime/src/atn/LexerPushModeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerPushModeAction.h
@@ -33,12 +33,7 @@ namespace atn {
     /// Get the lexer mode this action should transition the lexer to.
     /// </summary>
     /// <returns> The lexer mode for this {@code pushMode} command. </returns>
-    int getMode() const;
-
-    /// <summary>
-    /// {@inheritDoc} </summary>
-    /// <returns> This method returns {@code false}. </returns>
-    virtual bool isPositionDependent() const override;
+    int getMode() const { return _mode; }
 
     /// <summary>
     /// {@inheritDoc}
@@ -46,11 +41,13 @@ namespace atn {
     /// <para>This action is implemented by calling <seealso cref="Lexer#pushMode"/> with the
     /// value provided by <seealso cref="#getMode"/>.</para>
     /// </summary>
-    virtual void execute(Lexer *lexer) override;
+    void execute(Lexer *lexer) const override;
 
-    virtual size_t hashCode() const override;
-    virtual bool operator==(const LexerAction &obj) const override;
-    virtual std::string toString() const override;
+    bool equals(const LexerAction &obj) const override;
+    std::string toString() const override;
+
+  protected:
+    size_t hashCodeImpl() const override;
 
   private:
     const int _mode;

--- a/runtime/Cpp/runtime/src/atn/LexerSkipAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerSkipAction.cpp
@@ -12,27 +12,23 @@ using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
 
-const Ref<LexerSkipAction>& LexerSkipAction::getInstance() {
-  static Ref<LexerSkipAction> instance(new LexerSkipAction());
+const Ref<const LexerSkipAction>& LexerSkipAction::getInstance() {
+  static const Ref<const LexerSkipAction> instance(new LexerSkipAction());
   return instance;
 }
 
-bool LexerSkipAction::isPositionDependent() const {
-  return false;
-}
-
-void LexerSkipAction::execute(Lexer *lexer) {
+void LexerSkipAction::execute(Lexer *lexer) const {
   lexer->skip();
 }
 
-size_t LexerSkipAction::hashCode() const {
+size_t LexerSkipAction::hashCodeImpl() const {
   size_t hash = MurmurHash::initialize();
   hash = MurmurHash::update(hash, static_cast<size_t>(getActionType()));
   return MurmurHash::finish(hash, 1);
 }
 
-bool LexerSkipAction::operator == (const LexerAction &obj) const {
-  return &obj == this;
+bool LexerSkipAction::equals(const LexerAction &other) const {
+  return this == std::addressof(other);
 }
 
 std::string LexerSkipAction::toString() const {

--- a/runtime/Cpp/runtime/src/atn/LexerSkipAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerSkipAction.h
@@ -27,27 +27,24 @@ namespace atn {
     static bool is(const LexerAction *lexerAction) { return lexerAction != nullptr && is(*lexerAction); }
 
     /// Provides a singleton instance of this parameterless lexer action.
-    static const Ref<LexerSkipAction>& getInstance();
-
-    /// <summary>
-    /// {@inheritDoc} </summary>
-    /// <returns> This method returns {@code false}. </returns>
-    virtual bool isPositionDependent() const override;
+    static const Ref<const LexerSkipAction>& getInstance();
 
     /// <summary>
     /// {@inheritDoc}
     ///
     /// <para>This action is implemented by calling <seealso cref="Lexer#skip"/>.</para>
     /// </summary>
-    virtual void execute(Lexer *lexer) override;
+    void execute(Lexer *lexer) const override;
 
-    virtual size_t hashCode() const override;
-    virtual bool operator==(const LexerAction &obj) const override;
-    virtual std::string toString() const override;
+    bool equals(const LexerAction &obj) const override;
+    std::string toString() const override;
+
+  protected:
+    size_t hashCodeImpl() const override;
 
   private:
     /// Constructs the singleton instance of the lexer {@code skip} command.
-    LexerSkipAction() : LexerAction(LexerActionType::SKIP) {}
+    LexerSkipAction() : LexerAction(LexerActionType::SKIP, false) {}
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerTypeAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerTypeAction.cpp
@@ -5,48 +5,39 @@
 
 #include "misc/MurmurHash.h"
 #include "Lexer.h"
+#include "support/Casts.h"
 
 #include "atn/LexerTypeAction.h"
 
 using namespace antlr4;
 using namespace antlr4::atn;
 using namespace antlr4::misc;
+using namespace antlrcpp;
 
-LexerTypeAction::LexerTypeAction(int type) : LexerAction(LexerActionType::TYPE), _type(type) {
+LexerTypeAction::LexerTypeAction(int type) : LexerAction(LexerActionType::TYPE, false), _type(type) {}
+
+void LexerTypeAction::execute(Lexer *lexer) const {
+  lexer->setType(getType());
 }
 
-int LexerTypeAction::getType() const {
-  return _type;
-}
-
-bool LexerTypeAction::isPositionDependent() const {
-  return false;
-}
-
-void LexerTypeAction::execute(Lexer *lexer) {
-  lexer->setType(_type);
-}
-
-size_t LexerTypeAction::hashCode() const {
+size_t LexerTypeAction::hashCodeImpl() const {
   size_t hash = MurmurHash::initialize();
   hash = MurmurHash::update(hash, static_cast<size_t>(getActionType()));
-  hash = MurmurHash::update(hash, _type);
+  hash = MurmurHash::update(hash, getType());
   return MurmurHash::finish(hash, 2);
 }
 
-bool LexerTypeAction::operator==(const LexerAction &obj) const {
-  if (&obj == this) {
+bool LexerTypeAction::equals(const LexerAction &other) const {
+  if (this == std::addressof(other)) {
     return true;
   }
-
-  const LexerTypeAction *action = dynamic_cast<const LexerTypeAction *>(&obj);
-  if (action == nullptr) {
+  if (getActionType() != other.getActionType()) {
     return false;
   }
-
-  return _type == action->_type;
+  const auto &lexerAction = downCast<const LexerTypeAction&>(other);
+  return getType() == lexerAction.getType();
 }
 
 std::string LexerTypeAction::toString() const {
-  return "type(" + std::to_string(_type) + ")";
+  return "type(" + std::to_string(getType()) + ")";
 }

--- a/runtime/Cpp/runtime/src/atn/LexerTypeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerTypeAction.h
@@ -13,7 +13,7 @@ namespace atn {
 
   /// Implements the {@code type} lexer action by calling <seealso cref="Lexer#setType"/>
   /// with the assigned type.
-  class ANTLR4CPP_PUBLIC LexerTypeAction : public LexerAction {
+  class ANTLR4CPP_PUBLIC LexerTypeAction final : public LexerAction {
   public:
     static bool is(const LexerAction &lexerAction) { return lexerAction.getActionType() == LexerActionType::TYPE; }
 
@@ -27,12 +27,7 @@ namespace atn {
     /// <summary>
     /// Gets the type to assign to a token created by the lexer. </summary>
     /// <returns> The type to assign to a token created by the lexer. </returns>
-    virtual int getType() const;
-
-    /// <summary>
-    /// {@inheritDoc} </summary>
-    /// <returns> This method returns {@code false}. </returns>
-    virtual bool isPositionDependent() const override;
+    int getType() const { return _type; }
 
     /// <summary>
     /// {@inheritDoc}
@@ -40,11 +35,13 @@ namespace atn {
     /// <para>This action is implemented by calling <seealso cref="Lexer#setType"/> with the
     /// value provided by <seealso cref="#getType"/>.</para>
     /// </summary>
-    virtual void execute(Lexer *lexer) override;
+    void execute(Lexer *lexer) const override;
 
-    virtual size_t hashCode() const override;
-    virtual bool operator==(const LexerAction &obj) const override;
-    virtual std::string toString() const override;
+    bool equals(const LexerAction &obj) const override;
+    std::string toString() const override;
+
+  protected:
+    size_t hashCodeImpl() const override;
 
   private:
     const int _type;

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
@@ -651,8 +651,8 @@ namespace atn {
     virtual std::vector<Ref<const SemanticContext>> getPredsForAmbigAlts(const antlrcpp::BitSet &ambigAlts,
                                                                    ATNConfigSet *configs, size_t nalts);
 
-    virtual std::vector<dfa::DFAState::PredPrediction*> getPredicatePredictions(const antlrcpp::BitSet &ambigAlts,
-                                                                                std::vector<Ref<const SemanticContext>> const& altToPred);
+    std::vector<dfa::DFAState::PredPrediction> getPredicatePredictions(const antlrcpp::BitSet &ambigAlts,
+                                                                       const std::vector<Ref<const SemanticContext>> &altToPred);
 
     /**
      * This method is used to improve the localization of error messages by
@@ -724,8 +724,8 @@ namespace atn {
     ///  then we stop at the first predicate that evaluates to true. This
     ///  includes pairs with null predicates.
     /// </summary>
-    virtual antlrcpp::BitSet evalSemanticContext(std::vector<dfa::DFAState::PredPrediction*> predPredictions,
-                                                 ParserRuleContext *outerContext, bool complete);
+    antlrcpp::BitSet evalSemanticContext(const std::vector<dfa::DFAState::PredPrediction> &predPredictions,
+                                         ParserRuleContext *outerContext, bool complete);
 
     /**
      * Evaluate a semantic context within a specific parser context.

--- a/runtime/Cpp/runtime/src/dfa/DFA.h
+++ b/runtime/Cpp/runtime/src/dfa/DFA.h
@@ -11,13 +11,26 @@ namespace antlr4 {
 namespace dfa {
 
   class ANTLR4CPP_PUBLIC DFA final {
+  private:
+    struct DFAStateHasher final {
+      size_t operator()(const DFAState *dfaState) const {
+        return dfaState->hashCode();
+      }
+    };
+
+    struct DFAStateComparer final {
+      bool operator()(const DFAState *lhs, const DFAState *rhs) const {
+        return lhs == rhs || *lhs == *rhs;
+      }
+    };
+
   public:
     /// A set of all DFA states. Use a map so we can get old state back.
     /// Set only allows you to see if it's there.
 
     /// From which ATN state did we create this DFA?
     atn::DecisionState *atnStartState;
-    std::unordered_set<DFAState *, DFAState::Hasher, DFAState::Comparer> states; // States are owned by this class.
+    std::unordered_set<DFAState*, DFAStateHasher, DFAStateComparer> states; // States are owned by this class.
     DFAState *s0;
     size_t decision;
 

--- a/runtime/Cpp/runtime/src/dfa/DFASerializer.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFASerializer.cpp
@@ -48,7 +48,7 @@ std::string DFASerializer::getStateString(DFAState *s) const {
     if (!s->predicates.empty()) {
       std::string buf;
       for (size_t i = 0; i < s->predicates.size(); i++) {
-        buf.append(s->predicates[i]->toString());
+        buf.append(s->predicates[i].toString());
       }
       return baseStateStr + "=>" + buf;
     } else {

--- a/runtime/Cpp/runtime/src/support/Casts.h
+++ b/runtime/Cpp/runtime/src/support/Casts.h
@@ -6,28 +6,29 @@
 #pragma once
 
 #include <cassert>
+#include <memory>
 #include <type_traits>
 
 namespace antlrcpp {
 
-template <typename To, typename From>
-To downCast(From* from) {
-  static_assert(std::is_pointer<To>::value, "Target type not a pointer.");
-  static_assert((std::is_base_of<From, typename std::remove_pointer<To>::type>::value), "Target type not derived from source type.");
-#if !defined(__GNUC__) || defined(__GXX_RTTI)
-  assert(from == nullptr || dynamic_cast<To>(from) != nullptr);
-#endif
-  return static_cast<To>(from);
-}
+  template <typename To, typename From>
+  To downCast(From* from) {
+    static_assert(std::is_pointer_v<To>, "Target type not a pointer.");
+    static_assert(std::is_base_of_v<From, std::remove_pointer_t<To>>, "Target type not derived from source type.");
+  #if !defined(__GNUC__) || defined(__GXX_RTTI)
+    assert(from == nullptr || dynamic_cast<To>(from) != nullptr);
+  #endif
+    return static_cast<To>(from);
+  }
 
-template <typename To, typename From>
-To downCast(From& from) {
-  static_assert(std::is_lvalue_reference<To>::value, "Target type not a lvalue reference.");
-  static_assert((std::is_base_of<From, typename std::remove_reference<To>::type>::value), "Target type not derived from source type.");
-#if !defined(__GNUC__) || defined(__GXX_RTTI)
-  assert(dynamic_cast<typename std::add_pointer<typename std::remove_reference<To>::type>::type>(&from) != nullptr);
-#endif
-  return static_cast<To>(from);
-}
+  template <typename To, typename From>
+  To downCast(From& from) {
+    static_assert(std::is_lvalue_reference_v<To>, "Target type not a lvalue reference.");
+    static_assert(std::is_base_of_v<From, std::remove_reference_t<To>>, "Target type not derived from source type.");
+  #if !defined(__GNUC__) || defined(__GXX_RTTI)
+    assert(dynamic_cast<std::add_pointer_t<std::remove_reference_t<To>>>(std::addressof(from)) != nullptr);
+  #endif
+    return static_cast<To>(from);
+  }
 
 }


### PR DESCRIPTION
Cleanup `DFA`, `DFAState`, `LexerAction`, and `LexerActionExecutor`. Also makes `LexerAction` and `LexerActionExecutor` const correct. Lastly there are various performance improvements such as removing `dynamic_cast` usage.

This also fixes a flaw in my previous refactor related to `LexerIndexedCustomAction`. It is now equivalent to Java.