### PR TITLE
fix: Speed up  test suites

### DIFF
--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -4,114 +4,124 @@
   ~ can be found in the LICENSE.txt file in the project root.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.antlr</groupId>
-		<artifactId>antlr4-master</artifactId>
-		<version>4.13.1-SNAPSHOT</version>
-	</parent>
-	<artifactId>antlr4-runtime-testsuite</artifactId>
-	<name>ANTLR 4 Runtime Tests (4th generation)</name>
-	<description>A collection of tests for ANTLR 4 Runtime libraries.</description>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr4-master</artifactId>
+        <version>4.13.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>antlr4-runtime-testsuite</artifactId>
+    <name>ANTLR 4 Runtime Tests (4th generation)</name>
+    <description>A collection of tests for ANTLR 4 Runtime libraries.</description>
 
-	<prerequisites>
-		<maven>3.8</maven>
-	</prerequisites>
+    <prerequisites>
+        <maven>3.8</maven>
+    </prerequisites>
 
-	<inceptionYear>2009</inceptionYear>
+    <inceptionYear>2009</inceptionYear>
 
-	<properties>
-		<jUnitVersion>5.9.0</jUnitVersion>
-	</properties>
+    <properties>
+        <jUnitVersion>5.9.0</jUnitVersion>
+    </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>ST4</artifactId>
-			<version>4.3.4</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr4</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr4-runtime</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>${jUnitVersion}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>${jUnitVersion}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.json</artifactId>
-			<version>1.1.4</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-		    <groupId>org.openjdk.jol</groupId>
-		    <artifactId>jol-core</artifactId>
-		    <version>0.16</version>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+            <version>4.3.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${jUnitVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${jUnitVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <version>0.16</version>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<testSourceDirectory>test</testSourceDirectory>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.0</version>
-				<configuration>
-					<!-- SUREFIRE-951: file.encoding cannot be set via systemPropertyVariables -->
-					<argLine>-Dfile.encoding=UTF-8</argLine>
+    <build>
+        <testSourceDirectory>test</testSourceDirectory>
+        <resources>
+            <resource>
+                <!-- need to tell surefire where to get the jupiter config from. It isn't in the default dir for some reason -->
+                <directory>${project.basedir}/resources</directory>
+                <includes>
+                    <include>junit-platform.properties</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <!-- SUREFIRE-951: file.encoding cannot be set via systemPropertyVariables -->
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
                 </configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.2.0</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>test-jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.antlr</groupId>
-				<artifactId>antlr4-maven-plugin</artifactId>
-				<version>${project.version}</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>antlr4</goal>
-						</goals>
-						<configuration>
-							<sourceDirectory>${basedir}/test</sourceDirectory>
-							<outputDirectory>${project.build.directory}/generated-test-sources/antlr4</outputDirectory>
-							<visitor>true</visitor>
-							<generateTestSources>true</generateTestSources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>antlr4</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>${basedir}/test</sourceDirectory>
+                            <outputDirectory>${project.build.directory}/generated-test-sources/antlr4</outputDirectory>
+                            <visitor>true</visitor>
+                            <generateTestSources>true</generateTestSources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -122,5 +132,5 @@
                 </configuration>
             </plugin>
         </plugins>
-	</build>
+    </build>
 </project>

--- a/runtime-testsuite/resources/junit-platform.properties
+++ b/runtime-testsuite/resources/junit-platform.properties
@@ -1,3 +1,17 @@
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = concurrent
 junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+
+# Don't be fooled by the number here.
+# It is not a strict number of threads because  of the way our testsuite works.
+#
+# At 3, the go tests are slightly slower than at 2, but  after 3, any tests that require fork/exec,
+# such as go, C++ etc. will swamp any machine and  take forever. I did lots of testing on this.
+#
+# 3 is a good compromise on my 12 core system. Most people will not have 12 cores
+# and our github machines don't either. This setting (3) makes everything faster including
+# the Java testing which goes from 23 seconds to 16 on my system. Any more than this and
+# the systems are just waitio or defeating the memory cache. Don't change this.
+#
+junit.jupiter.execution.parallel.config.fixed.parallelism=3


### PR DESCRIPTION
  - Upgrades surefire
  - Limits amount of parallelism to stop swamping the test machines.

Because the test suite does not strictly follow the jupiter config, which was configured to use as many cores as possible, the machine would end up swamped and either IO bound, or just defeating any CPU cache advantages.

The change to limit parallelism to 3 means that everything goes faster, including the Java tests, which do not need to create external processes.

This took some working out.

Please note that the formatting in the pom was out of whack, hence there looks to be more changes to the pom than there are. Compare with whitespace ignored because the formatting needs to be done. 

I will go through the maven stuff next and see if we can't improve it. I don't think anyone has looked at the poms in quite some time.
