### PR TITLE
Fully qualify std::move invocations to fix -Wunqualified-std-cast-call

### DIFF
--- a/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
@@ -37,7 +37,7 @@ IntervalSet& IntervalSet::operator=(const IntervalSet& other) {
 }
 
 IntervalSet& IntervalSet::operator=(IntervalSet&& other) {
-  _intervals = move(other._intervals);
+  _intervals = std::move(other._intervals);
   return *this;
 }
 


### PR DESCRIPTION
Clang implemented a warning last year to detect bare `move` and `forward` calls, as they have the potential to be error prone: https://github.com/llvm/llvm-project/commit/70b1f6de539867353940d3dcb8b25786d5082d63. This warning should be available in clang-15.