### PR TITLE
Fix OSGi imports

### DIFF
--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -85,6 +85,7 @@
 							<instructions>
 								<Automatic-Module-Name>org.antlr.antlr4.runtime</Automatic-Module-Name>
 								<Bundle-SymbolicName>org.antlr.antlr4-runtime</Bundle-SymbolicName>
+								<Import-Package>org.antlr.v4.gui;resolution:=optional, *</Import-Package>
 							</instructions>
 						</configuration>
 						<goals>


### PR DESCRIPTION
org.antlr.v4.gui is only used for backwards compatibility, but the
manifest generated by upgraded maven-bundle-plugin generates an
Import-Package requirement. This breaks the ability to load
antlr4-runtime in an OSGi enviroment, when nothing provides
org.antlr.v4.gui.

Fix this by specifying resultion as optional.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>