### PR TITLE
Replace smart-quote with single-quote in code examples

### DIFF
--- a/doc/grammars.md
+++ b/doc/grammars.md
@@ -98,7 +98,7 @@ Not every kind of grammar can import every other kind of grammar:
 * Parsers can import parsers.
 * Combined grammars can import parsers or lexers without modes.
 
-ANTLR adds imported rules to the end of the rule list in a main lexer grammar. That means lexer rules in the main grammar get precedence over imported rules. For example, if a main grammar defines rule `IF : ’if’ ;` and an imported grammar defines rule `ID : [a-z]+ ;` (which also recognizes `if`), the imported `ID` won’t hide the main grammar’s `IF` token definition.
+ANTLR adds imported rules to the end of the rule list in a main lexer grammar. That means lexer rules in the main grammar get precedence over imported rules. For example, if a main grammar defines rule `IF : 'if' ;` and an imported grammar defines rule `ID : [a-z]+ ;` (which also recognizes `if`), the imported `ID` won’t hide the main grammar’s `IF` token definition.
 
 ## Tokens Section
 

--- a/doc/lexer-rules.md
+++ b/doc/lexer-rules.md
@@ -52,8 +52,8 @@ Match token T at the current input position. Tokens always begin with a capital 
 </tr>
 
 <tr>
-<td>’literal’</td><td>
-Match that character or sequence of characters. E.g., ’while’ or ’=’.</td>
+<td>'literal'</td><td>
+Match that character or sequence of characters. E.g., 'while' or '='.</td>
 </tr>
 
 <tr>
@@ -97,8 +97,8 @@ DASH : [---] ; // match a single -, i.e., "any character" between - and - (note 
 </tr>
 
 <tr>
-<td>’x’..’y’</td><td>
-Match any single character between range x and y, inclusively. E.g., ’a’..’z’. ’a’..’z’ is identical to [a-z].</td>
+<td>'x'..'y'</td><td>
+Match any single character between range x and y, inclusively. E.g., 'a'..'z'. 'a'..'z' is identical to [a-z].</td>
 </tr>
 
 <tr>
@@ -143,7 +143,7 @@ Evaluate semantic predicate «p». If «p» evaluates to false at runtime, the s
 
 <tr>
 <td>~x</td><td>
-Match any single character not in the set described by x. Set x can be a single character literal, a range, or a subrule set like ~(’x’|’y’|’z’) or ~[xyz]. Here is a rule that uses ~ to match any character other than characters using ~[\r\n]*:
+Match any single character not in the set described by x. Set x can be a single character literal, a range, or a subrule set like ~('x'|'y'|'z') or ~[xyz]. Here is a rule that uses ~ to match any character other than characters using ~[\r\n]*:
 <pre> 	
 COMMENT : '#' ~[\r\n]* '\r'? '\n' -> skip ;
 </pre>
@@ -176,7 +176,7 @@ mode STR;
 MASK : '&' ;
 ```
 
-A parser grammar cannot reference literal ’&’, but it can reference the name of the tokens:
+A parser grammar cannot reference literal '&', but it can reference the name of the tokens:
 
 ```
 parser grammar P;

--- a/doc/lexicon.md
+++ b/doc/lexicon.md
@@ -79,13 +79,13 @@ These more or less correspond to `isJavaIdentifierPart` and `isJavaIdentifierSta
 
 ## Literals
 
-ANTLR does not distinguish between character and string literals as most languages do. All literal strings one or more characters in length are enclosed in single quotes such as `’;’`, `’if’`, `’>=’`, and `’\’’` (refers to the one-character string containing the single quote character). Literals never contain regular expressions.
+ANTLR does not distinguish between character and string literals as most languages do. All literal strings one or more characters in length are enclosed in single quotes such as `';'`, `'if'`, `'>='`, and `'\''` (refers to the one-character string containing the single quote character). Literals never contain regular expressions.
 
-Literals can contain Unicode escape sequences of the form `’\uXXXX’` (for Unicode code points up to `’U+FFFF’`) or `’\u{XXXXXX}’` (for all Unicode code points), where `’XXXX’` is the hexadecimal Unicode code point value.
+Literals can contain Unicode escape sequences of the form `'\uXXXX'` (for Unicode code points up to `'U+FFFF'`) or `'\u{XXXXXX}'` (for all Unicode code points), where `'XXXX'` is the hexadecimal Unicode code point value.
 
-For example, `’\u00E8’` is the French letter with a grave accent: `’è’`, and `’\u{1F4A9}’` is the famous emoji: `’💩’`.
+For example, `'\u00E8'` is the French letter with a grave accent: `'è'`, and `'\u{1F4A9}'` is the famous emoji: `'💩'`.
 
-ANTLR also understands the usual special escape sequences: `’\n’` (newline), `’\r’` (carriage return), `’\t’` (tab), `’\b’` (backspace), and `’\f’` (form feed). You can use Unicode code points directly within literals or use the Unicode escape sequences:
+ANTLR also understands the usual special escape sequences: `'\n'` (newline), `'\r'` (carriage return), `'\t'` (tab), `'\b'` (backspace), and `'\f'` (form feed). You can use Unicode code points directly within literals or use the Unicode escape sequences:
 
 ```
 grammar Foreign;

--- a/doc/parser-rules.md
+++ b/doc/parser-rules.md
@@ -196,7 +196,7 @@ ANTLR generates a field holding the list of context objects:
 
 ## Rule Elements
 
-Rule elements specify what the parser should do at a given moment just like statements in a programming language. The elements can be rule, token, string literal like expression, ID, and ’return’. Here’s a complete list of the rule elements (we’ll look at actions and predicates in more detail later):
+Rule elements specify what the parser should do at a given moment just like statements in a programming language. The elements can be rule, token, string literal like expression, ID, and 'return'. Here’s a complete list of the rule elements (we’ll look at actions and predicates in more detail later):
 
 <table>
 <tr>
@@ -207,7 +207,7 @@ Rule elements specify what the parser should do at a given moment just like stat
 Match token T at the current input position. Tokens always begin with a capital letter.</td>
 </tr>
 <tr>
-<td>’literal’</td><td>
+<td>'literal'</td><td>
 Match the string literal at the current input position. A string literal is simply a token with a fixed string.</td>
 </tr>
 <tr>
@@ -232,7 +232,7 @@ Match any single token except for the end of file token. The “dot” operator 
 </tr>
 </table>
 
-When you want to match everything but a particular token or set of tokens, use the `~` “not” operator. This operator is rarely used in the parser but is available. `~INT` matches any token except the `INT` token. `~’,’` matches any token except the comma. `~(INT|ID)` matches any token except an INT or an ID.
+When you want to match everything but a particular token or set of tokens, use the `~` “not” operator. This operator is rarely used in the parser but is available. `~INT` matches any token except the `INT` token. `~','` matches any token except the comma. `~(INT|ID)` matches any token except an INT or an ID.
 
 Token, string literal, and semantic predicate rule elements can take options. See Rule Element Options.
 

--- a/doc/wildcard.md
+++ b/doc/wildcard.md
@@ -61,7 +61,7 @@ END    : '>>' ;
 <p>After crossing through a nongreedy subrule within a lexical rule, all decision-making from then on is "first match wins."
 </p>
 <p>
-For example, literal `ab` in rule right-hand side (grammar fragment) `.*? (’a’|’ab’)` is dead code and can never be matched. If the input is ab, the first alternative, ’a’, matches the first character and therefore succeeds. (’a’|’ab’) by itself on the right-hand side of a rule properly matches the second alternative for input ab. This quirk arises from a nongreedy design decision that’s too complicated to go into here.</p>
+For example, literal `ab` in rule right-hand side (grammar fragment) `.*? ('a'|'ab')` is dead code and can never be matched. If the input is ab, the first alternative, 'a', matches the first character and therefore succeeds. ('a'|'ab') by itself on the right-hand side of a rule properly matches the second alternative for input ab. This quirk arises from a nongreedy design decision that’s too complicated to go into here.</p>
 <li>
 </ol>
 
@@ -74,7 +74,7 @@ ACTION3 : '<' ( STRING | ~[">] )* '>' ; // Doesn't allow <"foo>; greedy *
 STRING : '"' ( '\\"' | . )*? '"' ;
 ```
 
-Rule `ACTION1` allows unterminated strings, such as `"foo`, because input `"foo` matches to the wildcard part of the loop. It doesn’t have to go into rule `STRING` to match a quote. To fix that, rule `ACTION2` uses `~’"’` to match any character but the quote. Expression `~’"’` is still ambiguous with the `’]’` that ends the rule, but the fact that the subrule is nongreedy means that the lexer will exit the loop upon a right square bracket. To avoid a nongreedy subrule, make the alternatives explicit. Expression `~[">]` matches anything but the quote and right angle bracket. Here’s a sample run:
+Rule `ACTION1` allows unterminated strings, such as `"foo`, because input `"foo` matches to the wildcard part of the loop. It doesn’t have to go into rule `STRING` to match a quote. To fix that, rule `ACTION2` uses `~'"'` to match any character but the quote. Expression `~'"'` is still ambiguous with the `']'` that ends the rule, but the fact that the subrule is nongreedy means that the lexer will exit the loop upon a right square bracket. To avoid a nongreedy subrule, make the alternatives explicit. Expression `~[">]` matches anything but the quote and right angle bracket. Here’s a sample run:
 
 ```bash
 $ antlr4 Actions.g4


### PR DESCRIPTION
This seems to be all the affected locations. I left smart-quotes alone in prose like `Here’s`.

Looks like my editor added a trailing newline on files that were missing one. I can back that out, but it's probably for the best. :-)