### PR TITLE
Fix build to set the release to Java 8

### DIFF
--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -105,15 +105,16 @@
 					</archive>
 				</configuration>
 			</plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<release>8</release>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
The 4.10.0 runtime of antlr correctly sets the `source` and `target` to 1.8, however, the compiler is still compiling against the Java 11 runtime classpath. This results in the runtime using a different method signature for `java.nio.CharBuffer.flip()`

This manifests as the following error when using antlr in a java8-based project: 

```
Caused by:
        java.lang.NoSuchMethodError: java.nio.CharBuffer.flip()Ljava/nio/CharBuffer;
```

This PR sets the release (used by the maven compiler plugin) to 8, thus forcing it to use the java 8 runtime when compiling.
