### PR TITLE
[C++] Fix the compiler errors reported by GCC 7

### DIFF
--- a/runtime/Cpp/runtime/src/FlatHashMap.h
+++ b/runtime/Cpp/runtime/src/FlatHashMap.h
@@ -48,9 +48,9 @@ namespace antlr4 {
   using FlatHashMap = absl::flat_hash_map<Key, Value, Hash, Equal, Allocator>;
 #else
   template <typename Key, typename Value,
-            typename Hash = typename std::unordered_map<Key, Value>::hasher,
-            typename Equal = typename std::unordered_map<Key, Value>::key_equal,
-            typename Allocator = typename std::unordered_map<Key, Value>::allocator_type>
+            typename Hash = std::hash<Key>,
+            typename Equal = std::equal_to<Key>,
+            typename Allocator = std::allocator<std::pair<const Key, Value>>>
   using FlatHashMap = std::unordered_map<Key, Value, Hash, Equal, Allocator>;
 #endif
 

--- a/runtime/Cpp/runtime/src/FlatHashSet.h
+++ b/runtime/Cpp/runtime/src/FlatHashSet.h
@@ -48,9 +48,9 @@ namespace antlr4 {
   using FlatHashSet = absl::flat_hash_set<Key, Hash, Equal, Allocator>;
 #else
   template <typename Key,
-            typename Hash = typename std::unordered_set<Key>::hasher,
-            typename Equal = typename std::unordered_set<Key>::key_equal,
-            typename Allocator = typename std::unordered_set<Key>::allocator_type>
+            typename Hash = std::hash<Key>,
+            typename Equal = std::equal_to<Key>,
+            typename Allocator = std::allocator<Key>>
   using FlatHashSet = std::unordered_set<Key, Hash, Equal, Allocator>;
 #endif
 


### PR DESCRIPTION
**Abstract:**

This PR fixes the compiler errors in `src/FlatHashSet.h` and `src/FlatHashMap.h` introduced in the previous PR https://github.com/antlr/antlr4/pull/3694.

**Details:**

```
template <typename Key,
          typename Hash = typename std::unordered_set<Key>::hasher,
          typename Equal = typename std::unordered_set<Key>::key_equal,
          typename Allocator = typename std::unordered_set<Key>::allocator_type>
using FlatHashSet = std::unordered_set<Key, Hash, Equal, Allocator>;
```

The existing type definition of `FlatHashSet/Map` is problematic if `Key` is not natively hashable (i.e. No specialization of `std::hash<Key>` available, so `std::unordered_set<Key>` cannot be specialized and therefore the member type `hasher` does not exist), resulting in errors when the runtime library is being compiled by GCC 7 or Clang with GCC installation path set to GCC 7. You may find the error message produced by the Conan CI pipeline at here: https://github.com/conan-io/conan-center-index/pull/12902#issuecomment-1243131690. 

Since the runtime library now targets C++17 which is supported by GCC 7, it would be great to fix this incompatibility. (To be honest, I was somewhat surprised by GCC 8+ that do not treat this as an error...)

Thank you.