### PR TITLE
[py2] Fix SyntaxError due to F string

### DIFF
--- a/runtime/Python2/setup.py
+++ b/runtime/Python2/setup.py
@@ -10,5 +10,5 @@ setup(
     package_dir={'': 'src'},
     author='Eric Vergnaud, Terence Parr, Sam Harwell',
     author_email='eric.vergnaud@wanadoo.fr',
-    description=f'ANTLR {v} runtime for Python 2.7.12'
+    description='ANTLR %s runtime for Python 2.7.12' % v
 )


### PR DESCRIPTION
Signed-off-by: Travis Thieman <travis.thieman@gmail.com>

Follow-up from https://github.com/antlr/antlr4/pull/3662. Fixes the F string syntax error in the Python 2 `setup.py` file. This should make the Python 2 runtime installable again from Python 2 pip.