### PR TITLE
[TypeScript] Fix types in template (missing null-union)

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -873,8 +873,8 @@ export default class <lexer.name> extends <superClass; null="Lexer"> {
 	<rest(lexer.modes):{m | public static readonly <m> = <i>;}; separator="\n">
 
 	public static readonly channelNames: string[] = [ "DEFAULT_TOKEN_CHANNEL", "HIDDEN"<if (lexer.channelNames)>, <lexer.channelNames:{c| "<c>"}; separator=", ", wrap, anchor><endif> ];
-	public static readonly literalNames: string[] = [ <lexer.literalNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
-	public static readonly symbolicNames: string[] = [ <lexer.symbolicNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
+	public static readonly literalNames: (string | null)[] = [ <lexer.literalNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
+	public static readonly symbolicNames: (string | null)[] = [ <lexer.symbolicNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
 	public static readonly modeNames: string[] = [ <lexer.modes:{m| "<m>",}; separator=" ", wrap, anchor> ];
 
 	public static readonly ruleNames: string[] = [


### PR DESCRIPTION
Hello,

the arrays `literalNames` and `symbolicNames` do not only contain strings, but also null. Therefore we should reflect that in the TypeScript type to prevent build errors in strict mode.

![image](https://user-images.githubusercontent.com/16149608/221855399-4e68e2fe-0e8a-4664-b14e-211be4140a37.png)
![image](https://user-images.githubusercontent.com/16149608/221855482-d8ff2746-a71a-4a30-969c-91b3e84fd4eb.png)

Thank you for your great work on the TypeScript target, loving it :)

Kind regards
Sharknoon