### PR TITLE
Add simplified Docker image

### DIFF
--- a/docker-simplified/Dockerfile
+++ b/docker-simplified/Dockerfile
@@ -1,0 +1,19 @@
+FROM adoptopenjdk/openjdk11:jre
+
+ARG user=appuser
+ARG group=appuser
+ARG uid=1000
+ARG gid=1000
+
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "$(pwd)" \
+    --no-create-home \
+    --uid "${uid}" \
+    "${user}"
+
+RUN curl https://www.antlr.org/download/antlr-4.12.0-complete.jar -o /usr/local/lib/antlr-4.12.0-complete.jar
+
+WORKDIR /work
+ENTRYPOINT ["java", "-Xmx500M", "-cp", "/usr/local/lib/antlr-4.12.0-complete.jar", "org.antlr.v4.Tool"]

--- a/docker-simplified/README.md
+++ b/docker-simplified/README.md
@@ -1,0 +1,27 @@
+# Simplified Docker
+
+Similar to the `docker` directory, but with a simplified and more universally runnable build.
+
+## Why would I want this?
+
+Good question! Docker contains a convenient cross platform way to manage dependencies that, at least for the most part "just works".
+
+You might want to use this if you don't have/don't want Java on your system, or if you're having issues with the Java versions etc...
+
+This was created because the Java installation on my ARM OSx Macbook Air was being a bit painful, and this (at least with  my skills) was easier.
+
+Compared to the full Docker image, the build is drastically faster and the base image was chosen to support more architectures (eg. OSx on ARM as in my case)
+
+## Build
+
+There are no dependencies other than Docker itself
+
+`cd` here: `cd docker-simplified`
+
+Build and tag this image: `docker build --tag antlr/antlr4 .`
+
+## Usage
+
+`./antlr4` is a simple shell script that will pass the arguments to the `antlr4` command in the container, using the CWD as the directory passed to antlr4.
+
+Should be pretty transparent compared to a native `antlr4` install

--- a/docker-simplified/antlr4
+++ b/docker-simplified/antlr4
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) -v "$(pwd):/work" antlr/antlr4 $@


### PR DESCRIPTION
G'day team!

*TLDR*; ANTLR is super easy to use, but matching Java installs and versions across architectures etc... can be painful. This provides a simple cross-platform, cross-architecture way to get started with ANTLR

I am a complete beginner with Java and ANTLR. I have just started working through the docs and with some examples, but found getting off the ground with Java on my ARM Macbook air a little tough - especially since ANTLR itself seems otherwise so sleek and seamless.

I took a look online at dockerhub and found various other users have contributed their pre-built docker images back to the community https://hub.docker.com/search?q=antlr , but all(/all I sifted through) on x86-64, some many years ago and all with unclear backgrounds, builds, versions etc...

I had a squizz at the existing `docker` directory, but ran into an issue where the JRE base image wasn't ARM compatible either and the builds hung (seemingly indefinitely?)

My eventual solution worked without a hitch though; take a slightly larger albeit widely compatible base JRE image and install the prebuilt ANTLR tool in it. It worked so much more easily than various existing methods I tried that I wanted to make sure it was available to others and figured a good start to that was a conversation here about it's potential place in the ANTLR world. 😊

Extended goals:
- [ ] I'd love to/happily help with setting up ANTLR docker CI so we can maintain official Docker images at `antlr/antlr4` without users needing to build locally.
- [ ] Add a Windows startup script too

Thanks for your project! It's awesome.

Matt