### PR TITLE
Python2+3 runtimes: Define getTokenNames.

### DIFF
--- a/runtime/Python2/src/antlr4/Recognizer.py
+++ b/runtime/Python2/src/antlr4/Recognizer.py
@@ -45,6 +45,12 @@ class Recognizer(object):
     def removeErrorListeners(self):
         self._listeners = []
 
+    def getTokenNames(self):
+        return tuple(self.literalNames + self.symbolicNames[len(self.literalNames):])
+
+    def getRuleNames(self):
+        return tuple(self.ruleNames)
+
     def getTokenTypeMap(self):
         tokenNames = self.getTokenNames()
         if tokenNames is None:
@@ -52,7 +58,7 @@ class Recognizer(object):
             raise UnsupportedOperationException("The current recognizer does not provide a list of token names.")
         result = self.tokenTypeMapCache.get(tokenNames, None)
         if result is None:
-            result = zip( tokenNames, range(0, len(tokenNames)))
+            result = dict(zip(tokenNames, range(0, len(tokenNames))))
             result["EOF"] = Token.EOF
             self.tokenTypeMapCache[tokenNames] = result
         return result
@@ -68,7 +74,7 @@ class Recognizer(object):
             raise UnsupportedOperationException("The current recognizer does not provide a list of rule names.")
         result = self.ruleIndexMapCache.get(ruleNames, None)
         if result is None:
-            result = zip( ruleNames, range(0, len(ruleNames)))
+            result = dict(zip(ruleNames, range(0, len(ruleNames))))
             self.ruleIndexMapCache[ruleNames] = result
         return result
 

--- a/runtime/Python3/src/antlr4/Recognizer.py
+++ b/runtime/Python3/src/antlr4/Recognizer.py
@@ -49,6 +49,12 @@ class Recognizer(object):
     def removeErrorListeners(self):
         self._listeners = []
 
+    def getTokenNames(self):
+        return tuple(self.literalNames + self.symbolicNames[len(self.literalNames):])
+
+    def getRuleNames(self):
+        return tuple(self.ruleNames)
+
     def getTokenTypeMap(self):
         tokenNames = self.getTokenNames()
         if tokenNames is None:
@@ -56,7 +62,7 @@ class Recognizer(object):
             raise UnsupportedOperationException("The current recognizer does not provide a list of token names.")
         result = self.tokenTypeMapCache.get(tokenNames, None)
         if result is None:
-            result = zip( tokenNames, range(0, len(tokenNames)))
+            result = dict(zip(tokenNames, range(0, len(tokenNames))))
             result["EOF"] = Token.EOF
             self.tokenTypeMapCache[tokenNames] = result
         return result
@@ -72,7 +78,7 @@ class Recognizer(object):
             raise UnsupportedOperationException("The current recognizer does not provide a list of rule names.")
         result = self.ruleIndexMapCache.get(ruleNames, None)
         if result is None:
-            result = zip( ruleNames, range(0, len(ruleNames)))
+            result = dict(zip(ruleNames, range(0, len(ruleNames))))
             self.ruleIndexMapCache[ruleNames] = result
         return result
 


### PR DESCRIPTION
Fixes #1043: a list of token names can be easily formulated by combining the lists of literalNames and symbolicNames, since they use the same indexing system.

Also similarly fixes the absence of getRuleNames.

Also fixes attempting to use the result of zip() as a map which broke both getTokenTypeMap and getRuleIndexMap. In Python 2, zip() returns a list of tuples. In Python3, zip returns an object that can only be iterated over once (and thus would not be useful to cache).

