### PR TITLE
[TypeScript] Explicitly allow parameters to be children of type Parser

### DIFF
--- a/runtime/JavaScript/src/antlr4/context/ParserRuleContext.d.ts
+++ b/runtime/JavaScript/src/antlr4/context/ParserRuleContext.d.ts
@@ -18,6 +18,6 @@ export declare class ParserRuleContext extends RuleContext {
     getChild(i: number) : ParseTree;
     getToken(ttype: number, i: number): TerminalNode;
     getTokens(ttype: number): TerminalNode[];
-    getTypedRuleContext<T extends ParserRuleContext>(ctxType: { new (parser?: Parser, parent?: ParserRuleContext, invokingState?: number, ...args: any[]) : T}, i: number): T;
-    getTypedRuleContexts<T extends ParserRuleContext>(ctxType: { new (parser?: Parser, parent?: ParserRuleContext, invokingState?: number, ...args: any[]) : T}): T[];
+    getTypedRuleContext<T extends ParserRuleContext, P extends Parser>(ctxType: { new (parser?: P, parent?: ParserRuleContext, invokingState?: number, ...args: any[]) : T}, i: number): T;
+    getTypedRuleContexts<T extends ParserRuleContext, P extends Parser>(ctxType: { new (parser?: P, parent?: ParserRuleContext, invokingState?: number, ...args: any[]) : T}): T[];
 }


### PR DESCRIPTION
Hello,

the two functions `getTypedRuleContext` and `getTypedRuleContexts` only accept a argument named `parser` of type `Parser`, but not of a type that extends `Parser`. This is causing the following problem: 
![parser](https://user-images.githubusercontent.com/16149608/222084058-3c374a55-1eba-4649-824c-4bf08a17cffa.png)
Therefore I propse to allow child types of `Parser`.

Thank you :)

Kind regards
Sharknoon