### PR TITLE
Fix 2016 round 2

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelForClosureContext.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelForClosureContext.txt
@@ -33,3 +33,5 @@ expression
 [input]
 a
 
+[skip]
+Go

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
@@ -6,11 +6,17 @@ Parser
 
 [grammar]
 grammar Test;
-expression: op=NOT args+=expression
-          | args+=expression (op=AND args+=expression)+
-          | args+=expression (op=OR args+=expression)+
-          | IDENTIFIER
-          ;
+
+expression
+@after {
+<AssertIsList("$args")>
+}
+    : op=NOT args+=expression
+    | args+=expression (op=AND args+=expression)+
+    | args+=expression (op=OR args+=expression)+
+    | IDENTIFIER
+    ;
+
 AND : 'and' ;
 OR : 'or' ;
 NOT : 'not' ;

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
@@ -31,3 +31,4 @@ a and b
 
 [skip]
 Go
+Cpp

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
@@ -1,0 +1,24 @@
+[notes]
+Checks that this compiles; see https://github.com/antlr/antlr4/issues/2016
+
+[type]
+Parser
+
+[grammar]
+grammar Test;
+expression: op=NOT args+=expression
+          | args+=expression (op=AND args+=expression)+
+          | args+=expression (op=OR args+=expression)+
+          | IDENTIFIER
+          ;
+AND : 'and' ;
+OR : 'or' ;
+NOT : 'not' ;
+IDENTIFIER : [a-zA-Z_][a-zA-Z0-9_]* ;
+WS : [ \t\r\n]+ -> skip ;
+
+[start]
+expression
+
+[input]
+a and b

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
@@ -28,3 +28,6 @@ expression
 
 [input]
 a and b
+
+[skip]
+Go

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CSharp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CSharp.test.stg
@@ -18,7 +18,7 @@ AppendStr(a,b) ::= <%<Append(a,b)>%>
 
 Concat(a,b) ::= "<a><b>"
 
-AssertIsList(v) ::= "System.Collections.IList __ttt__ = <v>;" // just use static type system
+AssertIsList(v) ::= "System.Collections.IList __ttt__ = (System.Collections.IList)<v>;" // just use static type system
 
 AssignLocal(s,v) ::= "<s> = <v>;"
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
@@ -18,7 +18,7 @@ AppendStr(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-AssertIsList(v) ::= ""
+AssertIsList(v) ::= "TODO!!"
 
 AssignLocal(s, v) ::= "<s> = <v>;"
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/JavaScript.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/JavaScript.test.stg
@@ -18,7 +18,7 @@ AppendStr(a,b) ::= <%<Append(a,b)>%>
 
 Concat(a,b) ::= "<a><b>"
 
-AssertIsList(v) ::= <<if ( !(v instanceof Array) ) {throw "value is not an array";}>>
+AssertIsList(v) ::= <<if ( !(<v> instanceof Array) ) {throw "value is not an array";}>>
 
 AssignLocal(s,v) ::= "<s> = <v>;"
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python2.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python2.test.stg
@@ -18,7 +18,7 @@ AppendStr(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-AssertIsList(v) ::= "assert isinstance(v, (list, tuple))"
+AssertIsList(v) ::= "assert isinstance(<v>, (list, tuple))"
 
 AssignLocal(s,v) ::= "<s> = <v>"
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python3.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python3.test.stg
@@ -18,7 +18,7 @@ AppendStr(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-AssertIsList(v) ::= "assert isinstance(v, (list, tuple))"
+AssertIsList(v) ::= "assert isinstance(<v>, (list, tuple))"
 
 AssignLocal(s,v) ::= "<s> = <v>"
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/Processor.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/Processor.java
@@ -19,8 +19,9 @@ public class Processor {
 	public final Map<String, String> environmentVariables;
 	public final boolean throwOnNonZeroErrorCode;
 
-	public static ProcessorResult run(String[] arguments, String workingDirectory, Map<String, String> environmentVariables
-	) throws InterruptedException, IOException {
+	public static ProcessorResult run(String[] arguments, String workingDirectory, Map<String, String> environmentVariables)
+			throws InterruptedException, IOException
+	{
 		return new Processor(arguments, workingDirectory, environmentVariables, true).start();
 	}
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/CppRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/cpp/CppRunner.java
@@ -21,6 +21,25 @@ import static org.antlr.v4.test.runtime.FileUtils.writeFile;
 import static org.antlr.v4.test.runtime.RuntimeTestUtils.getOS;
 import static org.antlr.v4.test.runtime.RuntimeTestUtils.isWindows;
 
+/**
+ * For my own information on I'm recording what I needed to do to get a unit test to compile and run in C++ on the Mac.
+ * I got a segmentation violation and couldn't figure out how to get information about it, so I turned on debugging
+ * and then figured out lldb enough to create this issue: https://github.com/antlr/antlr4/issues/3845 on a bug.
+ *
+ * cd ~/antlr/code/antlr4/runtime/Cpp
+ * cmake . -D CMAKE_OSX_ARCHITECTURES="arm64; x86_64" -DCMAKE_BUILD_TYPE=Debug
+ * make -j 8
+ *
+ * In test dir with generated test code:
+ *
+ * clang++ -g -std=c++17 -I /Users/parrt/antlr/code/antlr4/runtime/Cpp/runtime/src -L. -lantlr4-runtime *.cpp
+ * ./a.out input
+ *
+ * $ lldb ./a.out input
+ * (lldb) run
+ * ... crash ...
+ * (lldb) thread backtrace
+ */
 public class CppRunner extends RuntimeRunner {
 	@Override
 	public String getLanguage() {

--- a/runtime/Dart/lib/src/prediction_context.dart
+++ b/runtime/Dart/lib/src/prediction_context.dart
@@ -427,7 +427,7 @@ abstract class PredictionContext {
         return a_;
       }
 
-      mergedParents = List.generate(k, (n) => mergedParents[n]!);
+      mergedParents = List.generate(k, (n) => mergedParents[n]);
       mergedReturnStates = List.generate(k, (n) => mergedReturnStates[n]);
     }
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -1106,7 +1106,13 @@ recRuleSetStopToken() ::= "_ctx->stop = _input->LT(-1);"
 
 recRuleAltStartAction(ruleName, ctxName, label, isListLabel) ::= <<
 _localctx = _tracker.createInstance\<<ctxName>Context>(parentContext, parentState);
-<if (label)>_localctx-><label> = previousContext;<endif>
+<if(label)>
+<if(isListLabel)>
+_localctx-><label>.push_back(previousContext);
+<else>
+_localctx-><label> = previousContext;
+<endif>
+<endif>
 pushNewRecursionContext(_localctx, startState, Rule<ruleName; format = "cap">);
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -1104,7 +1104,7 @@ recRuleAltPredicate(ruleName,opPrec) ::= "precpred(_ctx, <opPrec>)"
 recRuleSetReturnAction(src,name) ::= "recRuleSetReturnAction(src,name) $<name>=$<src>.<name>;"
 recRuleSetStopToken() ::= "_ctx->stop = _input->LT(-1);"
 
-recRuleAltStartAction(ruleName, ctxName, label) ::= <<
+recRuleAltStartAction(ruleName, ctxName, label, isListLabel) ::= <<
 _localctx = _tracker.createInstance\<<ctxName>Context>(parentContext, parentState);
 <if (label)>_localctx-><label> = previousContext;<endif>
 pushNewRecursionContext(_localctx, startState, Rule<ruleName; format = "cap">);

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -855,7 +855,6 @@ _localctx.<label>.add(_prevctx);
 _localctx.<label> = _prevctx;
 <endif>
 <endif>
-<if(label)>_localctx.<label> = _prevctx;<endif>
 pushNewRecursionContext(_localctx, _startState, RULE_<ruleName>);
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -746,7 +746,13 @@ recRuleSetStopToken()                 ::= "this._ctx.stop = this._input.LT(-1);"
 
 recRuleAltStartAction(ruleName, ctxName, label, isListLabel) ::= <<
 localctx = new <ctxName>Context(this, _parentctx, _parentState);
-<if(label)>localctx.<label> = _prevctx;<endif>
+<if(label)>
+<if(isListLabel)>
+localctx.<label>.push(_prevctx);
+<else>
+localctx.<label> = _prevctx;
+<endif>
+<endif>
 this.pushNewRecursionContext(localctx, _startState, <parser.name>.RULE_<ruleName>);
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -744,7 +744,7 @@ recRuleAltPredicate(ruleName,opPrec)  ::= "this.precpred(this._ctx, <opPrec>)"
 recRuleSetReturnAction(src,name)	  ::= "$<name>=$<src>.<name>"
 recRuleSetStopToken()                 ::= "this._ctx.stop = this._input.LT(-1);"
 
-recRuleAltStartAction(ruleName, ctxName, label) ::= <<
+recRuleAltStartAction(ruleName, ctxName, label, isListLabel) ::= <<
 localctx = new <ctxName>Context(this, _parentctx, _parentState);
 <if(label)>localctx.<label> = _prevctx;<endif>
 this.pushNewRecursionContext(localctx, _startState, <parser.name>.RULE_<ruleName>);

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -709,7 +709,13 @@ recRuleSetStopToken()                 ::= "self._ctx.stop = self._input.LT(-1)"
 
 recRuleAltStartAction(ruleName, ctxName, label, isListLabel) ::= <<
 localctx = <parser.name>.<ctxName>Context(self, _parentctx, _parentState)
-<if(label)>localctx.<label> = _prevctx<endif>
+<if(label)>
+<if(isListLabel)>
+localctx.<label>.append(_prevctx)
+<else>
+localctx.<label> = _prevctx
+<endif>
+<endif>
 self.pushNewRecursionContext(localctx, _startState, self.RULE_<ruleName>)
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -707,7 +707,7 @@ recRuleAltPredicate(ruleName,opPrec)  ::= "self.precpred(self._ctx, <opPrec>)"
 recRuleSetReturnAction(src,name)	  ::= "$<name>=$<src>.<name>"
 recRuleSetStopToken()                 ::= "self._ctx.stop = self._input.LT(-1)"
 
-recRuleAltStartAction(ruleName, ctxName, label) ::= <<
+recRuleAltStartAction(ruleName, ctxName, label, isListLabel) ::= <<
 localctx = <parser.name>.<ctxName>Context(self, _parentctx, _parentState)
 <if(label)>localctx.<label> = _prevctx<endif>
 self.pushNewRecursionContext(localctx, _startState, self.RULE_<ruleName>)

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -721,7 +721,7 @@ recRuleAltPredicate(ruleName,opPrec)  ::= "self.precpred(self._ctx, <opPrec>)"
 recRuleSetReturnAction(src,name)	  ::= "$<name>=$<src>.<name>"
 recRuleSetStopToken()                 ::= "self._ctx.stop = self._input.LT(-1)"
 
-recRuleAltStartAction(ruleName, ctxName, label) ::= <<
+recRuleAltStartAction(ruleName, ctxName, label, isListLabel) ::= <<
 localctx = <parser.name>.<ctxName>Context(self, _parentctx, _parentState)
 <if(label)>localctx.<label> = _prevctx<endif>
 self.pushNewRecursionContext(localctx, _startState, self.RULE_<ruleName>)

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -723,7 +723,13 @@ recRuleSetStopToken()                 ::= "self._ctx.stop = self._input.LT(-1)"
 
 recRuleAltStartAction(ruleName, ctxName, label, isListLabel) ::= <<
 localctx = <parser.name>.<ctxName>Context(self, _parentctx, _parentState)
-<if(label)>localctx.<label> = _prevctx<endif>
+<if(label)>
+<if(isListLabel)>
+localctx.<label>.append(_prevctx)
+<else>
+localctx.<label> = _prevctx
+<endif>
+<endif>
 self.pushNewRecursionContext(localctx, _startState, self.RULE_<ruleName>)
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -922,7 +922,6 @@ _localctx.<label>.append(_prevctx)
 _localctx.<label> = _prevctx
 <endif>
 <endif>
-<if(label)>_localctx.<label> = _prevctx;<endif>
 try pushNewRecursionContext(_localctx, _startState, <parser.name>.RULE_<ruleName>)
 >>
 


### PR DESCRIPTION
Supercedes https://github.com/antlr/antlr4/pull/2022  Fixes #2016

@jimidle Go target fails this new test:

```
Test: ListLabelsOnRuleRefStartOfAlt; State: Execute; java.lang.InterruptedException: 
panic: interface conversion: antlr.PredictionContext is *antlr.EmptyPredictionContext, not *antlr.ArrayPredictionContext [recovered]
	panic: interface conversion: antlr.PredictionContext is *antlr.EmptyPredictionContext, not *antlr.ArrayPredictionContext

goroutine 1 [running]:
test/parser.(*TestParser).expression.func2()
	/private/var/folders/w1/_nr4stn13lq0rvjdkwh7q8cc0000gn/T/GoRunner-ForkJoinPool-1-worker-7-1661633249352/parser/test_parser.go:299 +0xfe
panic({0x10ed920, 0xc00007bc80})
	/usr/local/go/src/runtime/panic.go:884 +0x212
github.com/antlr/antlr4/runtime/Go/antlr.merge({0x113ebf0?, 0xc000014d80}, {0x113eca0?, 0xc000012048}, 0x0, 0xfffffffffffffffe?)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/prediction_context.go:407 +0x351
github.com/antlr/antlr4/runtime/Go/antlr.(*BaseATNConfigSet).Add(0xc00002acc0, {0x113f068?, 0xc000130a00}, 0x0?)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/atn_config_set.go:140 +0x21f
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureWork(0xc000064300, {0x113f068, 0xc000130a00}, {0x1140138, 0xc00002acc0}, 0xc00012eb70?, 0x0, 0x75?, 0xffffffffffffffff, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1030 +0xbd
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureCheckingStopState(0xc000064300, {0x113f068, 0xc000130a00}, {0x1140138, 0xc00002acc0}, 0x156ba98?, 0x40?, 0x1, 0xffffffffffffffff, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1022 +0x34a
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureWork(0xc000064300, {0x113f068, 0xc0001309b0}, {0x1140138, 0xc00002acc0}, 0xc00012ed10?, 0x0, 0x75?, 0xffffffffffffffff, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1088 +0x43d
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureCheckingStopState(0xc000064300, {0x113f068, 0xc0001309b0}, {0x1140138, 0xc00002acc0}, 0x156ba98?, 0x40?, 0x1, 0xffffffffffffffff, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1022 +0x34a
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureWork(0xc000064300, {0x113f068, 0xc000130960}, {0x1140138, 0xc00002acc0}, 0xc00012eeb0?, 0x0, 0x75?, 0xffffffffffffffff, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1088 +0x43d
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureCheckingStopState(0xc000064300, {0x113f068, 0xc000130960}, {0x1140138, 0xc00002acc0}, 0xc000130320?, 0x0?, 0x1, 0xffffffffffffffff, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1022 +0x34a
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureWork(0xc000064300, {0x113f068, 0xc000130910}, {0x1140138, 0xc00002acc0}, 0xc00012f0a0?, 0x0, 0xf0?, 0xffffffffffffffff, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1088 +0x43d
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureCheckingStopState(0xc000064300, {0x113f068, 0xc000130910}, {0x1140138, 0xc00002acc0}, 0xc00012f140?, 0x94?, 0x1, 0xffffffffffffffff, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1022 +0x34a
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureCheckingStopState(0xc000064300, {0x113f068, 0xc0001308c0}, {0x1140138, 0xc00002acc0}, 0x156ba98?, 0x40?, 0x1, 0x0, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1008 +0x747
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureWork(0xc000064300, {0x113f068, 0xc000130870}, {0x1140138, 0xc00002acc0}, 0xc00012f2e0?, 0x0, 0x75?, 0x0, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1088 +0x43d
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureCheckingStopState(0xc000064300, {0x113f068, 0xc000130870}, {0x1140138, 0xc00002acc0}, 0x156ba98?, 0x40?, 0x1, 0x0, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1022 +0x34a
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureWork(0xc000064300, {0x113f068, 0xc0001305f0}, {0x1140138, 0xc00002acc0}, 0xc00012f480?, 0x0, 0x75?, 0x0, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1088 +0x43d
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureCheckingStopState(0xc000064300, {0x113f068, 0xc0001305f0}, {0x1140138, 0xc00002acc0}, 0x8?, 0x50?, 0x1, 0x0, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1022 +0x34a
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureWork(0xc000064300, {0x113f068, 0xc0001305a0}, {0x1140138, 0xc00002acc0}, 0x20?, 0x0, 0x0?, 0x0, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1088 +0x43d
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closureCheckingStopState(0xc000064300, {0x113f068, 0xc0001305a0}, {0x1140138, 0xc00002acc0}, 0x1047994?, 0x40?, 0x1, 0x0, 0x0)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:1022 +0x34a
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).closure(...)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:969
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).computeReachSet(0xc000064300, {0x1140138, 0xc00002ab00}, 0x4, 0x1)
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:575 +0x3d5
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).execATNWithFullContext(0xc000064300, 0x1140138?, 0xc00002a980?, {0x1140138, 0xc00002aa40}, {0x113f508, 0xc00002a2c0}, 0xc00012fa40?, {0x29355e48, 0xc00006f4f0})
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:398 +0x17f
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).execATN(0xc000064300, 0xc00002a4c0, 0xc000106310, {0x113f508, 0xc00002a2c0}, 0x1, {0x29355e48?, 0xc00006f4f0})
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:251 +0xa8f
github.com/antlr/antlr4/runtime/Go/antlr.(*ParserATNSimulator).AdaptivePredict(0xc000064300, {0x113f508?, 0xc00002a2c0}, 0x4, {0x29355e48, 0xc00006f4f0})
	/Users/parrt/antlr/code/antlr4/runtime/Go/antlr/parser_atn_simulator.go:145 +0xbef
test/parser.(*TestParser).expression(0xc0000122d0, 0xc00002a2c0?)
	/private/var/folders/w1/_nr4stn13lq0rvjdkwh7q8cc0000gn/T/GoRunner-ForkJoinPool-1-worker-7-1661633249352/parser/test_parser.go:340 +0x507
test/parser.(*TestParser).Expression(...)
	/private/var/folders/w1/_nr4stn13lq0rvjdkwh7q8cc0000gn/T/GoRunner-ForkJoinPool-1-worker-7-1661633249352/parser/test_parser.go:273
main.main()
	/private/var/folders/w1/_nr4stn13lq0rvjdkwh7q8cc0000gn/T/GoRunner-ForkJoinPool-1-worker-7-1661633249352/Test.go:37 +0x15c
exit status 2
Test directory: /var/folders/w1/_nr4stn13lq0rvjdkwh7q8cc0000gn/T/GoRunner-ForkJoinPool-1-worker-7-1661633249352
```
