### PR TITLE
Fix for issue 3845 -- null pointer deref in Cpp target

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
@@ -22,12 +22,10 @@ namespace {
   }
 
   bool predictionContextEqual(const Ref<const PredictionContext> &lhs, const Ref<const PredictionContext> &rhs) {
-    if (lhs == nullptr && rhs == nullptr)
-        return true;
-    if (lhs == nullptr && !(rhs == nullptr))
-        return false;
-    if (!(lhs == nullptr) && rhs == nullptr)
-        return false;
+    if (lhs == nullptr)
+      return rhs == nullptr;
+    else if (rhs == nullptr)
+      return false;
     return *lhs == *rhs;
   }
 

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
@@ -22,6 +22,12 @@ namespace {
   }
 
   bool predictionContextEqual(const Ref<const PredictionContext> &lhs, const Ref<const PredictionContext> &rhs) {
+    if (lhs == nullptr && rhs == nullptr)
+        return true;
+    if (lhs == nullptr && !(rhs == nullptr))
+        return false;
+    if (!(lhs == nullptr) && rhs == nullptr)
+        return false;
     return *lhs == *rhs;
   }
 


### PR DESCRIPTION
Very simply, the code that compares two PredictionContext must test before dereferencing. https://github.com/antlr/antlr4/blob/aa1f1f12a846846fcb78544bdb2ad135471376db/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp#L25 . If both pointers are null then the compare is "true".