### PR TITLE
Export version information to support compatibility checks

### DIFF
--- a/runtime/Go/antlr/recognizer.go
+++ b/runtime/Go/antlr/recognizer.go
@@ -11,6 +11,10 @@ import (
 	"strconv"
 )
 
+const (
+	runtimeVersion = "4.10"
+)
+
 type Recognizer interface {
 	GetLiteralNames() []string
 	GetSymbolicNames() []string
@@ -48,11 +52,15 @@ func NewBaseRecognizer() *BaseRecognizer {
 var tokenTypeMapCache = make(map[string]int)
 var ruleIndexMapCache = make(map[string]int)
 
-func (b *BaseRecognizer) checkVersion(toolVersion string) {
-	runtimeVersion := "4.10"
+func (b *BaseRecognizer) CheckVersion(toolVersion string) error {
 	if runtimeVersion != toolVersion {
-		fmt.Println("ANTLR runtime and generated code versions disagree: " + runtimeVersion + "!=" + toolVersion)
+		return fmt.Errorf("ANTLR runtime and generated code versions disagree: %s != %s", runtimeVersion, toolVersion)
 	}
+	return nil
+}
+
+func (b *BaseRecognizer) GetVersion() string {
+	return runtimeVersion
 }
 
 func (b *BaseRecognizer) Action(context RuleContext, ruleIndex, actionIndex int) {

--- a/tool/src/org/antlr/v4/Tool.java
+++ b/tool/src/org/antlr/v4/Tool.java
@@ -133,6 +133,7 @@ public class Tool {
 		new Option("force_atn",                   "-Xforce-atn", "use the ATN simulator for all predictions"),
 		new Option("log",                         "-Xlog", "dump lots of logging info to antlr-timestamp.log"),
 	    new Option("exact_output_dir",            "-Xexact-output-dir", "all output goes into -o dir regardless of paths/package"),
+	    new Option("",                            "-version", "view the ANTLR Parser Generator version")
 	};
 
 	// helper vars for option management
@@ -201,6 +202,10 @@ public class Tool {
 		while ( args!=null && i<args.length ) {
 			String arg = args[i];
 			i++;
+			if ( arg.equals("-version") ) {
+				info(VERSION);
+				continue;
+			}
 			if ( arg.startsWith("-D") ) { // -Dlanguage=Java syntax
 				handleOptionSetArg(arg);
 				continue;
@@ -913,7 +918,7 @@ public class Tool {
 	}
 
 	public void help() {
-		info("ANTLR Parser Generator  Version " + Tool.VERSION);
+		this.version()
 		for (Option o : optionDefs) {
 			String name = o.name + (o.argType!=OptionArgType.NONE? " ___" : "");
 			String s = String.format(" %-19s %s", name, o.description);


### PR DESCRIPTION
Export version information to support compatibility checks between the Java tool and Go runtime.

- Create a `-version` command to expose the version of the Java Parser Generator;
- Encapsulate the Go runtime version in a constant, accessible via getter;
- Export the existing Go method `checkVersions()` to facilitate version checking; and
- Edit CheckVersions to more closely match idiomatic Go code. This includes returning an error type.

Signed-off-by: Lorenzo Bisceglia <lorenzo.bisceglia9@gmail.com>

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
