### PR TITLE
cpp runtime: Remove pthread dependency.

### DIFF
--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -39,20 +39,6 @@ if (ANTLR_BUILD_STATIC)
   add_library(antlr4_static STATIC ${libantlrcpp_SRC})
 endif()
 
-if (CMAKE_HOST_UNIX)
-  # Make sure to link against threads (pthreads) library in order to be able to
-  # make use of std::call_once in the code without producing runtime errors
-  # (see also https://github.com/antlr/antlr4/issues/3708 and/or https://stackoverflow.com/q/51584960).
-  find_package(Threads REQUIRED)
-
-  if (TARGET antlr4_shared)
-    target_link_libraries(antlr4_shared Threads::Threads)
-  endif()
-  if (TARGET antlr4_static)
-    target_link_libraries(antlr4_static Threads::Threads)
-  endif()
-endif()
-
 IF(TRACE_ATN)
     ADD_DEFINITIONS(-DTRACE_ATN_SIM=1)
 ENDIF(TRACE_ATN)


### PR DESCRIPTION
Hello, this is an old patch merged in February:
https://github.com/antlr/antlr4/pull/4086

But, it got reverted because it merged into `master` instead of `dev`. @parrt asked me to do another PR, but his message get lost.

I coming back today, because I saw two related issues this patch would fix:
- https://github.com/ArthurSonzogni/Diagon/discussions/66
- https://github.com/antlr/antlr4/issues/3418#issuecomment-1451880253