### PR TITLE
Add ATN tracing support for PHP target

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/Test.php.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/Test.php.stg
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
+use Antlr\Antlr4\Runtime\Atn\ParserATNSimulator;
 use Antlr\Antlr4\Runtime\CommonTokenStream;
 use Antlr\Antlr4\Runtime\Error\Listeners\ConsoleErrorListener;
+use Antlr\Antlr4\Runtime\Error\Listeners\DiagnosticErrorListener;
 use Antlr\Antlr4\Runtime\InputStream;
 use Antlr\Antlr4\Runtime\Lexer;
-use Antlr\Antlr4\Runtime\Error\Listeners\DiagnosticErrorListener;
 use Antlr\Antlr4\Runtime\ParserRuleContext;
 use Antlr\Antlr4\Runtime\Tree\ErrorNode;
 use Antlr\Antlr4\Runtime\Tree\ParseTreeListener;
@@ -52,6 +53,9 @@ $parser = new <parserName>($tokens);
 $parser->addErrorListener(new DiagnosticErrorListener());
 <endif>
 $parser->addErrorListener(new ConsoleErrorListener());
+<if(traceATN)>
+ParserATNSimulator::$traceAtnSimulation = true;
+<endif>
 $parser->setBuildParseTree(true);
 $tree = $parser-><parserStartRuleName>();
 


### PR DESCRIPTION
Add ATN tracing support for the PHP target, as requested [here](https://github.com/antlr/antlr4/pull/3957#event-7850225906).

Companion PR:
https://github.com/antlr/antlr-php-runtime/pull/32

@parrt, could you please check if I'm missing something?