### PR TITLE
upgrade maven-bundle-plugin: fixes last Reproducible Builds issue

### DIFF
--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -76,7 +76,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>5.1.7</version>
+				<version>5.1.9</version>
 				<executions>
 					<execution>
 						<id>bundle-manifest</id>


### PR DESCRIPTION
see last release check: https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/antlr/antlr4/README.md
it was hit by https://issues.apache.org/jira/browse/FELIX-6602 that is fixed in this 5.1.9 release of maven-bundle-plugin