### PR TITLE
[Swift] reduce Optionals in APIs

### DIFF
--- a/runtime/Swift/Sources/Antlr4/BufferedTokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/BufferedTokenStream.swift
@@ -472,12 +472,8 @@ public class BufferedTokenStream: TokenStream {
     }
 
 
-    public func getText(_ start: Token?, _ stop: Token?) throws -> String {
-        if let start = start, let stop = stop {
-            return try getText(Interval.of(start.getTokenIndex(), stop.getTokenIndex()))
-        }
-
-        return ""
+    public func getText(_ start: Token, _ stop: Token) throws -> String {
+        return try getText(Interval.of(start.getTokenIndex(), stop.getTokenIndex()))
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/BufferedTokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/BufferedTokenStream.swift
@@ -372,7 +372,7 @@ public class BufferedTokenStream: TokenStream {
     /// the current token up until we see a token on DEFAULT_TOKEN_CHANNEL or
     /// EOF. If channel is -1, find any non default channel token.
     /// 
-    public func getHiddenTokensToRight(_ tokenIndex: Int, _ channel: Int = -1) throws -> [Token]? {
+    public func getHiddenTokensToRight(_ tokenIndex: Int, _ channel: Int = -1) throws -> [Token] {
         try lazyInit()
         guard tokens.indices.contains(tokenIndex) else {
             throw ANTLRError.indexOutOfBounds(msg: "\(tokenIndex) not in 0 ..< \(tokens.count)")
@@ -397,7 +397,7 @@ public class BufferedTokenStream: TokenStream {
     /// the current token up until we see a token on DEFAULT_TOKEN_CHANNEL.
     /// If channel is -1, find any non default channel token.
     /// 
-    public func getHiddenTokensToLeft(_ tokenIndex: Int, _ channel: Int = -1) throws -> [Token]? {
+    public func getHiddenTokensToLeft(_ tokenIndex: Int, _ channel: Int = -1) throws -> [Token] {
         try lazyInit()
         guard tokens.indices.contains(tokenIndex) else {
             throw ANTLRError.indexOutOfBounds(msg: "\(tokenIndex) not in 0 ..< \(tokens.count)")
@@ -405,12 +405,12 @@ public class BufferedTokenStream: TokenStream {
 
         if tokenIndex == 0 {
             // obviously no tokens can appear before the first token
-            return nil
+            return []
         }
 
         let prevOnChannel = try previousTokenOnChannel(tokenIndex - 1, Lexer.DEFAULT_TOKEN_CHANNEL)
         if prevOnChannel == tokenIndex - 1 {
-            return nil
+            return []
         }
         // if none onchannel to left, prevOnChannel=-1 then from=0
         let from = prevOnChannel + 1
@@ -418,7 +418,7 @@ public class BufferedTokenStream: TokenStream {
         return filterForChannel(from, to, channel)
     }
 
-    internal func filterForChannel(_ from: Int, _ to: Int, _ channel: Int) -> [Token]? {
+    internal func filterForChannel(_ from: Int, _ to: Int, _ channel: Int) -> [Token] {
         var hidden = [Token]()
         for t in tokens[from...to] {
             if channel == -1 {
@@ -430,9 +430,6 @@ public class BufferedTokenStream: TokenStream {
                     hidden.append(t)
                 }
             }
-        }
-        if hidden.isEmpty {
-            return nil
         }
         return hidden
     }

--- a/runtime/Swift/Sources/Antlr4/TokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/TokenStream.swift
@@ -135,3 +135,39 @@ public protocol TokenStream: IntStream {
     /// 
     func getText(_ start: Token, _ stop: Token) throws -> String
 }
+
+extension TokenStream {
+    /// 
+    /// Return the text of all tokens in this stream between `start` and
+    /// `stop` (inclusive).
+    /// 
+    /// If the specified `start` or `stop` token was not provided by
+    /// this stream, or if the `stop` occurred before the `start`
+    /// token, the behavior is unspecified.
+    /// 
+    /// For streams which ensure that the _org.antlr.v4.runtime.Token#getTokenIndex_ method is
+    /// accurate for all of its provided tokens, this method behaves like the
+    /// following code. Other streams may implement this method in other ways
+    /// provided the behavior is consistent with this at a high level.
+    /// 
+    /// 
+    /// TokenStream stream = ...;
+    /// String text = "";
+    /// for (int i = start.getTokenIndex(); i &lt;= stop.getTokenIndex(); i++) {
+    /// text += stream.get(i).getText();
+    /// }
+    /// 
+    /// 
+    /// - Parameter start: The first token in the interval to get text for.
+    /// - Parameter stop: The last token in the interval to get text for (inclusive).
+    /// - Throws: ANTLRError.unsupportedOperation if this stream does not support
+    /// this method for the specified tokens
+    /// - Returns: The text of all tokens lying between the specified `start`
+    /// and `stop` tokens.
+    /// 
+    /// 
+    func getText(_ start: Token?, _ stop: Token?) throws -> String {
+        guard let start = start, let stop = stop else { return "" }
+        return try getText(start, stop)
+    }
+}

--- a/runtime/Swift/Sources/Antlr4/TokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/TokenStream.swift
@@ -133,5 +133,5 @@ public protocol TokenStream: IntStream {
     /// and `stop` tokens.
     /// 
     /// 
-    func getText(_ start: Token?, _ stop: Token?) throws -> String
+    func getText(_ start: Token, _ stop: Token) throws -> String
 }

--- a/runtime/Swift/Sources/Antlr4/UnbufferedTokenStream.swift
+++ b/runtime/Swift/Sources/Antlr4/UnbufferedTokenStream.swift
@@ -116,8 +116,8 @@ public class UnbufferedTokenStream: TokenStream {
     }
 
 
-    public func getText(_ start: Token?, _ stop: Token?) throws -> String {
-        return try getText(Interval.of(start!.getTokenIndex(), stop!.getTokenIndex()))
+    public func getText(_ start: Token, _ stop: Token) throws -> String {
+        return try getText(Interval.of(start.getTokenIndex(), stop.getTokenIndex()))
     }
 
 

--- a/runtime/Swift/Sources/Antlr4/atn/ATN.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ATN.swift
@@ -20,12 +20,12 @@ public class ATN {
     /// 
     /// Maps from rule index to starting state number.
     /// 
-    public internal(set) final var ruleToStartState: [RuleStartState]!
+    public internal(set) final var ruleToStartState: [RuleStartState] = []
 
     /// 
     /// Maps from rule index to stop state number.
     /// 
-    public internal(set) final var ruleToStopState: [RuleStopState]!
+    public internal(set) final var ruleToStopState: [RuleStopState] = []
 
     /// 
     /// The type of the ATN.
@@ -43,13 +43,13 @@ public class ATN {
     /// type if the `ATNDeserializationOptions.generateRuleBypassTransitions`
     /// deserialization option was specified; otherwise, this is `null`.
     /// 
-    public internal(set) final var ruleToTokenType: [Int]!
+    public internal(set) final var ruleToTokenType: [Int] = []
 
     /// 
     /// For lexer ATNs, this is an array of _org.antlr.v4.runtime.atn.LexerAction_ objects which may
     /// be referenced by action transitions in the ATN.
     /// 
-    public internal(set) final var lexerActions: [LexerAction]!
+    public internal(set) final var lexerActions: [LexerAction] = []
 
     public internal(set) final var modeToStartState = [TokensStartState]()
 

--- a/runtime/Swift/Sources/Antlr4/atn/AtomTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/AtomTransition.swift
@@ -27,7 +27,7 @@ public final class AtomTransition: Transition, CustomStringConvertible {
     }
 
     override
-    public func labelIntervalSet() -> IntervalSet? {
+    public func labelIntervalSet() -> IntervalSet {
         return IntervalSet(label)
     }
 

--- a/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ParserATNSimulator.swift
@@ -571,7 +571,8 @@ open class ParserATNSimulator: ATNSimulator {
     /// 
    func computeTargetState(_ dfa: DFA, _ previousD: DFAState, _ t: Int) throws -> DFAState {
 
-        guard let reach = try computeReachSet(previousD.configs, t, false) else {
+        let reach = try computeReachSet(previousD.configs, t, false)
+        guard !reach.isEmpty() else {
             addDFAEdge(dfa, previousD, t, ATNSimulator.ERROR)
             return ATNSimulator.ERROR
         }
@@ -649,7 +650,8 @@ open class ParserATNSimulator: ATNSimulator {
         var predictedAlt = ATN.INVALID_ALT_NUMBER
         while true {
             // while more work
-            if let computeReach = try computeReachSet(previous, t, fullCtx) {
+            let computeReach = try computeReachSet(previous, t, fullCtx)
+            if !computeReach.isEmpty() {
                 reach = computeReach
             } else {
                 // if any configs in previous dipped into outer context, that
@@ -752,7 +754,7 @@ open class ParserATNSimulator: ATNSimulator {
     }
 
     func computeReachSet(_ closureConfigSet: ATNConfigSet, _ t: Int,
-                         _ fullCtx: Bool) throws -> ATNConfigSet? {
+                         _ fullCtx: Bool) throws -> ATNConfigSet {
 
         if debug {
             print("in computeReachSet, starting closure: \(closureConfigSet)")
@@ -775,7 +777,7 @@ open class ParserATNSimulator: ATNSimulator {
         /// ensure that the alternative matching the longest overall sequence is
         /// chosen when multiple such configurations can match the input.
         /// 
-        var skippedStopStates: [ATNConfig]? = nil
+        var skippedStopStates: [ATNConfig] = []
 
         // First figure out where we can reach on input t
         let configs = closureConfigSet.configs
@@ -787,10 +789,7 @@ open class ParserATNSimulator: ATNSimulator {
             if config.state is RuleStopState {
                 assert(config.context!.isEmpty(), "Expected: c.context.isEmpty()")
                 if fullCtx || t == BufferedTokenStream.EOF {
-                    if skippedStopStates == nil {
-                        skippedStopStates = [ATNConfig]()
-                    }
-                    skippedStopStates!.append(config)
+                    skippedStopStates.append(config)
                 }
 
                 continue
@@ -808,7 +807,7 @@ open class ParserATNSimulator: ATNSimulator {
 
         // Now figure out where the reach operation can take us...
 
-        var reach: ATNConfigSet? = nil
+        var prepReach: ATNConfigSet? = nil
 
         /// 
         /// This block optimizes the reach operation for intermediate sets which
@@ -820,18 +819,18 @@ open class ParserATNSimulator: ATNSimulator {
         /// condition is not true when one or more configurations have been
         /// withheld in skippedStopStates, or when the current symbol is EOF.
         /// 
-        if skippedStopStates == nil && t != CommonToken.EOF {
+        if skippedStopStates.isEmpty && t != CommonToken.EOF {
             if intermediate.size() == 1 {
                 // Don't pursue the closure if there is just one state.
                 // It can only have one alternative; just add to result
                 // Also don't pursue the closure if there is unique alternative
                 // among the configurations.
-                reach = intermediate
+                prepReach = intermediate
             } else {
                 if ParserATNSimulator.getUniqueAlt(intermediate) != ATN.INVALID_ALT_NUMBER {
                     // Also don't pursue the closure if there is unique alternative
                     // among the configurations.
-                    reach = intermediate
+                    prepReach = intermediate
                 }
             }
         }
@@ -840,12 +839,15 @@ open class ParserATNSimulator: ATNSimulator {
         /// If the reach set could not be trivially determined, perform a closure
         /// operation on the intermediate set to compute its initial value.
         /// 
-        if reach == nil {
+        var reach: ATNConfigSet
+        if let r = prepReach {
+            reach = r
+        } else {
             reach = ATNConfigSet(fullCtx)
             var closureBusy = Set<ATNConfig>()
             let treatEofAsEpsilon = (t == CommonToken.EOF)
             for config in intermediate.configs {
-                try closure(config, reach!, &closureBusy, false, fullCtx, treatEofAsEpsilon)
+                try closure(config, reach, &closureBusy, false, fullCtx, treatEofAsEpsilon)
             }
         }
 
@@ -868,11 +870,11 @@ open class ParserATNSimulator: ATNSimulator {
             /// already guaranteed to meet this condition whether or not it's
             /// required.
             /// 
-            reach = removeAllConfigsNotInRuleStopState(reach!, reach! === intermediate)
+            reach = removeAllConfigsNotInRuleStopState(reach, reach === intermediate)
         }
 
         /// 
-        /// If skippedStopStates is not null, then it contains at least one
+        /// If skippedStopStates is not empty, then it contains at least one
         /// configuration. For full-context reach operations, these
         /// configurations reached the end of the start rule, in which case we
         /// only add them back to reach if no configuration during the current
@@ -880,16 +882,9 @@ open class ParserATNSimulator: ATNSimulator {
         /// chooses an alternative matching the longest overall sequence when
         /// multiple alternatives are viable.
         /// 
-        if let reach = reach {
-            if let skippedStopStates = skippedStopStates, (!fullCtx || !PredictionMode.hasConfigInRuleStopState(reach)) {
-                assert(!skippedStopStates.isEmpty, "Expected: !skippedStopStates.isEmpty()")
-                for c in skippedStopStates {
-                    try! reach.add(c, &mergeCache)
-                }
-            }
-
-            if reach.isEmpty() {
-                return nil
+        if !skippedStopStates.isEmpty, (!fullCtx || !PredictionMode.hasConfigInRuleStopState(reach)) {
+            for c in skippedStopStates {
+                try! reach.add(c, &mergeCache)
             }
         }
         return reach

--- a/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
@@ -119,7 +119,7 @@ public class ProfilingATNSimulator: ParserATNSimulator {
     }
 
     override
-    internal func computeReachSet(_ closure: ATNConfigSet, _ t: Int, _ fullCtx: Bool) throws -> ATNConfigSet? {
+    internal func computeReachSet(_ closure: ATNConfigSet, _ t: Int, _ fullCtx: Bool) throws -> ATNConfigSet {
         if fullCtx {
             // this method is called after each time the input position advances
             // during full context prediction
@@ -129,8 +129,7 @@ public class ProfilingATNSimulator: ParserATNSimulator {
         let reachConfigs = try super.computeReachSet(closure, t, fullCtx)
         if fullCtx {
             decisions[currentDecision].LL_ATNTransitions += 1 // count computation even if error
-            if reachConfigs != nil {
-            } else {
+            if reachConfigs.isEmpty() {
                 // no reach on current lookahead symbol. ERROR.
                 // TODO: does not handle delayed errors per getSynValidOrSemInvalidAltThatFinishedDecisionEntryRule()
                 decisions[currentDecision].errors.append(
@@ -139,8 +138,7 @@ public class ProfilingATNSimulator: ParserATNSimulator {
             }
         } else {
             decisions[currentDecision].SLL_ATNTransitions += 1
-            if reachConfigs != nil {
-            } else {
+            if reachConfigs.isEmpty() {
                 // no reach on current lookahead symbol. ERROR.
                 decisions[currentDecision].errors.append(
                 ErrorInfo(currentDecision, closure, _input, _startIndex, _sllStopIndex, false)

--- a/runtime/Swift/Sources/Antlr4/atn/RangeTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/RangeTransition.swift
@@ -22,7 +22,7 @@ public final class RangeTransition: Transition, CustomStringConvertible {
     }
 
     override
-    public func labelIntervalSet() -> IntervalSet? {
+    public func labelIntervalSet() -> IntervalSet {
         return IntervalSet.of(from, to)
     }
 

--- a/runtime/Swift/Sources/Antlr4/atn/SetTransition.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/SetTransition.swift
@@ -26,7 +26,7 @@ public class SetTransition: Transition, CustomStringConvertible {
     }
 
     override
-    public func labelIntervalSet() -> IntervalSet? {
+    public func labelIntervalSet() -> IntervalSet {
         return set
     }
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -945,7 +945,7 @@ _prevctx = _localctx
 >>
 
 recRuleSetPrevCtx() ::= <<
-if _parseListeners != nil {
+if !_parseListeners.isEmpty {
    try triggerExitRuleEvent()
 }
 _prevctx = _localctx


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->
This PR modifies public API and has several questions:
should `ParserRuleContext.removeLastChild` require it be not empty?
I think the change to `Parser._parseListeners` requires changes to code templates, but I couldn't get them to apply in local testing.
