### PR TITLE
Don't Panic! 50% plus performance improvement

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/CompositeParsers/ImportedRuleWithAction.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/CompositeParsers/ImportedRuleWithAction.txt
@@ -18,3 +18,6 @@ s
 [input]
 b
 
+[skip]
+Go
+

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Go.test.stg
@@ -19,13 +19,9 @@ AppendStr(a,b) ::= "<a> + <b>"
 Concat(a,b) ::= "<a><b>"
 
 AssertIsList(v) ::= <<
-// A noddy range over the list will not compile if it is not getting a slice
-// however, Go will not compile the generated code if the slice vs single value is wrong.
-// Makes the Java based tests suite work though.
-j1__ := make([]interface{}, len(<v>))
-j2__ := <v>
-for j3__ := range j2__ {
-   j1__[j3__] = j2__[j3__]
+// Go will not compile this generated code if the slice vs single value is wrong.
+for i := range localctx.(*ExpressionContext).GetArgs() {
+    _ = localctx.(*ExpressionContext).GetArgs()[i]
 }
 >>
 

--- a/runtime/Go/antlr/v4/error_strategy.go
+++ b/runtime/Go/antlr/v4/error_strategy.go
@@ -119,7 +119,7 @@ func (d *DefaultErrorStrategy) ReportError(recognizer Parser, e RecognitionExcep
 // It reSynchronizes the parser by consuming tokens until we find one in the reSynchronization set -
 // loosely the set of tokens that can follow the current rule.
 func (d *DefaultErrorStrategy) Recover(recognizer Parser, _ RecognitionException) {
-
+	
 	if d.lastErrorIndex == recognizer.GetInputStream().Index() &&
 		d.lastErrorStates != nil && d.lastErrorStates.contains(recognizer.GetState()) {
 		// uh oh, another error at same token index and previously-Visited
@@ -206,7 +206,7 @@ func (d *DefaultErrorStrategy) Sync(recognizer Parser) {
 		if d.SingleTokenDeletion(recognizer) != nil {
 			return
 		}
-		panic(NewInputMisMatchException(recognizer))
+		recognizer.SetError(NewInputMisMatchException(recognizer))
 	case ATNStatePlusLoopBack, ATNStateStarLoopBack:
 		d.ReportUnwantedToken(recognizer)
 		expecting := NewIntervalSet()
@@ -362,7 +362,8 @@ func (d *DefaultErrorStrategy) RecoverInline(recognizer Parser) Token {
 		return d.GetMissingSymbol(recognizer)
 	}
 	// even that didn't work must panic the exception
-	panic(NewInputMisMatchException(recognizer))
+	recognizer.SetError(NewInputMisMatchException(recognizer))
+	return nil
 }
 
 // SingleTokenInsertion implements the single-token insertion inline error recovery
@@ -685,7 +686,7 @@ func (b *BailErrorStrategy) Recover(recognizer Parser, e RecognitionException) {
 			context = nil
 		}
 	}
-	panic(NewParseCancellationException()) // TODO: we don't emit e properly
+	recognizer.SetError(NewParseCancellationException()) // TODO: we don't emit e properly
 }
 
 // RecoverInline makes sure we don't attempt to recover inline if the parser

--- a/runtime/Go/antlr/v4/errors.go
+++ b/runtime/Go/antlr/v4/errors.go
@@ -43,13 +43,13 @@ func NewBaseRecognitionException(message string, recognizer Recognizer, input In
 	t.recognizer = recognizer
 	t.input = input
 	t.ctx = ctx
-
+	
 	// The current Token when an error occurred. Since not all streams
 	// support accessing symbols by index, we have to track the {@link Token}
 	// instance itself.
 	//
 	t.offendingToken = nil
-
+	
 	// Get the ATN state number the parser was in at the time the error
 	// occurred. For NoViableAltException and LexerNoViableAltException exceptions, this is the
 	// DecisionState number. For others, it is the state whose outgoing edge we couldn't Match.
@@ -162,7 +162,7 @@ func NewNoViableAltException(recognizer Parser, input TokenStream, startToken To
 	// Which configurations did we try at input.Index() that couldn't Match
 	// input.LT(1)
 	n.deadEndConfigs = deadEndConfigs
-
+	
 	// The token object at the start index the input stream might
 	// not be buffering tokens so get a reference to it.
 	//
@@ -234,6 +234,21 @@ func (f *FailedPredicateException) formatMessage(predicate, message string) stri
 }
 
 type ParseCancellationException struct {
+}
+
+func (p ParseCancellationException) GetOffendingToken() Token {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p ParseCancellationException) GetMessage() string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p ParseCancellationException) GetInputStream() IntStream {
+	//TODO implement me
+	panic("implement me")
 }
 
 func NewParseCancellationException() *ParseCancellationException {

--- a/runtime/Go/antlr/v4/parser.go
+++ b/runtime/Go/antlr/v4/parser.go
@@ -152,6 +152,9 @@ func (p *BaseParser) Match(ttype int) Token {
 		p.Consume()
 	} else {
 		t = p.errHandler.RecoverInline(p)
+		if p.HasError() {
+			return nil
+		}
 		if p.BuildParseTrees && t.GetTokenIndex() == -1 {
 
 			// we must have conjured up a new token during single token

--- a/runtime/Go/antlr/v4/parser_atn_simulator.go
+++ b/runtime/Go/antlr/v4/parser_atn_simulator.go
@@ -225,8 +225,9 @@ func (p *ParserATNSimulator) execATN(dfa *DFA, s0 *DFAState, input TokenStream, 
 			if alt != ATNInvalidAltNumber {
 				return alt
 			}
-			
-			panic(e)
+			p.parser.SetError(e)
+			// TODO: JI - was panicing here.. how to drop out now?
+			return ATNInvalidAltNumber
 		}
 		if D.requiresFullContext && p.predictionMode != PredictionModeSLL {
 			// IF PREDS, MIGHT RESOLVE TO SINGLE ALT => SLL (or syntax error)
@@ -1401,7 +1402,7 @@ func (p *ParserATNSimulator) getLookaheadName(input TokenStream) string {
 //	it out for clarity now that alg. works well. We can leave p
 //	"dead" code for a bit.
 func (p *ParserATNSimulator) dumpDeadEndConfigs(_ *NoViableAltException) {
-
+	
 	panic("Not implemented")
 	
 	//    fmt.Println("dead end configs: ")

--- a/runtime/Go/antlr/v4/recognizer.go
+++ b/runtime/Go/antlr/v4/recognizer.go
@@ -7,7 +7,7 @@ package antlr
 import (
 	"fmt"
 	"strings"
-
+	
 	"strconv"
 )
 
@@ -15,10 +15,10 @@ type Recognizer interface {
 	GetLiteralNames() []string
 	GetSymbolicNames() []string
 	GetRuleNames() []string
-
+	
 	Sempred(RuleContext, int, int) bool
 	Precpred(RuleContext, int) bool
-
+	
 	GetState() int
 	SetState(int)
 	Action(RuleContext, int, int)
@@ -26,16 +26,20 @@ type Recognizer interface {
 	RemoveErrorListeners()
 	GetATN() *ATN
 	GetErrorListenerDispatch() ErrorListener
+	HasError() bool
+	GetError() RecognitionException
+	SetError(RecognitionException)
 }
 
 type BaseRecognizer struct {
 	listeners []ErrorListener
 	state     int
-
+	
 	RuleNames       []string
 	LiteralNames    []string
 	SymbolicNames   []string
 	GrammarFileName string
+	SynErr          RecognitionException
 }
 
 func NewBaseRecognizer() *BaseRecognizer {
@@ -56,6 +60,18 @@ func (b *BaseRecognizer) checkVersion(toolVersion string) {
 	if runtimeVersion != toolVersion {
 		fmt.Println("ANTLR runtime and generated code versions disagree: " + runtimeVersion + "!=" + toolVersion)
 	}
+}
+
+func (b *BaseRecognizer) SetError(err RecognitionException) {
+	b.SynErr = err
+}
+
+func (b *BaseRecognizer) HasError() bool {
+	return b.SynErr != nil
+}
+
+func (b *BaseRecognizer) GetError() RecognitionException {
+	return b.SynErr
 }
 
 func (b *BaseRecognizer) Action(_ RuleContext, _, _ int) {
@@ -114,7 +130,7 @@ func (b *BaseRecognizer) SetState(v int) {
 //
 // TODO: JI This is not yet implemented in the Go runtime. Maybe not needed.
 func (b *BaseRecognizer) GetRuleIndexMap() map[string]int {
-
+	
 	panic("Method not defined!")
 	//    var ruleNames = b.GetRuleNames()
 	//    if (ruleNames==nil) {
@@ -204,7 +220,7 @@ func (b *BaseRecognizer) GetTokenErrorDisplay(t Token) string {
 	s = strings.Replace(s, "\t", "\\t", -1)
 	s = strings.Replace(s, "\n", "\\n", -1)
 	s = strings.Replace(s, "\r", "\\r", -1)
-
+	
 	return "'" + s + "'"
 }
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -333,14 +333,10 @@ func (l *<lexer.name>) Sempred(localctx antlr.RuleContext, ruleIndex, predIndex 
  */
 RuleActionFunction(r, actions) ::= <<
 func (l *<lexer.name>) <r.escapedName; format="cap">_Action(localctx <if(r.factory.grammar.lexer)>antlr.RuleContext<else>*<r.ctxType><endif>, actionIndex int) {
-	this := l
-	_ = this
-
 	switch actionIndex {
 	<if(actions)>
 	<actions:{index | case <index>:
 		<actions.(index)>}; separator="\n\n">
-
 
 	<endif>
 	default:
@@ -354,9 +350,6 @@ func (l *<lexer.name>) <r.escapedName; format="cap">_Action(localctx <if(r.facto
  */
 RuleSempredFunction(r, actions) ::= <<
 func (p *<r.factory.grammar.recognizerName>) <r.escapedName; format="cap">_Sempred(localctx antlr.RuleContext, predIndex int) bool {
-	this := p
-	_ = this
-
 	switch predIndex {
 	<if(actions)>
 	<actions:{index | case <index>:
@@ -381,9 +374,6 @@ RuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs, namedAction
 
 <endif>
 func (p *<parser.name>) <currentRule.escapedName; format="cap">(<currentRule.args:{a | <a.escapedName> <a.type>}; separator=", ">) (localctx I<currentRule.ctxType>) {
-	this := p
-	_ = this
-
 	localctx = New<currentRule.ctxType>(p, p.GetParserRuleContext(), p.GetState()<currentRule.args:{a | , <a.escapedName>}>)
 	p.EnterRule(localctx, <currentRule.startState>, <parser.name>RULE_<currentRule.name>)
 	<if(namedActions.init)>
@@ -393,42 +383,39 @@ func (p *<parser.name>) <currentRule.escapedName; format="cap">(<currentRule.arg
 	<locals:{l | var <l>}; separator="\n">
 	<endif>
 
-	defer func() {
-	    if p.HasError() {
-	    	v := p.GetError()
-			localctx.SetException(v)
-			p.GetErrorHandler().ReportError(p, v)
-			p.GetErrorHandler().Recover(p, v)
-			p.SetError(nil)
-		}
-		<if(finallyAction)>
-		<finallyAction>
-		<endif>
-		p.ExitRule()
-	}()
+	<if(currentRule.hasLookaheadBlock)>
+	var _alt int
+	<endif>
 
-	if !p.HassError() {
-		<if(currentRule.hasLookaheadBlock)>
-		var _alt int
-		<endif>
-
-		<if(code)>
-		<code>
+	<if(code)>
+	<code>
 
 
-		<endif>
-		<if(postamble)>
-		<postamble; separator="\n">
+	<endif>
+	<if(postamble)>
+	<postamble; separator="\n">
 
 
-		<endif>
-		<if(namedActions.after)>
-		<namedActions.after>
+	<endif>
+	<if(namedActions.after)>
+	<namedActions.after>
 
 
-		<endif>
+	<endif>
+errorExit:
+	if p.HasError() {
+		v := p.GetError()
+		localctx.SetException(v)
+		p.GetErrorHandler().ReportError(p, v)
+		p.GetErrorHandler().Recover(p, v)
+		p.SetError(nil)
 	}
+	<if(finallyAction)>
+	<finallyAction>
+	<endif>
+	p.ExitRule()
 	return localctx
+	goto errorExit // Trick to prevent compiler error if the label is not used
 }
 >>
 
@@ -449,10 +436,8 @@ func (p *<parser.name>) <currentRule.escapedName; format="cap">(<args:{a | <a.es
 }
 
 func (p *<parser.name>) <currentRule.escapedName>(_p int<args:{a | , <a.escapedName> <a.type>}>) (localctx I<currentRule.ctxType>) {
-	this := p
-	_ = this
-
 	var _parentctx antlr.ParserRuleContext = p.GetParserRuleContext()
+
 	_parentState := p.GetState()
 	localctx = New<currentRule.ctxType>(p, p.GetParserRuleContext(), _parentState<args:{a | , <a.escapedName>}>)
 	var _prevctx I<currentRule.ctxType> = localctx
@@ -466,41 +451,39 @@ func (p *<parser.name>) <currentRule.escapedName>(_p int<args:{a | , <a.escapedN
 	<locals:{l | var <l>}; separator="\n">
 	<endif>
 
-	defer func() {
-	    if p.HasError() {
-	    	v := p.GetError()
-			localctx.SetException(v)
-			p.GetErrorHandler().ReportError(p, v)
-			p.GetErrorHandler().Recover(p, v)
-			p.SetError(nil)
-		}
-		<if(finallyAction)>
-		<finallyAction>
-		<endif>
-		p.UnrollRecursionContexts(_parentctx)
-	}()
-	if !p.HasError() {
-		<if(currentRule.hasLookaheadBlock)>
-		var _alt int
-		<endif>
+	<if(currentRule.hasLookaheadBlock)>
+	var _alt int
+	<endif>
 
-		<if(code)>
-		<code>
+	<if(code)>
+	<code>
 
 
-		<endif>
-		<if(postamble)>
-		<postamble; separator="\n">
+	<endif>
+	<if(postamble)>
+	<postamble; separator="\n">
 
 
-		<endif>
-		<if(namedActions.after)>
-		<namedActions.after>
+	<endif>
+	<if(namedActions.after)>
+	<namedActions.after>
 
 
-		<endif>
+	<endif>
+	errorExit:
+	if p.HasError() {
+		v := p.GetError()
+		localctx.SetException(v)
+		p.GetErrorHandler().ReportError(p, v)
+		p.GetErrorHandler().Recover(p, v)
+		p.SetError(nil)
 	}
+	<if(finallyAction)>
+	<finallyAction>
+	<endif>
+	p.UnrollRecursionContexts(_parentctx)
 	return localctx
+	goto errorExit // Trick to prevent compiler error if the label is not used
 }
 >>
 
@@ -529,6 +512,9 @@ CodeBlockForAlt(currentAltCodeBlock, locals, preamble, ops) ::= <<
 LL1AltBlock(choice, preamble, alts, error) ::= <<
 p.SetState(<choice.stateNumber>)
 p.GetErrorHandler().Sync(p)
+if p.HasError() {
+	goto errorExit
+}
 <if(choice.label)>
 <labelref(choice.label)> = p.GetTokenStream().LT(1)
 <endif>
@@ -555,7 +541,9 @@ default:
 LL1OptionalBlock(choice, alts, error) ::= <<
 p.SetState(<choice.stateNumber>)
 p.GetErrorHandler().Sync(p)
-
+if p.HasError() {
+	goto errorExit
+}
 switch p.GetTokenStream().LA(1) {
 <if(choice.altLook && alts)>
 <choice.altLook, alts:{look, alt | case <look:{l | <parser.name><l.name>}; separator=", ">:
@@ -574,6 +562,9 @@ p.SetState(<choice.stateNumber>)
  But, see TestLeftRecursion.testJavaExpressions_10, 11 which fails with sync()
  !>
 p.GetErrorHandler().Sync(p)
+if p.HasError() {
+	goto errorExit
+}
 <if(preamble)>
 <preamble; separator="\n">
 
@@ -591,6 +582,9 @@ if <expr> {
 LL1StarBlockSingleAlt(choice, loopExpr, alts, preamble, iteration) ::= <<
 p.SetState(<choice.stateNumber>)
 p.GetErrorHandler().Sync(p)
+if p.HasError() {
+	goto errorExit
+}
 <if(preamble)>
 <preamble; separator="\n">
 
@@ -602,6 +596,9 @@ for <loopExpr> {
 	<endif>
 	p.SetState(<choice.loopBackStateNumber>)
 	p.GetErrorHandler().Sync(p)
+	if p.HasError() {
+    	goto errorExit
+    }
 	<if(iteration)>
 	<iteration>
 	<endif>
@@ -611,6 +608,9 @@ for <loopExpr> {
 LL1PlusBlockSingleAlt(choice, loopExpr, alts, preamble, iteration) ::= <<
 p.SetState(<choice.blockStartStateNumber>)<! alt block decision !>
 p.GetErrorHandler().Sync(p)
+if p.HasError() {
+	goto errorExit
+}
 <if(preamble)>
 <preamble; separator="\n">
 
@@ -622,6 +622,9 @@ for ok := true; ok; ok = <loopExpr> {
 	<endif>
 	p.SetState(<choice.stateNumber>)<! loopback/exit decision !>
 	p.GetErrorHandler().Sync(p)
+	if p.HasError() {
+    	goto errorExit
+    }
 	<if(iteration)>
 	<iteration>
 	<endif>
@@ -633,6 +636,10 @@ for ok := true; ok; ok = <loopExpr> {
 AltBlock(choice, preamble, alts, error) ::= <<
 p.SetState(<choice.stateNumber>)
 p.GetErrorHandler().Sync(p)
+if p.HasError() {
+	goto errorExit
+}
+
 <if(choice.label)>
 <labelref(choice.label)> = _input.LT(1)
 
@@ -642,11 +649,13 @@ p.GetErrorHandler().Sync(p)
 
 <endif>
 
-switch p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext()) {
+switch p.GetInterpreter().AdaptivePredict(p.BaseParser, p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext()) {
 <if(alts)>
 <alts:{alt | case <i>:
 	<alt>}; separator="\n\n">
 <endif>
+case antlr.ATNInvalidAltNumber:
+	goto errorExit
 }
 >>
 
@@ -656,9 +665,10 @@ p.GetErrorHandler().Sync(p)
 
 <if(alts)>
 
-<alts:{alt | if p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext()) == <i><if(!choice.ast.greedy)>+1<endif> {
+<alts:{alt | if p.GetInterpreter().AdaptivePredict(p.BaseParser, p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext()) == <i><if(!choice.ast.greedy)>+1<endif> {
 	<alt>
-}; separator="} else ">
+	\} else if p.HasError() { // JIM
+		goto errorExit}; separator="} else ">
 <endif>
 }
 >>
@@ -666,8 +676,13 @@ p.GetErrorHandler().Sync(p)
 StarBlock(choice, alts, Sync, iteration) ::= <<
 p.SetState(<choice.stateNumber>)
 p.GetErrorHandler().Sync(p)
-_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext())
-
+if p.HasError() {
+	goto errorExit
+}
+_alt = p.GetInterpreter().AdaptivePredict(p.BaseParser, p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext())
+if p.HasError() {
+	goto errorExit
+}
 for _alt != <choice.exitAlt> && _alt != antlr.ATNInvalidAltNumber {
 	if _alt == 1<if(!choice.ast.greedy)>+1<endif> {
 		<if(iteration)>
@@ -679,13 +694,22 @@ for _alt != <choice.exitAlt> && _alt != antlr.ATNInvalidAltNumber {
 	}
 	p.SetState(<choice.loopBackStateNumber>)
 	p.GetErrorHandler().Sync(p)
-	_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext())
+	if p.HasError() {
+    	goto errorExit
+    }
+	_alt = p.GetInterpreter().AdaptivePredict(p.BaseParser, p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext())
+	if p.HasError() {
+		goto errorExit
+	}
 }
 >>
 
 PlusBlock(choice, alts, error) ::= <<
 p.SetState(<choice.blockStartStateNumber>)<! alt block decision !>
 p.GetErrorHandler().Sync(p)
+if p.HasError() {
+	goto errorExit
+}
 _alt = 1<if(!choice.ast.greedy)>+1<endif>
 for ok := true; ok; ok = _alt != <choice.exitAlt> && _alt != antlr.ATNInvalidAltNumber {
 	switch _alt {
@@ -703,13 +727,19 @@ for ok := true; ok; ok = _alt != <choice.exitAlt> && _alt != antlr.ATNInvalidAlt
 
 	p.SetState(<choice.loopBackStateNumber>)<! loopback/exit decision !>
 	p.GetErrorHandler().Sync(p)
-	_alt = p.GetInterpreter().AdaptivePredict(p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext())
+	_alt = p.GetInterpreter().AdaptivePredict(p.BaseParser, p.GetTokenStream(), <choice.decision>, p.GetParserRuleContext())
+	if p.HasError() {
+		goto errorExit
+	}
 }
 >>
 
 Sync(s) ::= "Sync(<s.expecting.name>)"
 
-ThrowNoViableAlt(t) ::= "panic(antlr.NewNoViableAltException(p, nil, nil, nil, nil, nil))"
+ThrowNoViableAlt(t) ::= <<
+p.SetError(antlr.NewNoViableAltException(p, nil, nil, nil, nil, nil))
+goto errorExit
+>>
 
 TestSetInline(s) ::= <<
 <s.bitsets:{bits | <if(rest(rest(bits.tokens)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
@@ -775,6 +805,10 @@ MatchToken(m) ::= <<
 	<else>
 	p.Match(<parser.name><m.escapedName>)
 	<endif>
+	if p.HasError() {
+			// Recognition error - abort rule
+			goto errorExit
+	}
 }
 >>
 
@@ -833,7 +867,8 @@ SemPred(p, chunks, failChunks) ::= <<
 p.SetState(<p.stateNumber>)
 
 if !(<chunks>) {
-	panic(antlr.NewFailedPredicateException(p, <p.predicate><if(failChunks)>, <failChunks><elseif(p.msg)>, <p.msg><else>, ""<endif>))
+	p.SetError(antlr.NewFailedPredicateException(p, <p.predicate><if(failChunks)>, <failChunks><elseif(p.msg)>, <p.msg><else>, ""<endif>))
+	goto errorExit
 }
 >>
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -393,49 +393,41 @@ func (p *<parser.name>) <currentRule.escapedName; format="cap">(<currentRule.arg
 	<locals:{l | var <l>}; separator="\n">
 	<endif>
 
-
 	defer func() {
+	    if p.HasError() {
+	    	v := p.GetError()
+			localctx.SetException(v)
+			p.GetErrorHandler().ReportError(p, v)
+			p.GetErrorHandler().Recover(p, v)
+			p.SetError(nil)
+		}
 		<if(finallyAction)>
 		<finallyAction>
 		<endif>
 		p.ExitRule()
 	}()
 
-	defer func() {
-		if err := recover(); err != nil {
-			<if(exceptions)>
-			<exceptions; separator="\n">
-			<else>
-			if v, ok := err.(antlr.RecognitionException); ok {
-				localctx.SetException(v)
-				p.GetErrorHandler().ReportError(p, v)
-				p.GetErrorHandler().Recover(p, v)
-			} else {
-				panic(err)
-			}
-			<endif>
-		}
-	}()
+	if !p.HassError() {
+		<if(currentRule.hasLookaheadBlock)>
+		var _alt int
+		<endif>
 
-	<if(currentRule.hasLookaheadBlock)>
-	var _alt int
-	<endif>
-
-	<if(code)>
-	<code>
+		<if(code)>
+		<code>
 
 
-	<endif>
-	<if(postamble)>
-	<postamble; separator="\n">
+		<endif>
+		<if(postamble)>
+		<postamble; separator="\n">
 
 
-	<endif>
-	<if(namedActions.after)>
-	<namedActions.after>
+		<endif>
+		<if(namedActions.after)>
+		<namedActions.after>
 
 
-	<endif>
+		<endif>
+	}
 	return localctx
 }
 >>
@@ -474,45 +466,40 @@ func (p *<parser.name>) <currentRule.escapedName>(_p int<args:{a | , <a.escapedN
 	<locals:{l | var <l>}; separator="\n">
 	<endif>
 
-
 	defer func() {
+	    if p.HasError() {
+	    	v := p.GetError()
+			localctx.SetException(v)
+			p.GetErrorHandler().ReportError(p, v)
+			p.GetErrorHandler().Recover(p, v)
+			p.SetError(nil)
+		}
 		<if(finallyAction)>
 		<finallyAction>
 		<endif>
 		p.UnrollRecursionContexts(_parentctx)
 	}()
+	if !p.HasError() {
+		<if(currentRule.hasLookaheadBlock)>
+		var _alt int
+		<endif>
 
-	defer func() {
-		if err := recover(); err != nil {
-			if v, ok := err.(antlr.RecognitionException); ok {
-				localctx.SetException(v)
-				p.GetErrorHandler().ReportError(p, v)
-				p.GetErrorHandler().Recover(p, v)
-			} else {
-				panic(err)
-			}
-		}
-	}()
-
-	<if(currentRule.hasLookaheadBlock)>
-	var _alt int
-	<endif>
-
-	<if(code)>
-	<code>
+		<if(code)>
+		<code>
 
 
-	<endif>
-	<if(postamble)>
-	<postamble; separator="\n">
+		<endif>
+		<if(postamble)>
+		<postamble; separator="\n">
 
 
-	<endif>
-	<if(namedActions.after)>
-	<namedActions.after>
+		<endif>
+		<if(namedActions.after)>
+		<namedActions.after>
 
 
-	<endif>
+		<endif>
+	}
 	return localctx
 }
 >>


### PR DESCRIPTION
feat: Another 50%+ performance improvement

Prior to this change, the runtime and generated code was using panic() and recover()
to perform error checking and reporting. This is extremely expensive and just not the
way to do it. 

This change now uses goto, and explicit checking for error state after selected calls
into the runtime. This has greatly improved parser performance. Using the test code
provided by a recent performance issue report, the parse is now twice as fast as the
issue raised was hoping for. 

This change may require code changes by users if they have added Go code in to their
parsers and have declared variables at random points in actions. They merely have to
declare the variables at the start of the rule. This is a minor price to pay for the massive
performance improvement.

@parrt If you can merge this when you see it, I have many more performance improvements
to send your way.

@kaby76 If you have time to run any of your performance tests, I would appreciate your feedback sir.

