### PR TITLE
Update dotnet to the latest version in runtime tests (6 -> 7)

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -257,7 +257,7 @@ jobs:
       if: matrix.target == 'csharp'
       uses: actions/setup-dotnet@v3.0.3
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '7.0.x'
 
     - name: Setup Dart 2.12.1
       if: matrix.target == 'dart'

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/Antlr4.Test.csproj.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/Antlr4.Test.csproj.stg
@@ -1,7 +1,7 @@
 ﻿\<Project Sdk="Microsoft.NET.Sdk">
 
   \<PropertyGroup>
-    \<TargetFramework>net6.0\</TargetFramework>
+    \<TargetFramework>net7.0\</TargetFramework>
     \<NoWarn>$(NoWarn);CS3021\</NoWarn>
     \<AssemblyName>Test\</AssemblyName>
     \<OutputType>Exe\</OutputType>


### PR DESCRIPTION
Surprisingly, the test `LargeLexer` is freezing on dotnet 7 (local machine). But it works fine if I change version of `.csproj` to 7. It looks like a bug in dotnet (there is something wrong with back compatibility) but it can be fixed by version upgrading.