### PR TITLE
Small tweaks to Swift.stg to allow throwing operations in actions

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -322,7 +322,7 @@ func action(_ _localctx: RuleContext?,  _ ruleIndex: Int, _ actionIndex: Int) th
 	switch (ruleIndex) {
 	<recog.actionFuncs.values:{f|
 case <f.ruleIndex>:
-	<f.name>_action((_localctx as <f.ctxType>?), actionIndex)
+	try <f.name>_action((_localctx as <f.ctxType>?), actionIndex)
 	 }; separator="\n">
 	default: break
 	}
@@ -364,7 +364,7 @@ init(_ input:TokenStream) throws {
  * overriding implementation impossible to maintain.
  */
 RuleActionFunction(r, actions) ::= <<
-private func <r.name>_action(_ _localctx: <r.ctxType>?,  _ actionIndex: Int) {
+private func <r.name>_action(_ _localctx: <r.ctxType>?,  _ actionIndex: Int) throws {
 	switch (actionIndex) {
 	<actions:{index|
 case <index>:


### PR DESCRIPTION
Signed-off-by: Mykola Pokhylets <mykola.pokhylets@gmail.com>

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
