### PR TITLE
Replace experimental dependency on golang.org/x/exp

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -257,7 +257,7 @@ jobs:
       if: matrix.target == 'csharp'
       uses: actions/setup-dotnet@v3.0.3
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '7.0.x'
 
     - name: Setup Dart 2.12.1
       if: matrix.target == 'dart'

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/Antlr4.Test.csproj.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/Antlr4.Test.csproj.stg
@@ -1,7 +1,7 @@
 ﻿\<Project Sdk="Microsoft.NET.Sdk">
 
   \<PropertyGroup>
-    \<TargetFramework>net6.0\</TargetFramework>
+    \<TargetFramework>net7.0\</TargetFramework>
     \<NoWarn>$(NoWarn);CS3021\</NoWarn>
     \<AssemblyName>Test\</AssemblyName>
     \<OutputType>Exe\</OutputType>

--- a/runtime/Go/antlr/v4/go.mod
+++ b/runtime/Go/antlr/v4/go.mod
@@ -1,5 +1,3 @@
 module github.com/antlr4-go/antlr/v4
 
 go 1.20
-
-require golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc

--- a/runtime/Go/antlr/v4/go.sum
+++ b/runtime/Go/antlr/v4/go.sum
@@ -1,4 +1,0 @@
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
-golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
-golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/runtime/Go/antlr/v4/lexer_action_executor.go
+++ b/runtime/Go/antlr/v4/lexer_action_executor.go
@@ -4,8 +4,6 @@
 
 package antlr
 
-import "golang.org/x/exp/slices"
-
 // Represents an executor for a sequence of lexer actions which traversed during
 // the Matching operation of a lexer rule (token).
 //
@@ -167,7 +165,11 @@ func (l *LexerActionExecutor) Equals(other interface{}) bool {
 	if len(l.lexerActions) != len(othert.lexerActions) {
 		return false
 	}
-	return slices.EqualFunc(l.lexerActions, othert.lexerActions, func(i, j LexerAction) bool {
-		return i.Equals(j)
-	})
+	for idx, lexerAction := range l.lexerActions {
+		otherAction := othert.lexerActions[idx]
+		if !lexerAction.Equals(otherAction) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
The `golang.org/x/exp` module does not make any guarantees about API or functionality stability; however, the functions being used [`slices.Equal`](https://pkg.go.dev/golang.org/x/exp/slices#Equal) and [`slices.EqualFunc`](https://pkg.go.dev/golang.org/x/exp/slices#EqualFunc) are relatively straight-forward. Equivalent functionality has been reproduced in the contexts where these functions were used.

This change means that ANTLR will no longer have any go.mod dependencies which might otherwise affect minimum version selection (MVS) on an unstable API surface.