### PR TITLE
Remove stray type annotations from Python2 runtime

### DIFF
--- a/runtime/Python2/src/antlr4/xpath/XPath.py
+++ b/runtime/Python2/src/antlr4/xpath/XPath.py
@@ -66,12 +66,12 @@ class XPath(object):
     WILDCARD = "*" # word not operator/separator
     NOT = "!" # word for invert operator
 
-    def __init__(self, parser:Parser, path:str):
+    def __init__(self, parser, path):
         self.parser = parser
         self.path = path
         self.elements = self.split(path)
 
-    def split(self, path:str):
+    def split(self, path):
         input = InputStream(path)
         lexer = XPathLexer(input)
         def recover(self, e):
@@ -124,7 +124,7 @@ class XPath(object):
     # element. {@code anywhere} is {@code true} if {@code //} precedes the
     # word.
     #
-    def getXPathElement(self, wordToken:Token, anywhere:bool):
+    def getXPathElement(self, wordToken, anywhere):
         if wordToken.type==Token.EOF:
             raise Exception("Missing path element at end of path")
 
@@ -156,7 +156,7 @@ class XPath(object):
 
 
     @staticmethod
-    def findAll(tree:ParseTree, xpath:str, parser:Parser):
+    def findAll(tree, xpath, parser):
         p = XPath(parser, xpath)
         return p.evaluate(tree)
 
@@ -165,7 +165,7 @@ class XPath(object):
     # path. The root {@code /} is relative to the node passed to
     # {@link #evaluate}.
     #
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         dummyRoot = ParserRuleContext()
         dummyRoot.children = [t] # don't set t's parent.
 
@@ -191,7 +191,7 @@ class XPath(object):
 
 class XPathElement(object):
 
-    def __init__(self, nodeName:str):
+    def __init__(self, nodeName):
         self.nodeName = nodeName
         self.invert = False
 
@@ -205,41 +205,41 @@ class XPathElement(object):
 #
 class XPathRuleAnywhereElement(XPathElement):
 
-    def __init__(self, ruleName:str, ruleIndex:int):
+    def __init__(self, ruleName, ruleIndexint):
         super().__init__(ruleName)
         self.ruleIndex = ruleIndex
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         # return all ParserRuleContext descendants of t that match ruleIndex (or do not match if inverted)
         return filter(lambda c: isinstance(c, ParserRuleContext) and (self.invert ^ (c.getRuleIndex() == self.ruleIndex)), Trees.descendants(t))
 
 class XPathRuleElement(XPathElement):
 
-    def __init__(self, ruleName:str, ruleIndex:int):
+    def __init__(self, ruleName, ruleIndex):
         super().__init__(ruleName)
         self.ruleIndex = ruleIndex
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         # return all ParserRuleContext children of t that match ruleIndex (or do not match if inverted)
         return filter(lambda c: isinstance(c, ParserRuleContext) and (self.invert ^ (c.getRuleIndex() == self.ruleIndex)), Trees.getChildren(t))
 
 class XPathTokenAnywhereElement(XPathElement):
 
-    def __init__(self, ruleName:str, tokenType:int):
+    def __init__(self, ruleName, tokenType):
         super().__init__(ruleName)
         self.tokenType = tokenType
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         # return all TerminalNode descendants of t that match tokenType (or do not match if inverted)
         return filter(lambda c: isinstance(c, TerminalNode) and (self.invert ^ (c.symbol.type == self.tokenType)), Trees.descendants(t))
 
 class XPathTokenElement(XPathElement):
 
-    def __init__(self, ruleName:str, tokenType:int):
+    def __init__(self, ruleName, tokenType):
         super().__init__(ruleName)
         self.tokenType = tokenType
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         # return all TerminalNode children of t that match tokenType (or do not match if inverted)
         return filter(lambda c: isinstance(c, TerminalNode) and (self.invert ^ (c.symbol.type == self.tokenType)), Trees.getChildren(t))
 
@@ -249,7 +249,7 @@ class XPathWildcardAnywhereElement(XPathElement):
     def __init__(self):
         super().__init__(XPath.WILDCARD)
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         if self.invert:
             return list() # !* is weird but valid (empty)
         else:
@@ -262,7 +262,7 @@ class XPathWildcardElement(XPathElement):
         super().__init__(XPath.WILDCARD)
 
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         if self.invert:
             return list() # !* is weird but valid (empty)
         else:


### PR DESCRIPTION
XPath support still retained Python3 type annotations. This yields a partial installation when using setuptools on both plain Python2

```
byte-compiling build/bdist.linux-x86_64/egg/antlr4/xpath/XPath.py to XPath.pyc
  File "build/bdist.linux-x86_64/egg/antlr4/xpath/XPath.py", line 69
    def __init__(self, parser:Parser, path:str):
                             ^
SyntaxError: invalid syntax
```

or Jython

```
Extracting antlr4_python2_runtime-4.13.0-py2.7.egg to build/jython/Lib/site-packages
SyntaxError: ("mismatched input ':' expecting RPAREN", ('build/jython/Lib/site-packages/antlr4_python2_runtime-4.13.0-py2.7.egg/antlr4/xpath/XPath.py', 69, 29, '    def __init__(self, parser:Parser, path:str):\n'))
```