### PR TITLE
Golang: Fixed Index Out of Range Bug With GetChild

### DIFF
--- a/runtime/Go/antlr/parser_rule_context.go
+++ b/runtime/Go/antlr/parser_rule_context.go
@@ -147,7 +147,7 @@ func (prc *BaseParserRuleContext) AddErrorNode(badToken Token) *ErrorNodeImpl {
 }
 
 func (prc *BaseParserRuleContext) GetChild(i int) Tree {
-	if prc.children != nil && len(prc.children) >= i {
+	if prc.children != nil && len(prc.children) > i {
 		return prc.children[i]
 	}
 

--- a/runtime/Go/antlr/v4/parser_rule_context.go
+++ b/runtime/Go/antlr/v4/parser_rule_context.go
@@ -147,7 +147,7 @@ func (prc *BaseParserRuleContext) AddErrorNode(badToken Token) *ErrorNodeImpl {
 }
 
 func (prc *BaseParserRuleContext) GetChild(i int) Tree {
-	if prc.children != nil && len(prc.children) >= i {
+	if prc.children != nil && len(prc.children) > i {
 		return prc.children[i]
 	}
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

The ANTLR Golang runtime has a index out of range bug with GetChild. To ensure this is a bug, I checked the [python3](https://github.com/antlr/antlr4/blob/master/runtime/Python3/src/antlr4/ParserRuleContext.py#L116) and [javascript](https://github.com/antlr/antlr4/blob/master/runtime/JavaScript/src/antlr4/context/ParserRuleContext.js#L122) runtimes. The logic for the Golang runtime differs here causing a index out of range error when a user gets the child at the length of the array.

