### PR TITLE
Feature/newrepo - Transition Go code to new runtime repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ The default branch for this repo is [`master`](https://github.com/antlr/antlr4/t
 
 <img src="doc/images/new-antlr-branches.png" width="500">
 
-Targets such as Go that pull directly from the repository can use the default `master` branch but can also pull from the active `dev` branch:
+The Go target now has its own dedicated repo:
 
 ```bash
-$ go get github.com/antlr/antlr4/runtime/Go/antlr@dev
+$ go get github.com/antlr4-go/antlr
 ```
+**Note**
+The dedicated Go repo is for `go get` and `import` only. Go runtime development is still performed in the main `antlr/antlr4` repo. 
 
 ## Authors and major contributors
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/Test.go.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/Test.go.stg
@@ -1,7 +1,7 @@
 package main
 import (
 	"fmt"
-    "github.com/antlr/antlr4/runtime/Go/antlr/v4"
+    "github.com/antlr4-go/antlr/v4"
     "os"
     "test/parser"
 )

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/GoRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/GoRunner.java
@@ -64,7 +64,7 @@ public class GoRunner extends RuntimeRunner {
 		return new String[]{"run"};
 	}
 
-	private static final String GoRuntimeImportPath = "github.com/antlr/antlr4/runtime/Go/antlr/v4";
+	private static final String GoRuntimeImportPath = "github.com/antlr4-go/antlr/v4";
 
 	private final static Map<String, String> environment;
 

--- a/runtime/Go/antlr/go.mod
+++ b/runtime/Go/antlr/go.mod
@@ -1,4 +1,0 @@
-// Deprecated: Please switch to the new v4 module path: github.com/antlr/antlr4/runtime/Go/antlr/v4 - see https://github.com/antlr/antlr4/blob/master/doc/go-target.md
-module github.com/antlr/antlr4/runtime/Go/antlr
-
-go 1.18

--- a/runtime/Go/antlr/v4/LICENSE
+++ b/runtime/Go/antlr/v4/LICENSE
@@ -1,26 +1,28 @@
-Copyright 2021 The ANTLR Project
+Copyright (c) 2012-2023 The ANTLR Project. All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-    this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright notice,
-    this list of conditions and the following disclaimer in the documentation
-    and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
 
-    3. Neither the name of the copyright holder nor the names of its
-    contributors may be used to endorse or promote products derived from this
-    software without specific prior written permission.
+3. Neither name of copyright holders nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/runtime/Go/antlr/v4/go.mod
+++ b/runtime/Go/antlr/v4/go.mod
@@ -1,4 +1,4 @@
-module github.com/antlr/antlr4/runtime/Go/antlr/v4
+module github.com/antlr4-go/antlr/v4
 
 go 1.20
 

--- a/runtime/Go/antlr/v4/go.mod
+++ b/runtime/Go/antlr/v4/go.mod
@@ -2,4 +2,4 @@ module github.com/antlr4-go/antlr/v4
 
 go 1.20
 
-require golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
+require golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc

--- a/runtime/Go/antlr/v4/go.sum
+++ b/runtime/Go/antlr/v4/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
+golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
+golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -25,7 +25,7 @@ import (
 	// Grammar author supplied additional includes
 	<namedActions.includes>
 	<endif>
-	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
+	"github.com/antlr4-go/antlr/v4"
 )
 
 <if(namedActions.header)>
@@ -54,7 +54,8 @@ package <file.genPackage> // <file.grammarName>
 package parser // <file.grammarName>
 <endif>
 
-import "github.com/antlr/antlr4/runtime/Go/antlr/v4"
+import "github.com/antlr4-go/antlr/v4"
+
 
 // <file.grammarName>Listener is a complete listener for a parse tree produced by <file.parserName>.
 type <file.grammarName>Listener interface {
@@ -78,7 +79,7 @@ package <file.genPackage> // <file.grammarName>
 package parser // <file.grammarName>
 <endif>
 
-import "github.com/antlr/antlr4/runtime/Go/antlr/v4"
+import "github.com/antlr4-go/antlr/v4"
 
 // Base<file.grammarName>Listener is a complete listener for a parse tree produced by <file.parserName>.
 type Base<file.grammarName>Listener struct{}
@@ -114,7 +115,9 @@ package <file.genPackage> // <file.grammarName>
 package parser // <file.grammarName>
 <endif>
 
-import "github.com/antlr/antlr4/runtime/Go/antlr/v4"
+import "github.com/antlr4-go/antlr/v4"
+
+
 <if(header)>
 
 <header>
@@ -140,7 +143,8 @@ package <file.genPackage> // <file.grammarName>
 package parser // <file.grammarName>
 <endif>
 
-import "github.com/antlr/antlr4/runtime/Go/antlr/v4"
+import "github.com/antlr4-go/antlr/v4"
+
 
 type Base<file.grammarName>Visitor struct {
 	*antlr.BaseParseTreeVisitor
@@ -1460,7 +1464,7 @@ import (
 	// Grammar author supplied additional includes
 	<namedActions.includes>
 	<endif>
-	"github.com/antlr/antlr4/runtime/Go/antlr/v4"
+	"github.com/antlr4-go/antlr/v4"
 )
 <if(namedActions.header)>
 <namedActions.header>


### PR DESCRIPTION
The go code for the Go runtime is now located at: antlr4-go/antlr

This PR:
 - Updates the main README file to point this out
 - Changes the test .stg file to use the new repo name
 - Changes the codegen to generate imports from the new repo

The new repo has been initialized with the code tagged as the v4.12.0 release and is tagged there. The README.md for that repo also includes the standard badges for Go modules to indicate code quality, release status and license type. It has been tested and found to be good. 

We should have no more problems with go module imports so long as everyone uses the new repo.

@parrt This is the last PR needed for Go to be released. Tests pass and run.