### PR TITLE
Fix docker build command

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,7 @@ You can build docker image from source code locally.
 
     git clone https://github.com/antlr/antlr4.git
     cd antlr4/docker
-    docker build -t antlr/antlr4 --platfort linux/amd64　.    
+    docker buildx build --platform linux/amd64 -t antlr/antlr4 .
 
 
 ## Run


### PR DESCRIPTION
Flag `--platform` is available only for `docker buildx`. [Docker buildx docs](https://docs.docker.com/engine/reference/commandline/buildx_build/#platform)

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
