### PR TITLE
Avoid usage of expensive FlexibleHashMap

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/misc/FlexibleHashMap.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/FlexibleHashMap.java
@@ -15,7 +15,9 @@ import java.util.Set;
 
 /** A limited map (many unsupported operations) that lets me use
  *  varying hashCode/equals.
+ * @deprecated in favor of using standard maps with custom keys.
  */
+@Deprecated
 public class FlexibleHashMap<K,V> implements Map<K, V> {
 	public static final int INITAL_CAPACITY = 16; // must be power of 2
 	public static final int INITAL_BUCKET_CAPACITY = 8;


### PR DESCRIPTION
Hi 👋 

I was profiling `checkstyle` the other day and noticed that the usage of `PredictionMode.getConflictingAltSubsets` is responsible for almost ~13% of all CPU frames inside my async-profiler flamegraphs. 
<img width="924" alt="image" src="https://user-images.githubusercontent.com/6304496/223957346-ed7f2ee3-f2a0-410f-9ce6-6319f24391b2.png">

When zooming in this can be largely traced back to the usage of `FlexibleHashMap`
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/6304496/223947238-8e9a44b1-e3fb-4358-8049-4a3d2f82cac0.png">

From the comments I couldn't find the exact reason for this Map, but it seems to be used in conjunction with `...EqualityComparator` to customize hash-codes.

Imho, the same can be achieved by using a normal `HashMap` and wrapping the key as proposed in this PR. By doing so and building checkstyle locally, I get the following improvements.

**Old**
```
       14,41 real        24,28 user         1,27 sys
```
**New**
```
       12,68 real        20,99 user         1,05 sys
```
And the flamegraphs look also cleaner
<img width="1668" alt="image" src="https://user-images.githubusercontent.com/6304496/223959357-9c5f8a96-1695-4b43-8a56-ed93d90a83b6.png">

Let me know if you think this is a viable solution.

Cheers,
Christoph