### PR TITLE
Declare @param in generated visitor methods

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -91,7 +91,10 @@ import antlr4 from 'antlr4';
 export default class <file.grammarName>Visitor extends antlr4.tree.ParseTreeVisitor {
 
 <file.visitorNames:{lname |
-	// Visit a parse tree produced by <file.parserName>#<lname>.
+	/**
+	 * Visit a parse tree produced by <file.parserName>#<lname>.
+	 * @param {antlr4.ParserRuleContext} ctx
+	 */
 	visit<lname; format="cap">(ctx) {
 	  return this.visitChildren(ctx);
 	\}


### PR DESCRIPTION
Helps out JavaScript projects which use JSDoc-based type checking using tsc.

Without this:

* the type checker does not know the type of `ctx` and editor integrations
  highlight that with the message "Parameter 'ctx' implicitly has an 'any'
  type, but a better type may be inferred from usage.ts(7044)".

* Invoking an editor/IDE "Find usages" on the `ParserRuleContext` identifier
  will not find these visitor methods.

Signed-off-by: Gunnlaugur Þór Briem <gunnlaugur@gmail.com>

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
