### PR TITLE
fix: Restore missing changes to v4 of go runtime

### DIFF
--- a/runtime/Go/antlr/antlrdoc.go
+++ b/runtime/Go/antlr/antlrdoc.go
@@ -48,7 +48,7 @@ And the generate.sh file will look similar to this:
 	#!/bin/sh
 
 	alias antlr4='java -Xmx500M -cp "./antlr4-4.11.1-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
-	antlr4 -Dlanguage=Go -no-visitor -package tgram *.g4
+	antlr4 -Dlanguage=Go -no-visitor -package parser *.g4
 
 depending on whether you want visitors or listeners or any other ANTLR options.
 


### PR DESCRIPTION
I had not thought about this, but I guess some of the fix PRs were out of order and did not have one fix that was in the legacy version of the runtime, copied in to the v4 branch. This PR fixes that.

It is not worth doing yet another minor release as if anyone needs this exact fix, they can use the dev branch until the next release.

Signed-off-by: Jim.Idle <jimi@gatherstars.com>

