### PR TITLE
[C++] Remove reference to antlrcpp:s2ws

### DIFF
--- a/runtime/Cpp/runtime/src/ANTLRFileStream.cpp
+++ b/runtime/Cpp/runtime/src/ANTLRFileStream.cpp
@@ -13,11 +13,7 @@ void ANTLRFileStream::loadFromFile(const std::string &fileName) {
     return;
   }
 
-#ifdef _MSC_VER
-  std::ifstream stream(antlrcpp::s2ws(fileName), std::ios::binary);
-#else
   std::ifstream stream(fileName, std::ios::binary);
-#endif
 
   ANTLRInputStream::load(stream);
 }


### PR DESCRIPTION
Fix #3467 and #3651.