### PR TITLE
#4078 [runtime/java] made CommonToken::getText return nonnull

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/CommonToken.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CommonToken.java
@@ -7,6 +7,7 @@ package org.antlr.v4.runtime;
 
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.misc.Pair;
+import org.antlr.v4.runtime.misc.Utils;
 
 import java.io.Serializable;
 
@@ -164,7 +165,7 @@ public class CommonToken implements WritableToken, Serializable {
 		}
 
 		CharStream input = getInputStream();
-		if ( input==null ) return null;
+		if ( input==null ) return "<no text>";
 		int n = input.size();
 		if ( start<n && stop<n) {
 			return input.getText(Interval.of(start,stop));
@@ -266,15 +267,7 @@ public class CommonToken implements WritableToken, Serializable {
 		if ( channel>0 ) {
 			channelStr=",channel="+channel;
 		}
-		String txt = getText();
-		if ( txt!=null ) {
-			txt = txt.replace("\n","\\n");
-			txt = txt.replace("\r","\\r");
-			txt = txt.replace("\t","\\t");
-		}
-		else {
-			txt = "<no text>";
-		}
+		String txt = Utils.escapeWhitespace(getText(), false);
 		String typeString = String.valueOf(type);
 		if ( r!=null ) {
 			typeString = r.getVocabulary().getDisplayName(type);


### PR DESCRIPTION
Solution of Issue https://github.com/antlr/antlr4/issues/4078.
Fix of PR https://github.com/antlr/antlr4/pull/4251.

The problem was that `CommonToken::getText()` returns `null` if and only if it has `InputStream` field is `null`, what happens when we call `CommonToken(int type)` as there source is equal to

```java
protected static final Pair<TokenSource, CharStream> EMPTY_SOURCE =
    new Pair<TokenSource, CharStream>(null, null);
```

```java
// CommonToken.java

@Override
public String getText() {
	if ( text!=null ) {
		return text;
	}
	CharStream input = getInputStream();
	if ( input==null ) return null; // <-- oops
	int n = input.size();
	if ( start<n && stop<n) {
		return input.getText(Interval.of(start,stop));
	}
	else {
		return "<EOF>";
	}
}
// ...
public String toString(Recognizer<?, ?> r) {
	String channelStr = "";
	if ( channel>0 ) {
		channelStr=",channel="+channel;
	}
	String txt = getText();
	if ( txt!=null ) { // <-- this is what saved us in toString
		txt = txt.replace("\n","\\n");
		txt = txt.replace("\r","\\r");
		txt = txt.replace("\t","\\t");
	}
	else {
		txt = "<no text>";
	}
	String typeString = String.valueOf(type);
	if ( r!=null ) {
		typeString = r.getVocabulary().getDisplayName(type);
	}
	return "[@"+getTokenIndex()+","+start+":"+stop+"='"+txt+"'<"+typeString+">"+channelStr+","+line+":"+getCharPositionInLine()+"]";
}
```

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
