### PR TITLE
Allow to switch off building C++ tests, needed if used as sub-project

### DIFF
--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -1,3 +1,5 @@
+option(ANTLR_BUILD_CPP_TESTS "Build C++ tests." ON)
+
 include_directories(
   ${PROJECT_SOURCE_DIR}/runtime/src
   ${PROJECT_SOURCE_DIR}/runtime/src/atn
@@ -35,35 +37,37 @@ add_custom_target(make_lib_output_dir ALL
 add_dependencies(antlr4_shared make_lib_output_dir)
 add_dependencies(antlr4_static make_lib_output_dir)
 
-include(FetchContent)
+if (ANTLR_BUILD_CPP_TESTS)
+  include(FetchContent)
 
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.zip
-)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.zip
+  )
 
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-FetchContent_MakeAvailable(googletest)
+  FetchContent_MakeAvailable(googletest)
 
-file(GLOB libantlrcpp_TESTS
-  "${PROJECT_SOURCE_DIR}/runtime/tests/*.cpp"
-)
+  file(GLOB libantlrcpp_TESTS
+    "${PROJECT_SOURCE_DIR}/runtime/tests/*.cpp"
+  )
 
-add_executable(
-  antlr4_tests
-  ${libantlrcpp_TESTS}
-)
+  add_executable(
+    antlr4_tests
+    ${libantlrcpp_TESTS}
+  )
 
-target_link_libraries(
-  antlr4_tests
-  antlr4_static
-  gtest_main
-)
+  target_link_libraries(
+    antlr4_tests
+    antlr4_static
+    gtest_main
+  )
 
-include(GoogleTest)
+  include(GoogleTest)
 
-gtest_discover_tests(antlr4_tests)
+  gtest_discover_tests(antlr4_tests)
+endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   target_link_libraries(antlr4_shared ${UUID_LIBRARIES})


### PR DESCRIPTION
The new option to cmake ANTLR_BUILD_CPP_TESTS is default
on (so the behavior is as before), but it provides a way to
switch off if not needed.

The C++ tests pull in an external dependency (googletests),
which might conflict if ANTLR is used as a subproject in
another cmake project.

Signed-off-by: Henner Zeller <h.zeller@acm.org>