### PR TITLE
Cpp: Disable warnings for external project

### DIFF
--- a/runtime/Cpp/CMakeLists.txt
+++ b/runtime/Cpp/CMakeLists.txt
@@ -32,6 +32,7 @@ endif(NOT WITH_DEMO)
 option(WITH_LIBCXX "Building with clang++ and libc++(in Linux). To enable with: -DWITH_LIBCXX=On" Off)
 option(WITH_STATIC_CRT "(Visual C++) Enable to statically link CRT, which avoids requiring users to install the redistribution package.
  To disable with: -DWITH_STATIC_CRT=Off" On)
+option(DISABLE_WARNINGS "Suppress compiler warnings for all built ANTLR targets" OFF)
 
 project(LIBANTLR4)
 
@@ -77,8 +78,16 @@ endif(WITH_DEMO)
 
 if(MSVC_VERSION)
   set(MY_CXX_WARNING_FLAGS "  /W4")
+
+  if(DISABLE_WARNINGS)
+    set(MY_CXX_WARNING_FLAGS "  /w")
+  endif()
 else()
   set(MY_CXX_WARNING_FLAGS "  -Wall -pedantic -W")
+
+  if(DISABLE_WARNINGS)
+    set(MY_CXX_WARNING_FLAGS "  -w")
+  endif()
 endif()
 
 # Define USE_UTF8_INSTEAD_OF_CODECVT macro.

--- a/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
+++ b/runtime/Cpp/cmake/ExternalAntlr4Cpp.cmake
@@ -96,6 +96,7 @@ if(ANTLR4_ZIP_REPOSITORY)
       CMAKE_CACHE_ARGS
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
           -DWITH_STATIC_CRT:BOOL=${ANTLR4_WITH_STATIC_CRT}
+          -DDISABLE_WARNINGS:BOOL=ON
           # -DCMAKE_CXX_STANDARD:STRING=17 # if desired, compile the runtime with a different C++ standard
           # -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD} # alternatively, compile the runtime with the same C++ standard as the outer project
       INSTALL_COMMAND ""
@@ -114,6 +115,7 @@ else()
       CMAKE_CACHE_ARGS
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
           -DWITH_STATIC_CRT:BOOL=${ANTLR4_WITH_STATIC_CRT}
+          -DDISABLE_WARNINGS:BOOL=ON
           # -DCMAKE_CXX_STANDARD:STRING=17 # if desired, compile the runtime with a different C++ standard
           # -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD} # alternatively, compile the runtime with the same C++ standard as the outer project
       INSTALL_COMMAND ""


### PR DESCRIPTION
When adding ANTLR as an external project, the downstream users will
(generally) not be interested in compiler warnings emitted for ANTLR
itself, as they won't be able to do anything about them anyway (in their
project).

Thus, this commit adds a new cmake option DISABLE_WARNINGS that can be
used to suppress compiler warnings. This flag is then subsequently set
whenever ANTLR is used as an ExternalProject.
