### PR TITLE
Typo in the generate.sh shell snippet

### DIFF
--- a/doc/go-target.md
+++ b/doc/go-target.md
@@ -84,7 +84,7 @@ And the `generate.sh` file will look similar to this:
 
 	#!/bin/sh
 
-	alias antlr4='java -Xmx500M -cp "./antlr4-4.11.0-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
+	alias antlr4='java -Xmx500M -cp "./antlr-4.11.0-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
 	antlr4 -Dlanguage=Go -no-visitor -package parser *.g4
 ```
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
