### PR TITLE
Restore support for py3.5 by removing f-string in setup.py

### DIFF
--- a/runtime/Python3/setup.py
+++ b/runtime/Python3/setup.py
@@ -15,5 +15,5 @@ setup(
     author='Eric Vergnaud, Terence Parr, Sam Harwell',
     author_email='eric.vergnaud@wanadoo.fr',
     entry_points={'console_scripts': ['pygrun=antlr4._pygrun:main']},
-    description=f'ANTLR {v} runtime for Python 3'
+    description='ANTLR %s runtime for Python 3' % v
 )


### PR DESCRIPTION
Python3 runtime's setup.py introduces the use of an f-string which needlessly breaks compatibility with Python3.5 (#3650)

Remove the use of an f-string to restore ability to use runtime in python3.5
