### PR TITLE
feat: Add a deprecation message to the existing v1 module

### DIFF
--- a/runtime/Go/antlr/go.mod
+++ b/runtime/Go/antlr/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Please switch to the new v4 module path: github.com/antlr/antlr4/runtime/Go/antlr/v4 - see https://github.com/antlr/antlr4/blob/master/doc/go-target.md
 module github.com/antlr/antlr4/runtime/Go/antlr
 
 go 1.18


### PR DESCRIPTION
feat: Add a deprecated message to the existing `v1` (default) module path to direct go module users to the latest `v4` path

Signed-off-by: Jim.Idle <jimi@gatherstars.com>


