### PR TITLE
Fix PathElement for Token type

### DIFF
--- a/runtime/Python3/src/antlr4/xpath/XPath.py
+++ b/runtime/Python3/src/antlr4/xpath/XPath.py
@@ -137,8 +137,8 @@ class XPath(object):
 
             ttype = Token.INVALID_TYPE
             if wordToken.type == XPathLexer.TOKEN_REF:
-                if word in tsource.ruleNames:
-                    ttype = tsource.ruleNames.index(word) + 1
+                if word in tsource.symbolicNames:
+                    ttype = tsource.symbolicNames.index(word)
             else:
                 if word in tsource.literalNames:
                     ttype = tsource.literalNames.index(word)


### PR DESCRIPTION
symbolicName must be appropriate for Token

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
