### PR TITLE
Fix incorrect TypeScript typings for CommonTokenStream.tokens

### DIFF
--- a/runtime/JavaScript/src/antlr4/CommonTokenStream.d.ts
+++ b/runtime/JavaScript/src/antlr4/CommonTokenStream.d.ts
@@ -1,9 +1,10 @@
-import {Lexer} from "./Lexer";
-import {BufferedTokenStream} from "./BufferedTokenStream";
+import { Lexer } from "./Lexer";
+import { BufferedTokenStream } from "./BufferedTokenStream";
+import { CommonToken } from "./CommonToken";
 
 export declare class CommonTokenStream extends BufferedTokenStream {
     // properties
-    tokens: string[];
+    tokens: CommonToken[];
     // methods
     constructor(lexer: Lexer);
     constructor(lexer: Lexer, channel: number);


### PR DESCRIPTION
In the TypeScript typings, the `CommonTokenStream.tokens` array was incorrectly declared as an array of `string`. It is an array of `CommonToken`.