### PR TITLE
fix: Some code that should have been destined for /v4 was instead put…

### DIFF
--- a/runtime/Go/antlr/v4/lexer.go
+++ b/runtime/Go/antlr/v4/lexer.go
@@ -118,7 +118,7 @@ const (
 	LexerMaxCharValue        = 0x10FFFF
 )
 
-func (b *BaseLexer) reset() {
+func (b *BaseLexer) Reset() {
 	// wack Lexer state variables
 	if b.input != nil {
 		b.input.Seek(0) // rewind the input
@@ -280,7 +280,7 @@ func (b *BaseLexer) inputStream() CharStream {
 func (b *BaseLexer) SetInputStream(input CharStream) {
 	b.input = nil
 	b.tokenFactorySourcePair = &TokenSourceCharStreamPair{b, b.input}
-	b.reset()
+	b.Reset()
 	b.input = input
 	b.tokenFactorySourcePair = &TokenSourceCharStreamPair{b, b.input}
 }

--- a/runtime/Go/antlr/v4/testing_api_test.go
+++ b/runtime/Go/antlr/v4/testing_api_test.go
@@ -1,0 +1,30 @@
+package antlr
+
+import (
+	"testing"
+)
+
+func next(t *testing.T, lexer *LexerB, want string) {
+	var token = lexer.NextToken()
+	var got = token.String()
+	if got != want {
+		t.Errorf("got %q, wanted %q", got, want)
+	}
+}
+
+func TestString(t *testing.T) {
+	str := NewInputStream("a b c 1 2 3")
+	lexer := NewLexerB(str)
+	next(t, lexer, "[@-1,0:0='a',<1>,1:0]")
+	next(t, lexer, "[@-1,1:1=' ',<7>,1:1]")
+	next(t, lexer, "[@-1,2:2='b',<1>,1:2]")
+	next(t, lexer, "[@-1,3:3=' ',<7>,1:3]")
+	next(t, lexer, "[@-1,4:4='c',<1>,1:4]")
+	next(t, lexer, "[@-1,5:5=' ',<7>,1:5]")
+	next(t, lexer, "[@-1,6:6='1',<2>,1:6]")
+	next(t, lexer, "[@-1,7:7=' ',<7>,1:7]")
+	next(t, lexer, "[@-1,8:8='2',<2>,1:8]")
+	next(t, lexer, "[@-1,9:9=' ',<7>,1:9]")
+	next(t, lexer, "[@-1,10:10='3',<2>,1:10]")
+	next(t, lexer, "[@-1,11:10='<EOF>',<-1>,1:11]")
+}

--- a/runtime/Go/antlr/v4/token.go
+++ b/runtime/Go/antlr/v4/token.go
@@ -35,6 +35,8 @@ type Token interface {
 
 	GetTokenSource() TokenSource
 	GetInputStream() CharStream
+
+	String() string
 }
 
 type BaseToken struct {


### PR DESCRIPTION
fix: Code that should have gone to the /v4 files was instead placed in to the root (pre v4) files

This PR merely copies the changes in to the correct place - code has already been reviewed. 

 - Incorporate an iterative tree walker
 - Expose Reset() and String() in lexer/token and add test

@parrt - please merge so I can then proceed with removing the pre-v4 files from the repo
