### PR TITLE
Improve runtime performance of the Go runtime test suite

### DIFF
--- a/runtime-testsuite/resources/junit-platform.properties
+++ b/runtime-testsuite/resources/junit-platform.properties
@@ -1,3 +1,4 @@
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = concurrent
 junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.config.fixed.parallelism=4

--- a/runtime-testsuite/resources/junit-platform.properties
+++ b/runtime-testsuite/resources/junit-platform.properties
@@ -1,4 +1,3 @@
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = concurrent
 junit.jupiter.execution.parallel.mode.classes.default = concurrent
-junit.jupiter.execution.parallel.config.fixed.parallelism=4

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeRunner.java
@@ -26,25 +26,45 @@ public abstract class RuntimeRunner implements AutoCloseable {
 
 	public abstract String getLanguage();
 
-	protected String getExtension() { return getLanguage().toLowerCase(); }
+	protected String getExtension() {
+		return getLanguage().toLowerCase();
+	}
 
-	protected String getTitleName() { return getLanguage(); }
+	protected String getTitleName() {
+		return getLanguage();
+	}
 
-	protected String getTestFileName() { return "Test"; }
+	protected String getTestFileName() {
+		return "Test";
+	}
 
-	protected String getLexerSuffix() { return "Lexer"; }
+	protected String getLexerSuffix() {
+		return "Lexer";
+	}
 
-	protected String getParserSuffix() { return "Parser"; }
+	protected String getParserSuffix() {
+		return "Parser";
+	}
 
-	protected String getBaseListenerSuffix() { return "BaseListener"; }
+	protected String getBaseListenerSuffix() {
+		return "BaseListener";
+	}
 
-	protected String getListenerSuffix() { return "Listener"; }
+	protected String getListenerSuffix() {
+		return "Listener";
+	}
 
-	protected String getBaseVisitorSuffix() { return "BaseVisitor"; }
+	protected String getBaseVisitorSuffix() {
+		return "BaseVisitor";
+	}
 
-	protected String getVisitorSuffix() { return "Visitor"; }
+	protected String getVisitorSuffix() {
+		return "Visitor";
+	}
 
-	protected String grammarNameToFileName(String grammarName) { return grammarName; }
+	protected String grammarNameToFileName(String grammarName) {
+		return grammarName;
+	}
 
 	private static String runtimeToolPath;
 	private static String compilerPath;
@@ -77,17 +97,29 @@ public abstract class RuntimeRunner implements AutoCloseable {
 		return runtimeToolPath;
 	}
 
-	protected String getCompilerName() { return null; }
+	protected String getCompilerName() {
+		return null;
+	}
 
-	protected String getRuntimeToolName() { return getLanguage().toLowerCase(); }
+	protected String getRuntimeToolName() {
+		return getLanguage().toLowerCase();
+	}
 
-	protected String getTestFileWithExt() { return getTestFileName() + "." + getExtension(); }
+	protected String getTestFileWithExt() {
+		return getTestFileName() + "." + getExtension();
+	}
 
-	protected String getExecFileName() { return getTestFileWithExt(); }
+	protected String getExecFileName() {
+		return getTestFileWithExt();
+	}
 
-	protected String[] getExtraRunArgs() { return null; }
+	protected String[] getExtraRunArgs() {
+		return null;
+	}
 
-	protected Map<String, String> getExecEnvironment() { return null; }
+	protected Map<String, String> getExecEnvironment() {
+		return null;
+	}
 
 	protected String getPropertyPrefix() {
 		return "antlr-" + getLanguage().toLowerCase();
@@ -157,7 +189,7 @@ public abstract class RuntimeRunner implements AutoCloseable {
 	// Allows any target to add additional options for the antlr tool such as the location of the output files
 	// which is useful for the Go target for instance to avoid having to move them before running the test
 	//
-	protected List<String> getTargetToolOptions() {
+	protected List<String> getTargetToolOptions(RunOptions ro) {
 		return null;
 	}
 
@@ -170,9 +202,9 @@ public abstract class RuntimeRunner implements AutoCloseable {
 			options.add("-DsuperClass=" + runOptions.superClass);
 		}
 
-		// See if the target wants to add tool options
+		// See if the target wants to add tool options.
 		//
-		List<String>targetOpts = getTargetToolOptions();
+		List<String> targetOpts = getTargetToolOptions(runOptions);
 		if (targetOpts != null) {
 			options.addAll(targetOpts);
 		}
@@ -254,7 +286,8 @@ public abstract class RuntimeRunner implements AutoCloseable {
 		return startRuleName;
 	}
 
-	protected void addExtraRecognizerParameters(ST template) {}
+	protected void addExtraRecognizerParameters(ST template) {
+	}
 
 	private boolean initAntlrRuntimeIfRequired(RunOptions runOptions) {
 		String language = getLanguage();
@@ -316,8 +349,7 @@ public abstract class RuntimeRunner implements AutoCloseable {
 			ProcessorResult result = Processor.run(args.toArray(new String[0]), getTempDirPath(), getExecEnvironment());
 			output = result.output;
 			errors = result.errors;
-		}
-		catch (InterruptedException | IOException e) {
+		} catch (InterruptedException | IOException e) {
 			exception = e;
 		}
 		return new ExecutedState(compiledState, output, errors, exception);
@@ -331,11 +363,10 @@ public abstract class RuntimeRunner implements AutoCloseable {
 		String cmd = String.join(" ", command);
 		try {
 			return Processor.run(command, workPath);
-		}
-		catch (InterruptedException | IOException e) {
-			String msg = "command \""+cmd+"\"\n  in "+workPath+" failed";
-			if ( description != null ) {
-				msg += ":\n  can't "+description;
+		} catch (InterruptedException | IOException e) {
+			String msg = "command \"" + cmd + "\"\n  in " + workPath + " failed";
+			if (description != null) {
+				msg += ":\n  can't " + description;
 			}
 			throw new Exception(msg, e);
 		}
@@ -347,8 +378,7 @@ public abstract class RuntimeRunner implements AutoCloseable {
 			if (dirFile.exists()) {
 				try {
 					deleteDirectory(dirFile);
-				}
-				catch (IOException e) {
+				} catch (IOException e) {
 					e.printStackTrace();
 				}
 			}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeRunner.java
@@ -154,6 +154,13 @@ public abstract class RuntimeRunner implements AutoCloseable {
 		return runtimePath.toString() + FileSeparator + language;
 	}
 
+	// Allows any target to add additional options for the antlr tool such as the location of the output files
+	// which is useful for the Go target for instance to avoid having to move them before running the test
+	//
+	protected List<String> getTargetToolOptions() {
+		return null;
+	}
+
 	public State run(RunOptions runOptions) {
 		List<String> options = new ArrayList<>();
 		if (runOptions.useVisitor) {
@@ -162,6 +169,14 @@ public abstract class RuntimeRunner implements AutoCloseable {
 		if (runOptions.superClass != null && runOptions.superClass.length() > 0) {
 			options.add("-DsuperClass=" + runOptions.superClass);
 		}
+
+		// See if the target wants to add tool options
+		//
+		List<String>targetOpts = getTargetToolOptions();
+		if (targetOpts != null) {
+			options.addAll(targetOpts);
+		}
+
 		ErrorQueue errorQueue = Generator.antlrOnString(getTempDirPath(), getLanguage(),
 				runOptions.grammarFileName, runOptions.grammarStr, false, options.toArray(new String[0]));
 

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeRunner.java
@@ -26,45 +26,25 @@ public abstract class RuntimeRunner implements AutoCloseable {
 
 	public abstract String getLanguage();
 
-	protected String getExtension() {
-		return getLanguage().toLowerCase();
-	}
+	protected String getExtension() { return getLanguage().toLowerCase(); }
 
-	protected String getTitleName() {
-		return getLanguage();
-	}
+	protected String getTitleName() { return getLanguage(); }
 
-	protected String getTestFileName() {
-		return "Test";
-	}
+	protected String getTestFileName() { return "Test"; }
 
-	protected String getLexerSuffix() {
-		return "Lexer";
-	}
+	protected String getLexerSuffix() { return "Lexer"; }
 
-	protected String getParserSuffix() {
-		return "Parser";
-	}
+	protected String getParserSuffix() { return "Parser"; }
 
-	protected String getBaseListenerSuffix() {
-		return "BaseListener";
-	}
+	protected String getBaseListenerSuffix() { return "BaseListener"; }
 
-	protected String getListenerSuffix() {
-		return "Listener";
-	}
+	protected String getListenerSuffix() { return "Listener"; }
 
-	protected String getBaseVisitorSuffix() {
-		return "BaseVisitor";
-	}
+	protected String getBaseVisitorSuffix() { return "BaseVisitor"; }
 
-	protected String getVisitorSuffix() {
-		return "Visitor";
-	}
+	protected String getVisitorSuffix() { return "Visitor"; }
 
-	protected String grammarNameToFileName(String grammarName) {
-		return grammarName;
-	}
+	protected String grammarNameToFileName(String grammarName) { return grammarName; }
 
 	private static String runtimeToolPath;
 	private static String compilerPath;
@@ -97,29 +77,17 @@ public abstract class RuntimeRunner implements AutoCloseable {
 		return runtimeToolPath;
 	}
 
-	protected String getCompilerName() {
-		return null;
-	}
+	protected String getCompilerName() { return null; }
 
-	protected String getRuntimeToolName() {
-		return getLanguage().toLowerCase();
-	}
+	protected String getRuntimeToolName() { return getLanguage().toLowerCase(); }
 
-	protected String getTestFileWithExt() {
-		return getTestFileName() + "." + getExtension();
-	}
+	protected String getTestFileWithExt() { return getTestFileName() + "." + getExtension(); }
 
-	protected String getExecFileName() {
-		return getTestFileWithExt();
-	}
+	protected String getExecFileName() { return getTestFileWithExt(); }
 
-	protected String[] getExtraRunArgs() {
-		return null;
-	}
+	protected String[] getExtraRunArgs() { return null; }
 
-	protected Map<String, String> getExecEnvironment() {
-		return null;
-	}
+	protected Map<String, String> getExecEnvironment() { return null; }
 
 	protected String getPropertyPrefix() {
 		return "antlr-" + getLanguage().toLowerCase();

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/GoRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/GoRunner.java
@@ -70,6 +70,7 @@ public class GoRunner extends RuntimeRunner {
 
 	private static String cachedGoMod;
 	private static String cachedGoSum;
+	private static ArrayList<String> options = new ArrayList<>();
 
 	static {
 		environment = new HashMap<>();
@@ -115,8 +116,13 @@ public class GoRunner extends RuntimeRunner {
 	}
 
 	@Override
-	protected  List<String> getTargetToolOptions() {
-		ArrayList<String> options = new ArrayList<String>();
+	protected List<String> getTargetToolOptions(RunOptions ro) {
+		// Unfortunately this cannot be cached because all the synchronization is out of whack, and
+		// we end up return the options before they are populated. I prefer to make this small change
+		// at the expense of an object rather than try to change teh synchronized initialization, which is
+		// very fragile.
+		// Also, the options may need to change in the future according to the test options. This is safe
+		ArrayList<String> options = new ArrayList<>();
 		options.add("-o");
 		options.add(tempTestDir.resolve("parser").toString());
 		return options;
@@ -124,27 +130,6 @@ public class GoRunner extends RuntimeRunner {
 
 	@Override
 	protected CompiledState compile(RunOptions runOptions, GeneratedState generatedState) {
-//		List<GeneratedFile> generatedFiles = generatedState.generatedFiles;
-//		String tempDirPath = getTempDirPath();
-//		File generatedParserDir = new File(tempDirPath, "parser");
-//		if (!generatedParserDir.mkdir()) {
-//			return new CompiledState(generatedState, new Exception("can't make dir " + generatedParserDir));
-//		}
-//
-//		// The generated files seem to need to be in the parser subdirectory.
-//		// We have no need to change the import of the runtime because of go mod replace so, we could just generate them
-//		// directly in to the parser subdir. But in case down the line, there is some reason to want to replace things in
-//		// the generated code, then I will leave this here, and we can use replaceInFile()
-//		//
-//		for (GeneratedFile generatedFile : generatedFiles) {
-//			try {
-//				Path originalFile = Paths.get(tempDirPath, generatedFile.name);
-//				Files.move(originalFile, Paths.get(tempDirPath, "parser", generatedFile.name));
-//			} catch (IOException e) {
-//				return new CompiledState(generatedState, e);
-//			}
-//		}
-
 		// We have already created a suitable go.mod file, though it may need to have go mod tidy run on it one time
 		//
 		writeFile(getTempDirPath(), "go.mod", cachedGoMod);


### PR DESCRIPTION
feat: Speed up the go runtime tests

Prior to this change, after writing the go.mod file for each test, we had to run a `go mod tidy` command. This is an extra process sparked for each test, which can be quite the overhead.

This change runs a `go mod tidy` only if we have not yet cached the results (`go.mod` and `go.sum`) for any prior test and therefore saves sparking a process for each test.

@parrt When you get a chance, could you change the Github test runtime environment to use go 1.20.1 ? I would like to keep our development and testing versions of the go compiler up to date, even if I decide not to require go 1.20 at this time. Cheers.