### PR TITLE
java runtime: add module-info.java and multi-release build to support…

### DIFF
--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -119,8 +119,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
+                            <release>8</release>
                         </configuration>
                     </execution>
 

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -101,6 +101,9 @@
 						<manifest>
 							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 						</manifest>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
 				</configuration>

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -83,7 +83,6 @@
 						<phase>process-classes</phase>
 						<configuration>
 							<instructions>
-								<Automatic-Module-Name>org.antlr.antlr4.runtime</Automatic-Module-Name>
 								<Bundle-SymbolicName>org.antlr.antlr4-runtime</Bundle-SymbolicName>
 								<Import-Package>org.antlr.v4.gui;resolution:=optional, *</Import-Package>
 							</instructions>
@@ -110,10 +109,35 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>module-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>9</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src9</compileSourceRoot>
+                            </compileSourceRoots>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                        </configuration>
+                    </execution>
+                </executions>
 				<configuration>
-					<release>8</release>
-					<source>1.8</source>
-					<target>1.8</target>
+
 				</configuration>
 			</plugin>
 		</plugins>

--- a/runtime/Java/src9/module-info.java
+++ b/runtime/Java/src9/module-info.java
@@ -1,0 +1,7 @@
+module org.antlr.antlr.runtime {
+	exports org.antlr.v4.runtime;
+	exports org.antlr.v4.runtime.atn;
+	exports org.antlr.v4.runtime.dfa;
+	exports org.antlr.v4.runtime.misc;
+	exports org.antlr.v4.runtime.tree;
+}


### PR DESCRIPTION
This PR fixes #2946 by adding module-info.java to antlr-runtime module of the project. This is done as "multi-release jar" which allows to specify multiple versions of classes for different java versions. In this case the module is compiled for java 8 with java 9 classes stored in META-INF/versions/9.

Module-info.java exports module named `org.antlr.antlr.runtime`. This differs from the original automatic-module-name (`org.antlr.antlr4.runtime`) because JPMS doesn't like trailing digits in names.

Module exports all packages except `org.antlr.v4.runtime.tree.pattern` and `org.antlr.v4.runtime.tree.xpath`. Please let me know if these are used outside the module and should be included as well.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
