### PR TITLE
Removed non existing type declaration file references fixes #4285

### DIFF
--- a/runtime/JavaScript/package.json
+++ b/runtime/JavaScript/package.json
@@ -51,13 +51,11 @@
   "exports": {
     ".": {
       "node": {
-        "types": "src/index.node.d.ts",
         "import": "./dist/antlr4.node.mjs",
         "require": "./dist/antlr4.node.cjs",
         "default": "./dist/antlr4.node.mjs"
       },
       "browser": {
-        "types": "src/index.web.d.ts",
         "import": "./dist/antlr4.web.mjs",
         "require": "./dist/antlr4.web.cjs",
         "default": "./dist/antlr4.web.mjs"


### PR DESCRIPTION
As stated in mentioned ticket #4285 type declaration files don't exist. As there only exists index.d.ts, and src folder is shipped in then bundle it seems we can reference this file as root file
