### PR TITLE
Add interp tool like TestRig

### DIFF
--- a/tool/src/org/antlr/v4/gui/Interpreter.java
+++ b/tool/src/org/antlr/v4/gui/Interpreter.java
@@ -27,7 +27,7 @@ import java.nio.file.Paths;
  *        [-tokens]
  *        [-profile filename.csv]
  */
-public class Intrepreter {
+public class Interpreter {
 	public static final String[] profilerColumnNames = {
 			"Rule","Invocations", "Time (ms)", "Total k", "Max k", "Ambiguities", "DFA cache miss"
 	};
@@ -60,7 +60,7 @@ public class Intrepreter {
 	protected String profileFileName = null;
 	protected String inputFileName;
 
-	public Intrepreter(String[] args) throws Exception {
+	public Interpreter(String[] args) throws Exception {
 		if ( args.length < 2 ) {
 			System.err.println("java org.antlr.v4.guIntrepreter [X.g4|XParser.g4 XLexer.g4] startRuleName\n" +
 					"  [-tokens] [-tree] [-gui] [-encoding encodingname]\n" +
@@ -270,7 +270,7 @@ public class Intrepreter {
 	}
 
 	public static void main(String[] args) throws Exception {
-		Intrepreter I = new Intrepreter(args);
+		Interpreter I = new Interpreter(args);
 		I.interp();
 	}
 }

--- a/tool/src/org/antlr/v4/gui/Interpreter.java
+++ b/tool/src/org/antlr/v4/gui/Interpreter.java
@@ -130,6 +130,9 @@ public class Interpreter {
 	}
 
 	protected ParseInfo interp() throws RecognitionException, IOException {
+		if ( grammarFileName==null && (parserGrammarFileName==null && lexerGrammarFileName==null) ) {
+			return null;
+		}
 		Grammar g;
 		LexerGrammar lg = null;
 		DefaultToolListener listener = new DefaultToolListener(new Tool());

--- a/tool/src/org/antlr/v4/gui/Intrepreter.java
+++ b/tool/src/org/antlr/v4/gui/Intrepreter.java
@@ -13,9 +13,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /** Interpret a lexer/parser, optionally printing tree string and dumping profile info
  *

--- a/tool/src/org/antlr/v4/gui/Intrepreter.java
+++ b/tool/src/org/antlr/v4/gui/Intrepreter.java
@@ -1,0 +1,198 @@
+package org.antlr.v4.gui;
+
+import org.antlr.runtime.RecognitionException;
+import org.antlr.v4.Tool;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.atn.DecisionInfo;
+import org.antlr.v4.runtime.atn.ParseInfo;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.tool.Grammar;
+import org.antlr.v4.tool.GrammarParserInterpreter;
+import org.antlr.v4.tool.LexerGrammar;
+import org.antlr.v4.tool.Rule;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** Run a lexer/parser combo, optionally printing tree string or generating
+ *  postscript file. Optionally taking input file.
+ *
+ *  $ java org.antlr.v4.runtime.misc.TestRig X.g4 startRuleName inputFileName
+ *        [-tree]
+ *        [-tokens]
+ *        [-profile]
+ *
+ *  $ java org.antlr.v4.runtime.misc.TestRig XParser.g4 XLexer.g4 startRuleName inputFileName
+ *        [-tree]
+ *        [-tokens]
+ *        [-profile]
+ */
+public class Intrepreter {
+	public static final String[] profilerColumnNames = {
+			"Rule","Invocations", "Time", "Total k", "Max k", "Ambiguities", "DFA cache miss"
+	};
+
+	protected String grammarFileName;
+	protected String parserGrammarFileName;
+	protected String lexerGrammarFileName;
+	protected String startRuleName;
+	protected boolean printTree = false;
+	protected boolean gui = false;
+	protected String encoding = null;
+	protected boolean showTokens = false;
+	protected boolean profile = false;
+	protected final List<String> inputFiles = new ArrayList<String>();
+
+	public Intrepreter(String[] args) throws Exception {
+		if ( args.length < 2 ) {
+			System.err.println("java org.antlr.v4.gui.Intrepreter GrammarFileName startRuleName\n" +
+					"  [-tokens] [-tree] [-gui] [-ps file.ps] [-encoding encodingname]\n" +
+					"  [-trace] [-diagnostics] [-SLL]\n"+
+					"  [input-filename(s)]");
+			System.err.println("Use startRuleName='tokens' if GrammarName is a lexer grammar.");
+			System.err.println("Omitting input-filename makes rig read from stdin.");
+			return;
+		}
+		int i=0;
+		grammarFileName = args[i];
+		i++;
+		if ( args[i].endsWith(".g4") ) {
+			parserGrammarFileName = grammarFileName;
+			lexerGrammarFileName = args[i];
+			i++;
+		}
+		startRuleName = args[i];
+		i++;
+		while ( i<args.length ) {
+			String arg = args[i];
+			i++;
+			if ( arg.charAt(0)!='-' ) { // input file name
+				inputFiles.add(arg);
+			}
+			else if ( arg.equals("-tree") ) {
+				printTree = true;
+			}
+			else if ( arg.equals("-gui") ) {
+				gui = true;
+			}
+			else if ( arg.equals("-tokens") ) {
+				showTokens = true;
+			}
+			else if ( arg.equals("-profile") ) {
+				profile = true;
+			}
+			else if ( arg.equals("-encoding") ) {
+				if ( i>=args.length ) {
+					System.err.println("missing encoding on -encoding");
+					return;
+				}
+				encoding = args[i];
+				i++;
+			}
+		}
+	}
+
+	protected ParseInfo interp(Grammar g, String startRule, String inputFileName)
+			throws RecognitionException, IOException {
+		Charset charset = ( encoding == null ? Charset.defaultCharset () : Charset.forName(encoding) );
+		CharStream charStream = CharStreams.fromPath(Paths.get(inputFileName), charset);
+		LexerInterpreter lexEngine = g.createLexerInterpreter(charStream);
+
+		class SyntaxErrorListener extends BaseErrorListener {
+			@Override
+			public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, org.antlr.v4.runtime.RecognitionException e) {
+				super.syntaxError(recognizer, offendingSymbol, line, charPositionInLine, msg, e);
+			}
+		};
+
+		SyntaxErrorListener syntaxErrorListener = new SyntaxErrorListener();
+//		lexEngine.removeErrorListeners();
+		lexEngine.addErrorListener(syntaxErrorListener);
+
+		CommonTokenStream tokens = new CommonTokenStream(lexEngine);
+		GrammarParserInterpreter parser = g.createGrammarParserInterpreter(tokens);
+		parser.setProfile(true);
+//		parser.setTrace(true);
+//		tokens.fill();
+//		System.out.println(tokens.getTokens());
+
+		Rule r = g.rules.get(startRule);
+		ParseInfo parseInfo = parser.getParseInfo();
+		if (r == null) {
+			return parseInfo;
+		}
+		ParseTree t = parser.parse(r.index);
+		System.out.println(t.toStringTree(parser));
+
+		String[] ruleNamesByDecision = new String[parser.getATN().decisionToState.size()];
+		for(int i = 0; i < ruleNamesByDecision .length; i++) {
+			ruleNamesByDecision [i] = parser.getRuleNames()[parser.getATN().getDecisionState(i).ruleIndex];
+		}
+
+		DecisionInfo[] decisionInfo = parseInfo.getDecisionInfo();
+		String[][] table = new String[decisionInfo.length][profilerColumnNames.length];
+
+		for (int decision = 0; decision < decisionInfo.length; decision++) {
+			for (int col = 0; col < profilerColumnNames.length; col++) {
+				Object colVal = getValue(decisionInfo[decision], ruleNamesByDecision, decision, col);
+				table[decision][col] = colVal.toString();
+			}
+		}
+		for (int i = 0; i < profilerColumnNames.length; i++) {
+			if ( i>0 ) System.out.print(",");
+			System.out.print(profilerColumnNames[i]);
+		}
+		System.out.println();
+		for (String[] row : table) {
+			for (int i = 0; i < profilerColumnNames.length; i++) {
+				if ( i>0 ) System.out.print(",");
+				System.out.print(row[i]);
+			}
+			System.out.println();
+		}
+
+		return parseInfo;
+	}
+
+	protected static Object getValue(DecisionInfo decisionInfo,
+									 String[] ruleNamesByDecision,
+									 int decision,
+									 int col)
+	{
+		switch (col) { // laborious but more efficient than reflection
+			case 0:
+				return  String.format("%s:%d",ruleNamesByDecision[decision],decision);
+			case 1:
+				return decisionInfo.invocations;
+			case 2:
+				return decisionInfo.timeInPrediction/(1000.0 * 1000.0);
+			case 3:
+				return decisionInfo.LL_TotalLook+decisionInfo.SLL_TotalLook;
+			case 4:
+				return Math.max(decisionInfo.LL_MaxLook, decisionInfo.SLL_MaxLook);
+			case 5:
+				return decisionInfo.ambiguities.size();
+			case 6:
+				return decisionInfo.SLL_ATNTransitions+
+						decisionInfo.LL_ATNTransitions;
+		}
+		return "n/a";
+	}
+
+
+	public static void main(String[] args) throws Exception {
+		Intrepreter I = new Intrepreter(args);
+
+		String grammarContent = Files.readString(Path.of(I.grammarFileName));
+		Grammar g = new Grammar(grammarContent);
+
+		ParseInfo parseInfo = I.interp(g, I.startRuleName, I.inputFiles.get(0));
+//		System.out.println(Arrays.toString(info));
+	}
+}


### PR DESCRIPTION
An interpreted version of TestRig, which only ran Java-based (and compiled) parser/lexers.  This uses java-based interp to process any grammar (ignoring actions of course).

Needed by new tools: https://github.com/antlr/antlr4-tools

```
$ java org.antlr.v4.gui.Interpreter \
    /Users/parrt/sample/TParser.g4 \
    /Users/parrt/sample/TLexer.g4 \
    expr -profile /tmp/T-profile.csv -tokens /tmp/foo.txt
```

```
$ java org.antlr.v4.gui.Interpreter /Users/parrt/sample/JSON.g4 json -profile /tmp/json.csv /tmp/foo.json
Rule,Invocations,Time,Total k,Max k,Ambiguities,DFA cache miss
obj:0,2,0.030417,2,1,0,2
obj:1,1,1.317417,2,2,0,2
arr:2,3,0.034917,3,1,0,2
arr:3,1,0.101917,2,2,0,2
value:4,6,0.341458,6,1,0,3
```

@kaby76 @KvanTTT @hzeller @mike-lischke @ericvergnaud might be interested.  Then I'll hook into python script which installs java/antlr.

```
$ java org.antlr.v4.gui.Interpreter /Users/parrt/sample/JavaParser.g4 /Users/parrt/sample/JavaLexer.g4 compilationUnit -profile /tmp/a.csv -trace
class T { int i; }
enter   compilationUnit, LT(1)=class
enter   typeDeclaration, LT(1)=class
enter   classDeclaration, LT(1)=class
consume [@0,0:4='class',<9>,1:0] rule classDeclaration
enter   identifier, LT(1)=T
consume [@2,6:6='T',<128>,1:6] rule identifier
exit    identifier, LT(1)={
enter   classBody, LT(1)={
consume [@4,8:8='{',<80>,1:8] rule classBody
enter   classBodyDeclaration, LT(1)=int
...
exit    compilationUnit, LT(1)=<EOF>
$ head /tmp/a.csv
Rule,Invocations,Time (ms),Total k,Max k,Ambiguities,DFA cache miss
compilationUnit:0,1,0.30525,1,1,0,1
compilationUnit:1,1,0.578416,1,1,0,1
compilationUnit:2,2,0.634208,2,1,0,2
compilationUnit:3,1,1.662042,1,1,0,1
packageDeclaration:4,0,0.0,0,0,0,0
importDeclaration:5,0,0.0,0,0,0,0
importDeclaration:6,0,0.0,0,0,0,0
typeDeclaration:7,1,0.0925,1,1,0,1
typeDeclaration:8,1,0.086917,1,1,0,1
```