### PR TITLE
[Cpp]Fix crashes in TokenStreamRewriter

### DIFF
--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
@@ -327,14 +327,16 @@ std::unordered_map<size_t, TokenStreamRewriter::RewriteOperation*> TokenStreamRe
       if (iop->index == rop->index) {
         // E.g., insert before 2, delete 2..2; update replace
         // text to include insert before, kill insert
-        delete rewrites[iop->instructionIndex];
-        rewrites[iop->instructionIndex] = nullptr;
+        auto iopInstructionIndex = iop->instructionIndex;
+        delete rewrites[iopInstructionIndex];
+        rewrites[iopInstructionIndex] = nullptr;
         rop->text = iop->text + (!rop->text.empty() ? rop->text : "");
       }
       else if (iop->index > rop->index && iop->index <= rop->lastIndex) {
         // delete insert as it's a no-op.
-        delete rewrites[iop->instructionIndex];
-        rewrites[iop->instructionIndex] = nullptr;
+        auto iopInstructionIndex = iop->instructionIndex;
+        delete rewrites[iopInstructionIndex];
+        rewrites[iopInstructionIndex] = nullptr;
       }
     }
     // Drop any prior replaces contained within
@@ -342,8 +344,9 @@ std::unordered_map<size_t, TokenStreamRewriter::RewriteOperation*> TokenStreamRe
     for (auto *prevRop : prevReplaces) {
       if (prevRop->index >= rop->index && prevRop->lastIndex <= rop->lastIndex) {
         // delete replace as it's a no-op.
-        delete rewrites[prevRop->instructionIndex];
-        rewrites[prevRop->instructionIndex] = nullptr;
+        auto prevRopInstructionIndex = prevRop->instructionIndex;
+        delete rewrites[prevRopInstructionIndex];
+        rewrites[prevRopInstructionIndex] = nullptr;
         continue;
       }
       // throw exception unless disjoint or identical
@@ -351,10 +354,13 @@ std::unordered_map<size_t, TokenStreamRewriter::RewriteOperation*> TokenStreamRe
       // Delete special case of replace (text==null):
       // D.i-j.u D.x-y.v    | boundaries overlap    combine to max(min)..max(right)
       if (prevRop->text.empty() && rop->text.empty() && !disjoint) {
-        delete rewrites[prevRop->instructionIndex];
-        rewrites[prevRop->instructionIndex] = nullptr; // kill first delete
-        rop->index = std::min(prevRop->index, rop->index);
-        rop->lastIndex = std::max(prevRop->lastIndex, rop->lastIndex);
+        auto prevRopIndex = prevRop->index;
+        auto prevRopLastIndex = prevRop->lastIndex; 
+        auto prevRopInstructionIndex = prevRop->instructionIndex;
+        delete rewrites[prevRopInstructionIndex];
+        rewrites[prevRopInstructionIndex] = nullptr; // kill first delete
+        rop->index = std::min(prevRopIndex, rop->index);
+        rop->lastIndex = std::max(prevRopLastIndex, rop->lastIndex);
         std::cout << "new rop " << rop << std::endl;
       }
       else if (!disjoint) {
@@ -379,8 +385,9 @@ std::unordered_map<size_t, TokenStreamRewriter::RewriteOperation*> TokenStreamRe
                                           // whole token buffer so no lazy eval issue with any templates
         iop->text = catOpText(&iop->text, &prevIop->text);
         // delete redundant prior insert
-        delete rewrites[prevIop->instructionIndex];
-        rewrites[prevIop->instructionIndex] = nullptr;
+        auto prevIopInstructionIndex = prevIop->instructionIndex; 
+        delete rewrites[prevIopInstructionIndex];
+        rewrites[prevIopInstructionIndex] = nullptr;
       }
     }
     // look for replaces where iop.index is in range; error


### PR DESCRIPTION
Signed-off-by: Tomasz Cybulski <98831780+tcy-bitstothings@users.noreply.github.com>

A simple PR fixing crashes in cpp TokenStreamRewriter.
Rewrite operation objects were accessed after deletion.