### PR TITLE
Modernize CMakeLists.txt and a few Windows specific fixes

### DIFF
--- a/runtime/Cpp/CMakeLists.txt
+++ b/runtime/Cpp/CMakeLists.txt
@@ -1,6 +1,14 @@
 # -*- mode:cmake -*-
-cmake_minimum_required (VERSION 3.14)
+cmake_minimum_required (VERSION 3.15)
 # 3.14 needed because of FetchContent
+# 3.15 needed to avid spew of warnings related to overriding cl command line flags
+
+cmake_policy(SET CMP0091 NEW) # Enable use of CMAKE_MSVC_RUNTIME_LIBRARY
+if(WITH_STATIC_CRT)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else()
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif(WITH_STATIC_CRT)
 
 enable_testing()
 

--- a/runtime/Cpp/CMakeSettings.json
+++ b/runtime/Cpp/CMakeSettings.json
@@ -6,13 +6,21 @@
             "generator": "Ninja",
             "configurationType": "Debug",
             "inheritEnvironments": [ "msvc_x86" ],
-            "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-            "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
             "cmakeCommandArgs": "",
             "variables": [
                 {
                     "name": "ANTLR4_INSTALL",
                     "value": "1"
+                },
+                {
+                    "name": "WITH_STATIC_CRT",
+                    "value": "OFF"
+                },
+                {
+                    "name": "WITH_DEMO",
+                    "value": "OFF"
                 }
             ],
             "buildCommandArgs": "-v",
@@ -23,13 +31,21 @@
             "generator": "Ninja",
             "configurationType": "RelWithDebInfo",
             "inheritEnvironments": [ "msvc_x86" ],
-            "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-            "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
             "cmakeCommandArgs": "",
             "variables": [
                 {
                     "name": "ANTLR4_INSTALL",
                     "value": "1"
+                },
+                {
+                    "name": "WITH_STATIC_CRT",
+                    "value": "OFF"
+                },
+                {
+                    "name": "WITH_DEMO",
+                    "value": "OFF"
                 }
             ],
             "buildCommandArgs": "-v",
@@ -40,13 +56,21 @@
             "generator": "Ninja",
             "configurationType": "Debug",
             "inheritEnvironments": [ "msvc_x64_x64" ],
-            "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-            "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
             "cmakeCommandArgs": "",
             "variables": [
                 {
                     "name": "ANTLR4_INSTALL",
                     "value": "1"
+                },
+                {
+                    "name": "WITH_STATIC_CRT",
+                    "value": "OFF"
+                },
+                {
+                    "name": "WITH_DEMO",
+                    "value": "OFF"
                 }
             ],
             "buildCommandArgs": "-v",
@@ -57,13 +81,21 @@
             "generator": "Ninja",
             "configurationType": "RelWithDebInfo",
             "inheritEnvironments": [ "msvc_x64_x64" ],
-            "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-            "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
             "cmakeCommandArgs": "",
             "variables": [
                 {
                     "name": "ANTLR4_INSTALL",
                     "value": "1"
+                },
+                {
+                    "name": "WITH_STATIC_CRT",
+                    "value": "OFF"
+                },
+                {
+                    "name": "WITH_DEMO",
+                    "value": "OFF"
                 }
             ],
             "buildCommandArgs": "-v",

--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -26,17 +26,6 @@ file(GLOB libantlrcpp_SRC
 add_library(antlr4_shared SHARED ${libantlrcpp_SRC})
 add_library(antlr4_static STATIC ${libantlrcpp_SRC})
 
-set(LIB_OUTPUT_DIR "${CMAKE_HOME_DIRECTORY}/dist") # put generated libraries here.
-message(STATUS "Output libraries to ${LIB_OUTPUT_DIR}")
-
-# make sure 'make' works fine even if ${LIB_OUTPUT_DIR} is deleted.
-add_custom_target(make_lib_output_dir ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_OUTPUT_DIR}
-    )
-
-add_dependencies(antlr4_shared make_lib_output_dir)
-add_dependencies(antlr4_static make_lib_output_dir)
-
 if (ANTLR_BUILD_CPP_TESTS)
   include(FetchContent)
 
@@ -45,7 +34,9 @@ if (ANTLR_BUILD_CPP_TESTS)
     URL https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.zip
   )
 
-  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  if(WITH_STATIC_CRT)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  endif()
 
   FetchContent_MakeAvailable(googletest)
 
@@ -92,47 +83,42 @@ endif()
 
 set(extra_share_compile_flags "")
 set(extra_static_compile_flags "")
-if(WIN32)
-  set(extra_share_compile_flags "-DANTLR4CPP_EXPORTS")
-  set(extra_static_compile_flags "-DANTLR4CPP_STATIC")
-endif(WIN32)
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  if(WITH_STATIC_CRT)
-    target_compile_options(antlr4_shared PRIVATE "/MT$<$<CONFIG:Debug>:d>")
-    target_compile_options(antlr4_static PRIVATE "/MT$<$<CONFIG:Debug>:d>")
-  else()
-    target_compile_options(antlr4_shared PRIVATE "/MD$<$<CONFIG:Debug>:d>")
-    target_compile_options(antlr4_static PRIVATE "/MD$<$<CONFIG:Debug>:d>")
-  endif()
-endif()
-
 set(static_lib_suffix "")
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   set(static_lib_suffix "-static")
-endif()
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  set(extra_share_compile_flags "-DANTLR4CPP_EXPORTS -MP /wd4251")
-  set(extra_static_compile_flags "-DANTLR4CPP_STATIC -MP")
+  target_compile_definitions(antlr4_shared PUBLIC ANTLR4CPP_EXPORTS)
+  target_compile_definitions(antlr4_static PUBLIC ANTLR4CPP_STATIC)
+  set(extra_share_compile_flags "-MP /wd4251")
+  set(extra_static_compile_flags "-MP")
 endif()
 
 set_target_properties(antlr4_shared
                       PROPERTIES VERSION   ${ANTLR_VERSION}
                                  SOVERSION ${ANTLR_VERSION}
                                  OUTPUT_NAME antlr4-runtime
-                                 LIBRARY_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
-                                 # TODO: test in windows. DLL is treated as runtime.
-                                 # see https://cmake.org/cmake/help/v3.0/prop_tgt/LIBRARY_OUTPUT_DIRECTORY.html
-                                 RUNTIME_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
-                                 ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
                                  COMPILE_FLAGS "${disabled_compile_warnings} ${extra_share_compile_flags}")
 
 set_target_properties(antlr4_static
                       PROPERTIES VERSION   ${ANTLR_VERSION}
                                  SOVERSION ${ANTLR_VERSION}
                                  OUTPUT_NAME "antlr4-runtime${static_lib_suffix}"
-                                 ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
+                                 COMPILE_PDB_NAME "antlr4-runtime${static_lib_suffix}"
                                  COMPILE_FLAGS "${disabled_compile_warnings} ${extra_static_compile_flags}")
+
+# Copy the generated binaries to dist folder (required by test suite)
+add_custom_command(
+  TARGET antlr4_shared
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_HOME_DIRECTORY}/dist
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:antlr4_shared> ${CMAKE_HOME_DIRECTORY}/dist
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_LINKER_FILE:antlr4_shared> ${CMAKE_HOME_DIRECTORY}/dist)
+
+add_custom_command(
+  TARGET antlr4_static
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_HOME_DIRECTORY}/dist
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:antlr4_static> ${CMAKE_HOME_DIRECTORY}/dist)
 
 install(TARGETS antlr4_shared
         EXPORT antlr4-targets

--- a/runtime/Cpp/runtime/src/misc/MurmurHash.cpp
+++ b/runtime/Cpp/runtime/src/misc/MurmurHash.cpp
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
@@ -63,23 +63,6 @@ size_t MurmurHash::update(size_t hash, size_t value) {
   return hash;
 }
 
-size_t MurmurHash::update(size_t hash, const void *data, size_t size) {
-  size_t value;
-  const uint8_t *bytes = static_cast<const uint8_t*>(data);
-  while (size >= sizeof(size_t)) {
-    std::memcpy(&value, bytes, sizeof(size_t));
-    hash = update(hash, value);
-    bytes += sizeof(size_t);
-    size -= sizeof(size_t);
-  }
-  if (size != 0) {
-    value = 0;
-    std::memcpy(&value, bytes, size);
-    hash = update(hash, value);
-  }
-  return hash;
-}
-
 size_t MurmurHash::finish(size_t hash, size_t entryCount) {
   hash ^= entryCount * 8;
   hash ^= hash >> 33;
@@ -118,3 +101,20 @@ size_t MurmurHash::finish(size_t hash, size_t entryCount) {
 #else
 #error "Expected sizeof(size_t) to be 4 or 8."
 #endif
+
+size_t MurmurHash::update(size_t hash, const void *data, size_t size) {
+  size_t value;
+  const uint8_t *bytes = static_cast<const uint8_t*>(data);
+  while (size >= sizeof(size_t)) {
+    std::memcpy(&value, bytes, sizeof(size_t));
+    hash = update(hash, value);
+    bytes += sizeof(size_t);
+    size -= sizeof(size_t);
+  }
+  if (size != 0) {
+    value = 0;
+    std::memcpy(&value, bytes, size);
+    hash = update(hash, value);
+  }
+  return hash;
+}


### PR DESCRIPTION
Modernize CMakeLists.txt and a few Windows specific fixes

* Upgraded to minimum version 3.15 (was 3.14)
* Use CMAKE_MSVC_RUNTIME_LIBRARY to configure CRT
* Use target_compile_definitions to configure definitions so they can selectively be propagated upward (ANTLR4CPP_EXPORTS & ANTLR4CPP_STATIC needed to be propagated upwards)
* Handle CRT requirement for test correctly (gtest configuration should depend on WITH_STATIC_CRT)
* Don't change the default CMake output directory. With multiple configurations CMake doesn't trigger a build when the configuration is switched resulting in link errors (debug linking against release or vice-versa).
* Rename the static pdb file the same as the library (this was a conflict with both static and shared attempting to write to the same pdb file)
* Fixed x86 targets (definition of MurmurHash::update was missing)
* Updated CMakeSettings.json to build within project directory hierarchy rather than in user profile directory (the latter used to be VS default)

Signed-off-by: HS <hs@apotell.com>
