### PR TITLE
Create emulation tracer

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulator.java
@@ -6,6 +6,7 @@
 
 package org.antlr.v4.runtime.atn;
 
+import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.dfa.DFAState;
 import org.antlr.v4.runtime.misc.IntervalSet;
 

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulatorTracer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulatorTracer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2012-2022 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
 package org.antlr.v4.runtime.atn;
 
 import org.antlr.v4.runtime.dfa.DFA;

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulatorTracer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATNSimulatorTracer.java
@@ -1,0 +1,50 @@
+package org.antlr.v4.runtime.atn;
+
+import org.antlr.v4.runtime.dfa.DFA;
+import org.antlr.v4.runtime.dfa.DFAState;
+
+/** This class encapsulates the functionality associated with tracing ATN simulation during lexing and parsing.
+ *  The goal is to create a machine readable traits from simulation so that we can compare across target.
+ *  Starting out by tracking DFA state construction.
+ *
+ * @since 4.10.2
+ */
+public class ATNSimulatorTracer {
+	/** Invoked after we have added state D to dfa (confirming that it does not already exist in dfa).
+	 *  Active if boolean trace is true.
+	 *
+	 * @since 4.10.2
+	 */
+	public void addDFAState(DFA dfa, DFAState D) {
+		System.out.println("NEW STATE: "+D.stateNumber+" in DFA for ATN.s0 "+dfa.atnStartState.stateNumber);
+		System.out.println("\t"+toString(D));
+	}
+
+	/** Invoked in {@link ParserATNSimulator#addDFAState} or {@link LexerATNSimulator#addDFAState}
+	 *  after we discover that dfa already has a state that is equivalent to D. No DFA state was added to dfa.
+	 *
+	 * @since 4.10.2
+	 */
+	public void addDFAState_existing(DFA dfa, DFAState D) {
+		System.out.println("EXISTS: "+D.stateNumber+" in DFA for ATN.s0 "+dfa.atnStartState.stateNumber);
+		System.out.println("\t"+toString(D));
+	}
+
+	/** Invoked after we have added from -> to edge in dfa.
+	 *
+	 *  Java target: This call is synchronized on `from` state in {@link ParserATNSimulator#addDFAState}
+	 *  and on `dfa.states` in {@link LexerATNSimulator#addDFAState}.
+	 *
+	 * @since 4.10.2
+	 */
+	public void addDFAEdge(DFA dfa, DFAState from, int t, DFAState to) {
+		System.out.println("EDGE: "+from.stateNumber+" -> "+to.stateNumber+" upon "+t+" in DFA for ATN.s0 "+dfa.atnStartState.stateNumber);
+		System.out.println("\t"+toString(from));
+		System.out.println("\t"+"->");
+		System.out.println("\t"+toString(to));
+	}
+
+	public String toString(DFAState D) {
+		return D.toString();
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -656,6 +656,7 @@ public class LexerATNSimulator extends ATNSimulator {
 				p.edges = new DFAState[MAX_DFA_EDGE-MIN_DFA_EDGE+1];
 			}
 			p.edges[t - MIN_DFA_EDGE] = q; // connect
+			trace_addDFAEdge(p, t, q);
 		}
 	}
 
@@ -689,7 +690,10 @@ public class LexerATNSimulator extends ATNSimulator {
 		DFA dfa = decisionToDFA[mode];
 		synchronized (dfa.states) {
 			DFAState existing = dfa.states.get(proposed);
-			if ( existing!=null ) return existing;
+			if ( existing!=null ) {
+				trace_addDFAState_existing(existing);
+				return existing;
+			}
 
 			DFAState newState = proposed;
 
@@ -697,6 +701,7 @@ public class LexerATNSimulator extends ATNSimulator {
 			configs.setReadonly(true);
 			newState.configs = configs;
 			dfa.states.put(newState, newState);
+			trace_addDFAState(newState);
 			return newState;
 		}
 	}
@@ -747,5 +752,35 @@ public class LexerATNSimulator extends ATNSimulator {
 		if ( t==-1 ) return "EOF";
 		//if ( atn.g!=null ) return atn.g.getTokenDisplayName(t);
 		return "'"+(char)t+"'";
+	}
+
+	/** Invoked after we have added state D to dfa (confirming that it does not already exist in dfa).
+	 *
+	 *  Java target: This call is synchronized on `dfa.states` state in {@link LexerATNSimulator#addDFAState}.
+	 *
+	 * @since 4.10.2
+	 */
+	public void trace_addDFAState(DFAState D) {
+	}
+
+	/** Invoked in {@link LexerATNSimulator#addDFAState}
+	 *  after we discover that dfa already has a state that is equivalent to D. No DFA state was added to dfa.
+	 *
+	 * @since 4.10.2
+	 */
+	public void trace_addDFAState_existing(DFAState D) {
+	}
+
+	/** Invoked after we have added from -> to edge in dfa.
+	 *
+	 *  Java target: This call is synchronized on `from` state in {@link LexerATNSimulator#addDFAEdge}.
+	 *
+	 * @since 4.10.2
+	 */
+	public void trace_addDFAEdge(DFAState from, int t, DFAState to) {
+	}
+
+	public String trace_toString(DFAState D) {
+		return D.toString();
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -272,11 +272,6 @@ public class ParserATNSimulator extends ATNSimulator {
 	public static final boolean dfa_debug = false;
 	public static final boolean retry_debug = false;
 
-	/** Used to generate machine-readable output for comparison across targets.
-	 *  To avoid runtime cost when not debugging, this is static final; must manually alter statically.
-	 */
-	public static final ATNSimulatorTracer tracer = new ATNSimulatorTracer(); // null;
-
 	/** Just in case this optimization is bad, add an ENV variable to turn it off */
 	public static final boolean TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT = Boolean.parseBoolean(getSafeEnv("TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT"));
 
@@ -2094,7 +2089,7 @@ public class ParserATNSimulator extends ATNSimulator {
 			}
 
 			from.edges[t+1] = to; // connect
-			if ( tracer!=null ) tracer.addDFAEdge(dfa, from, t, to);
+			trace_addDFAEdge(dfa, from, t, to);
 		}
 
 		if ( debug ) {
@@ -2127,7 +2122,7 @@ public class ParserATNSimulator extends ATNSimulator {
 		synchronized (dfa.states) {
 			DFAState existing = dfa.states.get(D);
 			if ( existing!=null ) {
-				if ( tracer!=null ) tracer.addDFAState_existing(dfa, existing);
+				trace_addDFAState_existing(dfa, existing);
 				return existing;
 			}
 
@@ -2138,7 +2133,7 @@ public class ParserATNSimulator extends ATNSimulator {
 			}
 			dfa.states.put(D, D);
 			if ( debug ) System.out.println("adding new DFA state: "+D);
-			if ( tracer!=null ) tracer.addDFAState(dfa, D);
+			trace_addDFAState(dfa, D);
 			return D;
 		}
 	}
@@ -2206,5 +2201,35 @@ public class ParserATNSimulator extends ATNSimulator {
 		}
 		catch (SecurityException e) { }
 		return null;
+	}
+
+	/** Invoked after we have added state D to dfa (confirming that it does not already exist in dfa).
+	 *
+	 *  Java target: This call is synchronized on `dfa.states` in {@link ParserATNSimulator#addDFAState}.
+	 *
+	 * @since 4.10.2
+	 */
+	public void trace_addDFAState(DFA dfa, DFAState D) {
+	}
+
+	/** Invoked in {@link ParserATNSimulator#addDFAState}
+	 *  after we discover that dfa already has a state that is equivalent to D. No DFA state was added to dfa.
+	 *
+	 * @since 4.10.2
+	 */
+	public void trace_addDFAState_existing(DFA dfa, DFAState D) {
+	}
+
+	/** Invoked after we have added from -> to edge in dfa.
+	 *
+	 *  Java target: This call is synchronized on `from` in {@link ParserATNSimulator#addDFAEdge}.
+	 *
+	 * @since 4.10.2
+	 */
+	public void trace_addDFAEdge(DFA dfa, DFAState from, int t, DFAState to) {
+	}
+
+	public String trace_toString(DFAState D) {
+		return D.toString();
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -272,6 +272,9 @@ public class ParserATNSimulator extends ATNSimulator {
 	public static final boolean dfa_debug = false;
 	public static final boolean retry_debug = false;
 
+	/** Used to generate machine-readable output for comparison across targets */
+	public static final ATNSimulatorTracer tracer = new ATNSimulatorTracer(); // null;
+
 	/** Just in case this optimization is bad, add an ENV variable to turn it off */
 	public static final boolean TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT = Boolean.parseBoolean(getSafeEnv("TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT"));
 
@@ -2089,6 +2092,7 @@ public class ParserATNSimulator extends ATNSimulator {
 			}
 
 			from.edges[t+1] = to; // connect
+			if ( tracer!=null ) tracer.addDFAEdge(dfa, from, t, to);
 		}
 
 		if ( debug ) {
@@ -2120,7 +2124,10 @@ public class ParserATNSimulator extends ATNSimulator {
 
 		synchronized (dfa.states) {
 			DFAState existing = dfa.states.get(D);
-			if ( existing!=null ) return existing;
+			if ( existing!=null ) {
+				if ( tracer!=null ) tracer.addDFAState_existing(dfa, existing);
+				return existing;
+			}
 
 			D.stateNumber = dfa.states.size();
 			if (!D.configs.isReadonly()) {
@@ -2129,6 +2136,7 @@ public class ParserATNSimulator extends ATNSimulator {
 			}
 			dfa.states.put(D, D);
 			if ( debug ) System.out.println("adding new DFA state: "+D);
+			if ( tracer!=null ) tracer.addDFAState(dfa, D);
 			return D;
 		}
 	}
@@ -2193,7 +2201,8 @@ public class ParserATNSimulator extends ATNSimulator {
 					return System.getenv(envName);
 				}
 			});
-		} catch (SecurityException e) { }
+		}
+		catch (SecurityException e) { }
 		return null;
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -272,7 +272,9 @@ public class ParserATNSimulator extends ATNSimulator {
 	public static final boolean dfa_debug = false;
 	public static final boolean retry_debug = false;
 
-	/** Used to generate machine-readable output for comparison across targets */
+	/** Used to generate machine-readable output for comparison across targets.
+	 *  To avoid runtime cost when not debugging, this is static final; must manually alter statically.
+	 */
 	public static final ATNSimulatorTracer tracer = new ATNSimulatorTracer(); // null;
 
 	/** Just in case this optimization is bad, add an ENV variable to turn it off */

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/TracingLexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/TracingLexerATNSimulator.java
@@ -1,7 +1,6 @@
 package org.antlr.v4.runtime.atn;
 
 import org.antlr.v4.runtime.Lexer;
-import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.dfa.DFAState;
 

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/TracingLexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/TracingLexerATNSimulator.java
@@ -1,0 +1,50 @@
+package org.antlr.v4.runtime.atn;
+
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.dfa.DFA;
+import org.antlr.v4.runtime.dfa.DFAState;
+
+public class TracingLexerATNSimulator extends LexerATNSimulator {
+	public TracingLexerATNSimulator(ATN atn, DFA[] decisionToDFA, PredictionContextCache sharedContextCache) {
+		super(atn, decisionToDFA, sharedContextCache);
+	}
+
+	public TracingLexerATNSimulator(Lexer recog, ATN atn, DFA[] decisionToDFA, PredictionContextCache sharedContextCache) {
+		super(recog, atn, decisionToDFA, sharedContextCache);
+	}
+
+	/** Invoked after we have added state D to dfa (confirming that it does not already exist in dfa).
+	 *  Active if boolean trace is true.
+	 *
+	 * @since 4.10.2
+	 */
+	public void trace_addDFAState(DFA dfa, DFAState D) {
+		System.out.println("NEW STATE: "+D.stateNumber+" in DFA for ATN.s0 "+dfa.atnStartState.stateNumber);
+		System.out.println("\t"+trace_toString(D));
+	}
+
+	/** Invoked in {@link ParserATNSimulator#addDFAState} or {@link LexerATNSimulator#addDFAState}
+	 *  after we discover that dfa already has a state that is equivalent to D. No DFA state was added to dfa.
+	 *
+	 * @since 4.10.2
+	 */
+	public void trace_addDFAState_existing(DFA dfa, DFAState D) {
+		System.out.println("EXISTS: "+D.stateNumber+" in DFA for ATN.s0 "+dfa.atnStartState.stateNumber);
+		System.out.println("\t"+trace_toString(D));
+	}
+
+	/** Invoked after we have added from -> to edge in dfa.
+	 *
+	 *  Java target: This call is synchronized on `from` state in {@link ParserATNSimulator#addDFAState}
+	 *  and on `dfa.states` in {@link LexerATNSimulator#addDFAState}.
+	 *
+	 * @since 4.10.2
+	 */
+	public void trace_addDFAEdge(DFA dfa, DFAState from, int t, DFAState to) {
+		System.out.println("EDGE: "+from.stateNumber+" -> "+to.stateNumber+" upon "+t+" in DFA for ATN.s0 "+dfa.atnStartState.stateNumber);
+		System.out.println("\t"+trace_toString(from));
+		System.out.println("\t"+"->");
+		System.out.println("\t"+trace_toString(to));
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/TracingParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/TracingParserATNSimulator.java
@@ -5,24 +5,32 @@
  */
 package org.antlr.v4.runtime.atn;
 
+import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.dfa.DFAState;
 
-/** This class encapsulates the functionality associated with tracing ATN simulation during lexing and parsing.
+/** This class encapsulates the functionality associated with tracing ATN simulation during parsing.
  *  The goal is to create a machine readable traits from simulation so that we can compare across target.
  *  Starting out by tracking DFA state construction.
  *
  * @since 4.10.2
  */
-public class ATNSimulatorTracer {
+public class TracingParserATNSimulator extends ParserATNSimulator {
+	public TracingParserATNSimulator(Parser parser) {
+		super(parser,
+			parser.getInterpreter().atn,
+			parser.getInterpreter().decisionToDFA,
+			parser.getInterpreter().sharedContextCache);
+	}
+
 	/** Invoked after we have added state D to dfa (confirming that it does not already exist in dfa).
 	 *  Active if boolean trace is true.
 	 *
 	 * @since 4.10.2
 	 */
-	public void addDFAState(DFA dfa, DFAState D) {
+	public void trace_addDFAState(DFA dfa, DFAState D) {
 		System.out.println("NEW STATE: "+D.stateNumber+" in DFA for ATN.s0 "+dfa.atnStartState.stateNumber);
-		System.out.println("\t"+toString(D));
+		System.out.println("\t"+trace_toString(D));
 	}
 
 	/** Invoked in {@link ParserATNSimulator#addDFAState} or {@link LexerATNSimulator#addDFAState}
@@ -30,9 +38,9 @@ public class ATNSimulatorTracer {
 	 *
 	 * @since 4.10.2
 	 */
-	public void addDFAState_existing(DFA dfa, DFAState D) {
+	public void trace_addDFAState_existing(DFA dfa, DFAState D) {
 		System.out.println("EXISTS: "+D.stateNumber+" in DFA for ATN.s0 "+dfa.atnStartState.stateNumber);
-		System.out.println("\t"+toString(D));
+		System.out.println("\t"+trace_toString(D));
 	}
 
 	/** Invoked after we have added from -> to edge in dfa.
@@ -42,14 +50,10 @@ public class ATNSimulatorTracer {
 	 *
 	 * @since 4.10.2
 	 */
-	public void addDFAEdge(DFA dfa, DFAState from, int t, DFAState to) {
+	public void trace_addDFAEdge(DFA dfa, DFAState from, int t, DFAState to) {
 		System.out.println("EDGE: "+from.stateNumber+" -> "+to.stateNumber+" upon "+t+" in DFA for ATN.s0 "+dfa.atnStartState.stateNumber);
-		System.out.println("\t"+toString(from));
+		System.out.println("\t"+trace_toString(from));
 		System.out.println("\t"+"->");
-		System.out.println("\t"+toString(to));
-	}
-
-	public String toString(DFAState D) {
-		return D.toString();
+		System.out.println("\t"+trace_toString(to));
 	}
 }


### PR DESCRIPTION
Create new tracer class for ATN simulation; currently it just tracks DFA State construction and edge construction.   The goal is to create a machine readable traits from simulation so that we can compare across target.

See https://github.com/antlr/antlr4/discussions/3814

Rationale to create new classes in the runtime: highlights the target developers need to generate output upon some key events.

Happy to get thoughts from @kaby76 about suitability of this output.