### PR TITLE
fix: #4128 - Prevent generating escape sequences when Windows directories start with  a 

### DIFF
--- a/tool/src/org/antlr/v4/codegen/model/OutputFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/OutputFile.java
@@ -26,7 +26,7 @@ public abstract class OutputFile extends OutputModelObject {
         super(factory);
         this.fileName = fileName;
         Grammar g = factory.getGrammar();
-		grammarFileName = g.fileName;
+		grammarFileName = g.fileName.replace("\\", "/"); // Prevent a path with windows delim and u breaking Java pre-parser on comments
 		ANTLRVersion = Tool.VERSION;
         TokenLabelType = g.getOptionString("TokenLabelType");
         InputSymbolType = TokenLabelType;


### PR DESCRIPTION
When code generating for Java on Windows, a grammar file may be contained in a subdirectory that starts with a 'u'. Because the generated file is comment with the source file that generated it, and windows path escaping is not used,
then the comment  looks like this in Java:

```java
// Generated from .\users\jim.g by ANTLR 4.13.0
```
 The \u is seen by the Java lexer as an invalid escape sequence because Java processes the whole translation unit through pre-processing and lexing.
 
So, here, just for the template generating the comment, we use Unix style delimiters instead of the backslashes.

NB: I have no Windows box, so I will have to let the GitHub triggers ensure that Windows builds.

Fixes #4128 
Closes #4128 