### PR TITLE
[C++] Free ATNConfig lookup set in readonly ATNConfigSet

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.cpp
@@ -31,7 +31,7 @@ ATNConfigSet::ATNConfigSet(const ATNConfigSet &other)
 }
 
 ATNConfigSet::ATNConfigSet(bool fullCtx)
-    : fullCtx(fullCtx), _configLookup(std::unordered_set<ATNConfig*, ATNConfigHasher, ATNConfigComparer>().bucket_count(), ATNConfigHasher{this}, ATNConfigComparer{this}) {}
+    : fullCtx(fullCtx), _configLookup(0, ATNConfigHasher{this}, ATNConfigComparer{this}) {}
 
 bool ATNConfigSet::add(const Ref<ATNConfig> &config) {
   return add(config, nullptr);
@@ -190,7 +190,7 @@ bool ATNConfigSet::isReadonly() const {
 
 void ATNConfigSet::setReadonly(bool readonly) {
   _readonly = readonly;
-  _configLookup.clear();
+  LookupContainer(0, ATNConfigHasher{this}, ATNConfigComparer{this}).swap(_configLookup);
 }
 
 std::string ATNConfigSet::toString() const {

--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
@@ -130,9 +130,11 @@ namespace atn {
 
     virtual bool equals(const ATNConfig &lhs, const ATNConfig &rhs) const;
 
+    using LookupContainer = std::unordered_set<ATNConfig*, ATNConfigHasher, ATNConfigComparer>;
+
     /// All configs but hashed by (s, i, _, pi) not including context. Wiped out
     /// when we go readonly as this set becomes a DFA state.
-    std::unordered_set<ATNConfig*, ATNConfigHasher, ATNConfigComparer> _configLookup;
+    LookupContainer _configLookup;
   };
 
   inline bool operator==(const ATNConfigSet &lhs, const ATNConfigSet &rhs) { return lhs.equals(rhs); }


### PR DESCRIPTION
Currently the underlying storage lives on as only `clear` is used. To actually free the underlying storage we have to perform a swap. The original intent was to free the storage when the config becomes readonly as its going to live on for a long time in the DFA cache.