### PR TITLE
[Swift] let the Swift Package Manager choose between static or dynamic linking 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     products: [
         .library(
             name: "Antlr4",
-            type: .dynamic,
+            type: .static,
             targets: ["Antlr4"]),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,6 @@ let package = Package(
     products: [
         .library(
             name: "Antlr4",
-            type: .static,
             targets: ["Antlr4"]),
     ],
     targets: [


### PR DESCRIPTION
When building an executable target using Swift Package Manager,  We should depend on a static Antlr runtime framework to make a portable executable binary.

Or we will have to deal with the linker problem like:

```
dyld[36790]: Library not loaded: @rpath/libAntlr4.dylib
  Referenced from: /Users/100mango/Desktop/RossetaDartDemo/Rosseta
  Reason: tried: '/usr/lib/swift/libAntlr4.dylib' (no such file),
 '/Users/100mango/Desktop/RossetaDartDemo/../lib/libAntlr4.dylib' (no such file),
 '/usr/lib/swift/libAntlr4.dylib' (no such file), 
'/Users/100mango/Desktop/RossetaDartDemo/../lib/libAntlr4.dylib' (no such file),
 '/usr/local/lib/libAntlr4.dylib' (no such file), 
'/usr/lib/libAntlr4.dylib' (no such file)
```