### PR TITLE
[Javascript] Added support for commonjs in nodejs package

### DIFF
--- a/runtime/JavaScript/package.json
+++ b/runtime/JavaScript/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "JavaScript runtime for ANTLR4",
   "browser": "dist/antlr4.web.js",
-  "main": "dist/antlr4.node.js",
+  "main": "dist/antlr4.node.mjs",
   "types": "src/antlr4/index.d.ts",
   "repository": "antlr/antlr4.git",
   "keywords": [
@@ -47,5 +47,9 @@
   },
   "engines": {
     "node": ">=16"
+  },
+  "exports": {
+    "import": "./dist/antlr4.node.mjs",
+    "require": "./dist/antlr4.node.cjs"
   }
 }

--- a/runtime/JavaScript/package.json
+++ b/runtime/JavaScript/package.json
@@ -49,7 +49,19 @@
     "node": ">=16"
   },
   "exports": {
-    "import": "./dist/antlr4.node.mjs",
-    "require": "./dist/antlr4.node.cjs"
+    ".": {
+      "node": {
+        "types": "src/index.node.d.ts",
+        "import": "./dist/antlr4.node.mjs",
+        "require": "./dist/antlr4.node.cjs",
+        "default": "./dist/antlr4.node.mjs"
+      },
+      "browser": {
+        "types": "src/index.web.d.ts",
+        "import": "./dist/antlr4.web.mjs",
+        "require": "./dist/antlr4.web.cjs",
+        "default": "./dist/antlr4.web.mjs"
+      }
+    }
   }
 }

--- a/runtime/JavaScript/spec/imports/NodeCommonJSImportSpec.cjs
+++ b/runtime/JavaScript/spec/imports/NodeCommonJSImportSpec.cjs
@@ -1,29 +1,6 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const antlr4 = __importStar(require("antlr4"));
+
+const antlr4 = require("antlr4");
 describe('Antlr4 Node CommonJs', () => {
     it('should use the CommonJS module on Node.js', () => {
         expect(antlr4).toBeDefined();

--- a/runtime/JavaScript/spec/imports/NodeCommonJSImportSpec.cjs
+++ b/runtime/JavaScript/spec/imports/NodeCommonJSImportSpec.cjs
@@ -1,0 +1,31 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const antlr4 = __importStar(require("antlr4"));
+describe('Antlr4 Node CommonJs', () => {
+    it('should use the CommonJS module on Node.js', () => {
+        expect(antlr4).toBeDefined();
+    });
+});

--- a/runtime/JavaScript/spec/imports/NodeEsmImportSpec.mjs
+++ b/runtime/JavaScript/spec/imports/NodeEsmImportSpec.mjs
@@ -1,0 +1,8 @@
+import * as antlr4 from 'antlr4'
+
+describe('Antlr4 Node Esm', () => {
+    it('should use the Esm module on Node.js', () => {
+        expect(antlr4).toBeDefined();
+    });
+});
+export {};

--- a/runtime/JavaScript/spec/support/jasmine.json
+++ b/runtime/JavaScript/spec/support/jasmine.json
@@ -1,6 +1,7 @@
 {
   "spec_dir": "spec",
   "spec_files": [
+    "**/*Spec.[c|m]*js",
     "**/*Spec.js"
   ],
   "helpers": [

--- a/runtime/JavaScript/webpack.config.js
+++ b/runtime/JavaScript/webpack.config.js
@@ -5,97 +5,63 @@ import {fileURLToPath} from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const nodeConfig = {
+
+const buildConfig = ( platform, extentions ) => ({
     mode: "production",
-    entry: './src/antlr4/index.node.js',
+    entry: `./src/antlr4/index.${platform}.js`,
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'antlr4.node.mjs',
-        chunkFormat: "module",
+        filename: `antlr4.${platform}.${extentions}`,
+        chunkFormat: extentions === "mjs" ? "module" : "commonjs",
         library: {
-            type: "module"
+            type: extentions === "mjs" ? "module" : "commonjs"
         }
     },
-    resolve: {
-        extensions: [ '.js']
-    },
-    target: "node",
+
+    ...(platform === 'web' && {
         module: {
-        rules: [{
-            test: /\.js$/,
-            exclude: /node_modules/,
-            use: [ 'babel-loader' ]
-        }]
-    },
-    plugins: [ new ESLintPlugin() ],
-        experiments: {
-            outputModule: true
-    },
-    devtool: "source-map"
-};
+            rules: [{
+                test: /\.js$/,
+                exclude: [ /node_modules/, path.resolve(__dirname, "src/FileStream.js") ],
+                use: [ 'babel-loader' ]
+            }]
+        },
+        performance: {
+            maxAssetSize: 512000,
+            maxEntrypointSize: 512000
+        },
+        resolve: {
+            extensions: [ '.js'],
+            fallback: {
+                fs: false
+            }
+        },
+    }),
 
-const nodeConfigCommonJs = {
-    mode: "production",
-    entry: './src/antlr4/index.node.js',
-    output: {
-        path: path.resolve(__dirname, 'dist'),
-        filename: 'antlr4.node.cjs',
-        chunkFormat: "commonjs",
-        library: {
-            type: "commonjs"
-        }
-    },
-    resolve: {
-        extensions: [ '.js']
-    },
-    target: "node",
-    module: {
-        rules: [{
-            test: /\.js$/,
-            exclude: /node_modules/,
-            use: [ 'babel-loader' ]
-        }]
-    },
+    ...(platform === 'node' && {
+        module: {
+            rules: [{
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: [ 'babel-loader' ]
+            }]
+        },
+        resolve: {
+            extensions: [ '.js'],
+        },
+    }),
+    target: platform,
     plugins: [ new ESLintPlugin() ],
+    devtool: "source-map",
     experiments: {
-        outputModule: false
+        outputModule: extentions === "mjs"
     },
-    devtool: "source-map"
-};
+})
 
-const webConfig = {
-    mode: "production",
-    entry: './src/antlr4/index.web.js',
-    output: {
-        path: path.resolve(__dirname, 'dist'),
-        filename: 'antlr4.web.js',
-        library: {
-            type: "module"
-        }
-    },
-    resolve: {
-        extensions: [ '.js'],
-        fallback: {
-            fs: false
-        }
-    },
-    target: "web",
-    module: {
-        rules: [{
-            test: /\.js$/,
-            exclude: [ /node_modules/, path.resolve(__dirname, "src/FileStream.js") ],
-            use: [ 'babel-loader' ]
-        }]
-    },
-    performance: {
-        maxAssetSize: 512000,
-        maxEntrypointSize: 512000
-    },
-    plugins: [ new ESLintPlugin() ],
-    experiments: {
-        outputModule: true
-    },
-    devtool: "source-map"
-};
 
-export default [ nodeConfig, nodeConfigCommonJs, webConfig ];
+export default [
+    buildConfig("node", "cjs"),
+    buildConfig("node", "mjs"),
+    buildConfig("web", "cjs"),
+    buildConfig("web", "mjs"),
+];

--- a/runtime/JavaScript/webpack.config.js
+++ b/runtime/JavaScript/webpack.config.js
@@ -10,7 +10,7 @@ const nodeConfig = {
     entry: './src/antlr4/index.node.js',
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'antlr4.node.js',
+        filename: 'antlr4.node.mjs',
         chunkFormat: "module",
         library: {
             type: "module"
@@ -30,6 +30,35 @@ const nodeConfig = {
     plugins: [ new ESLintPlugin() ],
         experiments: {
             outputModule: true
+    },
+    devtool: "source-map"
+};
+
+const nodeConfigCommonJs = {
+    mode: "production",
+    entry: './src/antlr4/index.node.js',
+    output: {
+        path: path.resolve(__dirname, 'dist'),
+        filename: 'antlr4.node.cjs',
+        chunkFormat: "commonjs",
+        library: {
+            type: "commonjs"
+        }
+    },
+    resolve: {
+        extensions: [ '.js']
+    },
+    target: "node",
+    module: {
+        rules: [{
+            test: /\.js$/,
+            exclude: /node_modules/,
+            use: [ 'babel-loader' ]
+        }]
+    },
+    plugins: [ new ESLintPlugin() ],
+    experiments: {
+        outputModule: false
     },
     devtool: "source-map"
 };
@@ -69,4 +98,4 @@ const webConfig = {
     devtool: "source-map"
 };
 
-export default [ nodeConfig, webConfig ];
+export default [ nodeConfig, nodeConfigCommonJs, webConfig ];

--- a/runtime/JavaScript/webpack.config.js
+++ b/runtime/JavaScript/webpack.config.js
@@ -6,15 +6,15 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 
-const buildConfig = ( platform, extentions ) => ({
+const buildConfig = ( platform, extensions ) => ({
     mode: "production",
     entry: `./src/antlr4/index.${platform}.js`,
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: `antlr4.${platform}.${extentions}`,
-        chunkFormat: extentions === "mjs" ? "module" : "commonjs",
+        filename: `antlr4.${platform}.${extensions}`,
+        chunkFormat: extensions === "mjs" ? "module" : "commonjs",
         library: {
-            type: extentions === "mjs" ? "module" : "commonjs"
+            type: extensions === "mjs" ? "module" : "commonjs"
         }
     },
 
@@ -54,7 +54,7 @@ const buildConfig = ( platform, extentions ) => ({
     plugins: [ new ESLintPlugin() ],
     devtool: "source-map",
     experiments: {
-        outputModule: extentions === "mjs"
+        outputModule: extensions === "mjs"
     },
 })
 


### PR DESCRIPTION
No package should enforce upon creator a need to migrate to ESM. As per this pull request, I added webpack configuration that produces cjs and mjs files Correspoding to CommonJS and ESM module. After this pull request if will be up to a project which one to use.

Cheers!