### PR TITLE
Remedied takari.maven.plugins build warning.

### DIFF
--- a/antlr4-maven-plugin/pom.xml
+++ b/antlr4-maven-plugin/pom.xml
@@ -143,6 +143,7 @@
       <plugin>
          <groupId>io.takari.maven.plugins</groupId>
          <artifactId>takari-lifecycle-plugin</artifactId>
+         <version>2.0.7</version>         
          <extensions>true</extensions>
          <executions>
            <execution>


### PR DESCRIPTION
Explicitly set version to: 2.0.7

Signed-off-by: chris-miner <94078897+chris-miner@users.noreply.github.com>

