### PR TITLE
Don’t specify a default type for the exported Swift package library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,6 @@ let package = Package(
     products: [
         .library(
             name: "Antlr4",
-            type: .dynamic,
             targets: ["Antlr4"]),
     ],
     targets: [


### PR DESCRIPTION
This PR proposes removing the `type: .dynamic` property of the main library exported from the Swift package. 

Forcing the type of the library means that the project will _always_ be generated as a framework bundle, which is fine for application targets, but complicates CLI targets. 

Xcode includes smarts to determine what the appropriate type is to use, and the library does not appear to make use of any framework-specific features like resource bundling, so this should be a low impact change for users of the library.