### PR TITLE
fix URL to download page.

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -41,7 +41,7 @@ $ alias grun='java -Xmx500M -cp "/usr/local/lib/antlr-4.10.1-complete.jar:$CLASS
 (*Thanks to Graham Wideman*)
 
 0. Install Java (version 1.7 or higher)
-1. Download antlr-4.10.1-complete.jar (or whatever version) from [https://www.antlr.org/download/](https://www.antlr.org/download/)
+1. Download antlr-4.10.1-complete.jar (or whatever version) from [https://www.antlr.org/download.html](https://www.antlr.org/download.html)
 Save to your directory for 3rd party Java libraries, say `C:\Javalib`
 2. Add `antlr-4.10.1-complete.jar` to CLASSPATH, either:
   * Permanently: Using System Properties dialog > Environment variables > Create or append to `CLASSPATH` variable


### PR DESCRIPTION
The URL to the download page in the Windows installation instructions is incorrect and needs to be corrected.

Signed-off-by: GCer-Hidenori <gcer.hidenori+github@gmail.com>

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
