### PR TITLE
Remove redundant __name__ check in multiple files

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python3.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Python3.test.stg
@@ -168,7 +168,7 @@ class LeafListener(MockListener):
 >>
 
 WalkListener(s) ::= <<
-if __name__ is not None and "." in __name__:
+if "." in __name__:
     from .TListener import TListener
 else:
     from TListener import TListener

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -65,7 +65,7 @@ else:
 ListenerFile(file, header, namedActions) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 from antlr4 import *
-if __name__ is not None and "." in __name__:
+if "." in __name__:
     from .<file.parserName> import <file.parserName>
 else:
     from <file.parserName> import <file.parserName>
@@ -92,7 +92,7 @@ del <file.parserName>
 VisitorFile(file, header, namedActions) ::= <<
 <fileHeader(file.grammarFileName, file.ANTLRVersion)>
 from antlr4 import *
-if __name__ is not None and "." in __name__:
+if "." in __name__:
     from .<file.parserName> import <file.parserName>
 else:
     from <file.parserName> import <file.parserName>
@@ -123,7 +123,7 @@ Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
 
 Parser_(parser, funcs, atn, sempredFuncs, ctor, superClass) ::= <<
 <if(superClass)>
-if __name__ is not None and "." in __name__:
+if "." in __name__:
     from .<superClass> import <superClass>
 else:
     from <superClass> import <superClass>
@@ -773,7 +773,7 @@ else:
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 <if(superClass)>
-if __name__ is not None and "." in __name__:
+if "." in __name__:
     from .<superClass> import <superClass>
 else:
     from <superClass> import <superClass>


### PR DESCRIPTION
Removed the redundant `__name__` checks in Python 3 files. In Python 3, `__name__` is implicitly set and will never be None, making this condition always true. Did not modify any of Python 2 files since I am not sure about Python 2, but I think the same logic may also apply.
