### PR TITLE
Add IWYU export pragma to umbrella header.

### DIFF
--- a/runtime/Cpp/runtime/src/antlr4-runtime.h
+++ b/runtime/Cpp/runtime/src/antlr4-runtime.h
@@ -7,6 +7,7 @@
 
 // This is the umbrella header for all ANTLR4 C++ runtime headers.
 
+// IWYU pragma: begin_exports
 #include "antlr4-common.h"
 
 #include "ANTLRErrorListener.h"
@@ -166,3 +167,4 @@
 #include "tree/xpath/XPathWildcardAnywhereElement.h"
 #include "tree/xpath/XPathWildcardElement.h"
 #include "internal/Synchronization.h"
+// IWYU pragma: end_exports


### PR DESCRIPTION
This hints IWYU and other include-management tools not to insert `#include`s of specific headers if the umbrella header is already included.

See https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md

Signed-off-by: Sam McCall <sam.mccall@gmail.com>
