### PR TITLE
Add missing space to actions.md

### DIFF
--- a/doc/actions.md
+++ b/doc/actions.md
@@ -65,7 +65,7 @@ Most of the time you access the attributes of the token, but sometimes it is use
 |text|String|The text matched for the token; translates to a call to getText. Example: $ID.text.|
 |type|int|The token type (nonzero positive integer) of the token such as INT; translates to a call to getType. Example: $ID.type.|
 |line|int|The line number on which the token occurs, counting from 1; translates to a call to getLine. Example: $ID.line.|
-|pos|int|The character position within the line at which the token’s first character occurs counting from zero; translates to a call togetCharPositionInLine. Example: $ID.pos.|
+|pos|int|The character position within the line at which the token’s first character occurs counting from zero; translates to a call to getCharPositionInLine. Example: $ID.pos.|
 |index|int|The overall index of this token in the token stream, counting from zero; translates to a call to getTokenIndex. Example: $ID.index.|
 |channel|int|The token’s channel number. The parser tunes to only one channel, effectively ignoring off-channel tokens. The default channel is 0 (Token.DEFAULT_CHANNEL), and the default hidden channel is Token.HIDDEN_CHANNEL. Translates to a call to getChannel. Example: $ID.channel.|
 |int|int|The integer value of the text held by this token; it assumes that the text is a valid numeric string. Handy for building calculators and so on. Translates to Integer.valueOf(text-of-token). Example: $INT.int.|


### PR DESCRIPTION
There is a missing space in `actions.md`. The docs could be improved with this small fix.