### PR TITLE
Improve ExternalProject cmake file

### DIFF
--- a/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
+++ b/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)
 
 if(POLICY CMP0114)
-	cmake_policy(SET CMP0114 NEW)
+    cmake_policy(SET CMP0114 NEW)
 endif()
 
 include(ExternalProject)
@@ -14,6 +14,10 @@ if(NOT DEFINED ANTLR4_TAG)
   # Set to commit hash to keep the build stable and does not need to rebuild after 'clean'
   set(ANTLR4_TAG master)
 endif()
+
+# Ensure that the include dir already exists at configure time (to avoid cmake erroring
+# on non-existent include dirs)
+file(MAKE_DIRECTORY "${ANTLR4_INCLUDE_DIRS}")
 
 if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
   set(ANTLR4_OUTPUT_DIR ${ANTLR4_ROOT}/runtime/Cpp/dist/$(Configuration))
@@ -139,6 +143,10 @@ add_library(antlr4_static STATIC IMPORTED)
 add_dependencies(antlr4_static antlr4_runtime-build_static)
 set_target_properties(antlr4_static PROPERTIES
                       IMPORTED_LOCATION ${ANTLR4_STATIC_LIBRARIES})
+target_include_directories(antlr4_static
+    INTERFACE
+        ${ANTLR4_INCLUDE_DIRS}
+)
 
 ExternalProject_Add_Step(
     antlr4_runtime
@@ -156,6 +164,11 @@ add_library(antlr4_shared SHARED IMPORTED)
 add_dependencies(antlr4_shared antlr4_runtime-build_shared)
 set_target_properties(antlr4_shared PROPERTIES
                       IMPORTED_LOCATION ${ANTLR4_RUNTIME_LIBRARIES})
+target_include_directories(antlr4_shared
+    INTERFACE
+        ${ANTLR4_INCLUDE_DIRS}
+)
+
 if(ANTLR4_SHARED_LIBRARIES)
   set_target_properties(antlr4_shared PROPERTIES
                         IMPORTED_IMPLIB ${ANTLR4_SHARED_LIBRARIES})

--- a/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
+++ b/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.7)
 
+if(POLICY CMP0114)
+	cmake_policy(SET CMP0114 NEW)
+endif()
+
 include(ExternalProject)
 
 set(ANTLR4_ROOT ${CMAKE_CURRENT_BINARY_DIR}/antlr4_runtime/src/antlr4_runtime)


### PR DESCRIPTION
Two small improvements to the CMake file used to setup the cpp runtime
as an externa project in cmake.

The first commit just silences a warning in newer cmake versions, whereas the latter
ensures that a user does not have to take care of setting up the correct include directories
themselves. Linking to either `antl4_static`  or `antlr4_shared` will now automatically
populate the include directories of the target these are linked to.