### PR TITLE
init Reproducible Builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<project.build.outputTimestamp>10</project.build.outputTimestamp>
 		<antlr.testinprocess>true</antlr.testinprocess>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
@@ -162,6 +163,16 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.2.2</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-release-plugin</artifactId>
+					<version>3.0.0-M6</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -76,7 +76,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>5.1.2</version>
+				<version>5.1.7</version>
 				<executions>
 					<execution>
 						<id>bundle-manifest</id>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -160,6 +160,38 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin><!-- workaround for https://github.com/antlr/antlr3/pull/209 -->
+              <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>fix-antlr3-RB</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <basedir>${project.build.directory}/generated-sources/antlr3/org/antlr/v4</basedir>
+                    <includes>
+                        <include>parse/*.java</include>
+                        <include>codegen/*.java</include>
+                    </includes>
+                    <replacements>
+                        <replacement>
+                            <token>(// .ANTLR .+) ....-..-.. ..:..:..</token>
+                            <value>$1</value>
+                        </replacement>
+                        <replacement>
+                            <token>(// elements: ).*</token>
+                            <value>$1</value>
+                        </replacement>
+                    </replacements>
+                    <regex>true</regex>
+                </configuration>
+            </plugin>
 			<plugin>
 				<groupId>com.webguys</groupId>
 				<artifactId>string-template-maven-plugin</artifactId>


### PR DESCRIPTION
Signed-off-by: Hervé Boutemy <hboutemy@apache.org>

equivalent to https://github.com/antlr/antlr3/pull/210 that I did for ANTLR3

given ANTLR4 uses ANTLR3, to get a full reproducible build for ANTLR4, ANTLR3 version will require to be upgraded once https://github.com/antlr/antlr3/pull/209 has been merged and a release done