### PR TITLE
feat: Reduce initial memory allocations for collections

### DIFF
--- a/runtime/Go/antlr/jcollect.go
+++ b/runtime/Go/antlr/jcollect.go
@@ -38,7 +38,7 @@ func NewJStore[T any, C Comparator[T]](comparator Comparator[T]) *JStore[T, C] {
 	}
 
 	s := &JStore[T, C]{
-		store:      make(map[int][]T),
+		store:      make(map[int][]T, 1),
 		comparator: comparator,
 	}
 	return s
@@ -138,7 +138,7 @@ type JMap[K, V any, C Comparator[K]] struct {
 
 func NewJMap[K, V any, C Comparator[K]](comparator Comparator[K]) *JMap[K, V, C] {
 	return &JMap[K, V, C]{
-		store:      make(map[int][]*entry[K, V]),
+		store:      make(map[int][]*entry[K, V], 1),
 		comparator: comparator,
 	}
 }


### PR DESCRIPTION
  - Many small collections are created at runtime, the default allocation for
    maps, even though small, still requires memory. Specifying a very small
    initial allocation prevents unnecesary allocations and has no measurable
    effect on performance. A small incremental change.

- [x] Test suite passes

Signed-off-by: Jim.Idle <jimi@gatherstars.com>

