### PR TITLE
Export DefaultErrorStrategy

### DIFF
--- a/runtime/JavaScript/src/antlr4/error/DefaultErrorStrategy.d.ts
+++ b/runtime/JavaScript/src/antlr4/error/DefaultErrorStrategy.d.ts
@@ -16,7 +16,7 @@ export declare class DefaultErrorStrategy implements ErrorStrategy {
 
     sync(recognizer: Parser): void;
 
-    inErrorRecoveryMode(recognizer: Parser): void;
+    inErrorRecoveryMode(recognizer: Parser): boolean;
 
     beginErrorCondition(recognizer: Parser): void;
 

--- a/runtime/JavaScript/src/antlr4/index.node.js
+++ b/runtime/JavaScript/src/antlr4/index.node.js
@@ -34,6 +34,7 @@ import RecognitionException from "./error/RecognitionException.js";
 import FailedPredicateException from "./error/FailedPredicateException.js";
 import NoViableAltException from "./error/NoViableAltException.js";
 import BailErrorStrategy from "./error/BailErrorStrategy.js";
+import DefaultErrorStrategy from "./error/DefaultErrorStrategy.js";
 import Interval from './misc/Interval.js';
 import IntervalSet from './misc/IntervalSet.js';
 import ParseTreeListener from "./tree/ParseTreeListener.js";
@@ -55,6 +56,6 @@ export {
     Token, CommonToken, CharStreams, CharStream, InputStream, FileStream, CommonTokenStream, Lexer, Parser,
     RuleNode, TerminalNode, ParseTreeWalker, RuleContext, ParserRuleContext, Interval, IntervalSet,
     PredictionMode, LL1Analyzer, ParseTreeListener, ParseTreeVisitor, ATN, ATNDeserializer, PredictionContextCache, LexerATNSimulator, ParserATNSimulator, DFA,
-    RecognitionException, NoViableAltException, FailedPredicateException, ErrorListener, DiagnosticErrorListener, BailErrorStrategy,
+    RecognitionException, NoViableAltException, FailedPredicateException, ErrorListener, DiagnosticErrorListener, BailErrorStrategy, DefaultErrorStrategy,
     arrayToString
 }

--- a/runtime/JavaScript/src/antlr4/index.web.js
+++ b/runtime/JavaScript/src/antlr4/index.web.js
@@ -33,6 +33,7 @@ import RecognitionException from "./error/RecognitionException.js";
 import FailedPredicateException from "./error/FailedPredicateException.js";
 import NoViableAltException from "./error/NoViableAltException.js";
 import BailErrorStrategy from "./error/BailErrorStrategy.js";
+import DefaultErrorStrategy from "./error/DefaultErrorStrategy.js";
 import Interval from './misc/Interval.js';
 import IntervalSet from './misc/IntervalSet.js';
 import ParseTreeListener from "./tree/ParseTreeListener.js";
@@ -54,6 +55,6 @@ export {
     Token, CommonToken, CharStreams, CharStream, InputStream, CommonTokenStream, Lexer, Parser,
     RuleNode, TerminalNode, ParseTreeWalker, RuleContext, ParserRuleContext, Interval, IntervalSet,
     PredictionMode, LL1Analyzer, ParseTreeListener, ParseTreeVisitor, ATN, ATNDeserializer, PredictionContextCache, LexerATNSimulator, ParserATNSimulator, DFA,
-    RecognitionException, NoViableAltException, FailedPredicateException, ErrorListener, DiagnosticErrorListener, BailErrorStrategy,
+    RecognitionException, NoViableAltException, FailedPredicateException, ErrorListener, DiagnosticErrorListener, BailErrorStrategy, DefaultErrorStrategy,
     arrayToString
 }


### PR DESCRIPTION
This PR is used to export DefaultErrorStrategy class. In #4145, DefaultErrorStrategy is exported only in typing files, not JS files.