### PR TITLE
Feat: Clean up go input streams to be a little more efficient

### DIFF
--- a/runtime/Go/antlr/v4/file_stream.go
+++ b/runtime/Go/antlr/v4/file_stream.go
@@ -40,7 +40,6 @@ func NewFileStream(fileName string) (*FileStream, error) {
 	fs := &FileStream{
 		InputStream: InputStream{
 			index: 0,
-			size:  int(fInfo.Size()),
 			name:  fileName,
 		},
 		filename: fileName,
@@ -48,7 +47,7 @@ func NewFileStream(fileName string) (*FileStream, error) {
 
 	// Pre-build the buffer and read runes efficiently
 	//
-	fs.data = make([]rune, 0, fs.size)
+	fs.data = make([]rune, 0, fInfo.Size())
 	for {
 		r, _, err := reader.ReadRune()
 		if err != nil {
@@ -56,6 +55,7 @@ func NewFileStream(fileName string) (*FileStream, error) {
 		}
 		fs.data = append(fs.data, r)
 	}
+	fs.size = len(fs.data) // Size in runes
 
 	// All done.
 	//


### PR DESCRIPTION
feat: Clean up input streams

  - The input streams were inefficient, making more copies of the incoming data than they needed to.
  -  Add new Go idiomatic IO stream,  though this cannot be open-ended such as a socket, it is easier for go programmers
     in certain situations.

