### PR TITLE
Add Go accessor for IntervalSet.intervals

### DIFF
--- a/runtime/Go/antlr/interval_set.go
+++ b/runtime/Go/antlr/interval_set.go
@@ -223,6 +223,10 @@ func (i *IntervalSet) StringVerbose(literalNames []string, symbolicNames []strin
 	return i.toIndexString()
 }
 
+func (i *IntervalSet) GetIntervals() []*Interval {
+	return i.intervals
+}
+
 func (i *IntervalSet) toCharString() string {
 	names := make([]string, len(i.intervals))
 


### PR DESCRIPTION
Signed-off-by: James Taylor <jamestaylor@apache.org>

Unlike the Java version, in the Go-based version of interval_sets, there's no way to access the IntervalSets.intervals field. This field is useful when using Parser.getExpectedTokens(). The alternative is to use IntervalSets#StringVerbose and parse the string returned (which is much more expensive).