### PR TITLE
Ensure that only the tokens needed are fetched

### DIFF
--- a/runtime/Go/antlr/common_token_stream.go
+++ b/runtime/Go/antlr/common_token_stream.go
@@ -331,10 +331,12 @@ func (c *CommonTokenStream) GetTextFromRuleContext(interval RuleContext) string 
 
 func (c *CommonTokenStream) GetTextFromInterval(interval *Interval) string {
 	c.lazyInit()
-	c.Fill()
 
 	if interval == nil {
+		c.Fill()
 		interval = NewInterval(0, len(c.tokens)-1)
+	} else {
+		c.Sync(interval.Stop)
 	}
 
 	start := interval.Start

--- a/runtime/Go/antlr/common_token_stream_test.go
+++ b/runtime/Go/antlr/common_token_stream_test.go
@@ -152,3 +152,27 @@ func TestCommonTokenStreamCannotConsumeEOF(t *testing.T) {
 	assert.Equal(1, tokens.Size())
 	assert.Panics(tokens.Consume)
 }
+
+func TestCommonTokenStreamGetTextFromInterval(t *testing.T) {
+	assert := assertNew(t)
+	lexEngine := &commonTokenStreamTestLexer{
+		tokens: []Token{
+			newTestCommonToken(1, " ", LexerHidden),                    // 0
+			newTestCommonToken(1, "x", LexerDefaultTokenChannel),       // 1
+			newTestCommonToken(1, " ", LexerHidden),                    // 2
+			newTestCommonToken(1, "=", LexerDefaultTokenChannel),       // 3
+			newTestCommonToken(1, "34", LexerDefaultTokenChannel),      // 4
+			newTestCommonToken(1, " ", LexerHidden),                    // 5
+			newTestCommonToken(1, " ", LexerHidden),                    // 6
+			newTestCommonToken(1, ";", LexerDefaultTokenChannel),       // 7
+			newTestCommonToken(1, " ", LexerHidden),                    // 8
+			newTestCommonToken(1, "\n", LexerHidden),                   // 9
+			newTestCommonToken(TokenEOF, "", LexerDefaultTokenChannel), // 10
+		},
+	}
+	tokens := NewCommonTokenStream(lexEngine, TokenDefaultChannel)
+	assert.Equal("x", tokens.GetTextFromInterval(&Interval{Start: 1, Stop: 1}))
+	assert.Equal(len(tokens.tokens), 2)
+	assert.Equal(" x =34  ; \n", tokens.GetTextFromInterval(nil))
+	assert.Equal(len(tokens.tokens), 11)
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/BufferedTokenStream.java
@@ -449,7 +449,7 @@ public class BufferedTokenStream implements TokenStream {
 		int start = interval.a;
 		int stop = interval.b;
 		if ( start<0 || stop<0 ) return "";
-		fill();
+		sync(stop);
         if ( stop>=tokens.size() ) stop = tokens.size()-1;
 
 		StringBuilder buf = new StringBuilder();


### PR DESCRIPTION
Update the Go and Java runtimes to match the C++ runtime for syncing to only the tokens needed
to read the text from the supplied interval. 

The `fill()` methods search for EOF as a signal to conclude the token syncing; however, when there
is an errant input, EOF may be missing and this can result in `fill()` re-reading the entire token stream
for each error encountered in the input. As such `fill()` has been replaced with `sync()` calls which
provide equivalent functionality.

Signed-off-by: Tristan Swadell <tswadell@google.com>