### PR TITLE
Update publishing instruction for Dart

### DIFF
--- a/doc/dart-target.md
+++ b/doc/dart-target.md
@@ -1,6 +1,6 @@
 # ANTLR4 Runtime for Dart
 
-From version 4.10 onwards antlr's dart generated code is null sound safety compatible and sets the minimum dart sdk version to 2.12.0.
+From version 4.9 onwards antlr's dart generated code is null sound safety compatible and sets the minimum dart sdk version to 2.12.0.
 
 ### First steps
 

--- a/doc/releasing-antlr.md
+++ b/doc/releasing-antlr.md
@@ -426,15 +426,13 @@ popd
 
 ### Dart
 
-*Looks like only [Lingyu.li](https://pub.dev/publishers/lingyu.li/packages) can install*
-
 Install Dart SDK from https://dart.dev/get-dart
 
 Push to pub.dev
 
 ```bash
 cd runtime/Dart
-pub publish
+dart pub publish
 ```
 
 It will warn that no change log found for the new version.


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

Dart `pub` tool got integrated in the `dart` CLI now. Updating the instruction.
