### PR TITLE
feat: Bump poms to use 4.11 Snapshot

### DIFF
--- a/antlr4-maven-plugin/pom.xml
+++ b/antlr4-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.antlr</groupId>
     <artifactId>antlr4-master</artifactId>
-    <version>4.10.2-SNAPSHOT</version>
+    <version>4.11-SNAPSHOT</version>
   </parent>
   <artifactId>antlr4-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 	<groupId>org.antlr</groupId>
 	<artifactId>antlr4-master</artifactId>
-	<version>4.10.2-SNAPSHOT</version>
+	<version>4.11-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>ANTLR 4</name>
@@ -70,6 +70,7 @@
 			<url>https://www.linkedin.com/in/jimidle/</url>
 			<roles>
 				<role>Developer - Maven Plugin</role>
+				<role>Developer - Go runtime</role>
 			</roles>
 		</developer>
 		<developer>

--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.antlr</groupId>
 		<artifactId>antlr4-master</artifactId>
-		<version>4.10.2-SNAPSHOT</version>
+		<version>4.11-SNAPSHOT</version>
 	</parent>
 	<artifactId>antlr4-runtime-testsuite</artifactId>
 	<name>ANTLR 4 Runtime Tests (4th generation)</name>

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.antlr</groupId>
 		<artifactId>antlr4-master</artifactId>
-		<version>4.10.2-SNAPSHOT</version>
+		<version>4.11-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>antlr4-runtime</artifactId>

--- a/tool-testsuite/pom.xml
+++ b/tool-testsuite/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.antlr</groupId>
     <artifactId>antlr4-master</artifactId>
-    <version>4.10.2-SNAPSHOT</version>
+    <version>4.11-SNAPSHOT</version>
   </parent>
   <artifactId>antlr4-tool-testsuite</artifactId>
   <name>ANTLR 4 Tool Tests</name>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.antlr</groupId>
 		<artifactId>antlr4-master</artifactId>
-		<version>4.10.2-SNAPSHOT</version>
+		<version>4.11-SNAPSHOT</version>
 	</parent>
 	<artifactId>antlr4</artifactId>
 	<name>ANTLR 4 Tool</name>


### PR DESCRIPTION
Move to new version numbers as Go target has had significant changes and needs a new minor version
