### PR TITLE
Constant folding for Python and other runtimes

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/CustomDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/CustomDescriptors.java
@@ -26,6 +26,10 @@ public class CustomDescriptors {
 						getLargeLexerDescriptor(),
 						getAtnStatesSizeMoreThan65535Descriptor()
 				});
+		descriptors.put("ParserExec",
+				new RuntimeTestDescriptor[] {
+						getMultiTokenAlternativeDescriptor()
+				});
 	}
 
 	private static RuntimeTestDescriptor getLineSeparatorLfDescriptor() {
@@ -145,5 +149,44 @@ public class CustomDescriptors {
 				grammar.toString(),
 				null, false, false,
 				new String[] {"CSharp", "Python2", "Python3", "Go", "PHP", "Swift", "JavaScript", "Dart"}, uri);
+	}
+
+	private static RuntimeTestDescriptor getMultiTokenAlternativeDescriptor() {
+		final int tokensCount = 64;
+
+		StringBuilder rule = new StringBuilder("t: ");
+		StringBuilder tokens = new StringBuilder();
+		StringBuilder input = new StringBuilder();
+		StringBuilder output = new StringBuilder();
+		for (int i = 0; i < tokensCount; i++) {
+			String currentToken = "T" + i;
+			rule.append(currentToken);
+			if (i < tokensCount - 1) {
+				rule.append(" | ");
+			} else {
+				rule.append(";");
+			}
+			tokens.append(currentToken).append(": '").append(currentToken).append("';\n");
+			input.append(currentToken).append(" ");
+			output.append(currentToken);
+		}
+
+		String grammar = "grammar P;\n" +
+				"r: t+ EOF {<writeln(\"$text\")>};\n" +
+				rule + "\n" +
+				tokens + "\n" +
+				"WS: [ ]+ -> skip;";
+
+		return new RuntimeTestDescriptor(
+				GrammarType.Parser,
+				"MultiTokenAlternative",
+				"https://github.com/antlr/antlr4/issues/3698",
+				input.toString(),
+				output + "\n",
+				"",
+				"r",
+				"P",
+				grammar,
+				null, false, false, null, uri);
 	}
 }

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/CustomDescriptors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/CustomDescriptors.java
@@ -154,10 +154,11 @@ public class CustomDescriptors {
 	private static RuntimeTestDescriptor getMultiTokenAlternativeDescriptor() {
 		final int tokensCount = 64;
 
-		StringBuilder rule = new StringBuilder("t: ");
+		StringBuilder rule = new StringBuilder("r1: ");
 		StringBuilder tokens = new StringBuilder();
 		StringBuilder input = new StringBuilder();
 		StringBuilder output = new StringBuilder();
+
 		for (int i = 0; i < tokensCount; i++) {
 			String currentToken = "T" + i;
 			rule.append(currentToken);
@@ -170,9 +171,13 @@ public class CustomDescriptors {
 			input.append(currentToken).append(" ");
 			output.append(currentToken);
 		}
+		String currentToken = "T" + tokensCount;
+		tokens.append(currentToken).append(": '").append(currentToken).append("';\n");
+		input.append(currentToken).append(" ");
+		output.append(currentToken);
 
 		String grammar = "grammar P;\n" +
-				"r: t+ EOF {<writeln(\"$text\")>};\n" +
+				"r: (r1 | T" + tokensCount + ")+ EOF {<writeln(\"$text\")>};\n" +
 				rule + "\n" +
 				tokens + "\n" +
 				"WS: [ ]+ -> skip;";
@@ -180,7 +185,7 @@ public class CustomDescriptors {
 		return new RuntimeTestDescriptor(
 				GrammarType.Parser,
 				"MultiTokenAlternative",
-				"https://github.com/antlr/antlr4/issues/3698",
+				"https://github.com/antlr/antlr4/issues/3698, https://github.com/antlr/antlr4/issues/3703",
 				input.toString(),
 				output + "\n",
 				"",

--- a/runtime/Swift/Sources/Antlr4/misc/Utils.swift
+++ b/runtime/Swift/Sources/Antlr4/misc/Utils.swift
@@ -2,7 +2,7 @@
 /// Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
 /// Use of this file is governed by the BSD 3-clause license that
 /// can be found in the LICENSE.txt file in the project root.
-/// 
+///
 
 
 import Foundation
@@ -38,25 +38,5 @@ public class Utils {
             m[v] = index
         }
         return m
-    }
-
-    public static func bitLeftShift(_ n: Int) -> Int64 {
-       return (Int64(1) &<< n)
-    }
-
-
-    public static func testBitLeftShiftArray(_ nArray: [Int],_ bitsShift: Int) -> Bool {
-        let test: Bool = (((nArray[0] - bitsShift) & ~0x3f) == 0)
-
-        var temp: Int64 =  Int64(nArray[0] - bitsShift)
-        temp = (temp < 0) ? (64 + (temp % 64 )) : (temp % 64)
-        let test1: Int64 = (Int64(1) << temp)
-
-        var test2: Int64 = Utils.bitLeftShift(nArray[1] - bitsShift)
-
-        for i in 1 ..< nArray.count {
-            test2 = test2 |  Utils.bitLeftShift(nArray[i] - bitsShift)
-        }
-        return test && (( test1 & test2 ) != 0)
     }
 }

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -557,7 +557,7 @@ ErrorHandler.Sync(this);
 <if(choice.label)><labelref(choice.label)> = TokenStream.LT(1);<endif>
 <preamble; separator="\n">
 switch (TokenStream.LA(1)) {
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
 	<alt>
 	break;}; separator="\n">
 default:
@@ -569,7 +569,7 @@ LL1OptionalBlock(choice, alts, error) ::= <<
 State = <choice.stateNumber>;
 ErrorHandler.Sync(this);
 switch (TokenStream.LA(1)) {
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
 	<alt>
 	break;}; separator="\n">
 default:
@@ -676,7 +676,7 @@ Sync(s) ::= "Sync(<s.expecting.name>);"
 ThrowNoViableAlt(t) ::= "throw new NoViableAltException(this);"
 
 TestSetInline(s) ::= <<
-<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
+<s.bitsets:{bits | <if(rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
 >>
 
 // Java language spec 15.19 - shift operators mask operands rather than overflow to 0... need range test
@@ -684,7 +684,7 @@ testShiftInRange(shiftAmount) ::= <<
 ((<shiftAmount>) & ~0x3f) == 0
 >>
 
-// produces smaller bytecode only when bits.ttypes contains more than two items
+// produces smaller bytecode only when bits.tokens contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
 <testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1L \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>L) != 0
 %>
@@ -698,13 +698,12 @@ offsetShift(shiftAmount, offset) ::= <%
 <if(!isZero.(offset))>(<shiftAmount> - <offset>)<else><shiftAmount><endif>
 %>
 
-// produces more efficient bytecode when bits.ttypes contains at most two items
 bitsetInlineComparison(s, bits) ::= <%
-<bits.ttypes:{ttype | <s.varName>==<tokenType.(ttype)>}; separator=" || ">
+<bits.tokens:{t | <s.varName>==<tokenType.(t.name)>}; separator=" || ">
 %>
 
-cases(ttypes) ::= <<
-<ttypes:{t | case <tokenType.(t)>:}; separator="\n">
+cases(tokens) ::= <<
+<tokens:{t | case <tokenType.(t.name)>:}; separator="\n">
 >>
 
 InvokeRule(r, argExprsChunks) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -686,7 +686,7 @@ testShiftInRange(shiftAmount) ::= <<
 
 // produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
-(<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1L \<\< <offsetShift(s.varName, bits.shift)>) & (<bits.ttypes:{ttype | (1L \<\< <offsetShift(tokenType.(ttype), bits.shift)>)}; separator=" | ">)) != 0)
+<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1L \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>L) != 0
 %>
 
 isZero ::= [

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -803,8 +803,8 @@ testShiftInRange(shiftAmount) ::= <<
 
 // produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <<
-(<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> &&
-  ((1ULL \<\< <offsetShift(s.varName, bits.shift)>) & (<bits.ttypes: {ttype | (1ULL \<\< <offsetShift(ttype, bits.shift, true)>)}; separator = "\n  | ">)) != 0)
+<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> &&
+  ((1ULL \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>) != 0
 >>
 
 isZero ::= [

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -652,7 +652,7 @@ _errHandler->sync(this);
 <! TODO: untested !><if (choice.label)>LL1AltBlock(choice, preamble, alts, error) <labelref(choice.label)> = _input->LT(1);<endif>
 <preamble; separator="\n">
 switch (_input->LA(1)) {
-  <choice.altLook, alts: {look, alt | <cases(ttypes = look)> {
+  <choice.altLook, alts: {look, alt | <cases(tokens = look)> {
   <alt>
   break;
 \}
@@ -667,7 +667,7 @@ LL1OptionalBlock(choice, alts, error) ::= <<
 setState(<choice.stateNumber>);
 _errHandler->sync(this);
 switch (_input->LA(1)) {
-  <choice.altLook, alts: {look, alt | <cases(ttypes = look)> {
+  <choice.altLook, alts: {look, alt | <cases(tokens = look)> {
   <alt>
   break;
 \}
@@ -793,7 +793,7 @@ ThrowNoViableAlt(t) ::= "throw NoViableAltException(this);"
 
 TestSetInlineHeader(s) ::= "<! Required but unused. !>"
 TestSetInline(s) ::= <<
-<s.bitsets: {bits | <if (rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
+<s.bitsets: {bits | <if (rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
 >>
 
 // Java language spec 15.19 - shift operators mask operands rather than overflow to 0... need range test
@@ -801,7 +801,6 @@ testShiftInRange(shiftAmount) ::= <<
 ((<shiftAmount> & ~ 0x3fULL) == 0)
 >>
 
-// produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <<
 <testShiftInRange({<offsetShift(s.varName, bits.shift)>})> &&
   ((1ULL \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>) != 0
@@ -816,13 +815,12 @@ offsetShift(shiftAmount, offset, prefix = false) ::= <%
 <if (!isZero.(offset))>(<if (prefix)><parser.name>::<endif><shiftAmount> - <offset>)<else><if (prefix)><parser.name>::<endif><shiftAmount><endif>
 %>
 
-// produces more efficient bytecode when bits.ttypes contains at most two items
 bitsetInlineComparison(s, bits) ::= <%
-<bits.ttypes: {ttype | <s.varName> == <parser.name>::<ttype>}; separator = "\n\n|| ">
+<bits.tokens: {t | <s.varName> == <parser.name>::<t.name>}; separator = "\n\n|| ">
 %>
 
-cases(ttypes) ::= <<
-<ttypes: {t | case <parser.name>::<t>:}; separator="\n">
+cases(tokens) ::= <<
+<tokens: {t | case <parser.name>::<t.name>:}; separator="\n">
 >>
 
 InvokeRuleHeader(r, argExprsChunks) ::= "InvokeRuleHeader"

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
@@ -391,7 +391,7 @@ errorHandler.sync(this);
 <if(choice.label)><labelref(choice.label)> = tokenStream.LT(1);<endif>
 <preamble; separator="\n">
 switch (tokenStream.LA(1)!) {
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
   <alt>
   break;}; separator="\n">
 default:
@@ -403,7 +403,7 @@ LL1OptionalBlock(choice, alts, error) ::= <<
 state = <choice.stateNumber>;
 errorHandler.sync(this);
 switch (tokenStream.LA(1)!) {
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
   <alt>
   break;}; separator="\n">
 default:
@@ -510,7 +510,7 @@ Sync(s) ::= "sync(<s.expecting.name>);"
 ThrowNoViableAlt(t) ::= "throw NoViableAltException(this);"
 
 TestSetInline(s) ::= <<
-<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
+<s.bitsets:{bits | <if(rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
 >>
 
 // Java language spec 15.19 - shift operators mask operands rather than overflow to 0... need range test
@@ -518,7 +518,6 @@ testShiftInRange(shiftAmount) ::= <<
 ((<shiftAmount>) & ~0x3f) == 0
 >>
 
-// produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
 <testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1 \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>) != 0
 %>
@@ -532,13 +531,12 @@ offsetShift(shiftAmount, offset) ::= <%
 <if(!isZero.(offset))>(<shiftAmount> - <offset>)<else><shiftAmount><endif>
 %>
 
-// produces more efficient bytecode when bits.ttypes contains at most two items
 bitsetInlineComparison(s, bits) ::= <%
-<bits.ttypes:{ttype | <s.varName> == TOKEN_<ttype>}; separator=" || ">
+<bits.tokens:{t | <s.varName> == TOKEN_<t.name>}; separator=" || ">
 %>
 
-cases(ttypes) ::= <<
-<ttypes:{t | case TOKEN_<t>:}; separator="\n">
+cases(tokens) ::= <<
+<tokens:{t | case TOKEN_<t.name>:}; separator="\n">
 >>
 
 InvokeRule(r, argExprsChunks) ::=<<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
@@ -520,7 +520,7 @@ testShiftInRange(shiftAmount) ::= <<
 
 // produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
-(<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((BigInt.one \<\< <offsetShift(s.varName, bits.shift)>) & (<bits.ttypes:{ttype | (BigInt.one \<\< <offsetShift({TOKEN_<ttype>}, bits.shift)>)}; separator=" | ">)) != BigInt.zero)
+<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1 \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>) != 0
 %>
 
 isZero ::= [

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -553,7 +553,7 @@ p.GetErrorHandler().Sync(p)
 
 switch p.GetTokenStream().LA(1) {
 <if(choice.altLook && alts)>
-<choice.altLook, alts:{look, alt | case <look:{l | <parser.name><l>}; separator=", ">:
+<choice.altLook, alts:{look, alt | case <look:{l | <parser.name><l.name>}; separator=", ">:
 	<alt>}; separator="\n\n">
 
 
@@ -571,7 +571,7 @@ p.GetErrorHandler().Sync(p)
 
 switch p.GetTokenStream().LA(1) {
 <if(choice.altLook && alts)>
-<choice.altLook, alts:{look, alt | case <look:{l | <parser.name><l>}; separator=", ">:
+<choice.altLook, alts:{look, alt | case <look:{l | <parser.name><l.name>}; separator=", ">:
 	<alt>}; separator="\n\n">
 
 
@@ -725,7 +725,7 @@ Sync(s) ::= "Sync(<s.expecting.name>)"
 ThrowNoViableAlt(t) ::= "panic(antlr.NewNoViableAltException(p, nil, nil, nil, nil, nil))"
 
 TestSetInline(s) ::= <<
-<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
+<s.bitsets:{bits | <if(rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
 >>
 
 // Javascript language spec - shift operators are 32 bits long max
@@ -733,7 +733,6 @@ testShiftInRange(shiftAmount) ::= <<
 (int64(<shiftAmount>) & ^0x3f) == 0
 >>
 
-// produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
 <testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> && ((int64(1) \<\< <offsetShiftVar(s.varName, bits.shift)>) & <bits.calculated>) != 0
 %>
@@ -751,9 +750,8 @@ offsetShiftType(shiftAmount, offset) ::= <%
 <if(!isZero.(offset))>(<parser.name><shiftAmount> - <offset>)<else><parser.name><shiftAmount><endif>
 %>
 
-// produces more efficient bytecode when bits.ttypes contains at most two items
 bitsetInlineComparison(s, bits) ::= <%
-<bits.ttypes:{ttype | <s.varName> == <parser.name><ttype>}; separator=" || ">
+<bits.tokens:{t | <s.varName> == <parser.name><t.name>}; separator=" || ">
 %>
 
 InvokeRule(r, argExprsChunks) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -730,12 +730,12 @@ TestSetInline(s) ::= <<
 
 // Javascript language spec - shift operators are 32 bits long max
 testShiftInRange(shiftAmount) ::= <<
-((<shiftAmount>) & -(0x1f+1)) == 0
+(int64(<shiftAmount>) & ^0x3f) == 0
 >>
 
 // produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
-(<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> && ((1 \<\< uint(<offsetShiftVar(s.varName, bits.shift)>)) & (<bits.ttypes:{ttype | (1 \<\< <offsetShiftType(ttype, bits.shift)>)}; separator=" | ">)) != 0)
+<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> && ((int64(1) \<\< <offsetShiftVar(s.varName, bits.shift)>) & <bits.calculated>) != 0
 %>
 
 isZero ::= [

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -486,7 +486,7 @@ _errHandler.sync(this);
 <if(choice.label)><labelref(choice.label)> = _input.LT(1);<endif>
 <preamble; separator="\n">
 switch (_input.LA(1)) {
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
 	<alt>
 	break;}; separator="\n">
 default:
@@ -498,7 +498,7 @@ LL1OptionalBlock(choice, alts, error) ::= <<
 setState(<choice.stateNumber>);
 _errHandler.sync(this);
 switch (_input.LA(1)) {
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
 	<alt>
 	break;}; separator="\n">
 default:
@@ -605,7 +605,7 @@ Sync(s) ::= "sync(<s.expecting.name>);"
 ThrowNoViableAlt(t) ::= "throw new NoViableAltException(this);"
 
 TestSetInline(s) ::= <<
-<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
+<s.bitsets:{bits | <if(rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
 >>
 
 // Java language spec 15.19 - shift operators mask operands rather than overflow to 0... need range test
@@ -613,7 +613,6 @@ testShiftInRange(shiftAmount) ::= <<
 ((<shiftAmount>) & ~0x3f) == 0
 >>
 
-// produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
 <testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1L \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>L) != 0
 %>
@@ -627,13 +626,12 @@ offsetShift(shiftAmount, offset) ::= <%
 <if(!isZero.(offset))>(<shiftAmount> - <offset>)<else><shiftAmount><endif>
 %>
 
-// produces more efficient bytecode when bits.ttypes contains at most two items
 bitsetInlineComparison(s, bits) ::= <%
-<bits.ttypes:{ttype | <s.varName>==<ttype>}; separator=" || ">
+<bits.tokens:{t | <s.varName>==<t.name>}; separator=" || ">
 %>
 
-cases(ttypes) ::= <<
-<ttypes:{t | case <t>:}; separator="\n">
+cases(tokens) ::= <<
+<tokens:{t | case <t.name>:}; separator="\n">
 >>
 
 InvokeRule(r, argExprsChunks) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -615,7 +615,7 @@ testShiftInRange(shiftAmount) ::= <<
 
 // produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
-(<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1L \<\< <offsetShift(s.varName, bits.shift)>) & (<bits.ttypes:{ttype | (1L \<\< <offsetShift(ttype, bits.shift)>)}; separator=" | ">)) != 0)
+<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1L \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>L) != 0
 %>
 
 isZero ::= [

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -459,7 +459,7 @@ testShiftInRange(shiftAmount) ::= <<
 
 // produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
-(<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> && ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & (<bits.ttypes:{ttype | (1 \<\< <offsetShiftType(ttype, bits.shift)>)}; separator=" | ">)) !== 0)
+(<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> && ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & <bits.calculated>) !== 0)
 %>
 
 isZero ::= [

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -327,7 +327,7 @@ this._errHandler.sync(this);
 <if(choice.label)><labelref(choice.label)> = this._input.LT(1);<endif>
 <preamble; separator="\n">
 switch(this._input.LA(1)) {
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
     <alt>
     break;}; separator="\n">
 default:
@@ -339,7 +339,7 @@ LL1OptionalBlock(choice, alts, error) ::= <<
 this.state = <choice.stateNumber>;
 this._errHandler.sync(this);
 switch (this._input.LA(1)) {
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
 	<alt>
 	break;}; separator="\n">
 default:
@@ -449,7 +449,7 @@ Sync(s) ::= "sync(<s.expecting.name>)"
 ThrowNoViableAlt(t) ::= "throw new antlr4.error.NoViableAltException(this);"
 
 TestSetInline(s) ::= <<
-<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
+<s.bitsets:{bits | <if(rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
 >>
 
 // Javascript language spec - shift operators are 32 bits long max
@@ -457,7 +457,6 @@ testShiftInRange(shiftAmount) ::= <<
 ((<shiftAmount>) & ~0x1f) == 0
 >>
 
-// produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
 (<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> && ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & <bits.calculated>) !== 0)
 %>
@@ -475,13 +474,12 @@ offsetShiftType(shiftAmount, offset) ::= <%
 <if(!isZero.(offset))>(<parser.name>.<shiftAmount> - <offset>)<else><parser.name>.<shiftAmount><endif>
 %>
 
-// produces more efficient bytecode when bits.ttypes contains at most two items
 bitsetInlineComparison(s, bits) ::= <%
-<bits.ttypes:{ttype | <s.varName>===<parser.name>.<ttype>}; separator=" || ">
+<bits.tokens:{t | <s.varName>===<t.type>}; separator=" || ">
 %>
 
-cases(ttypes) ::= <<
-<ttypes:{t | case <parser.name>.<t>:}; separator="\n">
+cases(tokens) ::= <<
+<tokens:{t | case <t.type>:}; separator="\n">
 >>
 
 InvokeRule(r, argExprsChunks) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
@@ -533,7 +533,7 @@ $this->errorHandler->sync($this);
 <preamble; separator="\n">
 
 switch ($this->input->LA(1)) {
-    <choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+    <choice.altLook,alts:{look,alt| <cases(tokens=look)>
 	<alt>
 	break;}; separator="\n\n">
 
@@ -547,7 +547,7 @@ $this->setState(<choice.stateNumber>);
 $this->errorHandler->sync($this);
 
 switch ($this->input->LA(1)) {
-    <choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+    <choice.altLook,alts:{look,alt| <cases(tokens=look)>
 	<alt>
 	break;}; separator="\n\n">
 
@@ -667,7 +667,7 @@ Sync(s) ::= "sync(<s.expecting.name>);"
 ThrowNoViableAlt(t) ::= "throw new NoViableAltException($this);"
 
 TestSetInline(s) ::= <<
-<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
+<s.bitsets:{bits | <if(rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
 >>
 
 // Java language spec 15.19 - shift operators mask operands rather than overflow to 0... need range test
@@ -675,7 +675,6 @@ testShiftInRange(shiftAmount) ::= <<
 ((<shiftAmount>) & ~0x3f) === 0
 >>
 
-// produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
 <testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> && ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & <bits.calculated>) !== 0
 %>
@@ -692,13 +691,12 @@ offsetShiftConst(shiftAmount, offset) ::= <%
 <if(!isZero.(offset))>(self::<shiftAmount> - <offset>)<else>self::<shiftAmount><endif>
 %>
 
-// produces more efficient bytecode when bits.ttypes contains at most two items
 bitsetInlineComparison(s, bits) ::= <%
-<bits.ttypes:{ttype | $<s.varName> === self::<ttype>}; separator=" || ">
+<bits.tokens:{t | $<s.varName> === self::<t.name>}; separator=" || ">
 %>
 
-cases(ttypes) ::= <<
-<ttypes:{t | case self::<t>:}; separator="\n">
+cases(tokens) ::= <<
+<tokens:{t | case self::<t.name>:}; separator="\n">
 >>
 
 InvokeRule(r, argExprsChunks) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
@@ -677,7 +677,7 @@ testShiftInRange(shiftAmount) ::= <<
 
 // produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
-(<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> && ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & (<bits.ttypes:{ttype | (1 \<\< <offsetShiftConst(ttype, bits.shift)>)}; separator=" | ">)) !== 0)
+<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> && ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & <bits.calculated>) !== 0
 %>
 
 isZero ::= [

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -324,7 +324,7 @@ self._errHandler.sync(self)
 <if(choice.label)><labelref(choice.label)> = _input.LT(1)<endif>
 <preamble; separator="\n">
 token = self._input.LA(1)
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
     <alt>
     pass}; separator="\nel">
 else:
@@ -336,7 +336,7 @@ LL1OptionalBlock(choice, alts, error) ::= <<
 self.state = <choice.stateNumber>
 self._errHandler.sync(self)
 token = self._input.LA(1)
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
     <alt>
     pass}; separator="\nel">
 else:
@@ -443,7 +443,7 @@ Sync(s) ::= "sync(<s.expecting.name>)"
 ThrowNoViableAlt(t) ::= "raise NoViableAltException(self)"
 
 TestSetInline(s) ::= <<
-<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" or ">
+<s.bitsets:{bits | <if(rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" or ">
 >>
 
 // Java language spec 15.19 - shift operators mask operands rather than overflow to 0... need range test
@@ -451,7 +451,6 @@ testShiftInRange(shiftAmount) ::= <<
 ((<shiftAmount>) & ~0x3f) == 0
 >>
 
-// produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
 <testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> and ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & <bits.calculated>) != 0
 %>
@@ -469,13 +468,12 @@ offsetShiftType(shiftAmount, offset) ::= <%
 <if(!isZero.(offset))>(<parser.name>.<shiftAmount> - <offset>)<else><parser.name>.<shiftAmount><endif>
 %>
 
-// produces more efficient bytecode when bits.ttypes contains at most two items
 bitsetInlineComparison(s, bits) ::= <%
-<bits.ttypes:{ttype | <s.varName>==<parser.name>.<ttype>}; separator=" or ">
+<bits.tokens:{t | <s.varName>==<t.type>}; separator=" or ">
 %>
 
-cases(ttypes) ::= <<
-if token in [<ttypes:{t | <parser.name>.<t>}; separator=", ">]:
+cases(tokens) ::= <<
+if token in [<tokens:{t | <t.type>}; separator=", ">]:
 >>
 
 InvokeRule(r, argExprsChunks) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -453,7 +453,7 @@ testShiftInRange(shiftAmount) ::= <<
 
 // produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
-(<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> and ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & (<bits.ttypes:{ttype | (1 \<\< <offsetShiftType(ttype, bits.shift)>)}; separator=" | ">)) != 0)
+<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> and ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & <bits.calculated>) != 0
 %>
 
 isZero ::= [

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -466,7 +466,7 @@ testShiftInRange(shiftAmount) ::= <<
 
 // produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
-(<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> and ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & (<bits.ttypes:{ttype | (1 \<\< <offsetShiftType(ttype, bits.shift)>)}; separator=" | ">)) != 0)
+<testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> and ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & <bits.calculated>) != 0
 %>
 
 isZero ::= [

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -337,7 +337,7 @@ self._errHandler.sync(self)
 <if(choice.label)><labelref(choice.label)> = _input.LT(1)<endif>
 <preamble; separator="\n">
 token = self._input.LA(1)
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
     <alt>
     pass}; separator="\nel">
 else:
@@ -349,7 +349,7 @@ LL1OptionalBlock(choice, alts, error) ::= <<
 self.state = <choice.stateNumber>
 self._errHandler.sync(self)
 token = self._input.LA(1)
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
     <alt>
     pass}; separator="\nel">
 else:
@@ -456,7 +456,7 @@ Sync(s) ::= "sync(<s.expecting.name>)"
 ThrowNoViableAlt(t) ::= "raise NoViableAltException(self)"
 
 TestSetInline(s) ::= <<
-<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" or ">
+<s.bitsets:{bits | <if(rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" or ">
 >>
 
 // Java language spec 15.19 - shift operators mask operands rather than overflow to 0... need range test
@@ -464,7 +464,6 @@ testShiftInRange(shiftAmount) ::= <<
 ((<shiftAmount>) & ~0x3f) == 0
 >>
 
-// produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <%
 <testShiftInRange({<offsetShiftVar(s.varName, bits.shift)>})> and ((1 \<\< <offsetShiftVar(s.varName, bits.shift)>) & <bits.calculated>) != 0
 %>
@@ -482,13 +481,12 @@ offsetShiftType(shiftAmount, offset) ::= <%
 <if(!isZero.(offset))>(<parser.name>.<shiftAmount> - <offset>)<else><parser.name>.<shiftAmount><endif>
 %>
 
-// produces more efficient bytecode when bits.ttypes contains at most two items
 bitsetInlineComparison(s, bits) ::= <%
-<bits.ttypes:{ttype | <s.varName>==<parser.name>.<ttype>}; separator=" or ">
+<bits.tokens:{t | <s.varName>==<t.type>}; separator=" or ">
 %>
 
-cases(ttypes) ::= <<
-if token in [<ttypes:{t | <parser.name>.<t>}; separator=", ">]:
+cases(tokens) ::= <<
+if token in [<tokens:{t | <t.type>}; separator=", ">]:
 >>
 
 InvokeRule(r, argExprsChunks) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -488,7 +488,7 @@ try _errHandler.sync(self)
 <if(choice.label)><labelref(choice.label)> = try _input.LT(1)<endif>
 <preamble; separator="\n">
 switch (<parser.name>.Tokens(rawValue: try _input.LA(1))!) {
-<choice.altLook,alts:{look,alt | <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt | <cases(tokens=look)>
 	<alt>
 	break}; separator="\n">
 default:
@@ -500,7 +500,7 @@ LL1OptionalBlock(choice, alts, error) ::= <<
 setState(<choice.stateNumber>)
 try _errHandler.sync(self)
 switch (<parser.name>.Tokens(rawValue: try _input.LA(1))!) {
-<choice.altLook,alts:{look,alt| <cases(ttypes=look)>
+<choice.altLook,alts:{look,alt| <cases(tokens=look)>
  	<alt>
 	break}; separator="\n">
 default:
@@ -609,7 +609,7 @@ Sync(s) ::= "sync(<s.expecting.name>);"
 ThrowNoViableAlt(t) ::= "throw ANTLRException.recognition(e: NoViableAltException(self))"
 
 TestSetInline(s) ::= <<
-<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
+<s.bitsets:{bits | <if(rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
 >>
 
 // Java language spec 15.19 - shift operators mask operands rather than overflow to 0... need range test
@@ -617,7 +617,6 @@ testShiftInRange(shiftAmount) ::= <<
 (Int64(<shiftAmount>) & ~0x3f) == 0
 >>
 
-// produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <<
 <testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((Int64(1) \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>) != 0
 >>
@@ -626,21 +625,20 @@ isZero ::= [
 "0": true,
 default: false
 ]
-parserName(ttype) ::= <%
- <parser.name>.Tokens.<ttype>.rawValue
+parserName(t) ::= <%
+ <parser.name>.Tokens.<t.name>.rawValue
 %>
 offsetShift(shiftAmount, offset) ::= <%
 <if(!isZero.(offset))>(<shiftAmount> - <offset>)<else><shiftAmount><endif>
 %>
 
-// produces more efficient bytecode when bits.ttypes contains at most two items
 bitsetInlineComparison(s, bits) ::= <%
-<bits.ttypes:{ttype | <s.varName> == <parser.name>.Tokens.<ttype>.rawValue}; separator=" || ">
+<bits.tokens:{t | <s.varName> == <parser.name>.Tokens.<t.name>.rawValue}; separator=" || ">
 %>
 
-cases(ttypes) ::= <<
-<trunc(ttypes): {t | case .<t>:fallthrough}  ; separator="\n">
-<last(ttypes): {t | case .<t>:}  ; separator="\n">
+cases(tokens) ::= <<
+<trunc(tokens): {t | case .<t.name>:fallthrough}  ; separator="\n">
+<last(tokens): {t | case .<t.name>:}  ; separator="\n">
 >>
 
 InvokeRule(r, argExprsChunks) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -609,34 +609,17 @@ Sync(s) ::= "sync(<s.expecting.name>);"
 ThrowNoViableAlt(t) ::= "throw ANTLRException.recognition(e: NoViableAltException(self))"
 
 TestSetInline(s) ::= <<
-<!<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">!>
- //closure
- { () -> Bool in
-      <if(rest(s.bitsets))>var<else>let<endif> testSet: Bool = <first(s.bitsets):{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}>
-          <rest(s.bitsets):{bits | testSet = testSet || <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator="\n">
-      return testSet
- }()
+<s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
 >>
 
 // Java language spec 15.19 - shift operators mask operands rather than overflow to 0... need range test
 testShiftInRange(shiftAmount) ::= <<
-((<shiftAmount>) & ~0x3f) == 0
+(Int64(<shiftAmount>) & ~0x3f) == 0
 >>
 
 // produces smaller bytecode only when bits.ttypes contains more than two items
 bitsetBitfieldComparison(s, bits) ::= <<
-<!(<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1 \<\< <offsetShift(s.varName, bits.shift)>) & (<bits.ttypes:{ttype | (1 \<\< <offsetShift(ttype, bits.shift)>)}; separator=" | ">)) != 0)!>
-{  () -> Bool in
-    <! let test: Bool = (<testShiftInRange({<offsetShift(s.varName, bits.shift)>})>)!>
-   <!var temp: Int64 =  Int64(<offsetShift(s.varName, bits.shift)>)!>
-   <!temp = (temp \< 0) ? (64 + (temp % 64 )) : (temp % 64)!>
-   <!let test1: Int64 = (Int64(1) \<\< temp)!>
-   <!var test2: Int64 = (<first(bits.ttypes):{ttype | Utils.bitLeftShift(<offsetShift(parserName(ttype), bits.shift)>)}>)!>
-   <!<rest(bits.ttypes):{ttype | test2 = test2 | Utils.bitLeftShift(<offsetShift(parserName(ttype), bits.shift)>)}; separator="\n">!>
-   let testArray: [Int] = [<s.varName>, <bits.ttypes:{ttype |<parserName(ttype)>}; separator=",">]
-   <!var test2: Int64 = Utils.testBitLeftShiftArray(testArray)!>
-    return  Utils.testBitLeftShiftArray(testArray, <bits.shift>)
-}()
+<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((Int64(1) \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>) != 0
 >>
 
 isZero ::= [

--- a/tool/src/org/antlr/v4/codegen/model/Choice.java
+++ b/tool/src/org/antlr/v4/codegen/model/Choice.java
@@ -7,10 +7,13 @@
 package org.antlr.v4.codegen.model;
 
 import org.antlr.v4.codegen.OutputModelFactory;
+import org.antlr.v4.codegen.Target;
 import org.antlr.v4.codegen.model.decl.Decl;
 import org.antlr.v4.codegen.model.decl.TokenTypeDecl;
 import org.antlr.v4.misc.Utils;
+import org.antlr.v4.runtime.misc.IntegerList;
 import org.antlr.v4.runtime.misc.IntervalSet;
+import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.ast.GrammarAST;
 
 import java.util.ArrayList;
@@ -45,10 +48,17 @@ public abstract class Choice extends RuleElement {
 		preamble.add(op);
 	}
 
-	public List<String[]> getAltLookaheadAsStringLists(IntervalSet[] altLookSets) {
-		List<String[]> altLook = new ArrayList<String[]>();
+	public List<TokenInfo[]> getAltLookaheadAsStringLists(IntervalSet[] altLookSets) {
+		List<TokenInfo[]> altLook = new ArrayList<>();
+		Target target = factory.getGenerator().getTarget();
+		Grammar grammar = factory.getGrammar();
 		for (IntervalSet s : altLookSets) {
-			altLook.add(factory.getGenerator().getTarget().getTokenTypesAsTargetLabels(factory.getGrammar(), s.toArray()));
+			IntegerList list = s.toIntegerList();
+			TokenInfo[] info = new TokenInfo[list.size()];
+			for (int i = 0; i < info.length; i++) {
+				info[i] = new TokenInfo(list.get(i), target.getTokenTypeAsTargetLabel(grammar, list.get(i)));
+			}
+			altLook.add(info);
 		}
 		return altLook;
 	}

--- a/tool/src/org/antlr/v4/codegen/model/LL1Choice.java
+++ b/tool/src/org/antlr/v4/codegen/model/LL1Choice.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public abstract class LL1Choice extends Choice {
 	/** Token names for each alt 0..n-1 */
-	public List<String[]> altLook;
+	public List<TokenInfo[]> altLook;
 	@ModelElement public ThrowNoViableAlt error;
 
 	public LL1Choice(OutputModelFactory factory, GrammarAST blkAST,

--- a/tool/src/org/antlr/v4/codegen/model/TestSetInline.java
+++ b/tool/src/org/antlr/v4/codegen/model/TestSetInline.java
@@ -57,7 +57,7 @@ public class TestSetInline extends SrcOp {
 
 	public static final class Bitset {
 		public final int shift;
-		private final List<String> ttypes = new ArrayList<>();
+		private final List<TokenInfo> tokens = new ArrayList<>();
 		private long calculated;
 
 		public Bitset(int shift) {
@@ -65,12 +65,12 @@ public class TestSetInline extends SrcOp {
 		}
 
 		public void addToken(int type, String name) {
-			ttypes.add(name);
+			tokens.add(new TokenInfo(type, name));
 			calculated |= 1L << (type - shift);
 		}
 
-		public List<String> getTtypes() {
-			return ttypes;
+		public List<TokenInfo> getTokens() {
+			return tokens;
 		}
 
 		public long getCalculated() {

--- a/tool/src/org/antlr/v4/codegen/model/TokenInfo.java
+++ b/tool/src/org/antlr/v4/codegen/model/TokenInfo.java
@@ -1,0 +1,19 @@
+package org.antlr.v4.codegen.model;
+
+public class TokenInfo {
+	public final int type;
+	public final String name;
+
+	public TokenInfo(int type, String name) {
+		this.type = type;
+		this.name = name;
+	}
+
+	@Override
+	public String toString() {
+		return "TokenInfo{" +
+				"type=" + type +
+				", name='" + name + '\'' +
+				'}';
+	}
+}

--- a/tool/src/org/antlr/v4/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/GoTarget.java
@@ -95,11 +95,6 @@ public class GoTarget extends Target {
 		}
 	}
 
-	@Override
-	public int getInlineTestSetWordSize() {
-		return 32;
-	}
-
 	public String getRecognizerFileName(boolean header) {
 		CodeGenerator gen = getCodeGenerator();
 		Grammar g = gen.g;


### PR DESCRIPTION
@SimonStPeter I've created [a benchmark](https://github.com/KvanTTT/AntlrBenchmarks/blob/master/ConstantFoldingBenchmark/checkParsers.py) with respective grammar and have got the following result:

```
no_const_folding: 2010734 ns
const_folding: 907140 ns
ratio: 0.4511
```

I haven't tested on real grammars, but It's already signficant improvement, more 2x faster and it should be considered. Also, resulting file > 20 % less than the file with not folded constants.

There is no improvement in speed for JavaScript.

fixes #3698, fixes #3699

@parrt I suggest using constant folding for all runtimes because:

* It reduces the size of generated parsers (more than 20% as I've checked for Python and JavaScript)
* It eliminates very long lines that are hard to read by human and text editors. Just compare (there are a lot of similar lines for SQL parsers):
  * Current: `if not(((((_la - 1)) & ~0x3f) == 0 and ((1 << (_la - 1)) & ((1 << (PParser.T0 - 1)) | (1 << (PParser.T1 - 1)) | (1 << (PParser.T2 - 1)) | (1 << (PParser.T3 - 1)) | (1 << (PParser.T4 - 1)) | (1 << (PParser.T5 - 1)) | (1 << (PParser.T6 - 1)) | (1 << (PParser.T7 - 1)) | (1 << (PParser.T8 - 1)) | (1 << (PParser.T9 - 1)) | (1 << (PParser.T10 - 1)) | (1 << (PParser.T11 - 1)) | (1 << (PParser.T12 - 1)) | (1 << (PParser.T13 - 1)) | (1 << (PParser.T14 - 1)) | (1 << (PParser.T15 - 1)) | (1 << (PParser.T16 - 1)) | (1 << (PParser.T17 - 1)) | (1 << (PParser.T18 - 1)) | (1 << (PParser.T19 - 1)) | (1 << (PParser.T20 - 1)) | (1 << (PParser.T21 - 1)) | (1 << (PParser.T22 - 1)) | (1 << (PParser.T23 - 1)) | (1 << (PParser.T24 - 1)) | (1 << (PParser.T25 - 1)) | (1 << (PParser.T26 - 1)) | (1 << (PParser.T27 - 1)) | (1 << (PParser.T28 - 1)) | (1 << (PParser.T29 - 1)) | (1 << (PParser.T30 - 1)) | (1 << (PParser.T31 - 1)) | (1 << (PParser.T32 - 1)) | (1 << (PParser.T33 - 1)) | (1 << (PParser.T34 - 1)) | (1 << (PParser.T35 - 1)) | (1 << (PParser.T36 - 1)) | (1 << (PParser.T37 - 1)) | (1 << (PParser.T38 - 1)) | (1 << (PParser.T39 - 1)) | (1 << (PParser.T40 - 1)) | (1 << (PParser.T41 - 1)) | (1 << (PParser.T42 - 1)) | (1 << (PParser.T43 - 1)) | (1 << (PParser.T44 - 1)) | (1 << (PParser.T45 - 1)) | (1 << (PParser.T46 - 1)) | (1 << (PParser.T47 - 1)) | (1 << (PParser.T48 - 1)) | (1 << (PParser.T49 - 1)) | (1 << (PParser.T50 - 1)) | (1 << (PParser.T51 - 1)) | (1 << (PParser.T52 - 1)) | (1 << (PParser.T53 - 1)) | (1 << (PParser.T54 - 1)) | (1 << (PParser.T55 - 1)) | (1 << (PParser.T56 - 1)) | (1 << (PParser.T57 - 1)) | (1 << (PParser.T58 - 1)) | (1 << (PParser.T59 - 1)) | (1 << (PParser.T60 - 1)) | (1 << (PParser.T61 - 1)) | (1 << (PParser.T62 - 1)) | (1 << (PParser.T63 - 1)))) != 0)):`
  * Folded: `if not((((_la - 1) & ~0x3f) == 0 and (1 << (_la - 1)) & -1) != 0):`
* Actually such expressions almost don't clarity how parser works in debug mode (if it's important).
* It improves compilation speed (for compilable languages) or interpretation performance (for dynamic languages such as Python or JavaScript)