### PR TITLE
Bring back the Package.swift in the project's root

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,13 +14,17 @@ let package = Package(
         .target(
             name: "Antlr4",
             dependencies: [],
-            path: "Sources/Antlr4"),
+            path: "./runtime/Swift/Sources/Antlr4"),
         .testTarget(
             name: "Antlr4Tests",
             dependencies: ["Antlr4"],
-            path:"Tests/Antlr4Tests",
+            path: "./runtime/Swift/Tests/Antlr4Tests",
             exclude: [
-                "VisitorBasic.g4", "VisitorCalc.g4", "LexerA.g4", "LexerB.g4", "Threading.g4"
+                "./runtime/Swift/Tests/VisitorBasic.g4",
+                "./runtime/Swift/Tests/VisitorCalc.g4",
+                "./runtime/Swift/Tests/LexerA.g4",
+                "./runtime/Swift/Tests/LexerB.g4",
+                "./runtime/Swift/Tests/Threading.g4"
             ]
         )
     ]

--- a/doc/swift-target.md
+++ b/doc/swift-target.md
@@ -131,8 +131,9 @@ Add Antlr4 as a dependency to your `Package.swift` file. For more information, p
 
 
 ```swift
-.package(name: "Antlr4", url: "https://github.com/antlr/antlr4", from: "4.11.1"
+.package(url: "https://github.com/antlr/antlr4", from: "4.11.1")
 ```
+
 ## Swift access levels
 
 You may use the `accessLevel` option to control the access levels on generated


### PR DESCRIPTION
Problem: https://github.com/antlr/antlr4/commit/c1b448f738dbc193977c5e17885640e6b1c10e13 introduced a regression to the https://github.com/antlr/antlr4/pull/3132, which allowed for ANTLR 4 library usage in Swift's Package Manager.

Solution: return `Package.swift` back to the project's root, so that other Swift projects can depend on ANTLR 4 just as described in the `swift-target.md`.