### PR TITLE
cpp runtime: Remove pthread dependency.

### DIFF
--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -28,13 +28,6 @@ file(GLOB libantlrcpp_SRC
 add_library(antlr4_shared SHARED ${libantlrcpp_SRC})
 add_library(antlr4_static STATIC ${libantlrcpp_SRC})
 
-# Make sure to link against threads (pthreads) library in order to be able to
-# make use of std::call_once in the code without producing runtime errors
-# (see also https://github.com/antlr/antlr4/issues/3708 and/or https://stackoverflow.com/q/51584960).
-find_package(Threads REQUIRED)
-target_link_libraries(antlr4_shared Threads::Threads)
-target_link_libraries(antlr4_static Threads::Threads)
-
 if (ANTLR_BUILD_CPP_TESTS)
   include(FetchContent)
 


### PR DESCRIPTION
ANTLR doesn't use threads, and it used not to depend on pthread library either.

It changed recently in 2022: https://github.com/antlr/antlr4/issues/3708 The patch linked against pthread, because the GNU libstdc++ used to depend on it in their implementation of `std::call_once`.

By the way, the libstdc++ stopped it in 2020:
https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=93e79ed391b9c636f087e6eb7e70f14963cd10ad So this is not more needed.

I would like to stop depending on pthread. I am using ANTLR in C++ WebAssembly for the website:
https://arthursonzogni.com/Diagon/

It doesn't compile with emscripten anymore, because by default pthread is not enabled. It could be enabled, but it would force me to deploy cross-origin-isolation:
https://web.dev/cross-origin-isolation-guide/

Solutions:
1. Stop linking against pthread, because the libstdc++ stopped depending on it for std::call_once.
2. Implement std::call_once ourself using std::atomic_flag
3. Implement std::call_once ourself using a boolean flag, assuming we don't need to support threads.

I chose to do (2) in this patch.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
