### PR TITLE
Python LexerNoViableAltException is created with messages (#4095)

### DIFF
--- a/runtime/Python2/src/antlr4/error/ErrorStrategy.py
+++ b/runtime/Python2/src/antlr4/error/ErrorStrategy.py
@@ -125,7 +125,7 @@ class DefaultErrorStrategy(ErrorStrategy):
             self.reportFailedPredicate(recognizer, e)
         else:
             print("unknown recognition error type: " + type(e).__name__)
-            recognizer.notifyErrorListeners(e.getOffendingToken(), e.getMessage(), e)
+            recognizer.notifyErrorListeners(e.message, e.getOffendingToken(), e)
 
     #
     # {@inheritDoc}

--- a/runtime/Python2/src/antlr4/error/Errors.py
+++ b/runtime/Python2/src/antlr4/error/Errors.py
@@ -79,6 +79,7 @@ class LexerNoViableAltException(RecognitionException):
         super(LexerNoViableAltException, self).__init__(message=None, recognizer=lexer, input=input, ctx=None)
         self.startIndex = startIndex
         self.deadEndConfigs = deadEndConfigs
+        self.message = ""
 
     def __unicode__(self):
         symbol = ""

--- a/runtime/Python3/src/antlr4/error/Errors.py
+++ b/runtime/Python3/src/antlr4/error/Errors.py
@@ -85,6 +85,7 @@ class LexerNoViableAltException(RecognitionException):
         super().__init__(message=None, recognizer=lexer, input=input, ctx=None)
         self.startIndex = startIndex
         self.deadEndConfigs = deadEndConfigs
+        self.message = ""
 
     def __str__(self):
         symbol = ""


### PR DESCRIPTION
- Added a message to LexerNoViableAltException (python2 & 3) : this avoids exception to be raised if the exception message is printed
- Corrected the ErrorStrategy (Python2) : 
   -> notifyErrorListeners first argument should be the message, and second the Offending Token 
   -> Exception does not have getMessage method