### PR TITLE
Fix cpp equals bug #3959

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@
 ANTLR 4 supports 10 target languages, and ensuring consistency across these targets is a unique and highly valuable feature.
 To ensure proper support of this feature, each release of ANTLR is a complete release of the tool and the 10 runtimes, all with the same version.
 As such, ANTLR versioning does not strictly follow semver semantics:
-- a component may be released with the latest version number even though nothing has changed within that component since the previous release
-- major version is bumped only when new grammar features are released (such as ANTLR3 -> ANTLR4)
-- minor version updates may include minor breaking changes, the policy is to regenerate parsers with every release
-- backwards compatibility is only guaranteed for patch version bumps 
+
+* a component may be released with the latest version number even though nothing has changed within that component since the previous release
+* major version is bumped only when ANTLR is rewritten for a totally new "generation", such as ANTLR3 -> ANTLR4 (LL(\*) -> ALL(\*) parsing)
+* minor version updates may include minor breaking changes, the policy is to regenerate parsers with every release (4.11 -> 4.12)
+* backwards compatibility is only guaranteed for patch version bumps (4.11.1 -> 4.11.2)
+
 If you use a semver verifier in your CI, you probably want to apply special rules for ANTLR, such as treating minor change as a major change.
 
 **ANTLR** (ANother Tool for Language Recognition) is a powerful parser generator for reading, processing, executing, or translating structured text or binary files. It's widely used to build languages, tools, and frameworks. From a grammar, ANTLR generates a parser that can build parse trees and also generates a listener interface (or visitor) that makes it easy to respond to the recognition of phrases of interest.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 [![License](https://img.shields.io/badge/license-BSD-blue.svg)](https://raw.githubusercontent.com/antlr/antlr4/master/LICENSE.txt)
 
 
+## Versioning
+
+ANTLR 4 supports 10 target languages, and ensuring consistency across these targets is a unique and highly valuable feature.
+To ensure proper support of this feature, each release of ANTLR is a complete release of the tool and the 10 runtimes, all with the same version.
+As such, ANTLR versioning does not strictly follow semver semantics:
+- a component may be released with the latest version number even though nothing has changed within that component since the previous release
+- major version is bumped only when new grammar features are released (such as ANTLR3 -> ANTLR4)
+- minor version updates may include minor breaking changes, the policy is to regenerate parsers with every release
+- backwards compatibility is only guaranteed for patch version bumps 
+If you use a semver verifier in your CI, you probably want to apply special rules for ANTLR, such as treating minor change as a major change.
+
 **ANTLR** (ANother Tool for Language Recognition) is a powerful parser generator for reading, processing, executing, or translating structured text or binary files. It's widely used to build languages, tools, and frameworks. From a grammar, ANTLR generates a parser that can build parse trees and also generates a listener interface (or visitor) that makes it easy to respond to the recognition of phrases of interest.
 
 **Dev branch build status**

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Performance/DropLoopEntryBranchInLRRule_4.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Performance/DropLoopEntryBranchInLRRule_4.txt
@@ -51,7 +51,6 @@ between X1 and X2 or between X3 and X4
 ;
 
 [skip]
-Cpp
 Python2
 Python3
 JavaScript

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
@@ -79,18 +79,37 @@ bool ArrayPredictionContext::equals(const PredictionContext &other) const {
   if (getContextType() != other.getContextType()) {
     return false;
   }
+/*
+   const auto &array = downCast<const ArrayPredictionContext&>(other);
+  return returnStates.size() == array.returnStates.size() &&
+         parents.size() == array.parents.size() &&
+         cachedHashCodeEqual(cachedHashCode(), array.cachedHashCode()) &&
+         std::memcmp(returnStates.data(), array.returnStates.data(), returnStates.size() * sizeof(decltype(returnStates)::value_type)) == 0 &&
+ */
   const auto &array = downCast<const ArrayPredictionContext&>(other);
   const bool sameSize = returnStates.size() == array.returnStates.size() &&
                         parents.size() == array.parents.size();
+  if ( !sameSize ) {
+      return false;
+  }
+
   const bool sameHash = cachedHashCodeEqual(cachedHashCode(), array.cachedHashCode());
+  if ( !sameHash ) {
+      return false;
+  }
+
   const size_t stateSizeBytes = sizeof(decltype(returnStates)::value_type);
   const bool returnStateArraysEqual =
           std::memcmp(returnStates.data(), array.returnStates.data(),
                       returnStates.size() * stateSizeBytes) == 0;
+  if ( !returnStateArraysEqual ) {
+      return false;
+  }
+
   // stack of contexts is the same
   const bool parentCtxEqual =
           std::equal(parents.begin(), parents.end(), array.parents.begin(), predictionContextEqual);
-  return sameSize && sameHash && returnStateArraysEqual && parentCtxEqual;
+  return parentCtxEqual;
 }
 
 std::string ArrayPredictionContext::toString() const {


### PR DESCRIPTION
DropLoopEntryBranchInLRRule_4.txt test was failing due to comparing diff size arrays in C++.