### PR TITLE
Optimize generated unicode data

### DIFF
--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
 			<artifactId>icu4j</artifactId>
-			<version>71.1</version>
+			<version>72.1</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/tool/resources/org/antlr/v4/tool/templates/unicodedata.st
+++ b/tool/resources/org/antlr/v4/tool/templates/unicodedata.st
@@ -1,4 +1,4 @@
-unicodedata(rawPropertyCodePointRanges, propertyAliases) ::= <<
+unicodedata(rawPropertyCodePointRanges, rawPropertyAliases) ::= <<
 package org.antlr.v4.unicode;
 
 import java.util.Arrays;
@@ -16,7 +16,7 @@ import org.antlr.v4.runtime.misc.Interval;
  */
 public abstract class UnicodeData {
 		private static final Map\<String, IntervalSet\> propertyCodePointRanges = new HashMap\<\>(<length(rawPropertyCodePointRanges)>);
-       private static final Map\<String, String\> propertyAliases = new HashMap\<\>(<length(propertyAliases)>);
+		private static final Map\<String, String\> propertyAliases = new HashMap\<\>(<length(rawPropertyAliases)>);
 
        // Work around Java 64k bytecode method limit by splitting up static
        // initialization into one method per Unicode property
@@ -34,29 +34,17 @@ public abstract class UnicodeData {
 		<rawPropertyCodePointRanges.keys:{ k |
 static private void addProperty<i>() { addProperty("<k>", new int[] { <rawPropertyCodePointRanges.(k):{j | <j>}; separator=",", wrap> \}); \}}; separator="\n">
 
-       static private class PropertyAliasesAdder {
-<propertyAliases.keys:{ k |
-               // Property aliases <i>
-               static private void addPropertyAliases<i>() {
-                      propertyAliases.put("<k>".toLowerCase(Locale.US), "<propertyAliases.(k)>".toLowerCase(Locale.US));
-               \}
-}; separator="\n">
-
-               // Property aliases all
-               static private void addPropertyAliasesAll() {
-<propertyAliases.keys:{ k | PropertyAliasesAdder.addPropertyAliases<i>();}; separator="\n">
-               }
-       }
-
-       // Property aliases
-       static private void addPropertyAliases() {
-              PropertyAliasesAdder.addPropertyAliasesAll();
-       }
+		static private void addPropertyAliases() {
+			String[] rawAliases = new String[] { <rawPropertyAliases:{k | "<k>"}; separator=",", wrap> };
+			for (int i = 0; i \< rawAliases.length; i += 2) {
+				propertyAliases.put(rawAliases[i], rawAliases[i + 1]);
+			}
+		}
 
        // Put it all together
        static {
 			<rawPropertyCodePointRanges.keys:{ k | addProperty<i>();}; separator="\n">
-              addPropertyAliases();
+			addPropertyAliases();
        }
 
        private static String normalize(String propertyCodeOrAlias) {

--- a/tool/resources/org/antlr/v4/tool/templates/unicodedata.st
+++ b/tool/resources/org/antlr/v4/tool/templates/unicodedata.st
@@ -15,54 +15,50 @@ import org.antlr.v4.runtime.misc.Interval;
  * Code-generated utility class mapping Unicode properties to Unicode code point ranges.
  */
 public abstract class UnicodeData {
-		private static final Map\<String, IntervalSet\> propertyCodePointRanges = new HashMap\<\>(<length(rawPropertyCodePointRanges)>);
-		private static final Map\<String, String\> propertyAliases = new HashMap\<\>(<length(rawPropertyAliases)>);
+	private static final Map\<String, IntervalSet\> propertyCodePointRanges = new HashMap\<\>(<length(rawPropertyCodePointRanges)>);
+	private static final Map\<String, String\> propertyAliases = new HashMap\<\>(<length(rawPropertyAliases)> / 2);
 
-       // Work around Java 64k bytecode method limit by splitting up static
-       // initialization into one method per Unicode property
-
-		private static void addProperty(String propertyName, int[] rawIntervals) {
-			List\<Interval> intervals = new ArrayList\<>(rawIntervals.length / 2);
-			for (int i = 0; i \< rawIntervals.length; i += 2) {
-				intervals.add(new Interval(rawIntervals[i], rawIntervals[i + 1]));
-			}
-			IntervalSet result = new IntervalSet(intervals);
-			result.setReadonly(true);
-			propertyCodePointRanges.put(propertyName, result);
+	private static void addProperty(String propertyName, int[] rawIntervals) {
+		List\<Interval> intervals = new ArrayList\<>(rawIntervals.length / 2);
+		for (int i = 0; i \< rawIntervals.length; i += 2) {
+			intervals.add(new Interval(rawIntervals[i], rawIntervals[i + 1]));
 		}
+		IntervalSet result = new IntervalSet(intervals);
+		result.setReadonly(true);
+		propertyCodePointRanges.put(propertyName, result);
+	}
 
-		<rawPropertyCodePointRanges.keys:{ k |
+	<rawPropertyCodePointRanges.keys:{ k |
 static private void addProperty<i>() { addProperty("<k>", new int[] { <rawPropertyCodePointRanges.(k):{j | <j>}; separator=",", wrap> \}); \}}; separator="\n">
 
-		static private void addPropertyAliases() {
-			String[] rawAliases = new String[] { <rawPropertyAliases:{k | "<k>"}; separator=",", wrap> };
-			for (int i = 0; i \< rawAliases.length; i += 2) {
-				propertyAliases.put(rawAliases[i], rawAliases[i + 1]);
-			}
+	static private void addPropertyAliases() {
+		String[] rawAliases = new String[] { <rawPropertyAliases:{k | "<k>"}; separator=",", wrap> };
+		for (int i = 0; i \< rawAliases.length; i += 2) {
+			propertyAliases.put(rawAliases[i], rawAliases[i + 1]);
 		}
+	}
 
-       // Put it all together
-       static {
-			<rawPropertyCodePointRanges.keys:{ k | addProperty<i>();}; separator="\n">
-			addPropertyAliases();
-       }
+	static {
+		<rawPropertyCodePointRanges.keys:{ k | addProperty<i>();}; separator="\n">
+		addPropertyAliases();
+	}
 
-       private static String normalize(String propertyCodeOrAlias) {
-               return propertyCodeOrAlias.toLowerCase(Locale.US).replace('-', '_');
-       }
+	private static String normalize(String propertyCodeOrAlias) {
+		return propertyCodeOrAlias.toLowerCase(Locale.US).replace('-', '_');
+	}
 
-       /**
-        * Given a Unicode property (general category code, binary property name, or script name),
-        * returns the {@link IntervalSet} of Unicode code point ranges which have that property.
-        */
-       public static IntervalSet getPropertyCodePoints(String propertyCodeOrAlias) {
-              String normalizedPropertyCodeOrAlias = normalize(propertyCodeOrAlias);
-              IntervalSet result = propertyCodePointRanges.get(normalizedPropertyCodeOrAlias);
-              if (result == null) {
-                 String propertyCode = propertyAliases.get(normalizedPropertyCodeOrAlias);
-                 result = propertyCodePointRanges.get(propertyCode);
-              }
-              return result;
-       }
+	/**
+	 * Given a Unicode property (general category code, binary property name, or script name),
+	 * returns the {@link IntervalSet} of Unicode code point ranges which have that property.
+	 */
+	public static IntervalSet getPropertyCodePoints(String propertyCodeOrAlias) {
+		String normalizedPropertyCodeOrAlias = normalize(propertyCodeOrAlias);
+		IntervalSet result = propertyCodePointRanges.get(normalizedPropertyCodeOrAlias);
+		if (result == null) {
+			String propertyCode = propertyAliases.get(normalizedPropertyCodeOrAlias);
+			result = propertyCodePointRanges.get(propertyCode);
+		}
+		return result;
+	}
 }
 >>

--- a/tool/resources/org/antlr/v4/tool/templates/unicodedata.st
+++ b/tool/resources/org/antlr/v4/tool/templates/unicodedata.st
@@ -1,4 +1,4 @@
-unicodedata(propertyCodePointRanges, propertyAliases) ::= <<
+unicodedata(rawPropertyCodePointRanges, propertyAliases) ::= <<
 package org.antlr.v4.unicode;
 
 import java.util.Arrays;
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.ArrayList;
 
 import org.antlr.v4.runtime.misc.IntervalSet;
 import org.antlr.v4.runtime.misc.Interval;
@@ -14,29 +15,24 @@ import org.antlr.v4.runtime.misc.Interval;
  * Code-generated utility class mapping Unicode properties to Unicode code point ranges.
  */
 public abstract class UnicodeData {
-       private static final Map\<String, IntervalSet\> propertyCodePointRanges = new HashMap\<\>(<length(propertyCodePointRanges)>);
+		private static final Map\<String, IntervalSet\> propertyCodePointRanges = new HashMap\<\>(<length(rawPropertyCodePointRanges)>);
        private static final Map\<String, String\> propertyAliases = new HashMap\<\>(<length(propertyAliases)>);
 
        // Work around Java 64k bytecode method limit by splitting up static
        // initialization into one method per Unicode property
 
-       <propertyCodePointRanges.keys:{ k | // Unicode code points with property "<k>"
-static private class PropertyAdder<i> {
-        static private void addProperty<i>() {
-               List\<Interval\> intervals = Arrays.asList(
-                       <propertyCodePointRanges.(k).intervals:{ interval | Interval.of(<interval.a>, <interval.b>)}; separator=",\n">
-               );
-               IntervalSet codePointRanges = new IntervalSet(intervals);
-               codePointRanges.setReadonly(true);
-               propertyCodePointRanges.put("<k>".toLowerCase(Locale.US), codePointRanges);
-       \}
-\}
+		private static void addProperty(String propertyName, int[] rawIntervals) {
+			List\<Interval> intervals = new ArrayList\<>(rawIntervals.length / 2);
+			for (int i = 0; i \< rawIntervals.length; i += 2) {
+				intervals.add(new Interval(rawIntervals[i], rawIntervals[i + 1]));
+			}
+			IntervalSet result = new IntervalSet(intervals);
+			result.setReadonly(true);
+			propertyCodePointRanges.put(propertyName, result);
+		}
 
-static private void addProperty<i>() {
-        PropertyAdder<i>.addProperty<i>();
-\}
-
-}; separator="\n\n">
+		<rawPropertyCodePointRanges.keys:{ k |
+static private void addProperty<i>() { addProperty("<k>", new int[] { <rawPropertyCodePointRanges.(k):{j | <j>}; separator=",", wrap> \}); \}}; separator="\n">
 
        static private class PropertyAliasesAdder {
 <propertyAliases.keys:{ k |
@@ -59,7 +55,7 @@ static private void addProperty<i>() {
 
        // Put it all together
        static {
-              <propertyCodePointRanges.keys:{ k | addProperty<i>(); }; separator="\n">
+			<rawPropertyCodePointRanges.keys:{ k | addProperty<i>();}; separator="\n">
               addPropertyAliases();
        }
 

--- a/tool/src/org/antlr/v4/unicode/UnicodeDataTemplateController.java
+++ b/tool/src/org/antlr/v4/unicode/UnicodeDataTemplateController.java
@@ -86,10 +86,15 @@ public abstract class UnicodeDataTemplateController {
 		for (Map.Entry<String, IntervalSet> entry : propertyCodePointRanges.entrySet()) {
 			rawPropertyCodePointRanges.put(entry.getKey().toLowerCase(Locale.US), convertToRawArray(entry.getValue()));
 		}
+		List<String> rawPropertyAliases = new ArrayList<>(propertyAliases.size() * 2);
+		for (Map.Entry<String, String> entry : propertyAliases.entrySet()) {
+			rawPropertyAliases.add(entry.getKey().toLowerCase(Locale.US));
+			rawPropertyAliases.add(entry.getValue().toLowerCase(Locale.US));
+		}
 
 		Map<String, Object> properties = new LinkedHashMap<>();
 		properties.put("rawPropertyCodePointRanges", rawPropertyCodePointRanges);
-		properties.put("propertyAliases", propertyAliases);
+		properties.put("rawPropertyAliases", rawPropertyAliases);
 		return properties;
 	}
 

--- a/tool/src/org/antlr/v4/unicode/UnicodeDataTemplateController.java
+++ b/tool/src/org/antlr/v4/unicode/UnicodeDataTemplateController.java
@@ -7,17 +7,13 @@
 package org.antlr.v4.unicode;
 
 import com.ibm.icu.lang.UCharacter;
-import com.ibm.icu.lang.UCharacterCategory;
 import com.ibm.icu.lang.UProperty;
-import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.RangeValueIterator;
-
+import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.misc.IntervalSet;
 
-import java.util.LinkedHashMap;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 /**
  * StringTemplate controller used to generate parameters to feed
@@ -86,10 +82,26 @@ public abstract class UnicodeDataTemplateController {
 		addUnicodeIntPropertyCodesToNames(propertyAliases);
 		propertyAliases.put("EP", "Extended_Pictographic");
 
+		Map<String, List<Integer>> rawPropertyCodePointRanges = new LinkedHashMap<>();
+		for (Map.Entry<String, IntervalSet> entry : propertyCodePointRanges.entrySet()) {
+			rawPropertyCodePointRanges.put(entry.getKey().toLowerCase(Locale.US), convertToRawArray(entry.getValue()));
+		}
+
 		Map<String, Object> properties = new LinkedHashMap<>();
-		properties.put("propertyCodePointRanges", propertyCodePointRanges);
+		properties.put("rawPropertyCodePointRanges", rawPropertyCodePointRanges);
 		properties.put("propertyAliases", propertyAliases);
 		return properties;
+	}
+
+	private static List<Integer> convertToRawArray(IntervalSet intervalSet) {
+		List<Interval> intervals = intervalSet.getIntervals();
+		int intervalSetSize = intervals.size();
+		List<Integer> rawArray = new ArrayList<>(intervalSetSize * 2);
+		for (Interval interval : intervals) {
+			rawArray.add(interval.a);
+			rawArray.add(interval.b);
+		}
+		return rawArray;
 	}
 
 	private static String getShortPropertyName(int property) {


### PR DESCRIPTION
Generated UnicodeData.java: 4417 KB -> 778 KB
Result antlr.jar artifact: 2566 KB -> 1322 KB

Now UnicodeData.java can be analyzed by IntelliJ, previously it was too big and IntelliJ encountered error when I opened this file.

fix #4226