### PR TITLE
Add test with grammar name that starts with u

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.txt
@@ -1,0 +1,20 @@
+[notes]
+Test for https://github.com/antlr/antlr4/issues/4128
+
+[type]
+Parser
+
+[grammar]
+grammar u;
+u : 'u' {<writeln("$text")>};
+
+[start]
+u
+
+[input]
+u
+
+[output]
+"""u
+"""
+


### PR DESCRIPTION
Fix producing of source with "illegal unicode escape"