### PR TITLE
[Go target] Fix for #3926: Add accessors for tree navigation to interfaces in generated parser

### DIFF
--- a/doc/go-target.md
+++ b/doc/go-target.md
@@ -84,7 +84,7 @@ And the `generate.sh` file will look similar to this:
 
 	#!/bin/sh
 
-	alias antlr4='java -Xmx500M -cp "./antlr4-4.11.0-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
+	alias antlr4='java -Xmx500M -cp "./antlr-4.11.1-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
 	antlr4 -Dlanguage=Go -no-visitor -package parser *.g4
 ```
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -858,7 +858,7 @@ ListLabelName(label)		  ::= "_<label>"
 CaptureNextToken(d) ::= "<d.varName> = TokenStream.LT(1);"
 CaptureNextTokenType(d) ::= "<d.varName> = TokenStream.LA(1);"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures,
            superClass={ParserRuleContext}) ::= <<
 public partial class <struct.escapedName> : <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 	<attrs:{a | public <a>;}; separator="\n">

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -575,7 +575,7 @@ public:
 
 >>
 
-StructDecl(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers) ::= <<
+StructDecl(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers, signatures) ::= <<
 //----------------- <struct.escapedName> ------------------------------------------------------------------
 
 <if (ctorAttrs)>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
@@ -681,7 +681,7 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = tokenStream.LT(1);"
 CaptureNextTokenType(d) ::= "<d.varName> = tokenStream.LA(1)!;"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers)
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures)
   ::= <<
 class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif> {
   <attrs:{a | <a>;}; separator="\n">

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -919,25 +919,25 @@ RuleContextListDecl(rdecl) ::= "<rdecl.escapedName> []I<rdecl.ctxName>"
 AttributeDecl(d) ::= "<d.escapedName> <d.type><if(d.initValue)>// TODO = <d.initValue><endif>"
 
 ContextTokenGetterDecl(t) ::= <<
-<t.escapedName; format="cap">() antlr.TerminalNode {
+<t.escapedName; format="cap">() antlr.TerminalNode<if(!t.signature)> {
 	return s.GetToken(<parser.name><t.escapedName>, 0)
-}
+}<endif>
 >>
 
 ContextTokenListGetterDecl(t) ::= <<
-All<t.escapedName; format="cap">() []antlr.TerminalNode {
+All<t.escapedName; format="cap">() []antlr.TerminalNode<if(!t.signature)> {
 	return s.GetTokens(<parser.name><t.escapedName>)
-}
+}<endif>
 >>
 
 ContextTokenListIndexedGetterDecl(t) ::= <<
-<t.escapedName; format="cap">(i int) antlr.TerminalNode {
+<t.escapedName; format="cap">(i int) antlr.TerminalNode<if(!t.signature)> {
 	return s.GetToken(<parser.name><t.escapedName>, i)
-}
+}<endif>
 >>
 
 ContextRuleGetterDecl(r) ::= <<
-<r.escapedName; format="cap">() I<r.ctxName> {
+<r.escapedName; format="cap">() I<r.ctxName><if(!r.signature)> {
 	var t antlr.RuleContext;
 	for _, ctx := range s.GetChildren() {
 		if _, ok := ctx.(I<r.ctxName>); ok {
@@ -951,11 +951,11 @@ ContextRuleGetterDecl(r) ::= <<
 	}
 
 	return t.(I<r.ctxName>)
-}
+}<endif>
 >>
 
 ContextRuleListGetterDecl(r) ::= <<
-All<r.escapedName; format="cap">() []I<r.ctxName> {
+All<r.escapedName; format="cap">() []I<r.ctxName><if(!r.signature)> {
 	children := s.GetChildren()
 	len := 0
 	for _, ctx := range children {
@@ -974,11 +974,11 @@ All<r.escapedName; format="cap">() []I<r.ctxName> {
 	}
 
 	return tst
-}
+}<endif>
 >>
 
 ContextRuleListIndexedGetterDecl(r) ::= <<
-<r.escapedName; format="cap">(i int) I<r.ctxName> {
+<r.escapedName; format="cap">(i int) I<r.ctxName><if(!r.signature)> {
 	var t antlr.RuleContext;
 	j := 0
 	for _, ctx := range s.GetChildren() {
@@ -996,7 +996,7 @@ ContextRuleListIndexedGetterDecl(r) ::= <<
 	}
 
 	return t.(I<r.ctxName>)
-}
+}<endif>
 >>
 
 LexerRuleContext() ::= "RuleContext"
@@ -1014,7 +1014,7 @@ ListLabelName(label) ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = p.GetTokenStream().LT(1)"
 CaptureNextTokenType(d) ::= "<d.varName> = p.GetTokenStream().LA(1)"
 
-StructDecl(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers) ::= <<
+StructDecl(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers, signatures) ::= <<
 // I<struct.escapedName> is an interface to support dynamic dispatch.
 type I<struct.escapedName> interface {
 	antlr.ParserRuleContext
@@ -1093,6 +1093,11 @@ Get<a.escapedName; format="cap">() <a.type>}; separator="\n\n">
 Set<a.escapedName; format="cap">(<a.type>)}; separator="\n\n">
 	<endif>
 
+	<if(signatures)>
+
+	// Getter signatures
+	<signatures:{s | <s>}; separator="\n">
+	<endif>
 
 	// Is<struct.escapedName> differentiates from other interfaces.
 	Is<struct.escapedName>()

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -782,7 +782,7 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = _input.LT(1);"
 CaptureNextTokenType(d) ::= "<d.varName> = _input.LA(1);"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers)
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures)
 	::= <<
 @SuppressWarnings("CheckReturnValue")
 public static class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif> {

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -657,7 +657,7 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = self._input.LT(1)"
 CaptureNextTokenType(d) ::= "<d.varName> = this._input.LA(1);"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers) ::= <<
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures) ::= <<
 class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>antlr4.ParserRuleContext<endif> {
 
     constructor(parser, parent, invokingState<struct.ctorAttrs:{a | , <a.escapedName>}>) {

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
@@ -923,7 +923,7 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "$<d.varName> = \$this->input->LT(1);"
 CaptureNextTokenType(d) ::= "$<d.varName> = $this->input->LA(1);"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers) ::= <<
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures) ::= <<
 class <struct.name> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif>
 {
 <PropertiesDecl(struct)>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python2/Python2.stg
@@ -637,7 +637,7 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = self._input.LT(1)"
 CaptureNextTokenType(d) ::= "<d.varName> = self._input.LA(1)"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers) ::= <<
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures) ::= <<
 class <struct.escapedName>(<if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>):
 
     def __init__(self, parser, parent=None, invokingState=-1<struct.ctorAttrs:{a | , <a.escapedName>=None}>):

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -650,7 +650,7 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = self._input.LT(1)"
 CaptureNextTokenType(d) ::= "<d.varName> = self._input.LA(1)"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers) ::= <<
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures) ::= <<
 class <struct.escapedName>(<if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>):
     __slots__ = 'parser'
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -812,7 +812,7 @@ ListLabelName(label)		  ::= "<label>"
 CaptureNextToken(d) ::= "<d.varName> = try _input.LT(1)"
 CaptureNextTokenType(d) ::= "<d.varName> = try _input.LA(1)"
 
-StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,
+StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures,
            superClass={ParserRuleContext}) ::= <<
 
 <accessLevelNotOpen(parser)> class <struct.escapedName>: <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {

--- a/tool/src/org/antlr/v4/codegen/model/decl/ContextGetterDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/ContextGetterDecl.java
@@ -11,13 +11,22 @@ import org.antlr.v4.runtime.misc.MurmurHash;
 
 public abstract class ContextGetterDecl extends Decl {
 	public ContextGetterDecl(OutputModelFactory factory, String name) {
+		this(factory, name, false);
+	}
+
+	public ContextGetterDecl(OutputModelFactory factory, String name, boolean signature) {
 		super(factory, name);
+		this.signature = signature;
 	}
 
 	/** Not used for output; just used to distinguish between decl types
 	 *  to avoid dups.
 	 */
 	public String getArgType() { return ""; }; // assume no args
+
+	private boolean signature = false;
+	public boolean getSignature() { return signature; }
+	abstract ContextGetterDecl getSignatureDecl();
 
 	@Override
 	public int hashCode() {

--- a/tool/src/org/antlr/v4/codegen/model/decl/ContextRuleGetterDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/ContextRuleGetterDecl.java
@@ -14,8 +14,17 @@ public class ContextRuleGetterDecl extends ContextGetterDecl {
 	public boolean optional;
 
 	public ContextRuleGetterDecl(OutputModelFactory factory, String name, String ctxName, boolean optional) {
-		super(factory, name);
+		this(factory, name, ctxName, optional, false);
+	}
+
+	public ContextRuleGetterDecl(OutputModelFactory factory, String name, String ctxName, boolean optional, boolean signature) {
+		super(factory, name, signature);
 		this.ctxName = ctxName;
 		this.optional = optional;
+	}
+
+	@Override
+	public ContextGetterDecl getSignatureDecl() {
+		return new ContextRuleGetterDecl(factory, name, ctxName, optional, true);
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/decl/ContextRuleListGetterDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/ContextRuleListGetterDecl.java
@@ -14,7 +14,16 @@ import org.antlr.v4.codegen.OutputModelFactory;
 public class ContextRuleListGetterDecl extends ContextGetterDecl {
 	public String ctxName;
 	public ContextRuleListGetterDecl(OutputModelFactory factory, String name, String ctxName) {
-		super(factory, name);
+		this(factory, name, ctxName, false);
+	}
+
+	public ContextRuleListGetterDecl(OutputModelFactory factory, String name, String ctxName, boolean signature) {
+		super(factory, name, signature);
 		this.ctxName = ctxName;
+	}
+
+	@Override
+	public ContextGetterDecl getSignatureDecl() {
+		return new ContextRuleListGetterDecl(factory, name, ctxName, true);
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/decl/ContextRuleListIndexedGetterDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/ContextRuleListIndexedGetterDecl.java
@@ -10,11 +10,20 @@ import org.antlr.v4.codegen.OutputModelFactory;
 
 public class ContextRuleListIndexedGetterDecl extends ContextRuleListGetterDecl {
 	public ContextRuleListIndexedGetterDecl(OutputModelFactory factory, String name, String ctxName) {
-		super(factory, name, ctxName);
+		this(factory, name, ctxName, false);
+	}
+
+	public ContextRuleListIndexedGetterDecl(OutputModelFactory factory, String name, String ctxName, boolean signature) {
+		super(factory, name, ctxName, signature);
 	}
 
 	@Override
 	public String getArgType() {
 		return "int";
+	}
+
+	@Override
+	public ContextGetterDecl getSignatureDecl() {
+		return new ContextRuleListIndexedGetterDecl(factory, name, ctxName, true);
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/decl/ContextTokenGetterDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/ContextTokenGetterDecl.java
@@ -13,7 +13,16 @@ public class ContextTokenGetterDecl extends ContextGetterDecl {
 	public boolean optional;
 
 	public ContextTokenGetterDecl(OutputModelFactory factory, String name, boolean optional) {
-		super(factory, name);
+		this(factory, name, optional, false);
+	}
+
+	public ContextTokenGetterDecl(OutputModelFactory factory, String name, boolean optional, boolean signature) {
+		super(factory, name, signature);
 		this.optional = optional;
+	}
+
+	@Override
+	public ContextGetterDecl getSignatureDecl() {
+		return new ContextTokenGetterDecl(factory, name, optional, true);
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/decl/ContextTokenListGetterDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/ContextTokenListGetterDecl.java
@@ -13,6 +13,15 @@ import org.antlr.v4.codegen.OutputModelFactory;
  */
 public class ContextTokenListGetterDecl extends ContextGetterDecl {
 	public ContextTokenListGetterDecl(OutputModelFactory factory, String name) {
-		super(factory, name);
+		this(factory, name, false);
+	}
+
+	public ContextTokenListGetterDecl(OutputModelFactory factory, String name, boolean signature) {
+		super(factory, name, signature);
+	}
+
+	@Override
+	public ContextGetterDecl getSignatureDecl() {
+		return new ContextTokenListGetterDecl(factory, name, true);
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/decl/ContextTokenListIndexedGetterDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/ContextTokenListIndexedGetterDecl.java
@@ -10,11 +10,20 @@ import org.antlr.v4.codegen.OutputModelFactory;
 
 public class ContextTokenListIndexedGetterDecl extends ContextTokenListGetterDecl {
 	public ContextTokenListIndexedGetterDecl(OutputModelFactory factory, String name) {
-		super(factory, name);
+		this(factory, name, false);
+	}
+
+	public ContextTokenListIndexedGetterDecl(OutputModelFactory factory, String name, boolean signature) {
+		super(factory, name, signature);
 	}
 
 	@Override
 	public String getArgType() {
 		return "int";
+	}
+
+	@Override
+	public ContextGetterDecl getSignatureDecl() {
+		return new ContextTokenListIndexedGetterDecl(factory, name, true);
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/decl/StructDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/StructDecl.java
@@ -32,6 +32,8 @@ public class StructDecl extends Decl {
 	@ModelElement public List<? super DispatchMethod> dispatchMethods;
 	@ModelElement public List<OutputModelObject> interfaces;
 	@ModelElement public List<OutputModelObject> extensionMembers;
+	// Used to generate method signatures in Go target interfaces
+	@ModelElement public OrderedHashSet<Decl> signatures = new OrderedHashSet<Decl>();
 
 	// Track these separately; Go target needs to generate getters/setters
 	// Do not make them templates; we only need the Decl object not the ST
@@ -71,7 +73,10 @@ public class StructDecl extends Decl {
 	public void addDecl(Decl d) {
 		d.ctx = this;
 
-		if ( d instanceof ContextGetterDecl ) getters.add(d);
+		if ( d instanceof ContextGetterDecl ) {
+			getters.add(d);
+			signatures.add(((ContextGetterDecl) d).getSignatureDecl());
+		}
 		else attrs.add(d);
 
 		// add to specific "lists"


### PR DESCRIPTION
# What does this PR fix?

* #3926 

# Discussion

This is an attempt to remove the need to always cast these interfaces to concrete types. I considered two options:

1. Update accessors to return concrete types instead of interfaces
2. Add the missing method signatures to the existing interfaces

This PR implements option (2), as (1) would be a breaking change for existing applications. I believe (2) is backwards compatible.

The strategy here is to add a flag, `signature`, to each of the `ContextGetterDecl` subclasses so that each of their corresponding template definitions can conditionally generate a method signature (for the interface) versus the complete method declaration.

The `getSignatureDecl()` functions on each of the `ContextGetterDecl` subclasses are pretty tedious... open to suggestions for a more elegant option...

### Grammar
[abb](https://github.com/antlr/grammars-v4/blob/master/abb/abbParser.g4)

```
module  : moduleData EOF   ;
moduleData : MODULE moduleName NEWLINE  dataList  NEWLINE* ENDMODULE ;
```

## Before this change

### Generated Go
```
func (p *abbParserParser) Module() (localctx IModuleContext) { ... }
func (s *ModuleContext) ModuleData() IModuleDataContext { ... }

type IModuleDataContext interface {
	antlr.ParserRuleContext

	// GetParser returns the parser.
	GetParser() antlr.Parser

	// IsModuleDataContext differentiates from other interfaces.
	IsModuleDataContext()
}

type ModuleDataContext struct {
	*antlr.BaseParserRuleContext
	parser antlr.Parser
}
```

### Navigation in Go
```
module.(*parser.ModuleContext).ModuleData().(*parser.ModuleDataContext).ModuleName()
```

## After this change

### Generated Go
```
func (p *abbParserParser) Module() (localctx IModuleContext) { ... }
func (s *ModuleContext) ModuleData() IModuleDataContext { ... }

type IModuleDataContext interface {
    antlr.ParserRuleContext

    // GetParser returns the parser.
    GetParser() antlr.Parser

    // Getter signatures
    MODULE() antlr.TerminalNode
    ModuleName() IModuleNameContext
    AllNEWLINE() []antlr.TerminalNode
    NEWLINE(i int) antlr.TerminalNode
    DataList() IDataListContext
    ENDMODULE() antlr.TerminalNode

    // IsModuleDataContext differentiates from other interfaces.
    IsModuleDataContext()
}

type ModuleDataContext struct {
	*antlr.BaseParserRuleContext
	parser antlr.Parser
}
```

### Navigation in Go
```
module.ModuleData().ModuleName()
```

# Why is this PR important?
This change increases the usability of the Go parsers. Without this change, code littered with type assertions is difficult to read/maintain.