### PR TITLE
[Python 3] use build and twine to publish source and wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ user.build.properties
 __pycache__/
 *.py[cod]
 *$py.class
+# Build results
+*.egg-info/
 
 ## CSharp and VisualStudio, selected lines from https://raw.githubusercontent.com/github/gitignore/master/VisualStudio.gitignore
 # User-specific files

--- a/doc/releasing-antlr.md
+++ b/doc/releasing-antlr.md
@@ -342,7 +342,13 @@ Nuget packages are also accessible as artifacts of [AppVeyor builds](https://ci.
 
 ### Python
 
-The Python targets get deployed with `setup.py`. First, set up `~/.pypirc` with tight privileges:
+The Python targets get deployed with `setup.py` (Python 2), or `build` and `twine` (Python 3).
+Install them by
+```sh
+pip3 install build twine
+```
+
+First, set up `~/.pypirc` with tight privileges:
 
 ```bash
 beast:~ $ ls -l ~/.pypirc
@@ -372,12 +378,13 @@ cd ~/antlr/code/antlr4/runtime/Python2
 python setup.py sdist upload
 ```
 
-and do again for Python 3 target
+For Python 3 target, do
 
 ```bash
 cd ~/antlr/code/antlr4/runtime/Python3
+python3 -m build
 # assume you have ~/.pypirc set up
-python3 setup.py sdist upload
+twine upload dist/antlr4-python3-runtime-<version>.tar.gz dist/antlr4_python3_runtime-<version>-py3-none-any.whl
 ```
 
 There are links to the artifacts in [download.html](http://www.antlr.org/download.html) already.


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
Closes #3805 

I'm using Python 3.9. I tried `python setup.py sdist upload -r pypitest` but got
```
...
Writing antlr4-python3-runtime-4.10.1/setup.cfg
Creating tar archive
removing 'antlr4-python3-runtime-4.10.1' (and everything under it)
running upload
Submitting dist/antlr4-python3-runtime-4.10.1.tar.gz to https://test.pypi.org/legacy/
Upload failed (400): Invalid value for blake2_256_digest. Error: Use a valid, hex-encoded, BLAKE2 message digest.
error: Upload failed (400): Invalid value for blake2_256_digest. Error: Use a valid, hex-encoded, BLAKE2 message digest.
```
The [answer](https://bugs.python.org/issue45590) seems using `twine` instead, and from the [link](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary) there calling `setup.py` should be deprecated.
So I use `build` and `twine` to publish both source and wheel to [test pypi](https://test.pypi.org/project/antlr4-python3-runtime/4.10.1/#files).

I also gave a try to Python 2, but `python -m build` gave error. I don't want to bother with that since Python 2 has reached EOL for 2 years and half. I think ANTLR should drop Python 2 support some time.