### PR TITLE
[Cpp] Don't define ANTLR4CPP_EXPORTS in *consumers* of ANTLR runtime.

### DIFF
--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -93,7 +93,7 @@ set(static_lib_suffix "")
 
 if (WIN32)
   set(static_lib_suffix "-static")
-  target_compile_definitions(antlr4_shared PUBLIC ANTLR4CPP_EXPORTS)
+  target_compile_definitions(antlr4_shared PRIVATE ANTLR4CPP_EXPORTS)
   target_compile_definitions(antlr4_static PUBLIC ANTLR4CPP_STATIC)
   if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     set(extra_share_compile_flags "-MP /wd4251")
@@ -122,7 +122,7 @@ if (ANTLR_BUILD_CPP_TESTS)
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_HOME_DIRECTORY}/dist
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:antlr4_shared> ${CMAKE_HOME_DIRECTORY}/dist
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_LINKER_FILE:antlr4_shared> ${CMAKE_HOME_DIRECTORY}/dist)
-  
+
   add_custom_command(
     TARGET antlr4_static
     POST_BUILD


### PR DESCRIPTION
This was originally submitted to vcpkg as https://github.com/microsoft/vcpkg/pull/29384

As currently written this is causing *consumers* of ANTLR's C++ runtime to define ANTLR4CPP_EXPORTS which means they are trying to `__declspec(dllexport)` rather than `__declspec(dllimport)` them.

Signed-off-by: Billy Robert O'Neal III <bion@microsoft.com>
