### PR TITLE
doc: quote ** in test invocation example

### DIFF
--- a/doc/antlr-project-testing.md
+++ b/doc/antlr-project-testing.md
@@ -98,7 +98,7 @@ From the `runtime-testsuite` dir
 ```bash
 $ cd runtime-testsuite
 $ export MAVEN_OPTS="-Xmx1G"     # don't forget this on linux
-$ mvn -Dtest=java.** test
+$ mvn -Dtest='java.**' test
 -------------------------------------------------------
  T E S T S
 -------------------------------------------------------


### PR DESCRIPTION
The `**` gets expanded in some shells (zsh), so protect it from that, else the
invocation may fail, e.g.:

```
$ mvn -Dtest=javascript.** test
zsh: no matches found: -Dtest=javascript.**
```

... and a hasty person such as myself might miss the `zsh` in that output line
and think the “no matches” is from Maven meaning that there are no tests
identified by `javascript.**`, but there are.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
