### PR TITLE
Cpp: Fix the unused parameter warning in the sempred function.

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -259,13 +259,13 @@ void <r.factory.grammar.name>::<r.name>Action(<r.ctxType> *context, size_t actio
 >>
 
 RuleSempredFunctionHeader(r, actions) ::= <<
-bool <r.name>Sempred(<r.ctxType> *_localctx, size_t predicateIndex);
+bool <r.name>Sempred([[maybe_unused]] <r.ctxType> *_localctx, size_t predicateIndex);
 >>
 
 RuleSempredFunction(r, actions) ::= <<
 <! Called for both lexer and parser. But only one of them is actually available. Testing for the parser directly
    generates a warning, however. So do the check via the factory instead. !>
-bool <if (r.factory.g.lexer)><lexer.name><else><parser.name><endif>::<r.name>Sempred(<r.ctxType> *_localctx, size_t predicateIndex) {
+bool <if (r.factory.g.lexer)><lexer.name><else><parser.name><endif>::<r.name>Sempred([[maybe_unused]] <r.ctxType> *_localctx, size_t predicateIndex) {
   switch (predicateIndex) {
     <actions: {index | case <index>: return <actions.(index)>}; separator=";\n">;
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

Consider the following simple grammar:

```antlr
Expression : Expression '*' Expression
           | Expression '+' Expression
```

ANTLR will generate the following member function:

```c++
bool SampleParser::expressionSempred(ExpressionContext *_localctx, size_t predicateIndex)
{
    switch (predicateIndex) 
    {
        case 0: return precpred(_ctx, 5);
        case 1: return precpred(_ctx, 4);

        default:
        break;
    }
    return true;
}
```

The first parameter is never used in the function body, resulting in an unused parameter warning. This PR fixes the warning by adding the attribute `[[maybe_unused]]` which is available as of C++17.

Thank you.