### PR TITLE
Don't make class SementicContext::Empty final.

### DIFF
--- a/runtime/Cpp/runtime/src/atn/SemanticContext.h
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.h
@@ -92,7 +92,7 @@ namespace atn {
     return !operator==(lhs, rhs);
   }
 
-  class ANTLR4CPP_PUBLIC SemanticContext::Empty final : public SemanticContext{
+  class ANTLR4CPP_PUBLIC SemanticContext::Empty : public SemanticContext{
   public:
     /**
      * The default {@link SemanticContext}, which is semantically equivalent to


### PR DESCRIPTION
Don't make class SementicContext::Empty final.
    
The class does not implement the pure virtual methods so can
not be considered 'final'. Clang 10 and 11 complain about this.
    
Context: https://github.com/chipsalliance/Surelog/issues/3081