### PR TITLE
[Cpp] CMake: use variables for specifying install paths consistently

### DIFF
--- a/runtime/Cpp/CMakeLists.txt
+++ b/runtime/Cpp/CMakeLists.txt
@@ -138,10 +138,11 @@ if(WITH_DEMO)
  add_subdirectory(demo)
 endif(WITH_DEMO)
 
+include(GNUInstallDirs)
+
 # Generate CMake Package Files only if install is active
 if (ANTLR4_INSTALL)
 
-  include(GNUInstallDirs)
   include(CMakePackageConfigHelpers)
 
   if(NOT ANTLR4_CMAKE_DIR)

--- a/runtime/Cpp/CMakeLists.txt
+++ b/runtime/Cpp/CMakeLists.txt
@@ -202,14 +202,14 @@ endif(ANTLR4_INSTALL)
 
 if(EXISTS LICENSE.txt)
 install(FILES LICENSE.txt
-        DESTINATION "share/doc/libantlr4")
+        DESTINATION ${CMAKE_INSTALL_DOCDIR})
 elseif(EXISTS ../../LICENSE.txt)
 install(FILES ../../LICENSE.txt
-    DESTINATION "share/doc/libantlr4")
+    DESTINATION ${CMAKE_INSTALL_DOCDIR})
 endif()
 
 install(FILES README.md VERSION
-    DESTINATION "share/doc/libantlr4")
+    DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 set(CPACK_PACKAGE_CONTACT "antlr-discussion@googlegroups.com")
 set(CPACK_PACKAGE_VERSION ${ANTLR_VERSION})

--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -7,7 +7,7 @@ if (NOT ANTLR_BUILD_SHARED AND NOT ANTLR_BUILD_STATIC)
   message(FATAL_ERROR "Options ANTLR_BUILD_SHARED and ANTLR_BUILD_STATIC can't both be OFF")
 endif()
 
-set(libantlrcpp_INCLUDE_INSTALL_DIR "include/antlr4-runtime")
+set(libantlrcpp_INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/antlr4-runtime")
 
 set(libantlrcpp_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/runtime/src


### PR DESCRIPTION
This allows overriding them if needed when the system uses different paths than usual (e.g. Haiku, which uses "develop/headers" for includes instead of "include").

Signed-off-by: Joachim Mairböck <j.mairboeck@gmail.com>

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
