### PR TITLE
Fix for Issue 4110

### DIFF
--- a/runtime/JavaScript/src/antlr4/CommonToken.d.ts
+++ b/runtime/JavaScript/src/antlr4/CommonToken.d.ts
@@ -1,0 +1,8 @@
+import { Token } from "./Token";
+
+export declare class CommonToken extends Token {
+    constructor(source: number, type: number, channel: number, start: number, stop: number);
+    clone(): CommonToken;
+    cloneWithType(type: number): CommonToken;
+    toString(): string;
+}

--- a/runtime/JavaScript/src/antlr4/Lexer.d.ts
+++ b/runtime/JavaScript/src/antlr4/Lexer.d.ts
@@ -18,7 +18,14 @@ export declare class Lexer extends Recognizer<number> {
     _type: number;
 
     constructor(input: CharStream);
-    nextToken(): Token;
-    emit(): Token;
     reset(): void;
+    nextToken(): Token;
+    skip(): void;
+    more(): void;
+    more(m: number): void;
+    pushMode(m: number): void;
+    popMode(): number;
+    emitToken(token: Token): void;
+    emit(): Token;
+    emitEOF(): Token;
 }

--- a/runtime/JavaScript/src/antlr4/index.d.ts
+++ b/runtime/JavaScript/src/antlr4/index.d.ts
@@ -4,6 +4,7 @@ export * from "./CharStream";
 export * from "./CharStreams";
 export * from "./TokenStream";
 export * from "./BufferedTokenStream";
+export * from "./CommonToken";
 export * from "./CommonTokenStream";
 export * from "./Recognizer";
 export * from "./Lexer";


### PR DESCRIPTION
These are some changes for Issue 4110, which is for the TypeScript target.
* CommonToken is needed. https://github.com/antlr/grammars-v4/blob/f1b4fc39279ce6a9e3878057fba935642f22c364/python/python3/JavaScript/Python3LexerBase.js#L59
* reset() is needed. https://github.com/kaby76/Domemtech.Trash/blob/2431705bdd3a2f3d64f1de5917ec07cd8f195c48/src/trgen/templates/TypeScript/Test.ts#L189
* skip() is needed. https://github.com/antlr/grammars-v4/blob/f1b4fc39279ce6a9e3878057fba935642f22c364/python/python3/JavaScript/Python3LexerBase.js#L109
* I'm including the export of other methods from Lexer as I know they are needed elsewhere.