### PR TITLE
C# runtime: use is operator with declaration where possible

### DIFF
--- a/runtime/CSharp/src/Atn/ATNConfig.cs
+++ b/runtime/CSharp/src/Atn/ATNConfig.cs
@@ -168,11 +168,11 @@ namespace Antlr4.Runtime.Atn
 		 */
 		public override bool Equals(Object o)
 		{
-			if (!(o is ATNConfig)) {
+			if (!(o is ATNConfig config)) {
 				return false;
 			}
 
-			return this.Equals((ATNConfig)o);
+			return Equals(config);
 		}
 
 		public virtual bool Equals(ATNConfig other)

--- a/runtime/CSharp/src/Atn/ATNConfigSet.cs
+++ b/runtime/CSharp/src/Atn/ATNConfigSet.cs
@@ -209,20 +209,20 @@ namespace Antlr4.Runtime.Atn
 			{
 				return true;
 			}
-			else if (!(o is ATNConfigSet))
+
+			if (!(o is ATNConfigSet other))
 			{
 				return false;
 			}
 
 			//		System.out.print("equals " + this + ", " + o+" = ");
-			ATNConfigSet other = (ATNConfigSet)o;
 			bool same = configs != null &&
-				configs.Equals(other.configs) &&  // includes stack context
-				this.fullCtx == other.fullCtx &&
-				this.uniqueAlt == other.uniqueAlt &&
-				this.conflictingAlts == other.conflictingAlts &&
-				this.hasSemanticContext == other.hasSemanticContext &&
-				this.dipsIntoOuterContext == other.dipsIntoOuterContext;
+			            configs.Equals(other.configs) &&  // includes stack context
+			            fullCtx == other.fullCtx &&
+			            uniqueAlt == other.uniqueAlt &&
+			            conflictingAlts == other.conflictingAlts &&
+			            hasSemanticContext == other.hasSemanticContext &&
+			            dipsIntoOuterContext == other.dipsIntoOuterContext;
 
 			//		System.out.println(same);
 			return same;

--- a/runtime/CSharp/src/Atn/ATNDeserializer.cs
+++ b/runtime/CSharp/src/Atn/ATNDeserializer.cs
@@ -240,11 +240,10 @@ namespace Antlr4.Runtime.Atn
 				for (int i_10 = 0; i_10 < state_1.NumberOfTransitions; i_10++)
 				{
 					Transition t = state_1.Transition(i_10);
-					if (!(t is RuleTransition))
+					if (!(t is RuleTransition ruleTransition))
 					{
 						continue;
 					}
-					RuleTransition ruleTransition = (RuleTransition)t;
 					int outermostPrecedenceReturn = -1;
 					if (atn.ruleToStartState[ruleTransition.target.ruleIndex].isPrecedenceRule)
 					{
@@ -259,41 +258,39 @@ namespace Antlr4.Runtime.Atn
 			}
 			foreach (ATNState state_2 in atn.states)
 			{
-				if (state_2 is BlockStartState)
+				if (state_2 is BlockStartState state)
 				{
 					// we need to know the end state to set its start state
-					if (((BlockStartState)state_2).endState == null)
+					if (state.endState == null)
 					{
 						throw new InvalidOperationException();
 					}
 					// block end states can only be associated to a single block start state
-					if (((BlockStartState)state_2).endState.startState != null)
+					if (state.endState.startState != null)
 					{
 						throw new InvalidOperationException();
 					}
-					((BlockStartState)state_2).endState.startState = (BlockStartState)state_2;
+					state.endState.startState = state;
 				}
-				else if (state_2 is PlusLoopbackState)
+				else if (state_2 is PlusLoopbackState backState)
 				{
-					PlusLoopbackState loopbackState = (PlusLoopbackState)state_2;
-					for (int i_10 = 0; i_10 < loopbackState.NumberOfTransitions; i_10++)
+					for (int i_10 = 0; i_10 < backState.NumberOfTransitions; i_10++)
 					{
-						ATNState target = loopbackState.Transition(i_10).target;
-						if (target is PlusBlockStartState)
+						ATNState target = backState.Transition(i_10).target;
+						if (target is PlusBlockStartState startState)
 						{
-							((PlusBlockStartState)target).loopBackState = loopbackState;
+							startState.loopBackState = backState;
 						}
 					}
 				}
-				else if (state_2 is StarLoopbackState)
+				else if (state_2 is StarLoopbackState loopbackState)
 				{
-					StarLoopbackState loopbackState = (StarLoopbackState)state_2;
 					for (int i_10 = 0; i_10 < loopbackState.NumberOfTransitions; i_10++)
 					{
 						ATNState target = loopbackState.Transition(i_10).target;
-						if (target is StarLoopEntryState)
+						if (target is StarLoopEntryState entryState)
 						{
-							((StarLoopEntryState)target).loopBackState = loopbackState;
+							entryState.loopBackState = loopbackState;
 						}
 					}
 				}
@@ -366,13 +363,12 @@ namespace Antlr4.Runtime.Atn
 			atn.ruleToStopState = new RuleStopState[nrules];
 			foreach (ATNState state in atn.states)
 			{
-				if (!(state is RuleStopState))
+				if (!(state is RuleStopState stopState))
 				{
 					continue;
 				}
-				RuleStopState stopState = (RuleStopState)state;
-				atn.ruleToStopState[state.ruleIndex] = stopState;
-				atn.ruleToStartState[state.ruleIndex].stopState = stopState;
+				atn.ruleToStopState[stopState.ruleIndex] = stopState;
+				atn.ruleToStartState[stopState.ruleIndex].stopState = stopState;
 			}
 		}
 
@@ -407,10 +403,10 @@ namespace Antlr4.Runtime.Atn
 				}
 				else
 				{
-					if (s is BlockStartState)
+					if (s is BlockStartState state)
 					{
 						int endStateNumber = ReadInt();
-						endStateNumbers.Add(Tuple.Create((BlockStartState)s, endStateNumber));
+						endStateNumbers.Add(Tuple.Create(state, endStateNumber));
 					}
 				}
 				atn.AddState(s);
@@ -469,18 +465,18 @@ namespace Antlr4.Runtime.Atn
         {
             foreach (ATNState state in atn.states)
             {
-                if (!(state is StarLoopEntryState))
+                if (!(state is StarLoopEntryState entryState))
                 {
                     continue;
                 }
-                if (atn.ruleToStartState[state.ruleIndex].isPrecedenceRule)
+                if (atn.ruleToStartState[entryState.ruleIndex].isPrecedenceRule)
                 {
-                    ATNState maybeLoopEndState = state.Transition(state.NumberOfTransitions - 1).target;
+                    ATNState maybeLoopEndState = entryState.Transition(entryState.NumberOfTransitions - 1).target;
                     if (maybeLoopEndState is LoopEndState)
                     {
                         if (maybeLoopEndState.epsilonOnlyTransitions && maybeLoopEndState.Transition(0).target is RuleStopState)
                         {
-							((StarLoopEntryState)state).isPrecedenceDecision = true;
+							entryState.isPrecedenceDecision = true;
                         }
                     }
                 }
@@ -497,14 +493,13 @@ namespace Antlr4.Runtime.Atn
                     continue;
                 }
                 CheckCondition(state.OnlyHasEpsilonTransitions || state.NumberOfTransitions <= 1);
-                if (state is PlusBlockStartState)
+                if (state is PlusBlockStartState startState)
                 {
-                    CheckCondition(((PlusBlockStartState)state).loopBackState != null);
+                    CheckCondition(startState.loopBackState != null);
                 }
-                if (state is StarLoopEntryState)
+                if (state is StarLoopEntryState starLoopEntryState)
                 {
-                    StarLoopEntryState starLoopEntryState = (StarLoopEntryState)state;
-                    CheckCondition(starLoopEntryState.loopBackState != null);
+	                CheckCondition(starLoopEntryState.loopBackState != null);
                     CheckCondition(starLoopEntryState.NumberOfTransitions == 2);
                     if (starLoopEntryState.Transition(0).target is StarBlockStartState)
                     {
@@ -529,26 +524,25 @@ namespace Antlr4.Runtime.Atn
                     CheckCondition(state.NumberOfTransitions == 1);
                     CheckCondition(state.Transition(0).target is StarLoopEntryState);
                 }
-                if (state is LoopEndState)
+                if (state is LoopEndState endState)
                 {
-                    CheckCondition(((LoopEndState)state).loopBackState != null);
+                    CheckCondition(endState.loopBackState != null);
                 }
-                if (state is RuleStartState)
+                if (state is RuleStartState ruleStartState)
                 {
-                    CheckCondition(((RuleStartState)state).stopState != null);
+                    CheckCondition(ruleStartState.stopState != null);
                 }
-                if (state is BlockStartState)
+                if (state is BlockStartState blockStartState)
                 {
-                    CheckCondition(((BlockStartState)state).endState != null);
+                    CheckCondition(blockStartState.endState != null);
                 }
-                if (state is BlockEndState)
+                if (state is BlockEndState blockEndState)
                 {
-                    CheckCondition(((BlockEndState)state).startState != null);
+                    CheckCondition(blockEndState.startState != null);
                 }
-                if (state is DecisionState)
+                if (state is DecisionState decisionState)
                 {
-                    DecisionState decisionState = (DecisionState)state;
-                    CheckCondition(decisionState.NumberOfTransitions <= 1 || decisionState.decision >= 0);
+	                CheckCondition(decisionState.NumberOfTransitions <= 1 || decisionState.decision >= 0);
                 }
                 else
                 {
@@ -626,7 +620,7 @@ namespace Antlr4.Runtime.Atn
                 for (int i_1 = 0; i_1 < state.NumberOfOptimizedTransitions; i_1++)
                 {
                     Transition transition = state.GetOptimizedTransition(i_1);
-                    if (!(transition is RuleTransition))
+                    if (!(transition is RuleTransition ruleTransition))
                     {
                         if (optimizedTransitions != null)
                         {
@@ -634,13 +628,13 @@ namespace Antlr4.Runtime.Atn
                         }
                         continue;
                     }
-                    RuleTransition ruleTransition = (RuleTransition)transition;
+
                     Transition effective = ruleToInlineTransition[ruleTransition.target.ruleIndex];
                     if (effective == null)
                     {
                         if (optimizedTransitions != null)
                         {
-                            optimizedTransitions.Add(transition);
+                            optimizedTransitions.Add(ruleTransition);
                         }
                         continue;
                     }
@@ -883,11 +877,10 @@ nextTransition_continue: ;
             {
                 foreach (Transition transition in state.transitions)
                 {
-                    if (!(transition is RuleTransition))
+                    if (!(transition is RuleTransition ruleTransition))
                     {
                         continue;
                     }
-                    RuleTransition ruleTransition = (RuleTransition)transition;
                     ruleTransition.tailCall = TestTailCall(atn, ruleTransition, false);
                     ruleTransition.optimizedTailCall = TestTailCall(atn, ruleTransition, true);
                 }
@@ -897,11 +890,11 @@ nextTransition_continue: ;
                 }
                 foreach (Transition transition_1 in state.optimizedTransitions)
                 {
-                    if (!(transition_1 is RuleTransition))
+                    if (!(transition_1 is RuleTransition ruleTransition))
                     {
                         continue;
                     }
-                    RuleTransition ruleTransition = (RuleTransition)transition_1;
+
                     ruleTransition.tailCall = TestTailCall(atn, ruleTransition, false);
                     ruleTransition.optimizedTailCall = TestTailCall(atn, ruleTransition, true);
                 }

--- a/runtime/CSharp/src/Atn/ATNState.cs
+++ b/runtime/CSharp/src/Atn/ATNState.cs
@@ -48,7 +48,7 @@ namespace Antlr4.Runtime.Atn
         public override bool Equals(object o)
         {
             return o==this ||
-				(o is ATNState && stateNumber == ((ATNState)o).stateNumber);
+				(o is ATNState state && stateNumber == state.stateNumber);
         }
 
         public virtual bool IsNonGreedyExitState

--- a/runtime/CSharp/src/Atn/ArrayPredictionContext.cs
+++ b/runtime/CSharp/src/Atn/ArrayPredictionContext.cs
@@ -76,19 +76,19 @@ namespace Antlr4.Runtime.Atn
 			{
 				return true;
 			}
-			else if (!(o is ArrayPredictionContext))
+
+			if (!(o is ArrayPredictionContext context))
 			{
 				return false;
 			}
 
-			if (this.GetHashCode() != o.GetHashCode())
+			if (GetHashCode() != context.GetHashCode())
 			{
 				return false; // can't be same if hash is different
 			}
 
-			ArrayPredictionContext a = (ArrayPredictionContext)o;
-			return Arrays.Equals(returnStates, a.returnStates) &&
-				   Arrays.Equals(parents, a.parents);
+			return Arrays.Equals(returnStates, context.returnStates) &&
+			       Arrays.Equals(parents, context.parents);
 		}
 
 

--- a/runtime/CSharp/src/Atn/LexerATNConfig.cs
+++ b/runtime/CSharp/src/Atn/LexerATNConfig.cs
@@ -92,12 +92,12 @@ namespace Antlr4.Runtime.Atn
 			{
 				return true;
 			}
-			else if (!(other is LexerATNConfig))
+
+			if (!(other is LexerATNConfig lexerOther))
 			{
 				return false;
 			}
 
-			LexerATNConfig lexerOther = (LexerATNConfig)other;
 			if (passedThroughNonGreedyDecision != lexerOther.passedThroughNonGreedyDecision)
 			{
 				return false;
@@ -108,13 +108,13 @@ namespace Antlr4.Runtime.Atn
 				return false;
 			}
 
-			return base.Equals(other);
+			return base.Equals(lexerOther);
 		}
 
 		private static bool checkNonGreedyDecision(LexerATNConfig source, ATNState target)
 		{
 			return source.passedThroughNonGreedyDecision
-				|| target is DecisionState && ((DecisionState)target).nonGreedy;
+				|| target is DecisionState decisionState && decisionState.nonGreedy;
 		}
 	}
 }

--- a/runtime/CSharp/src/Atn/LexerActionExecutor.cs
+++ b/runtime/CSharp/src/Atn/LexerActionExecutor.cs
@@ -220,11 +220,11 @@ namespace Antlr4.Runtime.Atn
                 foreach (ILexerAction lexerAction in lexerActions)
                 {
                     ILexerAction action = lexerAction;
-                    if (action is LexerIndexedCustomAction)
+                    if (action is LexerIndexedCustomAction customAction)
                     {
-                        int offset = ((LexerIndexedCustomAction)action).Offset;
+                        int offset = customAction.Offset;
                         input.Seek(startIndex + offset);
-                        action = ((LexerIndexedCustomAction)action).Action;
+                        action = customAction.Action;
                         requiresSeek = (startIndex + offset) != stopIndex;
                     }
                     else
@@ -258,14 +258,12 @@ namespace Antlr4.Runtime.Atn
             {
                 return true;
             }
-            else
+
+            if (!(obj is LexerActionExecutor other))
             {
-                if (!(obj is Antlr4.Runtime.Atn.LexerActionExecutor))
-                {
-                    return false;
-                }
+                return false;
             }
-            Antlr4.Runtime.Atn.LexerActionExecutor other = (Antlr4.Runtime.Atn.LexerActionExecutor)obj;
+
             return hashCode == other.hashCode && Arrays.Equals(lexerActions, other.lexerActions);
         }
     }

--- a/runtime/CSharp/src/Atn/LexerChannelAction.cs
+++ b/runtime/CSharp/src/Atn/LexerChannelAction.cs
@@ -111,14 +111,12 @@ namespace Antlr4.Runtime.Atn
             {
                 return true;
             }
-            else
+
+            if (!(obj is LexerChannelAction action))
             {
-                if (!(obj is Antlr4.Runtime.Atn.LexerChannelAction))
-                {
-                    return false;
-                }
+                return false;
             }
-            return channel == ((Antlr4.Runtime.Atn.LexerChannelAction)obj).channel;
+            return channel == action.channel;
         }
 
         public override string ToString()

--- a/runtime/CSharp/src/Atn/LexerCustomAction.cs
+++ b/runtime/CSharp/src/Atn/LexerCustomAction.cs
@@ -147,14 +147,12 @@ namespace Antlr4.Runtime.Atn
             {
                 return true;
             }
-            else
+
+            if (!(obj is LexerCustomAction other))
             {
-                if (!(obj is Antlr4.Runtime.Atn.LexerCustomAction))
-                {
-                    return false;
-                }
+                return false;
             }
-            Antlr4.Runtime.Atn.LexerCustomAction other = (Antlr4.Runtime.Atn.LexerCustomAction)obj;
+
             return ruleIndex == other.ruleIndex && actionIndex == other.actionIndex;
         }
     }

--- a/runtime/CSharp/src/Atn/LexerIndexedCustomAction.cs
+++ b/runtime/CSharp/src/Atn/LexerIndexedCustomAction.cs
@@ -162,14 +162,12 @@ namespace Antlr4.Runtime.Atn
             {
                 return true;
             }
-            else
+
+            if (!(obj is LexerIndexedCustomAction other))
             {
-                if (!(obj is Antlr4.Runtime.Atn.LexerIndexedCustomAction))
-                {
-                    return false;
-                }
+                return false;
             }
-            Antlr4.Runtime.Atn.LexerIndexedCustomAction other = (Antlr4.Runtime.Atn.LexerIndexedCustomAction)obj;
+
             return offset == other.offset && action.Equals(other.action);
         }
     }

--- a/runtime/CSharp/src/Atn/LexerModeAction.cs
+++ b/runtime/CSharp/src/Atn/LexerModeAction.cs
@@ -109,14 +109,12 @@ namespace Antlr4.Runtime.Atn
             {
                 return true;
             }
-            else
+
+            if (!(obj is LexerModeAction action))
             {
-                if (!(obj is Antlr4.Runtime.Atn.LexerModeAction))
-                {
-                    return false;
-                }
+                return false;
             }
-            return mode == ((Antlr4.Runtime.Atn.LexerModeAction)obj).mode;
+            return mode == action.mode;
         }
 
         public override string ToString()

--- a/runtime/CSharp/src/Atn/LexerPushModeAction.cs
+++ b/runtime/CSharp/src/Atn/LexerPushModeAction.cs
@@ -108,14 +108,12 @@ namespace Antlr4.Runtime.Atn
             {
                 return true;
             }
-            else
+
+            if (!(obj is LexerPushModeAction action))
             {
-                if (!(obj is Antlr4.Runtime.Atn.LexerPushModeAction))
-                {
-                    return false;
-                }
+                return false;
             }
-            return mode == ((Antlr4.Runtime.Atn.LexerPushModeAction)obj).mode;
+            return mode == action.mode;
         }
 
         public override string ToString()

--- a/runtime/CSharp/src/Atn/LexerTypeAction.cs
+++ b/runtime/CSharp/src/Atn/LexerTypeAction.cs
@@ -104,14 +104,12 @@ namespace Antlr4.Runtime.Atn
             {
                 return true;
             }
-            else
+
+            if (!(obj is LexerTypeAction action))
             {
-                if (!(obj is Antlr4.Runtime.Atn.LexerTypeAction))
-                {
-                    return false;
-                }
+                return false;
             }
-            return type == ((Antlr4.Runtime.Atn.LexerTypeAction)obj).type;
+            return type == action.type;
         }
 
         public override string ToString()

--- a/runtime/CSharp/src/Atn/ParserATNSimulator.cs
+++ b/runtime/CSharp/src/Atn/ParserATNSimulator.cs
@@ -2129,14 +2129,12 @@ namespace Antlr4.Runtime.Atn
 				if (c.state.NumberOfTransitions > 0)
 				{
 					Transition t = c.state.Transition(0);
-					if (t is AtomTransition)
+					if (t is AtomTransition at)
 					{
-						AtomTransition at = (AtomTransition)t;
 						trans = "Atom " + GetTokenName(at.token);
 					}
-					else if (t is SetTransition)
+					else if (t is SetTransition st)
 					{
-						SetTransition st = (SetTransition)t;
 						bool not = st is NotSetTransition;
 						trans = (not ? "~" : "") + "Set " + st.set.ToString();
 					}

--- a/runtime/CSharp/src/Atn/PredictionContext.cs
+++ b/runtime/CSharp/src/Atn/PredictionContext.cs
@@ -104,11 +104,9 @@ namespace Antlr4.Runtime.Atn
 			{
 				return a;
 			}
-			if (a is SingletonPredictionContext && b is SingletonPredictionContext)
+			if (a is SingletonPredictionContext aContext && b is SingletonPredictionContext predictionContext)
 			{
-				return MergeSingletons((SingletonPredictionContext)a,
-									   (SingletonPredictionContext)b,
-									   rootIsWildcard, mergeCache);
+				return MergeSingletons(aContext, predictionContext, rootIsWildcard, mergeCache);
 			}
 
 			// At least one of a or b is array
@@ -122,13 +120,13 @@ namespace Antlr4.Runtime.Atn
 			}
 
 			// convert singleton so both are arrays to normalize
-			if (a is SingletonPredictionContext)
+			if (a is SingletonPredictionContext singletonPredictionContext)
 			{
-				a = new ArrayPredictionContext((SingletonPredictionContext)a);
+				a = new ArrayPredictionContext(singletonPredictionContext);
 			}
-			if (b is SingletonPredictionContext)
+			if (b is SingletonPredictionContext bContext)
 			{
-				b = new ArrayPredictionContext((SingletonPredictionContext)b);
+				b = new ArrayPredictionContext(bContext);
 			}
 			return MergeArrays((ArrayPredictionContext)a, (ArrayPredictionContext)b,
 							   rootIsWildcard, mergeCache);

--- a/runtime/CSharp/src/Atn/SemanticContext.cs
+++ b/runtime/CSharp/src/Atn/SemanticContext.cs
@@ -72,16 +72,16 @@ namespace Antlr4.Runtime.Atn
 
             public override bool Equals(object obj)
             {
-                if (!(obj is SemanticContext.Predicate))
+                if (!(obj is Predicate o))
                 {
                     return false;
                 }
-                if (this == obj)
+                if (this == o)
                 {
                     return true;
                 }
-                SemanticContext.Predicate p = (SemanticContext.Predicate)obj;
-                return this.ruleIndex == p.ruleIndex && this.predIndex == p.predIndex && this.isCtxDependent == p.isCtxDependent;
+
+                return ruleIndex == o.ruleIndex && predIndex == o.predIndex && isCtxDependent == o.isCtxDependent;
             }
 
             public override string ToString()
@@ -135,16 +135,16 @@ namespace Antlr4.Runtime.Atn
 
             public override bool Equals(object obj)
             {
-                if (!(obj is SemanticContext.PrecedencePredicate))
+                if (!(obj is SemanticContext.PrecedencePredicate other))
                 {
                     return false;
                 }
-                if (this == obj)
+                if (this == other)
                 {
                     return true;
                 }
-                SemanticContext.PrecedencePredicate other = (SemanticContext.PrecedencePredicate)obj;
-                return this.precedence == other.precedence;
+
+                return precedence == other.precedence;
             }
 
             public override string ToString()
@@ -171,17 +171,17 @@ namespace Antlr4.Runtime.Atn
             public AND(SemanticContext a, SemanticContext b)
             {
                 HashSet<SemanticContext> operands = new HashSet<SemanticContext>();
-                if (a is SemanticContext.AND)
+                if (a is AND aAnd)
                 {
-                    operands.UnionWith(((AND)a).opnds);
+                    operands.UnionWith(aAnd.opnds);
                 }
                 else
                 {
                     operands.Add(a);
                 }
-                if (b is SemanticContext.AND)
+                if (b is AND bAnd)
                 {
-                    operands.UnionWith(((AND)b).opnds);
+                    operands.UnionWith(bAnd.opnds);
                 }
                 else
                 {
@@ -211,12 +211,12 @@ namespace Antlr4.Runtime.Atn
                 {
                     return true;
                 }
-                if (!(obj is SemanticContext.AND))
+                if (!(obj is AND other))
                 {
                     return false;
                 }
-                SemanticContext.AND other = (SemanticContext.AND)obj;
-                return Arrays.Equals(this.opnds, other.opnds);
+
+                return Arrays.Equals(opnds, other.opnds);
             }
 
             public override int GetHashCode()
@@ -289,17 +289,17 @@ namespace Antlr4.Runtime.Atn
             public OR(SemanticContext a, SemanticContext b)
             {
                 HashSet<SemanticContext> operands = new HashSet<SemanticContext>();
-                if (a is SemanticContext.OR)
+                if (a is OR aOr)
                 {
-                    operands.UnionWith(((OR)a).opnds);
+                    operands.UnionWith(aOr.opnds);
                 }
                 else
                 {
                     operands.Add(a);
                 }
-                if (b is SemanticContext.OR)
+                if (b is OR bOr)
                 {
-                    operands.UnionWith(((OR)b).opnds);
+                    operands.UnionWith(bOr.opnds);
                 }
                 else
                 {
@@ -329,12 +329,12 @@ namespace Antlr4.Runtime.Atn
                 {
                     return true;
                 }
-                if (!(obj is SemanticContext.OR))
+                if (!(obj is SemanticContext.OR other))
                 {
                     return false;
                 }
-                SemanticContext.OR other = (SemanticContext.OR)obj;
-                return Arrays.Equals(this.opnds, other.opnds);
+
+                return Arrays.Equals(opnds, other.opnds);
             }
 
             public override int GetHashCode()

--- a/runtime/CSharp/src/Atn/SingletonPredictionContext.cs
+++ b/runtime/CSharp/src/Atn/SingletonPredictionContext.cs
@@ -67,18 +67,16 @@ namespace Antlr4.Runtime.Atn
             {
                 return true;
             }
-            else
+
+            if (!(o is SingletonPredictionContext other))
             {
-                if (!(o is Antlr4.Runtime.Atn.SingletonPredictionContext))
-                {
-                    return false;
-                }
+	            return false;
             }
-            if (this.GetHashCode() != o.GetHashCode())
+            if (GetHashCode() != other.GetHashCode())
             {
                 return false;
             }
-			Antlr4.Runtime.Atn.SingletonPredictionContext other = (Antlr4.Runtime.Atn.SingletonPredictionContext)o;
+
             return returnState == other.returnState && (parent != null && parent.Equals(other.parent));
         }
 

--- a/runtime/CSharp/src/BufferedTokenStream.cs
+++ b/runtime/CSharp/src/BufferedTokenStream.cs
@@ -238,9 +238,9 @@ namespace Antlr4.Runtime
             for (int i = 0; i < n; i++)
             {
                 IToken t = _tokenSource.NextToken();
-                if (t is IWritableToken)
+                if (t is IWritableToken token)
                 {
-                    ((IWritableToken)t).TokenIndex = tokens.Count;
+                    token.TokenIndex = tokens.Count;
                 }
                 tokens.Add(t);
                 if (t.Type == TokenConstants.EOF)

--- a/runtime/CSharp/src/CommonToken.cs
+++ b/runtime/CSharp/src/CommonToken.cs
@@ -168,10 +168,10 @@ namespace Antlr4.Runtime
             _channel = oldToken.Channel;
             start = oldToken.StartIndex;
             stop = oldToken.StopIndex;
-            if (oldToken is Antlr4.Runtime.CommonToken)
+            if (oldToken is CommonToken token)
             {
-                _text = ((Antlr4.Runtime.CommonToken)oldToken)._text;
-                source = ((Antlr4.Runtime.CommonToken)oldToken).source;
+                _text = token._text;
+                source = token.source;
             }
             else
             {

--- a/runtime/CSharp/src/DefaultErrorStrategy.cs
+++ b/runtime/CSharp/src/DefaultErrorStrategy.cs
@@ -157,21 +157,21 @@ namespace Antlr4.Runtime
             }
             // don't report spurious errors
             BeginErrorCondition(recognizer);
-            if (e is NoViableAltException)
+            if (e is NoViableAltException exception)
             {
-                ReportNoViableAlternative(recognizer, (NoViableAltException)e);
+                ReportNoViableAlternative(recognizer, exception);
             }
             else
             {
-                if (e is InputMismatchException)
+                if (e is InputMismatchException mismatchException)
                 {
-                    ReportInputMismatch(recognizer, (InputMismatchException)e);
+                    ReportInputMismatch(recognizer, mismatchException);
                 }
                 else
                 {
-                    if (e is FailedPredicateException)
+                    if (e is FailedPredicateException predicateException)
                     {
-                        ReportFailedPredicate(recognizer, (FailedPredicateException)e);
+                        ReportFailedPredicate(recognizer, predicateException);
                     }
                     else
                     {

--- a/runtime/CSharp/src/Dfa/ArrayEdgeMap.cs
+++ b/runtime/CSharp/src/Dfa/ArrayEdgeMap.cs
@@ -90,31 +90,28 @@ namespace Antlr4.Runtime.Dfa
             {
                 return this;
             }
-            if (m is Antlr4.Runtime.Dfa.ArrayEdgeMap<T>)
+            if (m is ArrayEdgeMap<T> map)
             {
-                Antlr4.Runtime.Dfa.ArrayEdgeMap<T> other = (Antlr4.Runtime.Dfa.ArrayEdgeMap<T>)m;
-                int minOverlap = Math.Max(minIndex, other.minIndex);
-                int maxOverlap = Math.Min(maxIndex, other.maxIndex);
-                Antlr4.Runtime.Dfa.ArrayEdgeMap<T> result = this;
+                int minOverlap = Math.Max(minIndex, map.minIndex);
+                int maxOverlap = Math.Min(maxIndex, map.maxIndex);
+                ArrayEdgeMap<T> result = this;
                 for (int i = minOverlap; i <= maxOverlap; i++)
                 {
-                    result = ((Antlr4.Runtime.Dfa.ArrayEdgeMap<T>)result.Put(i, m[i]));
+                    result = ((ArrayEdgeMap<T>)result.Put(i, map[i]));
                 }
                 return result;
             }
             else
             {
-                if (m is SingletonEdgeMap<T>)
+                if (m is SingletonEdgeMap<T> pairs)
                 {
-                    SingletonEdgeMap<T> other = (SingletonEdgeMap<T>)m;
-                    System.Diagnostics.Debug.Assert(!other.IsEmpty);
-                    return Put(other.Key, other.Value);
+                    System.Diagnostics.Debug.Assert(!pairs.IsEmpty);
+                    return Put(pairs.Key, pairs.Value);
                 }
                 else
                 {
-                    if (m is SparseEdgeMap<T>)
+                    if (m is SparseEdgeMap<T> other)
                     {
-                        SparseEdgeMap<T> other = (SparseEdgeMap<T>)m;
                         lock (other)
                         {
                             int[] keys = other.Keys;

--- a/runtime/CSharp/src/Dfa/DFA.cs
+++ b/runtime/CSharp/src/Dfa/DFA.cs
@@ -41,8 +41,8 @@ namespace Antlr4.Runtime.Dfa
 			this.atnStartState = atnStartState;
 			this.decision = decision;
 
-			this.precedenceDfa = false;
-			if (atnStartState is StarLoopEntryState && ((StarLoopEntryState)atnStartState).isPrecedenceDecision)
+			precedenceDfa = false;
+			if (atnStartState is StarLoopEntryState state && state.isPrecedenceDecision)
 			{
 				this.precedenceDfa = true;
 				DFAState precedenceState = new DFAState(new ATNConfigSet());

--- a/runtime/CSharp/src/Dfa/DFAState.cs
+++ b/runtime/CSharp/src/Dfa/DFAState.cs
@@ -133,12 +133,11 @@ namespace Antlr4.Runtime.Dfa
 			// compare set of ATN configurations in this set with other
 			if (this == o) return true;
 
-			if (!(o is DFAState))
+			if (!(o is DFAState other))
 			{
 				return false;
 			}
 
-			DFAState other = (DFAState)o;
 			// TODO (sam): what to do when configs==null?
 			bool sameSet = this.configSet.Equals(other.configSet);
 			//		System.out.println("DFAState.equals: "+configs+(sameSet?"==":"!=")+other.configs);

--- a/runtime/CSharp/src/FailedPredicateException.cs
+++ b/runtime/CSharp/src/FailedPredicateException.cs
@@ -43,10 +43,10 @@ namespace Antlr4.Runtime
         {
             ATNState s = recognizer.Interpreter.atn.states[recognizer.State];
             AbstractPredicateTransition trans = (AbstractPredicateTransition)s.Transition(0);
-            if (trans is PredicateTransition)
+            if (trans is PredicateTransition transition)
             {
-                this.ruleIndex = ((PredicateTransition)trans).ruleIndex;
-                this.predicateIndex = ((PredicateTransition)trans).predIndex;
+                ruleIndex = transition.ruleIndex;
+                predicateIndex = transition.predIndex;
             }
             else
             {

--- a/runtime/CSharp/src/Misc/ArrayList.cs
+++ b/runtime/CSharp/src/Misc/ArrayList.cs
@@ -31,7 +31,7 @@ namespace Antlr4.Runtime.Misc
 		public override bool Equals(object o)
 		{
 			return o == this
-				|| (o is List<T> && this.Equals((List<T>)o));
+				|| (o is List<T> ts && Equals(ts));
 		}
 
 

--- a/runtime/CSharp/src/Misc/Interval.cs
+++ b/runtime/CSharp/src/Misc/Interval.cs
@@ -61,13 +61,12 @@ namespace Antlr4.Runtime.Misc
 
         public override bool Equals(object o)
         {
-            if (!(o is Antlr4.Runtime.Misc.Interval))
+            if (!(o is Interval other))
             {
                 return false;
             }
 
-            Antlr4.Runtime.Misc.Interval other = (Antlr4.Runtime.Misc.Interval)o;
-            return this.a == other.a && this.b == other.b;
+            return a == other.a && b == other.b;
         }
 
         public override int GetHashCode()

--- a/runtime/CSharp/src/Misc/IntervalSet.cs
+++ b/runtime/CSharp/src/Misc/IntervalSet.cs
@@ -203,9 +203,8 @@ namespace Antlr4.Runtime.Misc
             {
                 return this;
             }
-            if (set is Antlr4.Runtime.Misc.IntervalSet)
+            if (set is IntervalSet other)
             {
-                Antlr4.Runtime.Misc.IntervalSet other = (Antlr4.Runtime.Misc.IntervalSet)set;
                 // walk set and add each interval
                 int n = other.intervals.Count;
                 for (int i = 0; i < n; i++)
@@ -240,10 +239,10 @@ namespace Antlr4.Runtime.Misc
                 return null;
             }
             // nothing in common with null set
-            Antlr4.Runtime.Misc.IntervalSet vocabularyIS;
-            if (vocabulary is Antlr4.Runtime.Misc.IntervalSet)
+            IntervalSet vocabularyIS;
+            if (vocabulary is IntervalSet set)
             {
-                vocabularyIS = (Antlr4.Runtime.Misc.IntervalSet)vocabulary;
+                vocabularyIS = set;
             }
             else
             {
@@ -259,9 +258,9 @@ namespace Antlr4.Runtime.Misc
             {
                 return new Antlr4.Runtime.Misc.IntervalSet(this);
             }
-            if (a is Antlr4.Runtime.Misc.IntervalSet)
+            if (a is IntervalSet set)
             {
-                return Subtract(this, (Antlr4.Runtime.Misc.IntervalSet)a);
+                return Subtract(this, set);
             }
             Antlr4.Runtime.Misc.IntervalSet other = new Antlr4.Runtime.Misc.IntervalSet();
             other.AddAll(a);
@@ -600,12 +599,12 @@ namespace Antlr4.Runtime.Misc
         /// </remarks>
         public override bool Equals(object obj)
         {
-            if (obj == null || !(obj is Antlr4.Runtime.Misc.IntervalSet))
+            if (obj == null || !(obj is Antlr4.Runtime.Misc.IntervalSet other))
             {
                 return false;
             }
-            Antlr4.Runtime.Misc.IntervalSet other = (Antlr4.Runtime.Misc.IntervalSet)obj;
-            return this.intervals.SequenceEqual(other.intervals);
+
+            return intervals.SequenceEqual(other.intervals);
         }
 
         public override string ToString()

--- a/runtime/CSharp/src/Parser.cs
+++ b/runtime/CSharp/src/Parser.cs
@@ -76,9 +76,9 @@ namespace Antlr4.Runtime
 
             public virtual void ExitEveryRule(ParserRuleContext ctx)
             {
-                if (ctx.children is List<IParseTree>)
+                if (ctx.children is List<IParseTree> list)
                 {
-                    ((List<IParseTree>)ctx.children).TrimExcess();
+                    list.TrimExcess();
                 }
             }
         }
@@ -596,9 +596,8 @@ namespace Antlr4.Runtime
             if (((ITokenStream)InputStream) != null)
             {
                 ITokenSource tokenSource = ((ITokenStream)InputStream).TokenSource;
-                if (tokenSource is Lexer)
+                if (tokenSource is Lexer lexer)
                 {
-                    Lexer lexer = (Lexer)tokenSource;
                     return CompileParseTreePattern(pattern, patternRuleIndex, lexer);
                 }
             }
@@ -1173,9 +1172,9 @@ namespace Antlr4.Runtime
             get
             {
                 ParserATNSimulator interp = Interpreter;
-                if (interp is ProfilingATNSimulator)
+                if (interp is ProfilingATNSimulator simulator)
                 {
-                    return new ParseInfo((ProfilingATNSimulator)interp);
+                    return new ParseInfo(simulator);
                 }
                 return null;
             }

--- a/runtime/CSharp/src/ParserInterpreter.cs
+++ b/runtime/CSharp/src/ParserInterpreter.cs
@@ -54,13 +54,13 @@ namespace Antlr4.Runtime
             this.pushRecursionContextStates = new BitSet(atn.states.Count);
             foreach (ATNState state in atn.states)
             {
-                if (!(state is StarLoopEntryState))
+                if (!(state is StarLoopEntryState entryState))
                 {
                     continue;
                 }
-				if (((StarLoopEntryState)state).isPrecedenceDecision)
+				if (entryState.isPrecedenceDecision)
                 {
-                    this.pushRecursionContextStates.Set(state.stateNumber);
+                    pushRecursionContextStates.Set(entryState.stateNumber);
                 }
             }
 			

--- a/runtime/CSharp/src/ParserRuleContext.cs
+++ b/runtime/CSharp/src/ParserRuleContext.cs
@@ -243,12 +243,12 @@ namespace Antlr4.Runtime
             // what element have we found with ctxType?
             foreach (IParseTree o in children)
             {
-                if (o is T)
+                if (o is T tree)
                 {
                     j++;
                     if (j == i)
                     {
-                        return (T) o;
+                        return tree;
                     }
                 }
             }
@@ -267,9 +267,8 @@ namespace Antlr4.Runtime
             // what token with ttype have we found?
             foreach (IParseTree o in children)
             {
-                if (o is ITerminalNode)
+                if (o is ITerminalNode tnode)
                 {
-                    ITerminalNode tnode = (ITerminalNode) o;
                     IToken symbol = tnode.Symbol;
                     if (symbol.Type == ttype)
                     {
@@ -295,9 +294,8 @@ namespace Antlr4.Runtime
             List<ITerminalNode> tokens = null;
             foreach (IParseTree o in children)
             {
-                if (o is ITerminalNode)
+                if (o is ITerminalNode tnode)
                 {
-                    ITerminalNode tnode = (ITerminalNode) o;
                     IToken symbol = tnode.Symbol;
                     if (symbol.Type == ttype)
                     {
@@ -336,14 +334,14 @@ namespace Antlr4.Runtime
             List<T> contexts = null;
             foreach (IParseTree o in children)
             {
-                if (o is T)
+                if (o is T context)
                 {
                     if (contexts == null)
                     {
                         contexts = new List<T>();
                     }
 
-                    contexts.Add((T) o);
+                    contexts.Add(context);
                 }
             }
 

--- a/runtime/CSharp/src/ProxyParserErrorListener.cs
+++ b/runtime/CSharp/src/ProxyParserErrorListener.cs
@@ -21,11 +21,11 @@ namespace Antlr4.Runtime
         {
             foreach (IAntlrErrorListener<IToken> listener in Delegates)
             {
-                if (!(listener is IParserErrorListener))
+                if (!(listener is IParserErrorListener parserErrorListener))
                 {
                     continue;
                 }
-                IParserErrorListener parserErrorListener = (IParserErrorListener)listener;
+
                 parserErrorListener.ReportAmbiguity(recognizer, dfa, startIndex, stopIndex, exact, ambigAlts, configs);
             }
         }
@@ -34,11 +34,11 @@ namespace Antlr4.Runtime
         {
             foreach (IAntlrErrorListener<IToken> listener in Delegates)
             {
-                if (!(listener is IParserErrorListener))
+                if (!(listener is IParserErrorListener parserErrorListener))
                 {
                     continue;
                 }
-                IParserErrorListener parserErrorListener = (IParserErrorListener)listener;
+
                 parserErrorListener.ReportAttemptingFullContext(recognizer, dfa, startIndex, stopIndex, conflictingAlts, conflictState);
             }
         }
@@ -47,11 +47,11 @@ namespace Antlr4.Runtime
         {
             foreach (IAntlrErrorListener<IToken> listener in Delegates)
             {
-                if (!(listener is IParserErrorListener))
+                if (!(listener is IParserErrorListener parserErrorListener))
                 {
                     continue;
                 }
-                IParserErrorListener parserErrorListener = (IParserErrorListener)listener;
+
                 parserErrorListener.ReportContextSensitivity(recognizer, dfa, startIndex, stopIndex, prediction, acceptState);
             }
         }

--- a/runtime/CSharp/src/Tree/ParseTreeWalker.cs
+++ b/runtime/CSharp/src/Tree/ParseTreeWalker.cs
@@ -21,16 +21,16 @@ namespace Antlr4.Runtime.Tree
         /// <param name="t">The parse tree to be walked on</param>
         public virtual void Walk(IParseTreeListener listener, IParseTree t)
         {
-            if (t is IErrorNode)
+            if (t is IErrorNode node)
             {
-                listener.VisitErrorNode((IErrorNode)t);
+                listener.VisitErrorNode(node);
                 return;
             }
             else
             {
-                if (t is ITerminalNode)
+                if (t is ITerminalNode terminalNode)
                 {
-                    listener.VisitTerminal((ITerminalNode)t);
+                    listener.VisitTerminal(terminalNode);
                     return;
                 }
             }

--- a/runtime/CSharp/src/Tree/Pattern/ParseTreePatternMatcher.cs
+++ b/runtime/CSharp/src/Tree/Pattern/ParseTreePatternMatcher.cs
@@ -399,24 +399,21 @@ namespace Antlr4.Runtime.Tree.Pattern
                 throw new ArgumentException("patternTree cannot be null");
             }
             // x and <ID>, x and y, or x and x; or could be mismatched types
-            if (tree is ITerminalNode && patternTree is ITerminalNode)
+            if (tree is ITerminalNode t1 && patternTree is ITerminalNode t2)
             {
-                ITerminalNode t1 = (ITerminalNode)tree;
-                ITerminalNode t2 = (ITerminalNode)patternTree;
                 IParseTree mismatchedNode = null;
                 // both are tokens and they have same type
                 if (t1.Symbol.Type == t2.Symbol.Type)
                 {
-                    if (t2.Symbol is TokenTagToken)
+                    if (t2.Symbol is TokenTagToken tokenTagToken)
                     {
                         // x and <ID>
-                        TokenTagToken tokenTagToken = (TokenTagToken)t2.Symbol;
                         // track label->list-of-nodes for both token name and label (if any)
 
-                        labels.Map(tokenTagToken.TokenName, tree);
+                        labels.Map(tokenTagToken.TokenName, t1);
                         if (tokenTagToken.Label != null)
                         {
-                            labels.Map(tokenTagToken.Label, tree);
+                            labels.Map(tokenTagToken.Label, t1);
                         }
                     }
                     else
@@ -444,10 +441,8 @@ namespace Antlr4.Runtime.Tree.Pattern
                 }
                 return mismatchedNode;
             }
-            if (tree is ParserRuleContext && patternTree is ParserRuleContext)
+            if (tree is ParserRuleContext r1 && patternTree is ParserRuleContext r2)
             {
-                ParserRuleContext r1 = (ParserRuleContext)tree;
-                ParserRuleContext r2 = (ParserRuleContext)patternTree;
                 IParseTree mismatchedNode = null;
                 // (expr ...) and <expr>
                 RuleTagToken ruleTagToken = GetRuleTagToken(r2);
@@ -456,10 +451,10 @@ namespace Antlr4.Runtime.Tree.Pattern
                     if (r1.RuleIndex == r2.RuleIndex)
                     {
                         // track label->list-of-nodes for both rule name and label (if any)
-                        labels.Map(ruleTagToken.RuleName, tree);
+                        labels.Map(ruleTagToken.RuleName, r1);
                         if (ruleTagToken.Label != null)
                         {
-                            labels.Map(ruleTagToken.Label, tree);
+                            labels.Map(ruleTagToken.Label, r1);
                         }
                     }
                     else
@@ -504,16 +499,15 @@ namespace Antlr4.Runtime.Tree.Pattern
         /// </summary>
         protected internal virtual RuleTagToken GetRuleTagToken(IParseTree t)
         {
-            if (t is IRuleNode)
+            if (t is IRuleNode node)
             {
-                IRuleNode r = (IRuleNode)t;
-                if (r.ChildCount == 1 && r.GetChild(0) is ITerminalNode)
+                if (node.ChildCount == 1 && node.GetChild(0) is ITerminalNode)
                 {
-                    ITerminalNode c = (ITerminalNode)r.GetChild(0);
-                    if (c.Symbol is RuleTagToken)
+                    ITerminalNode c = (ITerminalNode)node.GetChild(0);
+                    if (c.Symbol is RuleTagToken token)
                     {
                         //					System.out.println("rule tag subtree "+t.toStringTree(parser));
-                        return (RuleTagToken)c.Symbol;
+                        return token;
                     }
                 }
             }
@@ -528,9 +522,8 @@ namespace Antlr4.Runtime.Tree.Pattern
             IList<IToken> tokens = new List<IToken>();
             foreach (Chunk chunk in chunks)
             {
-                if (chunk is TagChunk)
+                if (chunk is TagChunk tagChunk)
                 {
-                    TagChunk tagChunk = (TagChunk)chunk;
                     // add special rule token or conjure up new token from name
                     if (System.Char.IsUpper(tagChunk.Tag[0]))
                     {
@@ -691,9 +684,8 @@ namespace Antlr4.Runtime.Tree.Pattern
             for (int i_2 = 0; i_2 < chunks.Count; i_2++)
             {
                 Chunk c = chunks[i_2];
-                if (c is TextChunk)
+                if (c is TextChunk tc)
                 {
-                    TextChunk tc = (TextChunk)c;
                     string unescaped = tc.Text.Replace(escape, string.Empty);
                     if (unescaped.Length < tc.Text.Length)
                     {

--- a/runtime/CSharp/src/Tree/Trees.cs
+++ b/runtime/CSharp/src/Tree/Trees.cs
@@ -84,11 +84,11 @@ namespace Antlr4.Runtime.Tree
         {
             if (ruleNames != null)
             {
-                if (t is RuleContext)
+                if (t is RuleContext context)
                 {
-                    int ruleIndex = ((RuleContext)t).RuleIndex;
+                    int ruleIndex = context.RuleIndex;
                     string ruleName = ruleNames[ruleIndex];
-					int altNumber = ((RuleContext)t).getAltNumber();
+					int altNumber = context.getAltNumber();
 					if ( altNumber!=Atn.ATN.INVALID_ALT_NUMBER ) {
 						return ruleName+":"+altNumber;
 					}
@@ -102,9 +102,9 @@ namespace Antlr4.Runtime.Tree
                     }
                     else
                     {
-                        if (t is ITerminalNode)
+                        if (t is ITerminalNode node)
                         {
-                            IToken symbol = ((ITerminalNode)t).Symbol;
+                            IToken symbol = node.Symbol;
                             if (symbol != null)
                             {
                                 string s = symbol.Text;
@@ -116,9 +116,9 @@ namespace Antlr4.Runtime.Tree
             }
             // no recog for rule names
             object payload = t.Payload;
-            if (payload is IToken)
+            if (payload is IToken token)
             {
-                return ((IToken)payload).Text;
+                return token.Text;
             }
             return t.Payload.ToString();
         }
@@ -177,22 +177,20 @@ namespace Antlr4.Runtime.Tree
         private static void _findAllNodes(IParseTree t, int index, bool findTokens, IList<IParseTree> nodes)
         {
             // check this node (the root) first
-            if (findTokens && t is ITerminalNode)
+            if (findTokens && t is ITerminalNode tnode)
             {
-                ITerminalNode tnode = (ITerminalNode)t;
                 if (tnode.Symbol.Type == index)
                 {
-                    nodes.Add(t);
+                    nodes.Add(tnode);
                 }
             }
             else
             {
-                if (!findTokens && t is ParserRuleContext)
+                if (!findTokens && t is ParserRuleContext ctx)
                 {
-                    ParserRuleContext ctx = (ParserRuleContext)t;
                     if (ctx.RuleIndex == index)
                     {
-                        nodes.Add(t);
+                        nodes.Add(ctx);
                     }
                 }
             }

--- a/runtime/CSharp/src/Tree/Xpath/XPathRuleElement.cs
+++ b/runtime/CSharp/src/Tree/Xpath/XPathRuleElement.cs
@@ -26,9 +26,8 @@ namespace Antlr4.Runtime.Tree.Xpath
             IList<IParseTree> nodes = new List<IParseTree>();
             foreach (ITree c in Trees.GetChildren(t))
             {
-                if (c is ParserRuleContext)
+                if (c is ParserRuleContext ctx)
                 {
-                    ParserRuleContext ctx = (ParserRuleContext)c;
                     if ((ctx.RuleIndex == ruleIndex && !invert) || (ctx.RuleIndex != ruleIndex && invert))
                     {
                         nodes.Add(ctx);

--- a/runtime/CSharp/src/Tree/Xpath/XPathTokenElement.cs
+++ b/runtime/CSharp/src/Tree/Xpath/XPathTokenElement.cs
@@ -25,9 +25,8 @@ namespace Antlr4.Runtime.Tree.Xpath
             IList<IParseTree> nodes = new List<IParseTree>();
             foreach (ITree c in Trees.GetChildren(t))
             {
-                if (c is ITerminalNode)
+                if (c is ITerminalNode tnode)
                 {
-                    ITerminalNode tnode = (ITerminalNode)c;
                     if ((tnode.Symbol.Type == tokenType && !invert) || (tnode.Symbol.Type != tokenType && invert))
                     {
                         nodes.Add(tnode);

--- a/runtime/CSharp/src/UnbufferedTokenStream.cs
+++ b/runtime/CSharp/src/UnbufferedTokenStream.cs
@@ -262,9 +262,9 @@ namespace Antlr4.Runtime
             {
                 tokens = Arrays.CopyOf(tokens, tokens.Length * 2);
             }
-            if (t is IWritableToken)
+            if (t is IWritableToken token)
             {
-                ((IWritableToken)t).TokenIndex = GetBufferStartIndex() + n;
+                token.TokenIndex = GetBufferStartIndex() + n;
             }
             tokens[n++] = t;
         }


### PR DESCRIPTION
It simplifies and clarifies code. Also, @toolgood [said](https://github.com/antlr/antlr4/pull/3982) it improves performance.

Signed-off-by: Ivan Kochurkin <kvanttt@gmail.com>