### PR TITLE
[Swift] An interval ought to be a value

### DIFF
--- a/runtime/Swift/Sources/Antlr4/misc/Interval.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/Interval.swift
@@ -9,22 +9,11 @@
 /// An immutable inclusive interval a..b
 /// 
 
-public class Interval: Hashable {
-    public static let INTERVAL_POOL_MAX_VALUE: Int = 1000
-
-    public static let INVALID: Interval = Interval(-1, -2)
-
-    //static var cache: Dictionary<Int, Interval> = Dictionary<Int, Interval>()
-    static var cache: Array<Interval?> = Array<Interval?>(repeating: nil, count: INTERVAL_POOL_MAX_VALUE + 1)
-    // new; Interval[INTERVAL_POOL_MAX_VALUE+1];
+public struct Interval: Hashable {
+   public static let INVALID: Interval = Interval(-1, -2)
 
     public var a: Int
     public var b: Int
-
-    public static var creates: Int = 0
-    public static var misses: Int = 0
-    public static var hits: Int = 0
-    public static var outOfRange: Int = 0
 
     public init(_ a: Int, _ b: Int) {
         self.a = a
@@ -39,15 +28,7 @@ public class Interval: Hashable {
     /// have a..a (set with 1 element).
     /// 
     public static func of(_ a: Int, _ b: Int) -> Interval {
-        // cache just a..a
-        if a != b || a < 0 || a > INTERVAL_POOL_MAX_VALUE {
-            return Interval(a, b)
-        }
-        if cache[a] == nil {
-            cache[a] = Interval(a, a)
-        }
-
-        return cache[a]!
+        return Interval(a, b)
     }
 
     /// 

--- a/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/IntervalSet.swift
@@ -657,7 +657,17 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
         if readonly {
             throw ANTLRError.illegalState(msg: "can't alter readonly IntervalSet")
         }
-        for interval in intervals {
+        var idx = intervals.startIndex
+        while idx < intervals.endIndex {
+            defer { intervals.formIndex(after: &idx) }
+            var interval: Interval {
+                get {
+                    return intervals[idx]
+                }
+                set {
+                    intervals[idx] = newValue
+                }
+            } 
             let a = interval.a
             let b = interval.b
             if el < a {
@@ -665,7 +675,7 @@ public class IntervalSet: IntSet, Hashable, CustomStringConvertible {
             }
             // if whole interval x..x, rm
             if el == a && el == b {
-                intervals.removeObject(interval)
+                intervals.remove(at: idx)
                 break
             }
             // if on left edge x..b, adjust left


### PR DESCRIPTION
Interval was a pointer to 2 Ints
it ought to be just 2 Ints, which is smaller and more semantically correct,
with no need for a cache.

However, this breaks AnyObject conformance and changes type metadata but people shouldn't be relying on those for an Interval.

<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->