### PR TITLE
Fix for #4342--EmitToken(token) must be exported and virtualized

### DIFF
--- a/runtime/Go/antlr/v4/lexer.go
+++ b/runtime/Go/antlr/v4/lexer.go
@@ -20,6 +20,7 @@ type Lexer interface {
 	Recognizer
 
 	Emit() Token
+	EmitToken(Token)
 
 	SetChannel(int)
 	PushMode(int)
@@ -311,7 +312,7 @@ func (b *BaseLexer) EmitToken(token Token) {
 // /
 func (b *BaseLexer) Emit() Token {
 	t := b.factory.Create(b.tokenFactorySourcePair, b.thetype, b.text, b.channel, b.TokenStartCharIndex, b.GetCharIndex()-1, b.TokenStartLine, b.TokenStartColumn)
-	b.EmitToken(t)
+	b.Virt.EmitToken(t)
 	return t
 }
 


### PR DESCRIPTION
 Required for porting https://github.com/antlr/grammars-v4/tree/master/python/python3 to the Go target. This change just mirrors the APIs for the other targets, like Java, CSharp, and JavaScript/TypeScript.
