### PR TITLE
fix missing union type

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -137,8 +137,8 @@ export default class <parser.name> extends <superClass; null="Parser"> {
 	<endif>
 	public static readonly EOF = Token.EOF;
 	<parser.rules:{r | public static readonly RULE_<r.name> = <r.index>;}; separator="\n", wrap, anchor>
-	public static readonly literalNames: string[] = [ <parser.literalNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
-	public static readonly symbolicNames: string[] = [ <parser.symbolicNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
+	public static readonly literalNames: (string | null)[] = [ <parser.literalNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
+	public static readonly symbolicNames: (string | null)[] = [ <parser.symbolicNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
 	// tslint:disable:no-trailing-whitespace
 	public static readonly ruleNames: string[] = [
 		<parser.ruleNames:{r | "<r>",}; separator=" ", wrap, anchor>


### PR DESCRIPTION
Signed-off-by: Eric Vergnaud <eric.vergnaud@wanadoo.fr>

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
