### PR TITLE
Fix golang tests by regenerating test lexers

### DIFF
--- a/runtime/Go/antlr/testing_lexer_b_test.go
+++ b/runtime/Go/antlr/testing_lexer_b_test.go
@@ -20,47 +20,16 @@ MULT : '*';
 WS : ' '+;
 */
 
-var lexerB_serializedLexerAtn = []int32{
-	4, 0, 7, 38, 6, 65535, 2, 0, 7, 0, 2, 1, 7, 1, 2, 2, 7, 2, 2, 3, 7, 3,
-	2, 4, 7, 4, 2, 5, 7, 5, 2, 6, 7, 6, 1, 0, 4, 0, 17, 8, 0, 11, 0, 12, 0,
-	18, 1, 1, 4, 1, 22, 8, 1, 11, 1, 12, 1, 23, 1, 2, 1, 2, 1, 3, 1, 3, 1,
-	4, 1, 4, 1, 5, 1, 5, 1, 6, 4, 6, 35, 8, 6, 11, 6, 12, 6, 36, 0, 0, 7, 1,
-	1, 3, 2, 5, 3, 7, 4, 9, 5, 11, 6, 13, 7, 1, 0, 0, 0, 40, 0, 1, 1, 0, 0,
-	0, 0, 3, 1, 0, 0, 0, 0, 5, 1, 0, 0, 0, 0, 7, 1, 0, 0, 0, 0, 9, 1, 0, 0,
-	0, 0, 11, 1, 0, 0, 0, 0, 13, 1, 0, 0, 0, 1, 16, 1, 0, 0, 0, 3, 21, 1, 0,
-	0, 0, 5, 25, 1, 0, 0, 0, 7, 27, 1, 0, 0, 0, 9, 29, 1, 0, 0, 0, 11, 31,
-	1, 0, 0, 0, 13, 34, 1, 0, 0, 0, 15, 17, 2, 97, 122, 0, 16, 15, 1, 0, 0,
-	0, 17, 18, 1, 0, 0, 0, 18, 16, 1, 0, 0, 0, 18, 19, 1, 0, 0, 0, 19, 2, 1,
-	0, 0, 0, 20, 22, 2, 48, 57, 0, 21, 20, 1, 0, 0, 0, 22, 23, 1, 0, 0, 0,
-	23, 21, 1, 0, 0, 0, 23, 24, 1, 0, 0, 0, 24, 4, 1, 0, 0, 0, 25, 26, 5, 59,
-	0, 0, 26, 6, 1, 0, 0, 0, 27, 28, 5, 61, 0, 0, 28, 8, 1, 0, 0, 0, 29, 30,
-	5, 43, 0, 0, 30, 10, 1, 0, 0, 0, 31, 32, 5, 42, 0, 0, 32, 12, 1, 0, 0,
-	0, 33, 35, 5, 32, 0, 0, 34, 33, 1, 0, 0, 0, 35, 36, 1, 0, 0, 0, 36, 34,
-	1, 0, 0, 0, 36, 37, 1, 0, 0, 0, 37, 14, 1, 0, 0, 0, 4, 0, 18, 23, 36, 0,
-}
+import (
+	"fmt"
+	"sync"
+	"unicode"
+)
 
-var lexerB_lexerDeserializer = NewATNDeserializer(nil)
-var lexerB_lexerAtn = lexerB_lexerDeserializer.Deserialize(lexerB_serializedLexerAtn)
-
-var lexerB_lexerChannelNames = []string{
-	"DEFAULT_TOKEN_CHANNEL", "HIDDEN",
-}
-
-var lexerB_lexerModeNames = []string{
-	"DEFAULT_MODE",
-}
-
-var lexerB_lexerLiteralNames = []string{
-	"", "", "", "';'", "'='", "'+'", "'*'",
-}
-
-var lexerB_lexerSymbolicNames = []string{
-	"", "ID", "INT", "SEMI", "ASSIGN", "PLUS", "MULT", "WS",
-}
-
-var lexerB_lexerRuleNames = []string{
-	"ID", "INT", "SEMI", "ASSIGN", "PLUS", "MULT", "WS",
-}
+// Suppress unused import error
+var _ = fmt.Printf
+var _ = sync.Once{}
+var _ = unicode.IsLetter
 
 type LexerB struct {
 	*BaseLexer
@@ -69,27 +38,89 @@ type LexerB struct {
 	// TODO: EOF string
 }
 
-var lexerB_lexerDecisionToDFA = make([]*DFA, len(lexerB_lexerAtn.DecisionToState))
+var lexerbLexerStaticData struct {
+	once                   sync.Once
+	serializedATN          []int32
+	channelNames           []string
+	modeNames              []string
+	literalNames           []string
+	symbolicNames          []string
+	ruleNames              []string
+	predictionContextCache *PredictionContextCache
+	atn                    *ATN
+	decisionToDFA          []*DFA
+}
 
-func init() {
-	for index, ds := range lexerB_lexerAtn.DecisionToState {
-		lexerB_lexerDecisionToDFA[index] = NewDFA(ds, index)
+func lexerbLexerInit() {
+	staticData := &lexerbLexerStaticData
+	staticData.channelNames = []string{
+		"DEFAULT_TOKEN_CHANNEL", "HIDDEN",
+	}
+	staticData.modeNames = []string{
+		"DEFAULT_MODE",
+	}
+	staticData.literalNames = []string{
+		"", "", "", "';'", "'='", "'+'", "'*'",
+	}
+	staticData.symbolicNames = []string{
+		"", "ID", "INT", "SEMI", "ASSIGN", "PLUS", "MULT", "WS",
+	}
+	staticData.ruleNames = []string{
+		"ID", "INT", "SEMI", "ASSIGN", "PLUS", "MULT", "WS",
+	}
+	staticData.predictionContextCache = NewPredictionContextCache()
+	staticData.serializedATN = []int32{
+		4, 0, 7, 38, 6, -1, 2, 0, 7, 0, 2, 1, 7, 1, 2, 2, 7, 2, 2, 3, 7, 3, 2,
+		4, 7, 4, 2, 5, 7, 5, 2, 6, 7, 6, 1, 0, 4, 0, 17, 8, 0, 11, 0, 12, 0, 18,
+		1, 1, 4, 1, 22, 8, 1, 11, 1, 12, 1, 23, 1, 2, 1, 2, 1, 3, 1, 3, 1, 4, 1,
+		4, 1, 5, 1, 5, 1, 6, 4, 6, 35, 8, 6, 11, 6, 12, 6, 36, 0, 0, 7, 1, 1, 3,
+		2, 5, 3, 7, 4, 9, 5, 11, 6, 13, 7, 1, 0, 0, 40, 0, 1, 1, 0, 0, 0, 0, 3,
+		1, 0, 0, 0, 0, 5, 1, 0, 0, 0, 0, 7, 1, 0, 0, 0, 0, 9, 1, 0, 0, 0, 0, 11,
+		1, 0, 0, 0, 0, 13, 1, 0, 0, 0, 1, 16, 1, 0, 0, 0, 3, 21, 1, 0, 0, 0, 5,
+		25, 1, 0, 0, 0, 7, 27, 1, 0, 0, 0, 9, 29, 1, 0, 0, 0, 11, 31, 1, 0, 0,
+		0, 13, 34, 1, 0, 0, 0, 15, 17, 2, 97, 122, 0, 16, 15, 1, 0, 0, 0, 17, 18,
+		1, 0, 0, 0, 18, 16, 1, 0, 0, 0, 18, 19, 1, 0, 0, 0, 19, 2, 1, 0, 0, 0,
+		20, 22, 2, 48, 57, 0, 21, 20, 1, 0, 0, 0, 22, 23, 1, 0, 0, 0, 23, 21, 1,
+		0, 0, 0, 23, 24, 1, 0, 0, 0, 24, 4, 1, 0, 0, 0, 25, 26, 5, 59, 0, 0, 26,
+		6, 1, 0, 0, 0, 27, 28, 5, 61, 0, 0, 28, 8, 1, 0, 0, 0, 29, 30, 5, 43, 0,
+		0, 30, 10, 1, 0, 0, 0, 31, 32, 5, 42, 0, 0, 32, 12, 1, 0, 0, 0, 33, 35,
+		5, 32, 0, 0, 34, 33, 1, 0, 0, 0, 35, 36, 1, 0, 0, 0, 36, 34, 1, 0, 0, 0,
+		36, 37, 1, 0, 0, 0, 37, 14, 1, 0, 0, 0, 4, 0, 18, 23, 36, 0,
+	}
+	deserializer := NewATNDeserializer(nil)
+	staticData.atn = deserializer.Deserialize(staticData.serializedATN)
+	atn := staticData.atn
+	staticData.decisionToDFA = make([]*DFA, len(atn.DecisionToState))
+	decisionToDFA := staticData.decisionToDFA
+	for index, state := range atn.DecisionToState {
+		decisionToDFA[index] = NewDFA(state, index)
 	}
 }
 
+// LexerBInit initializes any static state used to implement LexerB. By default the
+// static state used to implement the lexer is lazily initialized during the first call to
+// NewLexerB(). You can call this function if you wish to initialize the static state ahead
+// of time.
+func LexerBInit() {
+	staticData := &lexerbLexerStaticData
+	staticData.once.Do(lexerbLexerInit)
+}
+
+// NewLexerB produces a new lexer instance for the optional input antlr.CharStream.
 func NewLexerB(input CharStream) *LexerB {
+	LexerBInit()
 	l := new(LexerB)
 
 	l.BaseLexer = NewBaseLexer(input)
-	l.Interpreter = NewLexerATNSimulator(l, lexerB_lexerAtn, lexerB_lexerDecisionToDFA, NewPredictionContextCache())
-
-	l.channelNames = lexerB_lexerChannelNames
-	l.modeNames = lexerB_lexerModeNames
-	l.RuleNames = lexerB_lexerRuleNames
-	l.LiteralNames = lexerB_lexerLiteralNames
-	l.SymbolicNames = lexerB_lexerSymbolicNames
+	staticData := &lexerbLexerStaticData
+	l.Interpreter = NewLexerATNSimulator(l, staticData.atn, staticData.decisionToDFA, staticData.predictionContextCache)
+	l.channelNames = staticData.channelNames
+	l.modeNames = staticData.modeNames
+	l.RuleNames = staticData.ruleNames
+	l.LiteralNames = staticData.literalNames
+	l.SymbolicNames = staticData.symbolicNames
 	l.GrammarFileName = "LexerB.g4"
-	// TODO: l.EOF = TokenEOF
+	// TODO: l.EOF = antlr.TokenEOF
 
 	return l
 }

--- a/runtime/Go/antlr/tokenstream_rewriter_test.go
+++ b/runtime/Go/antlr/tokenstream_rewriter_test.go
@@ -4,12 +4,12 @@
 package antlr
 
 import (
-	"testing"
 	"fmt"
-	"unicode"
 	"strings"
+	"sync"
+	"testing"
+	"unicode"
 )
-
 
 /* Assume the following grammar for this test.
 
@@ -20,7 +20,7 @@ C : 'c';
 
 */
 
-func TestInsertBeforeIndex0(t *testing.T){
+func TestInsertBeforeIndex0(t *testing.T) {
 	input := NewInputStream("abc")
 	lexer := NewLexerA(input)
 	stream := NewCommonTokenStream(lexer, 0)
@@ -28,12 +28,12 @@ func TestInsertBeforeIndex0(t *testing.T){
 	tokens := NewTokenStreamRewriter(stream)
 	tokens.InsertBeforeDefault(0, "0")
 	result := tokens.GetTextDefault()
-	if result != "0abc"{
+	if result != "0abc" {
 		t.Errorf("test failed, got %s", result)
 	}
 }
 
-func prepare_rewriter(str string) *TokenStreamRewriter{
+func prepare_rewriter(str string) *TokenStreamRewriter {
 	input := NewInputStream(str)
 	lexer := NewLexerA(input)
 	stream := NewCommonTokenStream(lexer, 0)
@@ -42,32 +42,31 @@ func prepare_rewriter(str string) *TokenStreamRewriter{
 }
 
 type LexerTest struct {
-	input string
-	expected string
-	description string
+	input              string
+	expected           string
+	description        string
 	expected_exception []string
-	ops func(*TokenStreamRewriter)
+	ops                func(*TokenStreamRewriter)
 }
 
-func NewLexerTest(input, expected, desc string, ops func(*TokenStreamRewriter)) LexerTest{
-	return LexerTest{input:input, expected:expected, description:desc, ops:ops}
+func NewLexerTest(input, expected, desc string, ops func(*TokenStreamRewriter)) LexerTest {
+	return LexerTest{input: input, expected: expected, description: desc, ops: ops}
 }
 
-func NewLexerExceptionTest(input string, expected_err []string, desc string, ops func(*TokenStreamRewriter)) LexerTest{
-	return LexerTest{input:input, expected_exception:expected_err, description:desc, ops:ops}
+func NewLexerExceptionTest(input string, expected_err []string, desc string, ops func(*TokenStreamRewriter)) LexerTest {
+	return LexerTest{input: input, expected_exception: expected_err, description: desc, ops: ops}
 }
 
-func panic_tester(t *testing.T, expected_msg []string, r *TokenStreamRewriter){
+func panic_tester(t *testing.T, expected_msg []string, r *TokenStreamRewriter) {
 	defer func() {
-		r :=recover()
-		if r == nil{
+		r := recover()
+		if r == nil {
 			t.Errorf("Panic is expected, but finished normally")
-		}else
-		{
+		} else {
 			s_e := r.(string)
-			for _, e := range expected_msg{
-				if !strings.Contains(s_e, e){
-					t.Errorf("Element [%s] is not in error message: [%s]", e, s_e )
+			for _, e := range expected_msg {
+				if !strings.Contains(s_e, e) {
+					t.Errorf("Element [%s] is not in error message: [%s]", e, s_e)
 				}
 			}
 		}
@@ -75,290 +74,257 @@ func panic_tester(t *testing.T, expected_msg []string, r *TokenStreamRewriter){
 	r.GetTextDefault()
 }
 
-func TestLexerA(t *testing.T){
+func TestLexerA(t *testing.T) {
 	tests := []LexerTest{
 		NewLexerTest("abc", "0abc", "InsertBeforeIndex0",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(0, "0")
-		}),
-		NewLexerTest("abc", "abcx","InsertAfterLastIndex",
-		func(r *TokenStreamRewriter){
-			r.InsertAfterDefault(2, "x")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(0, "0")
+			}),
+		NewLexerTest("abc", "abcx", "InsertAfterLastIndex",
+			func(r *TokenStreamRewriter) {
+				r.InsertAfterDefault(2, "x")
+			}),
 		NewLexerTest("abc", "axbxc", "2InsertBeforeAfterMiddleIndex",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(1, "x")
-			r.InsertAfterDefault(1, "x")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(1, "x")
+				r.InsertAfterDefault(1, "x")
+			}),
 		NewLexerTest("abc", "xbc", "ReplaceIndex0",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefaultPos(0, "x")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefaultPos(0, "x")
+			}),
 		NewLexerTest("abc", "abx", "ReplaceLastIndex",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefaultPos(2, "x")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefaultPos(2, "x")
+			}),
 		NewLexerTest("abc", "axc", "ReplaceMiddleIndex",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefaultPos(1, "x")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefaultPos(1, "x")
+			}),
 		NewLexerTest("abc", "ayc", "2ReplaceMiddleIndex",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefaultPos(1, "x")
-			r.ReplaceDefaultPos(1, "y")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefaultPos(1, "x")
+				r.ReplaceDefaultPos(1, "y")
+			}),
 		NewLexerTest("abc", "_ayc", "2ReplaceMiddleIndex1InsertBefore",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(0, "_")
-			r.ReplaceDefaultPos(1, "x")
-			r.ReplaceDefaultPos(1, "y")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(0, "_")
+				r.ReplaceDefaultPos(1, "x")
+				r.ReplaceDefaultPos(1, "y")
+			}),
 		NewLexerTest("abc", "ac", "ReplaceThenDeleteMiddleIndex",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefaultPos(1, "x")
-			r.DeleteDefaultPos(1)
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefaultPos(1, "x")
+				r.DeleteDefaultPos(1)
+			}),
 		NewLexerExceptionTest("abc", []string{"insert op", "within boundaries of previous"},
 			"InsertInPriorReplace",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(0,2, "x")
-			r.InsertBeforeDefault(1, "0")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(0, 2, "x")
+				r.InsertBeforeDefault(1, "0")
+			}),
 		NewLexerTest("abc", "0xbc", "InsertThenReplaceSameIndex",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(0,"0")
-			r.ReplaceDefaultPos(0, "x")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(0, "0")
+				r.ReplaceDefaultPos(0, "x")
+			}),
 		NewLexerTest("abc", "ayxbc", "2InsertMiddleIndex",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(1, "x")
-			r.InsertBeforeDefault(1, "y")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(1, "x")
+				r.InsertBeforeDefault(1, "y")
+			}),
 		NewLexerTest("abc", "yxzbc", "2InsertThenReplaceIndex0",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(0, "x")
-			r.InsertBeforeDefault(0, "y")
-			r.ReplaceDefaultPos(0,"z")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(0, "x")
+				r.InsertBeforeDefault(0, "y")
+				r.ReplaceDefaultPos(0, "z")
+			}),
 		NewLexerTest("abc", "abyx", "ReplaceThenInsertBeforeLastIndex",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefaultPos(2, "x")
-			r.InsertBeforeDefault(2, "y")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefaultPos(2, "x")
+				r.InsertBeforeDefault(2, "y")
+			}),
 		NewLexerTest("abc", "abyx", "InsertThenReplaceLastIndex",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(2, "y")
-			r.ReplaceDefaultPos(2, "x")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(2, "y")
+				r.ReplaceDefaultPos(2, "x")
+			}),
 		NewLexerTest("abc", "abxy", "ReplaceThenInsertAfterLastIndex",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefaultPos(2, "x")
-			r.InsertAfterDefault(2, "y")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefaultPos(2, "x")
+				r.InsertAfterDefault(2, "y")
+			}),
 		NewLexerTest("abcccba", "abyxba", "ReplaceThenInsertAtLeftEdge",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(2, 4, "x")
-			r.InsertBeforeDefault(2, "y")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(2, 4, "x")
+				r.InsertBeforeDefault(2, "y")
+			}),
 		NewLexerTest("abcccba", "abyxba", "ReplaceThenInsertAtLeftEdge",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(2, 4, "x")
-			r.InsertBeforeDefault(2, "y")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(2, 4, "x")
+				r.InsertBeforeDefault(2, "y")
+			}),
 		NewLexerExceptionTest("abcccba",
 			[]string{"insert op", "InsertBeforeOp", "within boundaries of previous", "ReplaceOp"},
 			"ReplaceRangeThenInsertAtRightEdge",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(2, 4, "x")
-			r.InsertBeforeDefault(4, "y")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(2, 4, "x")
+				r.InsertBeforeDefault(4, "y")
+			}),
 		NewLexerTest("abcccba", "abxyba", "ReplaceRangeThenInsertAfterRightEdge",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(2, 4, "x")
-			r.InsertAfterDefault(4, "y")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(2, 4, "x")
+				r.InsertAfterDefault(4, "y")
+			}),
 		NewLexerTest("abcccba", "x", "ReplaceAll",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(0, 6, "x")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(0, 6, "x")
+			}),
 		NewLexerTest("abcccba", "abxyzba", "ReplaceSubsetThenFetch",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(2, 4, "xyz")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(2, 4, "xyz")
+			}),
 		NewLexerExceptionTest("abcccba",
 			[]string{"replace op boundaries of", "ReplaceOp", "overlap with previous"},
 			"ReplaceThenReplaceSuperset",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(2, 4, "xyz")
-			r.ReplaceDefault(3, 5, "foo")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(2, 4, "xyz")
+				r.ReplaceDefault(3, 5, "foo")
+			}),
 		NewLexerExceptionTest("abcccba",
 			[]string{"replace op boundaries of", "ReplaceOp", "overlap with previous"},
 			"ReplaceThenReplaceLowerIndexedSuperset",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(2, 4, "xyz")
-			r.ReplaceDefault(1, 3, "foo")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(2, 4, "xyz")
+				r.ReplaceDefault(1, 3, "foo")
+			}),
 		NewLexerTest("abcba", "fooa", "ReplaceSingleMiddleThenOverlappingSuperset",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(2, 2, "xyz")
-			r.ReplaceDefault(0, 3, "foo")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(2, 2, "xyz")
+				r.ReplaceDefault(0, 3, "foo")
+			}),
 		NewLexerTest("abc", "yxabc", "CombineInserts",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(0, "x")
-			r.InsertBeforeDefault(0, "y")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(0, "x")
+				r.InsertBeforeDefault(0, "y")
+			}),
 		NewLexerTest("abc", "yazxbc", "Combine3Inserts",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(1, "x")
-			r.InsertBeforeDefault(0, "y")
-			r.InsertBeforeDefault(1, "z")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(1, "x")
+				r.InsertBeforeDefault(0, "y")
+				r.InsertBeforeDefault(1, "z")
+			}),
 		NewLexerTest("abc", "zfoo", "CombineInsertOnLeftWithReplace",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(0, 2, "foo")
-			r.InsertBeforeDefault(0, "z")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(0, 2, "foo")
+				r.InsertBeforeDefault(0, "z")
+			}),
 		NewLexerTest("abc", "z", "CombineInsertOnLeftWithDelete",
-		func(r *TokenStreamRewriter){
-			r.DeleteDefault(0,2)
-			r.InsertBeforeDefault(0, "z")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.DeleteDefault(0, 2)
+				r.InsertBeforeDefault(0, "z")
+			}),
 		NewLexerTest("abc", "zaxbyc", "DisjointInserts",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(1, "x")
-			r.InsertBeforeDefault(2, "y")
-			r.InsertBeforeDefault(0, "z")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(1, "x")
+				r.InsertBeforeDefault(2, "y")
+				r.InsertBeforeDefault(0, "z")
+			}),
 		NewLexerTest("abcc", "bar", "OverlappingReplace",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(1,2, "foo")
-			r.ReplaceDefault(0, 3, "bar")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(1, 2, "foo")
+				r.ReplaceDefault(0, 3, "bar")
+			}),
 		NewLexerExceptionTest("abcc",
 			[]string{"replace op boundaries of", "ReplaceOp", "overlap with previous"},
 			"OverlappingReplace2",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(0, 3, "bar")
-			r.ReplaceDefault(1, 2, "foo")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(0, 3, "bar")
+				r.ReplaceDefault(1, 2, "foo")
+			}),
 		NewLexerTest("abcc", "barc", "OverlappingReplace3",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(1,2, "foo")
-			r.ReplaceDefault(0, 2, "bar")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(1, 2, "foo")
+				r.ReplaceDefault(0, 2, "bar")
+			}),
 		NewLexerTest("abcc", "abar", "OverlappingReplace4",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(1,2, "foo")
-			r.ReplaceDefault(1, 3, "bar")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(1, 2, "foo")
+				r.ReplaceDefault(1, 3, "bar")
+			}),
 		NewLexerTest("abcc", "afooc", "DropIdenticalReplace",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(1,2, "foo")
-			r.ReplaceDefault(1, 2, "foo")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(1, 2, "foo")
+				r.ReplaceDefault(1, 2, "foo")
+			}),
 		NewLexerTest("abc", "afoofoo", "DropPrevCoveredInsert",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(1, "foo")
-			r.ReplaceDefault(1, 2, "foo")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(1, "foo")
+				r.ReplaceDefault(1, 2, "foo")
+			}),
 		NewLexerTest("abcc", "axbfoo", "LeaveAloneDisjointInsert",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(1, "x")
-			r.ReplaceDefault(2, 3, "foo")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(1, "x")
+				r.ReplaceDefault(2, 3, "foo")
+			}),
 		NewLexerTest("abcc", "axbfoo", "LeaveAloneDisjointInsert2",
-		func(r *TokenStreamRewriter){
-			r.ReplaceDefault(2, 3, "foo")
-			r.InsertBeforeDefault(1, "x")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.ReplaceDefault(2, 3, "foo")
+				r.InsertBeforeDefault(1, "x")
+			}),
 		NewLexerTest("abc", "aby", "InsertBeforeTokenThenDeleteThatToken",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(2, "y")
-			r.DeleteDefaultPos(2)
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(2, "y")
+				r.DeleteDefaultPos(2)
+			}),
 		NewLexerTest("aa", "<b>a</b><b>a</b>", "DistinguishBetweenInsertAfterAndInsertBeforeToPreserverOrder",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(0, "<b>")
-			r.InsertAfterDefault(0, "</b>")
-			r.InsertBeforeDefault(1, "<b>")
-			r.InsertAfterDefault(1,"</b>")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(0, "<b>")
+				r.InsertAfterDefault(0, "</b>")
+				r.InsertBeforeDefault(1, "<b>")
+				r.InsertAfterDefault(1, "</b>")
+			}),
 		NewLexerTest("aa", "<b><p>a</p></b><b>a</b>", "DistinguishBetweenInsertAfterAndInsertBeforeToPreserverOrder2",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(0, "<p>")
-			r.InsertBeforeDefault(0, "<b>")
-			r.InsertAfterDefault(0, "</p>")
-			r.InsertAfterDefault(0, "</b>")
-			r.InsertBeforeDefault(1, "<b>")
-			r.InsertAfterDefault(1,"</b>")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(0, "<p>")
+				r.InsertBeforeDefault(0, "<b>")
+				r.InsertAfterDefault(0, "</p>")
+				r.InsertAfterDefault(0, "</b>")
+				r.InsertBeforeDefault(1, "<b>")
+				r.InsertAfterDefault(1, "</b>")
+			}),
 		NewLexerTest("ab", "<div><b><p>a</p></b></div>!b", "DistinguishBetweenInsertAfterAndInsertBeforeToPreserverOrder2",
-		func(r *TokenStreamRewriter){
-			r.InsertBeforeDefault(0, "<p>")
-			r.InsertBeforeDefault(0, "<b>")
-			r.InsertBeforeDefault(0, "<div>")
-			r.InsertAfterDefault(0, "</p>")
-			r.InsertAfterDefault(0, "</b>")
-			r.InsertAfterDefault(0, "</div>")
-			r.InsertBeforeDefault(1, "!")
-		}),
+			func(r *TokenStreamRewriter) {
+				r.InsertBeforeDefault(0, "<p>")
+				r.InsertBeforeDefault(0, "<b>")
+				r.InsertBeforeDefault(0, "<div>")
+				r.InsertAfterDefault(0, "</p>")
+				r.InsertAfterDefault(0, "</b>")
+				r.InsertAfterDefault(0, "</div>")
+				r.InsertBeforeDefault(1, "!")
+			}),
 	}
 
-
-	for _,c := range tests{
-		t.Run(c.description,func(t *testing.T) {
+	for _, c := range tests {
+		t.Run(c.description, func(t *testing.T) {
 			rewriter := prepare_rewriter(c.input)
 			c.ops(rewriter)
-			if len(c.expected_exception)>0{
+			if len(c.expected_exception) > 0 {
 				panic_tester(t, c.expected_exception, rewriter)
-			}else{
+			} else {
 				result := rewriter.GetTextDefault()
-				if result!=c.expected{
+				if result != c.expected {
 					t.Errorf("Expected:%s | Result: %s", c.expected, result)
 				}
 			}
-		} )
+		})
 	}
 }
 
-
 // Suppress unused import error
 var _ = fmt.Printf
+var _ = sync.Once{}
 var _ = unicode.IsLetter
-
-var serializedLexerAtn = []int32{
-	4, 0, 3, 13, 6, 65535, 2, 0, 7, 0, 2, 1, 7, 1, 2, 2, 7, 2, 1, 0, 1, 0,
-	1, 1, 1, 1, 1, 2, 1, 2, 0, 0, 3, 1, 1, 3, 2, 5, 3, 1, 0, 0, 0, 12, 0, 1,
-	1, 0, 0, 0, 0, 3, 1, 0, 0, 0, 0, 5, 1, 0, 0, 0, 1, 7, 1, 0, 0, 0, 3, 9,
-	1, 0, 0, 0, 5, 11, 1, 0, 0, 0, 7, 8, 5, 97, 0, 0, 8, 2, 1, 0, 0, 0, 9,
-	10, 5, 98, 0, 0, 10, 4, 1, 0, 0, 0, 11, 12, 5, 99, 0, 0, 12, 6, 1, 0, 0,
-	0, 1, 0, 0,
-}
-
-var lexerDeserializer = NewATNDeserializer(nil)
-var lexerAtn = lexerDeserializer.Deserialize(serializedLexerAtn)
-
-var lexerChannelNames = []string{
-	"DEFAULT_TOKEN_CHANNEL", "HIDDEN",
-}
-
-var lexerModeNames = []string{
-	"DEFAULT_MODE",
-}
-
-var lexerLiteralNames = []string{
-	"", "'a'", "'b'", "'c'",
-}
-
-var lexerSymbolicNames = []string{
-	"", "A", "B", "C",
-}
-
-var lexerRuleNames = []string{
-	"A", "B", "C",
-}
 
 type LexerA struct {
 	*BaseLexer
@@ -367,26 +333,76 @@ type LexerA struct {
 	// TODO: EOF string
 }
 
-var lexerDecisionToDFA = make([]*DFA, len(lexerAtn.DecisionToState))
+var lexeraLexerStaticData struct {
+	once                   sync.Once
+	serializedATN          []int32
+	channelNames           []string
+	modeNames              []string
+	literalNames           []string
+	symbolicNames          []string
+	ruleNames              []string
+	predictionContextCache *PredictionContextCache
+	atn                    *ATN
+	decisionToDFA          []*DFA
+}
 
-func init() {
-	for index, ds := range lexerAtn.DecisionToState {
-		lexerDecisionToDFA[index] = NewDFA(ds, index)
+func lexeraLexerInit() {
+	staticData := &lexeraLexerStaticData
+	staticData.channelNames = []string{
+		"DEFAULT_TOKEN_CHANNEL", "HIDDEN",
+	}
+	staticData.modeNames = []string{
+		"DEFAULT_MODE",
+	}
+	staticData.literalNames = []string{
+		"", "'a'", "'b'", "'c'",
+	}
+	staticData.symbolicNames = []string{
+		"", "A", "B", "C",
+	}
+	staticData.ruleNames = []string{
+		"A", "B", "C",
+	}
+	staticData.predictionContextCache = NewPredictionContextCache()
+	staticData.serializedATN = []int32{
+		4, 0, 3, 13, 6, -1, 2, 0, 7, 0, 2, 1, 7, 1, 2, 2, 7, 2, 1, 0, 1, 0, 1,
+		1, 1, 1, 1, 2, 1, 2, 0, 0, 3, 1, 1, 3, 2, 5, 3, 1, 0, 0, 12, 0, 1, 1, 0,
+		0, 0, 0, 3, 1, 0, 0, 0, 0, 5, 1, 0, 0, 0, 1, 7, 1, 0, 0, 0, 3, 9, 1, 0,
+		0, 0, 5, 11, 1, 0, 0, 0, 7, 8, 5, 97, 0, 0, 8, 2, 1, 0, 0, 0, 9, 10, 5,
+		98, 0, 0, 10, 4, 1, 0, 0, 0, 11, 12, 5, 99, 0, 0, 12, 6, 1, 0, 0, 0, 1,
+		0, 0,
+	}
+	deserializer := NewATNDeserializer(nil)
+	staticData.atn = deserializer.Deserialize(staticData.serializedATN)
+	atn := staticData.atn
+	staticData.decisionToDFA = make([]*DFA, len(atn.DecisionToState))
+	decisionToDFA := staticData.decisionToDFA
+	for index, state := range atn.DecisionToState {
+		decisionToDFA[index] = NewDFA(state, index)
 	}
 }
 
+// LexerAInit initializes any static state used to implement LexerA. By default the
+// static state used to implement the lexer is lazily initialized during the first call to
+// NewLexerA(). You can call this function if you wish to initialize the static state ahead
+// of time.
+func LexerAInit() {
+	staticData := &lexeraLexerStaticData
+	staticData.once.Do(lexeraLexerInit)
+}
+
+// NewLexerA produces a new lexer instance for the optional input antlr.CharStream.
 func NewLexerA(input CharStream) *LexerA {
-
+	LexerAInit()
 	l := new(LexerA)
-
 	l.BaseLexer = NewBaseLexer(input)
-	l.Interpreter = NewLexerATNSimulator(l, lexerAtn, lexerDecisionToDFA, NewPredictionContextCache())
-
-	l.channelNames = lexerChannelNames
-	l.modeNames = lexerModeNames
-	l.RuleNames = lexerRuleNames
-	l.LiteralNames = lexerLiteralNames
-	l.SymbolicNames = lexerSymbolicNames
+	staticData := &lexeraLexerStaticData
+	l.Interpreter = NewLexerATNSimulator(l, staticData.atn, staticData.decisionToDFA, staticData.predictionContextCache)
+	l.channelNames = staticData.channelNames
+	l.modeNames = staticData.modeNames
+	l.RuleNames = staticData.ruleNames
+	l.LiteralNames = staticData.literalNames
+	l.SymbolicNames = staticData.symbolicNames
 	l.GrammarFileName = "LexerA.g4"
 	// TODO: l.EOF = antlr.TokenEOF
 
@@ -399,4 +415,3 @@ const (
 	LexerAB = 2
 	LexerAC = 3
 )
-


### PR DESCRIPTION
Regenerate the codegen and ATN content for test-related `LexerA` and `LexerB`, so that `go test` will execute successfully.

Similar issue to https://github.com/antlr/antlr4/issues/3557