### PR TITLE
README: Update required Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ANTLR v4
 
-[![Java 7+](https://img.shields.io/badge/java-7+-4c7e9f.svg)](http://java.oracle.com)
+[![Java 11+](https://img.shields.io/badge/java-11+-4c7e9f.svg)](http://java.oracle.com)
 [![License](https://img.shields.io/badge/license-BSD-blue.svg)](https://raw.githubusercontent.com/antlr/antlr4/master/LICENSE.txt)
 
 


### PR DESCRIPTION
The badge in the README suggests that ANTLR requires Java 7 or higher, whereas since ANTLR v4.10 Java 11 or higher is required.

NOTE: This is a commit against the `master` branch, but given that the latest versions already have this requirement, I figured it makes more sense to base this against `master` rather than `dev`.
