### PR TITLE
Go: InputStream GetTextFromTokens can't get the content of the tokens correctly

### DIFF
--- a/runtime/Go/antlr/v4/input_stream.go
+++ b/runtime/Go/antlr/v4/input_stream.go
@@ -94,7 +94,7 @@ func (is *InputStream) GetText(start int, stop int) string {
 
 func (is *InputStream) GetTextFromTokens(start, stop Token) string {
 	if start != nil && stop != nil {
-		return is.GetTextFromInterval(NewInterval(start.GetTokenIndex(), stop.GetTokenIndex()))
+		return is.GetTextFromInterval(NewInterval(start.GetStart(), stop.GetStop()))
 	}
 
 	return ""


### PR DESCRIPTION
I'm using antrl4 these days, and I found this problem, when I try to get the original content from two tokens, I can't get it correctly,
```go
start := ctx.TokenBegin()
stop := ctx.TokenEnd()
content := ctx.TokenBegin().GetInputStream().GetTextFromTokens(start, stop)
```
so I can only do it this way, I think it's a bug
```go
start := ctx.TokenBegin().GetStart()
stop := ctx.TokenEnd().GetStop()
content := ctx.TokenBegin().GetInputStream().GetText(start, stop)
```