### PR TITLE
fix: #2016 Fix Go template list reference, go runtime and got test te…

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
@@ -30,5 +30,4 @@ expression
 a and b
 
 [skip]
-Go
 Cpp

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
@@ -18,7 +18,16 @@ AppendStr(a,b) ::= "<a> + <b>"
 
 Concat(a,b) ::= "<a><b>"
 
-AssertIsList(v) ::= "TODO!!"
+AssertIsList(v) ::= <<
+// A noddy range over the list will not compile if it is not getting a slice
+// however, Go will not compile the generated code if the slice vs single value is wrong.
+// Makes the Java based tests suite work though.
+j1__ := make([]interface{}, len(<v>))
+j2__ := <v>
+for j3__ := range j2__ {
+   j1__[j3__] = j2__[j3__]
+}
+>>
 
 AssignLocal(s, v) ::= "<s> = <v>;"
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -879,7 +879,7 @@ QRetValueRef(a) ::= "<ctx(a)>.Get<a.dict;format={cap}>().Get<a.escapedName;forma
 /** How to translate $tokenLabel */
 TokenRef(t) ::= "<ctx(t)>.Get<t.escapedName;format={cap}>()"
 LabelRef(t) ::= "<ctx(t)>.Get<t.escapedName;format={cap}>()"
-ListLabelRef(t) ::= "<ctx(t)>.Get<ListLabelName(t.escapedName);format={cap}>"
+ListLabelRef(t) ::= "<ctx(t)>.Get<t.escapedName;format={cap}>()"
 
 SetAttr(s, rhsChunks) ::= "<ctx(s)>.Set<s.escapedName; format={cap}>(<rhsChunks>)"
 


### PR DESCRIPTION
fix: #2016 Fix runtime, test templates and go codegen template

The go Runtime was confused about the EmprtyPredictionContext vs SIngletonPredictionContext.

For now, I have fixed up the go code for merge(), but I think longer term I will have to change the way the structures for
prediction context are organized, which is a piece of work that isn't worth it for v4.11. I will come back to that.
