### PR TITLE
JavaScript: Export named exports in addition to default.

### DIFF
--- a/runtime/JavaScript/src/antlr4/index.js
+++ b/runtime/JavaScript/src/antlr4/index.js
@@ -30,3 +30,8 @@ const antlr4 = {
 };
 
 export default antlr4;
+
+export {
+    atn, dfa, tree, error, Token, CommonToken, CharStreams, InputStream, FileStream, CommonTokenStream, Lexer, Parser,
+    PredictionContextCache, ParserRuleContext, Interval, IntervalSet, LL1Analyzer, Utils
+}


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
This change adds named exports to the JavaScript runtime, the default export is left to maintain compatibility.

### Motivation
There is a better outline of the issues encountered when using solely default exports as described by the esbuild team: 

https://esbuild.github.io/content-types/#default-interop
```
If you are a library author: When writing new code, you should strongly consider avoiding the default export entirely. It has unfortunately been tainted with compatibility problems and using it will likely cause problems for your users at some point.
```

See #3912 for more info

Resolves #3912 