### PR TITLE
Preven bndtools from erroneously adding "org.antlr.v4.gui" to the Import-Package header

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/misc/TestRig.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/TestRig.java
@@ -16,9 +16,14 @@ import java.lang.reflect.Method;
  */
 @Deprecated
 public class TestRig {
+	/*
+	 * Ofuscate the TestRig class name a bit as bndtools (via maven-bundle-plugin) is too smart for its
+	 * own good and erroneously adds it to the Import-Package header when packaging
+	 */
+	static final String TESTRIG = new StringBuilder("org.antlr.v4.gui.TestRig").toString();
 	public static void main(String[] args) {
 		try {
-			Class<?> testRigClass = Class.forName("org.antlr.v4.gui.TestRig");
+			Class<?> testRigClass = Class.forName(TESTRIG);
 			System.err.println("Warning: TestRig moved to org.antlr.v4.gui.TestRig; calling automatically");
 			try {
 				Method mainMethod = testRigClass.getMethod("main", String[].class);


### PR DESCRIPTION
Since a recent update of the version of maven-bundle-plugin used when building the java runtime, the resulting jar file fails to load in OSGI servers due to an unsatisfied package dependency:
`Unable to resolve org.antlr.antlr4-runtime/4.10.1: missing requirement [org.antlr.antlr4-runtime/4.10.1] osgi.wiring.package; filter:="(osgi.wiring.package=org.antlr.v4.gui)"`

The cause of this is an erroneous reference to `org.antlr.v4.gui` in the Import-Package header in MANIFEST.MF.

It appears that newer versions of bndtools are a little to good at discovering class usage, and are detecting the static string reference in the `Class.forName("org.antlr.v4.gui.TestRig")` call in TestRig.java.

This commit obscures the class name a bit to prevent bndtools from finding it at compile-time.

