### PR TITLE
Fix Docker README for arm OS user

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,7 @@ You can build docker image from source code locally.
 
     git clone https://github.com/antlr/antlr4.git
     cd antlr4/docker
-    docker build -t antlr/antlr4 .    
+    docker build -t antlr/antlr4 --platfort linux/amd64　.    
 
 
 ## Run


### PR DESCRIPTION
Fixes: #3688

The jdk image used in the Dockerfile does not support arm, so it may be necessary to specify the platform.
https://hub.docker.com/r/adoptopenjdk/openjdk11/tags

It would be better to fix the README.