### PR TITLE
fix: #3758 Extrememly poor performance on poorly written grammars

### DIFF
--- a/runtime/Go/antlr/v4/atn_config_set.go
+++ b/runtime/Go/antlr/v4/atn_config_set.go
@@ -6,7 +6,6 @@ package antlr
 
 import (
 	"fmt"
-	"strconv"
 )
 
 type ATNConfigSet interface {
@@ -278,11 +277,12 @@ func (b *BaseATNConfigSet) Hash() int {
 	return b.hashCodeConfigs()
 }
 
-// TODO: This is terrible. Many config sets hash to the same thing. Fix it Jim
 func (b *BaseATNConfigSet) hashCodeConfigs() int {
-	as := fmt.Sprintf("%p", b.configs)
-	h, _ := strconv.ParseInt(as[2:], 16, 64)
-	return int(h)
+	h := 1
+	for _, config := range b.configs {
+		h = 31*h + config.Hash()
+	}
+	return h
 }
 
 func (b *BaseATNConfigSet) Length() int {

--- a/runtime/Go/antlr/v4/comparators.go
+++ b/runtime/Go/antlr/v4/comparators.go
@@ -21,6 +21,16 @@ package antlr
 // allows us to use it in any collection instance that does nto require a special hash or equals implementation.
 type ObjEqComparator[T Collectable[T]] struct{}
 
+var (
+	aStateEqInst    = &ObjEqComparator[ATNState]{}
+	aConfEqInst     = &ObjEqComparator[ATNConfig]{}
+	aConfCompInst   = &ATNConfigComparator[ATNConfig]{}
+	atnConfCompInst = &BaseATNConfigComparator[ATNConfig]{}
+	dfaStateEqInst  = &ObjEqComparator[*DFAState]{}
+	semctxEqInst    = &ObjEqComparator[SemanticContext]{}
+	atnAltCfgEqInst = &ATNAltConfigComparator[ATNConfig]{}
+)
+
 // Equals2 delegates to the Equals() method of type T
 func (c *ObjEqComparator[T]) Equals2(o1, o2 T) bool {
 	return o1.Equals(o2)

--- a/runtime/Go/antlr/v4/dfa.go
+++ b/runtime/Go/antlr/v4/dfa.go
@@ -32,7 +32,7 @@ func NewDFA(atnStartState DecisionState, decision int) *DFA {
 	dfa := &DFA{
 		atnStartState: atnStartState,
 		decision:      decision,
-		states:        NewJStore[*DFAState, *ObjEqComparator[*DFAState]](&ObjEqComparator[*DFAState]{}),
+		states:        NewJStore[*DFAState, *ObjEqComparator[*DFAState]](dfaStateEqInst),
 	}
 	if s, ok := atnStartState.(*StarLoopEntryState); ok && s.precedenceRuleDecision {
 		dfa.precedenceDfa = true
@@ -95,7 +95,7 @@ func (d *DFA) getPrecedenceDfa() bool {
 // true or nil otherwise, and d.precedenceDfa is updated.
 func (d *DFA) setPrecedenceDfa(precedenceDfa bool) {
 	if d.getPrecedenceDfa() != precedenceDfa {
-		d.states = NewJStore[*DFAState, *ObjEqComparator[*DFAState]](&ObjEqComparator[*DFAState]{})
+		d.states = NewJStore[*DFAState, *ObjEqComparator[*DFAState]](dfaStateEqInst)
 		d.numstates = 0
 
 		if precedenceDfa {

--- a/runtime/Go/antlr/v4/jcollect.go
+++ b/runtime/Go/antlr/v4/jcollect.go
@@ -4,7 +4,9 @@ package antlr
 // Use of this file is governed by the BSD 3-clause license that
 // can be found in the LICENSE.txt file in the project root.
 
-import "sort"
+import (
+	"sort"
+)
 
 // Collectable is an interface that a struct should implement if it is to be
 // usable as a key in these collections.
@@ -149,6 +151,7 @@ func NewJMap[K, V any, C Comparator[K]](comparator Comparator[K]) *JMap[K, V, C]
 
 func (m *JMap[K, V, C]) Put(key K, val V) {
 	kh := m.comparator.Hash1(key)
+
 	m.store[kh] = append(m.store[kh], &entry[K, V]{key, val})
 	m.len++
 }

--- a/runtime/Go/antlr/v4/ll1_analyzer.go
+++ b/runtime/Go/antlr/v4/ll1_analyzer.go
@@ -39,7 +39,7 @@ func (la *LL1Analyzer) getDecisionLookahead(s ATNState) []*IntervalSet {
 	look := make([]*IntervalSet, count)
 	for alt := 0; alt < count; alt++ {
 		look[alt] = NewIntervalSet()
-		lookBusy := NewJStore[ATNConfig, Comparator[ATNConfig]](&ObjEqComparator[ATNConfig]{})
+		lookBusy := NewJStore[ATNConfig, Comparator[ATNConfig]](aConfEqInst)
 		seeThruPreds := false // fail to get lookahead upon pred
 		la.look1(s.GetTransitions()[alt].getTarget(), nil, BasePredictionContextEMPTY, look[alt], lookBusy, NewBitSet(), seeThruPreds, false)
 		// Wipe out lookahead for la alternative if we found nothing
@@ -76,7 +76,7 @@ func (la *LL1Analyzer) Look(s, stopState ATNState, ctx RuleContext) *IntervalSet
 	if ctx != nil {
 		lookContext = predictionContextFromRuleContext(s.GetATN(), ctx)
 	}
-	la.look1(s, stopState, lookContext, r, NewJStore[ATNConfig, Comparator[ATNConfig]](&ObjEqComparator[ATNConfig]{}), NewBitSet(), seeThruPreds, true)
+	la.look1(s, stopState, lookContext, r, NewJStore[ATNConfig, Comparator[ATNConfig]](aConfEqInst), NewBitSet(), seeThruPreds, true)
 	return r
 }
 

--- a/runtime/Go/antlr/v4/parser_atn_simulator.go
+++ b/runtime/Go/antlr/v4/parser_atn_simulator.go
@@ -568,7 +568,7 @@ func (p *ParserATNSimulator) computeReachSet(closure ATNConfigSet, t int, fullCt
 	//
 	if reach == nil {
 		reach = NewBaseATNConfigSet(fullCtx)
-		closureBusy := NewJStore[ATNConfig, Comparator[ATNConfig]](&ObjEqComparator[ATNConfig]{})
+		closureBusy := NewJStore[ATNConfig, Comparator[ATNConfig]](aConfEqInst)
 		treatEOFAsEpsilon := t == TokenEOF
 		amount := len(intermediate.configs)
 		for k := 0; k < amount; k++ {
@@ -661,7 +661,7 @@ func (p *ParserATNSimulator) computeStartState(a ATNState, ctx RuleContext, full
 	for i := 0; i < len(a.GetTransitions()); i++ {
 		target := a.GetTransitions()[i].getTarget()
 		c := NewBaseATNConfig6(target, i+1, initialContext)
-		closureBusy := NewJStore[ATNConfig, Comparator[ATNConfig]](&BaseATNConfigComparator[ATNConfig]{})
+		closureBusy := NewJStore[ATNConfig, Comparator[ATNConfig]](atnConfCompInst)
 		p.closure(c, configs, closureBusy, true, fullCtx, false)
 	}
 	return configs

--- a/runtime/Go/antlr/v4/prediction_mode.go
+++ b/runtime/Go/antlr/v4/prediction_mode.go
@@ -468,7 +468,7 @@ func PredictionModeGetAlts(altsets []*BitSet) *BitSet {
 // alt and not pred
 // </pre>
 func PredictionModegetConflictingAltSubsets(configs ATNConfigSet) []*BitSet {
-	configToAlts := NewJMap[ATNConfig, *BitSet, *ATNAltConfigComparator[ATNConfig]](&ATNAltConfigComparator[ATNConfig]{})
+	configToAlts := NewJMap[ATNConfig, *BitSet, *ATNAltConfigComparator[ATNConfig]](atnAltCfgEqInst)
 
 	for _, c := range configs.GetItems() {
 

--- a/runtime/Go/antlr/v4/semantic_context.go
+++ b/runtime/Go/antlr/v4/semantic_context.go
@@ -198,7 +198,7 @@ type AND struct {
 
 func NewAND(a, b SemanticContext) *AND {
 
-	operands := NewJStore[SemanticContext, Comparator[SemanticContext]](&ObjEqComparator[SemanticContext]{})
+	operands := NewJStore[SemanticContext, Comparator[SemanticContext]](semctxEqInst)
 	if aa, ok := a.(*AND); ok {
 		for _, o := range aa.opnds {
 			operands.Put(o)
@@ -349,7 +349,7 @@ type OR struct {
 
 func NewOR(a, b SemanticContext) *OR {
 
-	operands := NewJStore[SemanticContext, Comparator[SemanticContext]](&ObjEqComparator[SemanticContext]{})
+	operands := NewJStore[SemanticContext, Comparator[SemanticContext]](semctxEqInst)
 	if aa, ok := a.(*OR); ok {
 		for _, o := range aa.opnds {
 			operands.Put(o)


### PR DESCRIPTION
fix: #3875 Extremely poor performance on poorly written grammars

The problem was once again a poorly written hash function, which caused ATN config sets to
hash poorly. The poor grammar caused many thousands of DFA states to hash to the same 
bucket. In your average grammar, this situation would not arise.

For now, I have changed that hash function to use the memory address of the slice that
contains the configs, though i think that this is sub-optimal.  I will revisit this as part of a
general attack at further performance gains.

