### PR TITLE
Feature/gotestfix Fixes Go runtime test suite

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/GoRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/GoRunner.java
@@ -79,7 +79,7 @@ public class GoRunner extends RuntimeRunner {
 	protected void initRuntime(RunOptions runOptions) throws Exception {
 		String cachePath = getCachePath();
 		mkdir(cachePath);
-		Path runtimeFilesPath = Paths.get(getRuntimePath("Go"), "antlr");
+		Path runtimeFilesPath = Paths.get(getRuntimePath("Go"), "antlr", "v4");
 		String runtimeToolPath = getRuntimeToolPath();
 		File goModFile = new File(cachePath, "go.mod");
 		if (goModFile.exists())


### PR DESCRIPTION
Ensures that the /v4 directory is used in the go.mod file produced on the fly by the GoRunner.java code.
