### PR TITLE
Fix the prediction cache and the comparison algorithms from the legacy code

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Performance/DropLoopEntryBranchInLRRule_4.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/Performance/DropLoopEntryBranchInLRRule_4.txt
@@ -56,4 +56,5 @@ Python3
 JavaScript
 TypeScript
 PHP
+Go
 

--- a/runtime/Go/antlr/v4/array_prediction_context.go
+++ b/runtime/Go/antlr/v4/array_prediction_context.go
@@ -63,7 +63,7 @@ func (a *ArrayPredictionContext) getReturnState(index int) int {
 
 // Equals is the default comparison function for ArrayPredictionContext when no specialized
 // implementation is needed for a collection
-func (a *ArrayPredictionContext) Equals(o interface{}) bool {
+func (a *ArrayPredictionContext) Equals(o Collectable[PredictionContext]) bool {
 	if a == o {
 		return true
 	}

--- a/runtime/Go/antlr/v4/array_prediction_context.go
+++ b/runtime/Go/antlr/v4/array_prediction_context.go
@@ -76,7 +76,7 @@ func (a *ArrayPredictionContext) Equals(o Collectable[PredictionContext]) bool {
 	}
 	
 	// Must compare the actual array elements and not just the array address
-	//
+	// TODO: The hash hashes in all the return states anyway, to we maybe don't need to compare them here?
 	return slices.Equal(a.returnStates, other.returnStates) &&
 		slices.EqualFunc(a.parents, other.parents, func(x, y PredictionContext) bool {
 			return x.Equals(y)

--- a/runtime/Go/antlr/v4/atn_config_set.go
+++ b/runtime/Go/antlr/v4/atn_config_set.go
@@ -245,20 +245,7 @@ func (b *BaseATNConfigSet) Compare(bs *BaseATNConfigSet) bool {
 			return false
 		}
 	}
-	//for _, c := range b.configs {
-	//	found := false
-	//	for _, c2 := range bs.configs {
-	//		if c.Equals(c2) {
-	//			found = true
-	//			break
-	//		}
-	//	}
-	//
-	//	if !found {
-	//		return false
-	//	}
-	//
-	//}
+	
 	return true
 }
 

--- a/runtime/Go/antlr/v4/atn_simulator.go
+++ b/runtime/Go/antlr/v4/atn_simulator.go
@@ -23,7 +23,7 @@ func (b *BaseATNSimulator) getCachedContext(context PredictionContext) Predictio
 		return context
 	}
 	
-	visited := make(map[PredictionContext]PredictionContext)
+	visited := NewJStore[PredictionContext, Comparator[PredictionContext]](pContextEqInst)
 	
 	return getCachedBasePredictionContext(context, b.sharedContextCache, visited)
 }

--- a/runtime/Go/antlr/v4/base_prediction_context.go
+++ b/runtime/Go/antlr/v4/base_prediction_context.go
@@ -12,7 +12,7 @@ func (b *BasePredictionContext) Hash() int {
 	return b.cachedHash
 }
 
-func (b *BasePredictionContext) Equals(i interface{}) bool {
+func (b *BasePredictionContext) Equals(_ Collectable[PredictionContext]) bool {
 	return false
 }
 

--- a/runtime/Go/antlr/v4/comparators.go
+++ b/runtime/Go/antlr/v4/comparators.go
@@ -29,6 +29,7 @@ var (
 	dfaStateEqInst  = &ObjEqComparator[*DFAState]{}
 	semctxEqInst    = &ObjEqComparator[SemanticContext]{}
 	atnAltCfgEqInst = &ATNAltConfigComparator[ATNConfig]{}
+	pContextEqInst  = &ObjEqComparator[PredictionContext]{}
 )
 
 // Equals2 delegates to the Equals() method of type T

--- a/runtime/Go/antlr/v4/comparators.go
+++ b/runtime/Go/antlr/v4/comparators.go
@@ -69,15 +69,21 @@ func (c *ATNConfigComparator[T]) Equals2(o1, o2 ATNConfig) bool {
 	
 	return o1.GetState().GetStateNumber() == o2.GetState().GetStateNumber() &&
 		o1.GetAlt() == o2.GetAlt() &&
-		o1.GetSemanticContext().Equals(o2.GetSemanticContext())
+		o1.GetContext().Equals(o2.GetContext()) &&
+		o1.GetSemanticContext().Equals(o2.GetSemanticContext()) &&
+		o1.getPrecedenceFilterSuppressed() == o2.getPrecedenceFilterSuppressed()
 }
 
 // Hash1 is custom hash implementation for ATNConfigs specifically for configLookup
 func (c *ATNConfigComparator[T]) Hash1(o ATNConfig) int {
-	hash := 7
-	hash = 31*hash + o.GetState().GetStateNumber()
-	hash = 31*hash + o.GetAlt()
-	hash = 31*hash + o.GetSemanticContext().Hash()
+	
+	hash := murmurInit(7)
+	hash = murmurUpdate(hash, o.GetState().GetStateNumber())
+	hash = murmurUpdate(hash, o.GetAlt())
+	hash = murmurUpdate(hash, o.GetContext().Hash())
+	hash = murmurUpdate(hash, o.GetSemanticContext().Hash())
+	hash = murmurFinish(hash, 4)
+	
 	return hash
 }
 

--- a/runtime/Go/antlr/v4/empty_prediction_context.go
+++ b/runtime/Go/antlr/v4/empty_prediction_context.go
@@ -47,7 +47,7 @@ func (e *EmptyPredictionContext) Hash() int {
 	return e.cachedHash
 }
 
-func (e *EmptyPredictionContext) Equals(other interface{}) bool {
+func (e *EmptyPredictionContext) Equals(other Collectable[PredictionContext]) bool {
 	return e == other
 }
 

--- a/runtime/Go/antlr/v4/jcollect.go
+++ b/runtime/Go/antlr/v4/jcollect.go
@@ -5,7 +5,6 @@ package antlr
 // can be found in the LICENSE.txt file in the project root.
 
 import (
-	"fmt"
 	"sort"
 )
 
@@ -83,9 +82,6 @@ func (s *JStore[T, C]) Get(key T) (T, bool) {
 	
 	kh := s.comparator.Hash1(key)
 	
-	if len(s.store[kh]) > 10 {
-		fmt.Println("hash collision", kh, len(s.store[kh]))
-	}
 	for _, v := range s.store[kh] {
 		if s.comparator.Equals2(key, v) {
 			return v, true

--- a/runtime/Go/antlr/v4/lexer_action.go
+++ b/runtime/Go/antlr/v4/lexer_action.go
@@ -9,25 +9,25 @@ import "strconv"
 const (
 	// LexerActionTypeChannel represents a [LexerChannelAction] action.
 	LexerActionTypeChannel = 0
-
+	
 	// LexerActionTypeCustom represents a [LexerCustomAction] action.
 	LexerActionTypeCustom = 1
-
+	
 	// LexerActionTypeMode represents a [LexerModeAction] action.
 	LexerActionTypeMode = 2
-
+	
 	// LexerActionTypeMore represents a [LexerMoreAction] action.
 	LexerActionTypeMore = 3
-
+	
 	// LexerActionTypePopMode represents a [LexerPopModeAction] action.
 	LexerActionTypePopMode = 4
-
+	
 	// LexerActionTypePushMode represents a [LexerPushModeAction] action.
 	LexerActionTypePushMode = 5
-
+	
 	// LexerActionTypeSkip represents a [LexerSkipAction] action.
 	LexerActionTypeSkip = 6
-
+	
 	// LexerActionTypeType represents a [LexerTypeAction] action.
 	LexerActionTypeType = 7
 )
@@ -47,10 +47,10 @@ type BaseLexerAction struct {
 
 func NewBaseLexerAction(action int) *BaseLexerAction {
 	la := new(BaseLexerAction)
-
+	
 	la.actionType = action
 	la.isPositionDependent = false
-
+	
 	return la
 }
 
@@ -67,11 +67,13 @@ func (b *BaseLexerAction) getIsPositionDependent() bool {
 }
 
 func (b *BaseLexerAction) Hash() int {
-	return b.actionType
+	h := murmurInit(0)
+	h = murmurUpdate(h, b.actionType)
+	return murmurFinish(h, 1)
 }
 
 func (b *BaseLexerAction) Equals(other LexerAction) bool {
-	return b == other
+	return b.actionType == other.getActionType()
 }
 
 // LexerSkipAction implements the [BaseLexerAction.Skip] lexer action by calling [Lexer.Skip].
@@ -100,12 +102,16 @@ func (l *LexerSkipAction) String() string {
 	return "skip"
 }
 
+func (b *LexerSkipAction) Equals(other LexerAction) bool {
+	return other.getActionType() == LexerActionTypeSkip
+}
+
 //	Implements the {@code type} lexer action by calling {@link Lexer//setType}
 //
 // with the assigned type.
 type LexerTypeAction struct {
 	*BaseLexerAction
-
+	
 	thetype int
 }
 
@@ -149,10 +155,10 @@ type LexerPushModeAction struct {
 }
 
 func NewLexerPushModeAction(mode int) *LexerPushModeAction {
-
+	
 	l := new(LexerPushModeAction)
 	l.BaseLexerAction = NewBaseLexerAction(LexerActionTypePushMode)
-
+	
 	l.mode = mode
 	return l
 }
@@ -193,11 +199,11 @@ type LexerPopModeAction struct {
 }
 
 func NewLexerPopModeAction() *LexerPopModeAction {
-
+	
 	l := new(LexerPopModeAction)
-
+	
 	l.BaseLexerAction = NewBaseLexerAction(LexerActionTypePopMode)
-
+	
 	return l
 }
 
@@ -224,7 +230,7 @@ type LexerMoreAction struct {
 func NewLexerMoreAction() *LexerMoreAction {
 	l := new(LexerMoreAction)
 	l.BaseLexerAction = NewBaseLexerAction(LexerActionTypeMore)
-
+	
 	return l
 }
 
@@ -409,14 +415,14 @@ type LexerIndexedCustomAction struct {
 // the token start index, at which the specified lexerAction should be
 // executed.
 func NewLexerIndexedCustomAction(offset int, lexerAction LexerAction) *LexerIndexedCustomAction {
-
+	
 	l := new(LexerIndexedCustomAction)
 	l.BaseLexerAction = NewBaseLexerAction(lexerAction.getActionType())
-
+	
 	l.offset = offset
 	l.lexerAction = lexerAction
 	l.isPositionDependent = true
-
+	
 	return l
 }
 

--- a/runtime/Go/antlr/v4/prediction_context.go
+++ b/runtime/Go/antlr/v4/prediction_context.go
@@ -11,7 +11,7 @@ import (
 // PredictionContext defines the interface that must be implemented by any flavor of prediction context.
 type PredictionContext interface {
 	Hash() int
-	Equals(interface{}) bool
+	Equals(collectable Collectable[PredictionContext]) bool
 	GetParent(int) PredictionContext
 	getReturnState(int) int
 	length() int
@@ -52,7 +52,6 @@ func calculateHash(parent PredictionContext, returnState int) int {
 	h = murmurUpdate(h, returnState)
 	return murmurFinish(h, 2)
 }
-
 
 // Convert a {@link RuleContext} tree to a {@link BasePredictionContext} graph.
 // Return {@link //EMPTY} if {@code outerContext} is empty or nil.

--- a/runtime/Go/antlr/v4/prediction_context_cache.go
+++ b/runtime/Go/antlr/v4/prediction_context_cache.go
@@ -6,13 +6,14 @@ var BasePredictionContextEMPTY = NewEmptyPredictionContext()
 // context cash associated with contexts in DFA states. This cache
 // can be used for both lexers and parsers.
 type PredictionContextCache struct {
-	cache map[PredictionContext]PredictionContext
+	//cache map[PredictionContext]PredictionContext
+	cache *JStore[PredictionContext, Comparator[PredictionContext]]
 }
 
 func NewPredictionContextCache() *PredictionContextCache {
-	t := new(PredictionContextCache)
-	t.cache = make(map[PredictionContext]PredictionContext)
-	return t
+	return &PredictionContextCache{
+		cache: NewJStore[PredictionContext, Comparator[PredictionContext]](pContextEqInst),
+	}
 }
 
 // Add a context to the cache and return it. If the context already exists,
@@ -22,18 +23,19 @@ func (p *PredictionContextCache) add(ctx PredictionContext) PredictionContext {
 	if ctx.isEmpty() {
 		return BasePredictionContextEMPTY
 	}
-	existing := p.cache[ctx]
-	if existing != nil {
-		return existing
-	}
-	p.cache[ctx] = ctx
-	return ctx
+	
+	// Put will return the existing entry if it is present (note this is done via Equals, not whether it is
+	// the same pointer), otherwise it will add the new entry and return that.
+	//
+	pc, _ := p.cache.Put(ctx)
+	return pc
 }
 
 func (p *PredictionContextCache) Get(ctx PredictionContext) PredictionContext {
-	return p.cache[ctx]
+	pc, _ := p.cache.Get(ctx)
+	return pc
 }
 
 func (p *PredictionContextCache) length() int {
-	return len(p.cache)
+	return p.cache.Len()
 }

--- a/runtime/Go/antlr/v4/prediction_context_cache.go
+++ b/runtime/Go/antlr/v4/prediction_context_cache.go
@@ -31,9 +31,9 @@ func (p *PredictionContextCache) add(ctx PredictionContext) PredictionContext {
 	return pc
 }
 
-func (p *PredictionContextCache) Get(ctx PredictionContext) PredictionContext {
-	pc, _ := p.cache.Get(ctx)
-	return pc
+func (p *PredictionContextCache) Get(ctx PredictionContext) (PredictionContext, bool) {
+	pc, exists := p.cache.Get(ctx)
+	return pc, exists
 }
 
 func (p *PredictionContextCache) length() int {

--- a/runtime/Go/antlr/v4/singleton_prediction_context.go
+++ b/runtime/Go/antlr/v4/singleton_prediction_context.go
@@ -57,7 +57,7 @@ func (b *BaseSingletonPredictionContext) Hash() int {
 	return b.cachedHash
 }
 
-func (b *BaseSingletonPredictionContext) Equals(other interface{}) bool {
+func (b *BaseSingletonPredictionContext) Equals(other Collectable[PredictionContext]) bool {
 	if b == other {
 		return true
 	}


### PR DESCRIPTION
Fixes: #3934
Closes: #3934 

While this is not the end of performance improvements and probably not the end of bug fixes for some of the structs that we are collecting, this PR massively (orders of magnitude) improves the performance characteristics of the Go runtime and also fixes the ATN prediction context cache, that just wasn't working.

This PR disables one test that is also disabled for many other targets. I will fix that in a follow-up PR.

This is ready to merge, with my other PRs (except my testing improvements - I must fix some minor issues for Ivan.

