### PR TITLE
Make swift runtime available through cocoapods

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -3,6 +3,8 @@ name: antlr4
 on:
   push:
     branches: [ master, dev, hostedci ]
+  tags:
+      - '*'
   pull_request:
     branches: [ master, dev ]
 
@@ -179,6 +181,15 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Get tag
+      id: tag
+      run: |
+        if [[ $GITHUB_REF == 'refs/tags/'* ]]; then
+            echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        else
+            echo "TAG=" >> $GITHUB_ENV
+        fi
+
     - name: Checkout antlr PHP runtime
       if: matrix.target == 'php'
       uses: actions/checkout@v2
@@ -331,3 +342,14 @@ jobs:
       with:
         name: antlr_${{ matrix.os }}_${{ matrix.target }}
         path: antlr_${{ matrix.os }}_${{ matrix.target }}.tgz
+
+    - name: Publish CocoaPod
+      if: (env.TAG != null) && startsWith(matrix.os, 'macos') && (matrix.target == 'swift')
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      run: |
+        cp runtime/Swift/Antlr4.podspec .
+        set -eo pipefail
+        export ANTLR4_VERSION=${{ env.TAG }}
+        pod lib lint --allow-warnings
+        pod trunk push --allow-warnings

--- a/doc/swift-target.md
+++ b/doc/swift-target.md
@@ -51,9 +51,9 @@ for information about this script.
 
 ### Xcode Projects
 
-Note that even if you are otherwise using ANTLR from a binary distribution,
-you should compile the ANTLR Swift runtime from source, because the Swift
-language does not yet have a stable ABI.
+Note that if you are otherwise using ANTLR from a binary distribution,
+you should make sure that BUILD_LIBRARY_FOR_DISTRIBUTION is set to YES to
+enable library evolution support.
 
 ANTLR uses Swift Package Manager to generate Xcode project files. 
 
@@ -133,6 +133,16 @@ Add Antlr4 as a dependency to your `Package.swift` file. For more information, p
 ```swift
 .package(name: "Antlr4", url: "https://github.com/antlr/antlr4", from: "4.10.1"
 ```
+
+## CocoaPods
+
+Antlr4 runtime is available through [CocoaPods](https://cocoapods.org). To install
+it, simply add the following line to your Podfile:
+
+```ruby
+pod 'Antlr4'
+```
+
 ## Swift access levels
 
 You may use the `accessLevel` option to control the access levels on generated

--- a/runtime/Swift/.gitignore
+++ b/runtime/Swift/.gitignore
@@ -2,3 +2,25 @@
 Antlr4.xcodeproj/
 Tests/Antlr4Tests/gen/
 xcuserdata/
+
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+
+# Bundler
+.bundle
+
+Pods/

--- a/runtime/Swift/Antlr4.podspec
+++ b/runtime/Swift/Antlr4.podspec
@@ -1,0 +1,31 @@
+#
+# Be sure to run `pod lib lint Antlr4.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Antlr4'
+  s.version          = ENV['ANTLR4_VERSION'] || '4.10.1'
+  s.summary          = 'ANTLR runtime for iOS and macOS.'
+
+  s.description      = <<-DESC
+ANTLR (ANother Tool for Language Recognition) is a powerful parser generator for reading, processing, executing, or translating structured text or binary files.
+                       DESC
+
+  s.homepage         = 'https://www.antlr.org/'
+  s.license          = { :type => 'BSD 3-Clause license', :file => 'LICENSE.txt' }
+  s.author           = { 'Terence Parr' => 'parrt@cs.usfca.edu' }
+  s.source           = { :git => 'https://github.com/antlr/antlr4.git', :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/the_antlr_guy'
+
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.10'
+
+  s.swift_versions   = "5.3"
+
+  s.source_files = 'runtime/Swift/Sources/Antlr4/**/*'
+
+end

--- a/runtime/Swift/boot.py
+++ b/runtime/Swift/boot.py
@@ -155,7 +155,7 @@ def generate_spm_module(in_folder=TMP_FOLDER):
     antlr_says("Created local repository.")
     antlr_says("(swift-tools-version:3.0) " 
                "Put .Package(url: \"{}\", majorVersion: {}) in Package.swift.".format(os.getcwd(), MAJOR_VERSION))
-    antlr_says("(swift-tools-wersion:4.0) "
+    antlr_says("(swift-tools-version:4.0) "
                "Put .package(url: \"{}\", from: \"{}.0.0\") in Package.swift "
                "and add \"Antlr4\" to target dependencies. ".format(os.getcwd(), MAJOR_VERSION))
 


### PR DESCRIPTION
This PR adds a CocoaPod for Swift runtime. I saw in the documentation that it is recommended to compile the runtime from sources together with generated files for grammar but CocoaPod provides more flexibility in case we want to distribute a library which depends on Antlr4.

Signed-off-by: spinnerok <serhiy.bobyr@zoho.eu>

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
