### PR TITLE
Extract unit test updates by @ericvergnaud needed for TypeScript

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LeftRecursion/MultipleAlternativesWithCommonLabel_1.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LeftRecursion/MultipleAlternativesWithCommonLabel_1.txt
@@ -10,8 +10,8 @@ Parser
 grammar T;
 s : e {<writeln("$e.v")>};
 e returns [int v]
-  : e '*' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
-  | e '+' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
+  : e '*' e     {$v = <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
+  | e '+' e     {$v = <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
   | INT{$v = $INT.int;} # anInt
   | '(' e ')'   {$v = $e.v;}     # parens
   | left=e INC  {<ContextRuleFunction(Cast("UnaryContext","$ctx"), "INC()"):Concat(" != null"):Assert()>$v = $left.v + 1;}      # unary

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LeftRecursion/MultipleAlternativesWithCommonLabel_2.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LeftRecursion/MultipleAlternativesWithCommonLabel_2.txt
@@ -10,8 +10,8 @@ Parser
 grammar T;
 s : e {<writeln("$e.v")>};
 e returns [int v]
-  : e '*' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
-  | e '+' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
+  : e '*' e     {$v = <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
+  | e '+' e     {$v = <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
   | INT{$v = $INT.int;} # anInt
   | '(' e ')'   {$v = $e.v;}     # parens
   | left=e INC  {<ContextRuleFunction(Cast("UnaryContext","$ctx"), "INC()"):Concat(" != null"):Assert()>$v = $left.v + 1;}      # unary

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LeftRecursion/MultipleAlternativesWithCommonLabel_3.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LeftRecursion/MultipleAlternativesWithCommonLabel_3.txt
@@ -10,8 +10,8 @@ Parser
 grammar T;
 s : e {<writeln("$e.v")>};
 e returns [int v]
-  : e '*' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
-  | e '+' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
+  : e '*' e     {$v = <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
+  | e '+' e     {$v = <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
   | INT{$v = $INT.int;} # anInt
   | '(' e ')'   {$v = $e.v;}     # parens
   | left=e INC  {<ContextRuleFunction(Cast("UnaryContext","$ctx"), "INC()"):Concat(" != null"):Assert()>$v = $left.v + 1;}      # unary

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LeftRecursion/MultipleAlternativesWithCommonLabel_4.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LeftRecursion/MultipleAlternativesWithCommonLabel_4.txt
@@ -10,8 +10,8 @@ Parser
 grammar T;
 s : e {<writeln("$e.v")>};
 e returns [int v]
-  : e '*' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
-  | e '+' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
+  : e '*' e     {$v = <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
+  | e '+' e     {$v = <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
   | INT{$v = $INT.int;} # anInt
   | '(' e ')'   {$v = $e.v;}     # parens
   | left=e INC  {<ContextRuleFunction(Cast("UnaryContext","$ctx"), "INC()"):Concat(" != null"):Assert()>$v = $left.v + 1;}      # unary

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LeftRecursion/MultipleAlternativesWithCommonLabel_5.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/LeftRecursion/MultipleAlternativesWithCommonLabel_5.txt
@@ -10,8 +10,8 @@ Parser
 grammar T;
 s : e {<writeln("$e.v")>};
 e returns [int v]
-  : e '*' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
-  | e '+' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
+  : e '*' e     {$v = <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
+  | e '+' e     {$v = <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):SubContextLocal({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
   | INT{$v = $INT.int;} # anInt
   | '(' e ')'   {$v = $e.v;}     # parens
   | left=e INC  {<ContextRuleFunction(Cast("UnaryContext","$ctx"), "INC()"):Concat(" != null"):Assert()>$v = $left.v + 1;}      # unary

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/Basic.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/Basic.txt
@@ -9,8 +9,8 @@ grammar T;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextMember("$ctx", "r"):ToStringTree():writeln()>
+<ContextMember("$ctx", "r"):WalkListener()>
 }
   : r=a ;
 a : INT INT

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/LR.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/LR.txt
@@ -9,8 +9,8 @@ grammar T;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextMember("$ctx", "r"):ToStringTree():writeln()>
+<ContextMember("$ctx", "r"):WalkListener()>
 }
    : r=e ;
 e : e op='*' e

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/LRWithLabels.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/LRWithLabels.txt
@@ -9,8 +9,8 @@ grammar T;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextMember("$ctx", "r"):ToStringTree():writeln()>
+<ContextMember("$ctx", "r"):WalkListener()>
 }
   : r=e ;
 e : e '(' eList ')' # Call

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/RuleGetters_1.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/RuleGetters_1.txt
@@ -9,8 +9,8 @@ grammar T;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextMember("$ctx", "r"):ToStringTree():writeln()>
+<ContextMember("$ctx", "r"):WalkListener()>
 }
   : r=a ;
 a : b b        // forces list

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/RuleGetters_2.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/RuleGetters_2.txt
@@ -9,8 +9,8 @@ grammar T;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextMember("$ctx", "r"):ToStringTree():writeln()>
+<ContextMember("$ctx", "r"):WalkListener()>
 }
   : r=a ;
 a : b b        // forces list

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/TokenGetters_1.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/TokenGetters_1.txt
@@ -9,8 +9,8 @@ grammar T;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextMember("$ctx", "r"):ToStringTree():writeln()>
+<ContextMember("$ctx", "r"):WalkListener()>
 }
   : r=a ;
 a : INT INT

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/TokenGetters_2.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Listeners/TokenGetters_2.txt
@@ -9,8 +9,8 @@ grammar T;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextMember("$ctx", "r"):ToStringTree():writeln()>
+<ContextMember("$ctx", "r"):WalkListener()>
 }
   : r=a ;
 a : INT INT

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParseTrees/TokenAndRuleContextString.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParseTrees/TokenAndRuleContextString.txt
@@ -3,6 +3,8 @@ Parser
 
 [grammar]
 grammar T;
+<ImportRuleInvocationStack()>
+
 s
 @init {
 <BuildParseTrees()>

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelForClosureContext.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelForClosureContext.txt
@@ -9,7 +9,7 @@ Parser
 grammar T;
 ifStatement
 @after {
-<AssertIsList({<ContextRuleFunction("$ctx", "elseIfStatement()")>})>
+<AssertIsList({<ContextListFunction("$ctx","elseIfStatement")>})>
 }
     : 'if' expression
       ( ( 'then'

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ListLabelsOnRuleRefStartOfAlt.txt
@@ -28,3 +28,6 @@ expression
 
 [input]
 a and b
+
+[skip]
+PHP

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ReservedWordsEscaping.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/ReservedWordsEscaping.txt
@@ -11,14 +11,14 @@ root
     : {0==0}? continue+ {<write("$text")>}
     ;
 
-continue returns [int return]
+continue returns [<IntArg("return")>]
     : for for? {1==1}?              #else
     | break=BREAK BREAK+ (for | IF) #else
     | if+=IF  if+=IF*               #int
     | continue CONTINUE_ {<AssignLocal("$return","0")>}   #class
     ;
 
-args[int else] locals [int return]
+args[int else] locals [<IntArg("return")>]
     : for
     ;
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CSharp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CSharp.test.stg
@@ -78,6 +78,8 @@ ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "this.GetExpectedTokens().ToString(this.Vocabulary)"
 
+ImportRuleInvocationStack() ::= ""
+
 RuleInvocationStack() ::= "GetRuleInvocationStackAsString()"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<Interpreter.PredictionMode = PredictionMode.LL_EXACT_AMBIG_DETECTION;>>
@@ -323,5 +325,8 @@ Declare_pred() ::= <<bool pred(bool v) {
 Invoke_pred(v) ::= <<this.pred(<v>)>>
 ParserTokenType(t) ::= "Parser.<t>"
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
+ContextListFunction(ctx, rule) ::= "<ctx>.<rule>()"
 StringType() ::= "String"
-ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"
+ContextMember(ctx, member) ::= "<ctx>.<member>"
+SubContextLocal(ctx, subctx, local) ::= "<ctx>.<subctx>.<local>"
+SubContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Cpp.test.stg
@@ -49,6 +49,8 @@ ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "getExpectedTokens().toString(getVocabulary())"
 
+ImportRuleInvocationStack() ::= ""
+
 RuleInvocationStack() ::= "Arrays::listToString(getRuleInvocationStack(), \", \")"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<getInterpreter\<atn::ParserATNSimulator>()->setPredictionMode(atn::PredictionMode::LL_EXACT_AMBIG_DETECTION);>>
@@ -274,5 +276,8 @@ bool pred(bool v) {
 Invoke_pred(v) ::= <<pred(<v>)>>
 
 ContextRuleFunction(ctx, rule) ::= "<ctx>-><rule>"
+ContextListFunction(ctx, rule) ::= "<ctx>-><rule>()"
 StringType() ::= "std::string"
-ContextMember(ctx, subctx, member) ::= "<ctx>-><subctx>-><member>"
+ContextMember(ctx, member) ::= "<ctx>-><member>"
+SubContextLocal(ctx, subctx, local) ::= "<ctx>-><subctx>-><local>"
+SubContextMember(ctx, subctx, member) ::= "<ctx>-><subctx>-><member>"

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Dart.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Dart.test.stg
@@ -78,6 +78,8 @@ ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "this.expectedTokens.toString(vocabulary: this.vocabulary)"
 
+ImportRuleInvocationStack() ::= ""
+
 RuleInvocationStack() ::= "ruleInvocationStack"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<interpreter!.predictionMode = PredictionMode.LL_EXACT_AMBIG_DETECTION;>>
@@ -314,5 +316,8 @@ Invoke_pred(v) ::= <<this.pred(<v>)>>
 
 ParserTokenType(t) ::= "Parser.<t>"
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
+ContextListFunction(ctx, rule) ::= "<ctx>.<rule>()"
 StringType() ::= "String"
-ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>!.<member>!"
+ContextMember(ctx, member) ::= "<ctx>.<member>!"
+SubContextLocal(ctx, subctx, local) ::= "<ctx>.<subctx>!.<local>!"
+SubContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>!.<member>!"

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
@@ -87,6 +87,8 @@ ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "p.GetExpectedTokens().StringVerbose(p.GetTokenNames(), nil, false)"
 
+ImportRuleInvocationStack() ::= ""
+
 RuleInvocationStack() ::= "antlr.PrintArrayJavaStyle(p.GetRuleInvocationStack(nil))"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);>>
@@ -340,5 +342,8 @@ func pred(v bool) bool {
 
 Invoke_pred(v) ::= <<pred(<v>)>>
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
+ContextListFunction(ctx, rule) ::= "<ctx>.<rule>()"
 StringType() ::= "string"
-ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member; format={cap}>"
+ContextMember(ctx, member) ::= "<ctx>.<member>"
+SubContextLocal(ctx, subctx, local) ::= "<ctx>.<subctx>.<local; format={cap}>"
+SubContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member; format={cap}>"

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Java.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Java.test.stg
@@ -78,6 +78,8 @@ ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "this.getExpectedTokens().toString(this.tokenNames)"
 
+ImportRuleInvocationStack() ::= ""
+
 RuleInvocationStack() ::= "getRuleInvocationStack()"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<_interp.setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);>>
@@ -292,5 +294,8 @@ Invoke_pred(v) ::= <<this.pred(<v>)>>
 
 ParserTokenType(t) ::= "Parser.<t>"
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
+ContextListFunction(ctx, rule) ::= "<ctx>.<rule>()"
 StringType() ::= "String"
-ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"
+ContextMember(ctx, member) ::= "<ctx>.<member>"
+SubContextLocal(ctx, subctx, local) ::= "<ctx>.<subctx>.<local>"
+SubContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/JavaScript.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/JavaScript.test.stg
@@ -1,5 +1,5 @@
-writeln(s) ::= <<console.log(<s>);>>
-write(s) ::= <<process.stdout.write(<s>);>>
+writeln(s) ::= <<console.log(<s> || '');>>
+write(s) ::= <<process.stdout.write(<s> || '');>>
 writeList(s) ::= <<console.log(<s; separator="+">);>>
 
 False() ::= "false"
@@ -77,6 +77,8 @@ TokenStartColumnEquals(i) ::= <%this._tokenStartColumn===<i>%>
 ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "this.getExpectedTokens().toString(this.literalNames)"
+
+ImportRuleInvocationStack() ::= ""
 
 RuleInvocationStack() ::= "antlr4.Utils.arrayToString(this.getRuleInvocationStack())"
 
@@ -298,5 +300,8 @@ Declare_pred() ::= <<this.pred = function(v) {
 Invoke_pred(v) ::= <<this.pred(<v>)>>
 ParserTokenType(t) ::= "Parser.<t>"
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
+ContextListFunction(ctx, rule) ::= "<ctx>.<rule>_list()"
 StringType() ::= "String"
-ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"
+ContextMember(ctx, member) ::= "<ctx>.<member>"
+SubContextLocal(ctx, subctx, local) ::= "<ctx>.<subctx>.<local>"
+SubContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/PHP.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/PHP.test.stg
@@ -52,6 +52,8 @@ ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "\$this->getExpectedTokens()->toStringVocabulary(\$this->getVocabulary())"
 
+ImportRuleInvocationStack() ::= ""
+
 RuleInvocationStack() ::= "'[' . \implode(', ', \$this->getRuleInvocationStack()) . ']'"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<\$this->interp->setPredictionMode(Antlr\\Antlr4\\Runtime\\Atn\\PredictionMode::LL_EXACT_AMBIG_DETECTION);>>
@@ -268,5 +270,8 @@ Invoke_pred(v) ::= "\$this->pred(<v>)"
 
 ParserTokenType(t) ::= "Parser::<t>"
 ContextRuleFunction(ctx, rule) ::= "<ctx>-><rule>"
+ContextListFunction(ctx, rule) ::= "<ctx>-><rule>()"
 StringType() ::= ""
-ContextMember(ctx, subctx, member) ::= "<ctx>-><subctx>-><member>"
+ContextMember(ctx, member) ::= "<ctx>-><member>"
+SubContextLocal(ctx, subctx, local) ::= "<ctx>-><subctx>-><local>"
+SubContextMember(ctx, subctx, member) ::= "<ctx>-><subctx>-><member>"

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python2.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python2.test.stg
@@ -78,6 +78,8 @@ ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "self.getExpectedTokens().toString(self.literalNames, self.symbolicNames)"
 
+ImportRuleInvocationStack() ::= ""
+
 RuleInvocationStack() ::= "str_list(self.getRuleInvocationStack())"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<self._interp.predictionMode =  PredictionMode.LL_EXACT_AMBIG_DETECTION>>
@@ -277,5 +279,8 @@ Declare_pred() ::= <<def pred(self, v):
 Invoke_pred(v) ::= <<self.pred(<v>)>>
 ParserTokenType(t) ::= "Parser.<t>"
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
+ContextListFunction(ctx, rule) ::= "<ctx>.<rule>_list()"
 StringType() ::= "String"
-ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"
+ContextMember(ctx, member) ::= "<ctx>.<member>"
+SubContextLocal(ctx, subctx, local) ::= "<ctx>.<subctx>.<local>"
+SubContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python3.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python3.test.stg
@@ -83,6 +83,8 @@ class MockListener:
 
 GetExpectedTokenNames() ::= "self.getExpectedTokens().toString(self.literalNames, self.symbolicNames)"
 
+ImportRuleInvocationStack() ::= ""
+
 RuleInvocationStack() ::= "str_list(self.getRuleInvocationStack())"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<self._interp.predictionMode =  PredictionMode.LL_EXACT_AMBIG_DETECTION>>
@@ -262,5 +264,8 @@ Declare_pred() ::= <<def pred(self, v):
 Invoke_pred(v) ::= <<self.pred(<v>)>>
 ParserTokenType(t) ::= "Parser.<t>"
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
+ContextListFunction(ctx, rule) ::= "<ctx>.<rule>_list()"
 StringType() ::= "String"
-ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"
+ContextMember(ctx, member) ::= "<ctx>.<member>"
+SubContextLocal(ctx, subctx, local) ::= "<ctx>.<subctx>.<local>"
+SubContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Swift.test.stg
@@ -78,6 +78,8 @@ ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "try self.getExpectedTokens().toString(self.getVocabulary())"
 
+ImportRuleInvocationStack() ::= ""
+
 RuleInvocationStack() ::= "getRuleInvocationStack().description.replacingOccurrences(of: \"\\\"\", with: \"\")"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<_interp.setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);>>
@@ -299,9 +301,9 @@ func pred(_ v: Bool) -> Bool {
 >>
 
 StringType() ::= "String"
-
 Invoke_pred(v) ::= <<self.pred(<v>)>>
-
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
-
-ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>!.<member>"
+ContextListFunction(ctx, rule) ::= "<ctx>.<rule>()"
+ContextMember(ctx, member) ::= "<ctx>!.<member>"
+SubContextLocal(ctx, subctx, local) ::= "<ctx>.<subctx>!.<local>"
+SubContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>!.<member>"


### PR DESCRIPTION
Extract unit test updates by @ericvergnaud in https://github.com/antlr/antlr4/pull/4027 then he can rebase after we merge this into dev.  All tests pass locally (didn't check python2 actually but python3 works).

Eric needed these changes so he can have more fine grained control over fields of rule ctx objects.

Signed-off-by: Terence Parr <parrt@antlr.org>
