### PR TITLE
Proposal: Add action templates functionality

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/RunOptions.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/RunOptions.java
@@ -24,6 +24,7 @@ public class RunOptions {
 	public final boolean showDFA;
 	public final Stage endStage;
 	public final String superClass;
+	public final String actionTemplates;
 	public final PredictionMode predictionMode;
 	public final boolean buildParseTree;
 
@@ -31,7 +32,7 @@ public class RunOptions {
 					  boolean useListener, boolean useVisitor, String startRuleName,
 					  String input, boolean profile, boolean showDiagnosticErrors,
 					  boolean traceATN, boolean showDFA, Stage endStage,
-					  String language, String superClass, PredictionMode predictionMode, boolean buildParseTree) {
+					  String language, String superClass, String actionTemplates, PredictionMode predictionMode, boolean buildParseTree) {
 		this.grammarFileName = grammarFileName;
 		this.grammarStr = grammarStr;
 		this.parserName = parserName;
@@ -69,6 +70,7 @@ public class RunOptions {
 		this.showDFA = showDFA;
 		this.endStage = endStage;
 		this.superClass = superClass;
+		this.actionTemplates = actionTemplates;
 		this.predictionMode = predictionMode;
 		this.buildParseTree = buildParseTree;
 	}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeRunner.java
@@ -172,6 +172,10 @@ public abstract class RuntimeRunner implements AutoCloseable {
 			options.add("-DsuperClass=" + runOptions.superClass);
 		}
 
+		if (runOptions.actionTemplates != null && runOptions.actionTemplates.length() > 0) {
+			options.add("-DactionTemplates=" + runOptions.actionTemplates);
+		}
+
 		// See if the target wants to add tool options.
 		//
 		List<String> targetOpts = getTargetToolOptions(runOptions);

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeTests.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/RuntimeTests.java
@@ -167,6 +167,7 @@ public abstract class RuntimeTests {
 				Stage.Execute,
 				targetName,
 				superClass,
+				null,
 				descriptor.predictionMode,
 				descriptor.buildParseTree
 		);

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/TraceATN.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/TraceATN.java
@@ -158,6 +158,7 @@ public class TraceATN {
 				Stage.Execute,
 				targetName,
 				superClass,
+				null,
 				PredictionMode.LL,
 				true
 		);

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestActionTemplates.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestActionTemplates.java
@@ -1,0 +1,131 @@
+package org.antlr.v4.test.tool;
+
+import org.antlr.v4.test.runtime.RunOptions;
+import org.antlr.v4.test.runtime.Stage;
+import org.antlr.v4.test.runtime.java.JavaRunner;
+import org.antlr.v4.test.runtime.states.ExecutedState;
+import org.antlr.v4.test.runtime.states.GeneratedState;
+import org.antlr.v4.test.runtime.states.State;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.antlr.v4.test.runtime.FileUtils.writeFile;
+import static org.antlr.v4.test.runtime.RuntimeTestUtils.FileSeparator;
+import static org.antlr.v4.test.tool.ToolTestUtils.createOptionsForJavaToolTests;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestActionTemplates {
+	@Test() void testIncorrectActionTemplateGroupExtension(@TempDir Path tempDir) {
+		String actionTemplates = tempDir + FileSeparator + "Java.st";
+
+		String grammar =
+			"lexer grammar L;"+
+			"WS : (' '|'\\n') -> skip ;";
+
+		State state = execLexer(grammar, "34 34", tempDir, actionTemplates);
+
+		assertInstanceOf(GeneratedState.class, state);
+		GeneratedState generated = (GeneratedState) state;
+		assertTrue(generated.containsErrors());
+		assertEquals(
+			"State: Generate; \n" +
+			"error(207):  error reading action templates file " + actionTemplates + ": " +
+			"Group file names must end in .stg: " + actionTemplates + "\n",
+			generated.getErrorMessage());
+	}
+
+	@Test() void testActionTemplateFileMissing(@TempDir Path tempDir) {
+		String actionTemplates = tempDir + FileSeparator + "Java.stg";
+
+		String grammar =
+			"lexer grammar L;"+
+			"WS : (' '|'\\n') -> skip ;";
+
+		State state = execLexer(grammar, "34 34", tempDir, actionTemplates);
+
+		assertInstanceOf(GeneratedState.class, state);
+		GeneratedState generated = (GeneratedState) state;
+		assertTrue(generated.containsErrors());
+		assertEquals(
+			"State: Generate; \n" +
+			"error(206):  cannot find action templates file " + actionTemplates + " given for L\n",
+			generated.getErrorMessage());
+	}
+
+	@Test void testActionTemplateLexerAction(@TempDir Path tempDir) {
+		writeActionTemplatesFile(tempDir, "writeln(s) ::= <<outStream.println(\"<s>\");>>");
+
+		String actionTemplates = tempDir + FileSeparator + "Java.stg";
+
+		String grammar =
+			"lexer grammar L;\n"+
+			"I : '0'..'9'+ {<writeln(\"I\")>} ;\n"+
+			"WS : (' '|'\\n') -> skip ;";
+
+		State state = execLexer(grammar, "34 34", tempDir, actionTemplates);
+
+		// Should have identical output to TestLexerActions.testActionExecutedInDFA
+		String expecting =
+			"I\n" +
+			"I\n" +
+			"[@0,0:1='34',<1>,1:0]\n" +
+			"[@1,3:4='34',<1>,1:3]\n" +
+			"[@2,5:4='<EOF>',<-1>,1:5]\n";
+
+		assertInstanceOf(ExecutedState.class, state);
+
+		assertEquals(expecting, ((ExecutedState) state).output);
+	}
+
+	@Test void testActionTemplateHeader(@TempDir Path tempDir) {
+		String sb =
+			"normalizerImports() ::= <<\n" +
+			"import java.text.Normalizer;\n" +
+			"import java.text.Normalizer.Form;\n" +
+			">>\n" +
+			"normalize(s) ::= <<Normalizer.normalize(<s>, Form.NFKC)>>\n" +
+			"getText() ::= <<getText()>>\n" +
+			"setText(s) ::= <<setText(<s>);>>";
+
+		writeActionTemplatesFile(tempDir, sb);
+
+		String actionTemplates = tempDir + FileSeparator + "Java.stg";
+
+		String grammar =
+			"lexer grammar L;\n"+
+			"@lexer::header {\n"+
+			"<normalizerImports()>\n"+
+			"}\n"+
+			"ID : (ID_START ID_CONTINUE* | '_' ID_CONTINUE+) { <setText(normalize(getText()))> } ;\n"+
+			"ID_START : [\\p{XID_Start}] ;\n"+
+			"ID_CONTINUE: [\\p{XID_Continue}] ;\n"+
+			"WS : (' '|'\\n') -> skip ;";
+
+		State state = execLexer(grammar, "This _is \ufb01ne", tempDir, actionTemplates);
+
+		String expecting =
+			"[@0,0:3='This',<1>,1:0]\n"+
+			"[@1,5:7='_is',<1>,1:5]\n"+
+			"[@2,9:11='fine',<1>,1:9]\n"+
+			"[@3,12:11='<EOF>',<-1>,1:12]\n";
+
+		assertInstanceOf(ExecutedState.class, state);
+
+		assertEquals(expecting, ((ExecutedState) state).output);
+	}
+
+	void writeActionTemplatesFile(Path tempDir, String template) {
+		writeFile(tempDir.toString(), "Java.stg", template);
+	}
+
+	State execLexer(String grammarStr, String input, Path tempDir, String actionTemplates) {
+		RunOptions runOptions = createOptionsForJavaToolTests("L.g4", grammarStr, null, "L",
+			false, true, null, input,
+			false, false, Stage.Execute, actionTemplates);
+		try (JavaRunner runner = new JavaRunner(tempDir, false)) {
+			return runner.run(runOptions);
+		}
+	}
+}

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestActionTemplates.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestActionTemplates.java
@@ -133,7 +133,7 @@ public class TestActionTemplates {
 
 		assertEquals(
 			"State: Generate; \n" +
-			"error(210):  error rendering action template file " + actionTemplates + ": Java.stg 1:11: mismatched input ':' expecting '::='\n" +
+			"error(209):  error compiling action templates file " + actionTemplates + ": Java.stg 1:11: mismatched input ':' expecting '::='\n" +
 			"error(212): " + grammarFile + ":2:14: error rendering action template: 2:16: no such template: /writeln\n",
 			generated.getErrorMessage());
 	}

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestActionTemplates.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestActionTemplates.java
@@ -5,7 +5,6 @@ import org.antlr.v4.test.runtime.Stage;
 import org.antlr.v4.test.runtime.java.JavaRunner;
 import org.antlr.v4.test.runtime.states.ExecutedState;
 import org.antlr.v4.test.runtime.states.GeneratedState;
-import org.antlr.v4.test.runtime.states.JavaCompiledState;
 import org.antlr.v4.test.runtime.states.State;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -18,7 +17,9 @@ import static org.antlr.v4.test.tool.ToolTestUtils.createOptionsForJavaToolTests
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestActionTemplates {
-	@Test() void testIncorrectActionTemplateGroupExtension(@TempDir Path tempDir) {
+	@Test void testIncorrectActionTemplateGroupExtension(@TempDir Path tempDir) {
+		writeFile(tempDir.toString(), "Java.st", "");
+
 		String actionTemplates = tempDir + FileSeparator + "Java.st";
 
 		String grammar =
@@ -40,7 +41,7 @@ public class TestActionTemplates {
 			generated.getErrorMessage());
 	}
 
-	@Test() void testActionTemplateFileMissing(@TempDir Path tempDir) {
+	@Test void testActionTemplateFileMissing(@TempDir Path tempDir) {
 		String actionTemplates = tempDir + FileSeparator + "Java.stg";
 
 		String grammar =
@@ -276,8 +277,7 @@ public class TestActionTemplates {
 		assertEquals(expecting, ((ExecutedState) state).output);
 	}
 
-	@Test
-	void testActionTemplateSemanticPredicate(@TempDir Path tempDir) {
+	@Test void testActionTemplateSemanticPredicate(@TempDir Path tempDir) {
 		String actionTemplates = "pred() ::= <<true>>";
 
 		writeActionTemplatesFile(tempDir, actionTemplates);

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestActionTemplates.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestActionTemplates.java
@@ -80,7 +80,7 @@ public class TestActionTemplates {
 	}
 
 	@Test void testActionTemplateHeader(@TempDir Path tempDir) {
-		String sb =
+		String actionTemplates =
 			"normalizerImports() ::= <<\n" +
 			"import java.text.Normalizer;\n" +
 			"import java.text.Normalizer.Form;\n" +
@@ -89,9 +89,9 @@ public class TestActionTemplates {
 			"getText() ::= <<getText()>>\n" +
 			"setText(s) ::= <<setText(<s>);>>";
 
-		writeActionTemplatesFile(tempDir, sb);
+		writeActionTemplatesFile(tempDir, actionTemplates);
 
-		String actionTemplates = tempDir + FileSeparator + "Java.stg";
+		String actionTemplatesFile = tempDir + FileSeparator + "Java.stg";
 
 		String grammar =
 			"lexer grammar L;\n"+
@@ -103,7 +103,7 @@ public class TestActionTemplates {
 			"ID_CONTINUE: [\\p{XID_Continue}] ;\n"+
 			"WS : (' '|'\\n') -> skip ;";
 
-		State state = execLexer(grammar, "This _is \ufb01ne", tempDir, actionTemplates);
+		State state = execLexer(grammar, "This _is \ufb01ne", tempDir, actionTemplatesFile);
 
 		String expecting =
 			"[@0,0:3='This',<1>,1:0]\n"+

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestCompositeGrammars.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestCompositeGrammars.java
@@ -727,7 +727,7 @@ public class TestCompositeGrammars {
 	) {
 		RunOptions runOptions = createOptionsForJavaToolTests(grammarFileName, grammarStr, parserName, null,
 				false, false, startRuleName, null,
-				false, false, Stage.Compile);
+				false, false, Stage.Compile, null);
 		try (JavaRunner runner = new JavaRunner(tempDirPath, false)) {
 			JavaCompiledState compiledState = (JavaCompiledState) runner.run(runOptions);
 			return !compiledState.containsErrors();

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestParseTreeMatcher.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestParseTreeMatcher.java
@@ -392,7 +392,7 @@ public class TestParseTreeMatcher {
 		String lexerName = grammarName+"Lexer";
 		RunOptions runOptions = createOptionsForJavaToolTests(grammarFileName, grammar, parserName, lexerName,
 				false, false, startRule, input,
-				false, false, Stage.Execute);
+				false, false, Stage.Execute, null);
 		try (JavaRunner runner = new JavaRunner()) {
 			JavaExecutedState executedState = (JavaExecutedState)runner.run(runOptions);
 			JavaCompiledState compiledState = (JavaCompiledState)executedState.previousState;
@@ -413,7 +413,7 @@ public class TestParseTreeMatcher {
 	) throws Exception {
 		RunOptions runOptions = createOptionsForJavaToolTests(grammarFileName, grammar, parserName, lexerName,
 				false, false, startRule, null,
-				false, false, Stage.Compile);
+				false, false, Stage.Compile, null);
 		try (JavaRunner runner = new JavaRunner()) {
 			JavaCompiledState compiledState = (JavaCompiledState) runner.run(runOptions);
 

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestParserProfiler.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestParserProfiler.java
@@ -223,7 +223,7 @@ public class TestParserProfiler {
 
 		RunOptions runOptions = createOptionsForJavaToolTests("T.g4", grammar, "TParser", "TLexer",
 				false, false, "s", "xyz;abc;z.q",
-				true, false, Stage.Execute);
+				true, false, Stage.Execute, null);
 		try (JavaRunner runner = new JavaRunner()) {
 			ExecutedState state = (ExecutedState) runner.run(runOptions);
 			String expecting =

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestPerformance.java
@@ -1103,7 +1103,7 @@ public class TestPerformance {
 
 		RunOptions runOptions = createOptionsForJavaToolTests(grammarFileName, body, parserName, lexerName,
 				false, true, null, null,
-				false, false, Stage.Compile);
+				false, false, Stage.Compile, null);
 		try (RuntimeRunner runner = new JavaRunner()) {
 			return (JavaCompiledState) runner.run(runOptions);
 		}

--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestXPath.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestXPath.java
@@ -201,7 +201,7 @@ public class TestXPath {
 	) throws Exception {
 		RunOptions runOptions = createOptionsForJavaToolTests(grammarFileName, grammar, parserName, lexerName,
 				false, false, startRuleName, input,
-				false, false, Stage.Execute);
+				false, false, Stage.Execute, null);
 		try (JavaRunner runner = new JavaRunner()) {
 			JavaExecutedState executedState = (JavaExecutedState)runner.run(runOptions);
 			JavaCompiledState compiledState = (JavaCompiledState)executedState.previousState;

--- a/tool-testsuite/test/org/antlr/v4/test/tool/ToolTestUtils.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/ToolTestUtils.java
@@ -69,7 +69,7 @@ public class ToolTestUtils {
 										 Path workingDir, boolean saveTestDir) {
 		RunOptions runOptions = createOptionsForJavaToolTests(grammarFileName, grammarStr, parserName, lexerName,
 				false, true, startRuleName, input,
-				false, showDiagnosticErrors, Stage.Execute);
+				false, showDiagnosticErrors, Stage.Execute, null);
 		try (JavaRunner runner = new JavaRunner(workingDir, saveTestDir)) {
 			State result = runner.run(runOptions);
 			if (!(result instanceof ExecutedState)) {
@@ -83,11 +83,11 @@ public class ToolTestUtils {
 			String grammarFileName, String grammarStr, String parserName, String lexerName,
 			boolean useListener, boolean useVisitor, String startRuleName,
 			String input, boolean profile, boolean showDiagnosticErrors,
-			Stage endStage
+			Stage endStage, String actionTemplates
 	) {
 		return new RunOptions(grammarFileName, grammarStr, parserName, lexerName, useListener, useVisitor, startRuleName,
 				input, profile, showDiagnosticErrors, false, false, endStage, "Java",
-				JavaRunner.runtimeTestParserName, PredictionMode.LL, true);
+				JavaRunner.runtimeTestParserName, actionTemplates, PredictionMode.LL, true);
 	}
 
 	public static void testErrors(String[] pairs, boolean printTree) {

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -1235,6 +1235,18 @@ public enum ErrorType {
 	 */
 	@Deprecated
 	V3_SYNPRED(205, "(...)=> syntactic predicates are not supported in ANTLR 4", ErrorSeverity.ERROR),
+	/**
+	 * Compiler Error 206.
+	 *
+	 * <p>cannot find actions template file <em>filename</em></p>
+	 */
+	CANNOT_FIND_ACTIONS_TEMPLATE_FILE_GIVEN_ON_CMDLINE(206, "cannot find action templates file <arg> given for <arg2>", ErrorSeverity.ERROR),
+	/**
+	 * Compiler Error 207.
+	 *
+	 * <p>error reading action templates file <em>filename</em>: <em>reason</em></p>
+	 */
+	ERROR_READING_ACTION_TEMPLATES_FILE(207, "error reading action templates file <arg>: <arg2>", ErrorSeverity.ERROR),
 
     // Dependency sorting errors
 

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -1238,13 +1238,13 @@ public enum ErrorType {
 	/**
 	 * Compiler Error 206.
 	 *
-	 * <p>cannot find action templates file <em>filename</em></p>
+	 * <p>cannot find action templates file <em>filename</em> given for <em>grammar</em></p>
 	 */
 	CANNOT_FIND_ACTION_TEMPLATES_FILE_GIVEN_ON_CMDLINE(206, "cannot find action templates file <arg> given for <arg2>", ErrorSeverity.ERROR),
 	/**
 	 * Compiler Error 207.
 	 *
-	 * <p>cannot find action tempaltes file <em>filename</em></p>
+	 * <p>cannot find action templates file <em>filename</em></p>
 	 */
 	CANNOT_FIND_ACTION_TEMPLATES_FILE_REFD_IN_GRAMMAR(207, "cannot find action templates file <arg>", ErrorSeverity.ERROR),
 	/**
@@ -1256,15 +1256,15 @@ public enum ErrorType {
 	/**
 	 * Compiler Error 209.
 	 *
-	 * <p>error compiling action template file <em>filename</em>: <em>reason</em></p>
+	 * <p>error compiling action templates file <em>filename</em>: <em>reason</em></p>
 	 */
-	ERROR_COMPILING_ACTION_TEMPLATE_FILE(209, "error compiling action templates file <arg>: <arg2>", ErrorSeverity.ERROR),
+	ERROR_COMPILING_ACTION_TEMPLATES_FILE(209, "error compiling action templates file <arg>: <arg2>", ErrorSeverity.ERROR),
 	/**
 	 * Compiler Error 210.
 	 *
-	 * <p>error rendering action template file <em>filename</em>: <em>reason</em></p>
+	 * <p>error rendering action templates file <em>filename</em>: <em>reason</em></p>
 	 */
-	ERROR_RENDERING_ACTION_TEMPLATE_FILE(210, "error rendering action template file <arg>: <arg2>", ErrorSeverity.ERROR),
+	ERROR_RENDERING_ACTION_TEMPLATES_FILE(210, "error rendering action templates file <arg>: <arg2>", ErrorSeverity.ERROR),
 	/**
 	 * Compiler Error 211.
 	 *

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -1238,9 +1238,9 @@ public enum ErrorType {
 	/**
 	 * Compiler Error 206.
 	 *
-	 * <p>cannot find actions template file <em>filename</em></p>
+	 * <p>cannot find action templates file <em>filename</em></p>
 	 */
-	CANNOT_FIND_ACTIONS_TEMPLATE_FILE_GIVEN_ON_CMDLINE(206, "cannot find action templates file <arg> given for <arg2>", ErrorSeverity.ERROR),
+	CANNOT_FIND_ACTION_TEMPLATES_FILE_GIVEN_ON_CMDLINE(206, "cannot find action templates file <arg> given for <arg2>", ErrorSeverity.ERROR),
 	/**
 	 * Compiler Error 207.
 	 *

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -1244,9 +1244,39 @@ public enum ErrorType {
 	/**
 	 * Compiler Error 207.
 	 *
+	 * <p>cannot find action tempaltes file <em>filename</em></p>
+	 */
+	CANNOT_FIND_ACTION_TEMPLATES_FILE_REFD_IN_GRAMMAR(207, "cannot find action templates file <arg>", ErrorSeverity.ERROR),
+	/**
+	 * Compiler Error 208.
+	 *
 	 * <p>error reading action templates file <em>filename</em>: <em>reason</em></p>
 	 */
-	ERROR_READING_ACTION_TEMPLATES_FILE(207, "error reading action templates file <arg>: <arg2>", ErrorSeverity.ERROR),
+	ERROR_READING_ACTION_TEMPLATES_FILE(208, "error reading action templates file <arg>: <arg2>", ErrorSeverity.ERROR),
+	/**
+	 * Compiler Error 209.
+	 *
+	 * <p>error compiling action template file <em>filename</em>: <em>reason</em></p>
+	 */
+	ERROR_COMPILING_ACTION_TEMPLATE_FILE(209, "error compiling action templates file <arg>: <arg2>", ErrorSeverity.ERROR),
+	/**
+	 * Compiler Error 210.
+	 *
+	 * <p>error rendering action template file <em>filename</em>: <em>reason</em></p>
+	 */
+	ERROR_RENDERING_ACTION_TEMPLATE_FILE(210, "error rendering action template file <arg>: <arg2>", ErrorSeverity.ERROR),
+	/**
+	 * Compiler Error 211.
+	 *
+	 * <p>error compiling action template: <em>reason</em></p>
+	 */
+	ERROR_COMPILING_ACTION_TEMPLATE(211, "error compiling action template: <arg>", ErrorSeverity.ERROR),
+	/**
+	 * Compiler Error 212.
+	 *
+	 * <p>error rendering action template: <em>reason</em></p>
+	 */
+	ERROR_RENDERING_ACTION_TEMPLATE(212, "error rendering action template: <arg>", ErrorSeverity.ERROR),
 
     // Dependency sorting errors
 

--- a/tool/src/org/antlr/v4/tool/Grammar.java
+++ b/tool/src/org/antlr/v4/tool/Grammar.java
@@ -80,6 +80,7 @@ public class Grammar implements AttributeResolver {
 		parserOptions.add("TokenLabelType");
 		parserOptions.add("tokenVocab");
 		parserOptions.add("language");
+		parserOptions.add("actionTemplates");
 		parserOptions.add("accessLevel");
 		parserOptions.add("exportMacro");
 		parserOptions.add(caseInsensitiveOptionName);
@@ -1176,6 +1177,10 @@ public class Grammar implements AttributeResolver {
 
 	public String getLanguage() {
 		return getOptionString("language");
+	}
+
+	public String getActionTemplates() {
+		return getOptionString("actionTemplates");
 	}
 
 	public String getOptionString(String key) { return ast.getOptionString(key); }

--- a/tool/src/org/antlr/v4/tool/GrammarTransformPipeline.java
+++ b/tool/src/org/antlr/v4/tool/GrammarTransformPipeline.java
@@ -537,7 +537,7 @@ public class GrammarTransformPipeline {
 			});
 		} catch (IllegalArgumentException e) {
 			if (e.getMessage() != null && e.getMessage().startsWith("No such group file")) {
-				tool.errMgr.toolError(ErrorType.CANNOT_FIND_ACTIONS_TEMPLATE_FILE_GIVEN_ON_CMDLINE, e, fileName, root.g.name);
+				tool.errMgr.toolError(ErrorType.CANNOT_FIND_ACTION_TEMPLATES_FILE_GIVEN_ON_CMDLINE, e, fileName, root.g.name);
 			} else {
 				tool.errMgr.toolError(ErrorType.ERROR_READING_ACTION_TEMPLATES_FILE, e, fileName, e.getMessage());
 			}

--- a/tool/src/org/antlr/v4/tool/GrammarTransformPipeline.java
+++ b/tool/src/org/antlr/v4/tool/GrammarTransformPipeline.java
@@ -528,12 +528,18 @@ public class GrammarTransformPipeline {
 
 			@Override
 			public void compileTimeError(STMessage stMessage) {
-				reportActionTemplateError(stMessage);
+				errorManager.toolError(
+					ErrorType.ERROR_COMPILING_ACTION_TEMPLATES_FILE,
+					actionTemplateGroupFile.fileName,
+					stMessage.toString());
 			}
 
 			@Override
 			public void runTimeError(STMessage stMessage) {
-				reportActionTemplateError(stMessage);
+				errorManager.toolError(
+					ErrorType.ERROR_RENDERING_ACTION_TEMPLATES_FILE,
+					actionTemplateGroupFile.fileName,
+					stMessage.toString());
 			}
 
 			@Override
@@ -544,13 +550,6 @@ public class GrammarTransformPipeline {
 			@Override
 			public void internalError(STMessage stMessage) {
 				reportInternalError(stMessage);
-			}
-
-			private void reportActionTemplateError(STMessage stMessage) {
-				errorManager.toolError(
-					ErrorType.ERROR_RENDERING_ACTION_TEMPLATE_FILE,
-					actionTemplateGroupFile.fileName,
-					stMessage.toString());
 			}
 
 			private void reportInternalError(STMessage stMessage) {

--- a/tool/src/org/antlr/v4/tool/GrammarTransformPipeline.java
+++ b/tool/src/org/antlr/v4/tool/GrammarTransformPipeline.java
@@ -7,6 +7,7 @@
 package org.antlr.v4.tool;
 
 import org.antlr.runtime.CommonToken;
+import org.antlr.runtime.RecognitionException;
 import org.antlr.runtime.tree.CommonTree;
 import org.antlr.runtime.tree.CommonTreeNodeStream;
 import org.antlr.runtime.tree.Tree;
@@ -27,11 +28,12 @@ import org.antlr.v4.tool.ast.GrammarASTWithOptions;
 import org.antlr.v4.tool.ast.GrammarRootAST;
 import org.antlr.v4.tool.ast.RuleAST;
 import org.antlr.v4.tool.ast.TerminalAST;
-import org.stringtemplate.v4.ST;
-import org.stringtemplate.v4.STGroupFile;
-import org.stringtemplate.v4.STGroupString;
+import org.stringtemplate.v4.*;
 import org.stringtemplate.v4.compiler.STException;
+import org.stringtemplate.v4.misc.*;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -517,16 +519,262 @@ public class GrammarTransformPipeline {
 		return lexerAST;
 	}
 
-	public void expandActionTemplates(GrammarRootAST root) {
-		String fileName = root.g.getActionTemplates();
+	/**
+	 * Create an error listener for .stg action template group files provided via grammar options or via the command line.
+	 */
+	private STErrorListener createActionTemplateErrorListener(GrammarAST ast, STGroupFile actionTemplateGroupFile) {
+		return new STErrorListener() {
+			private final ErrorManager errorManager = ast.g.tool.errMgr;
+
+			@Override
+			public void compileTimeError(STMessage stMessage) {
+				reportActionTemplateError(stMessage);
+			}
+
+			@Override
+			public void runTimeError(STMessage stMessage) {
+				reportActionTemplateError(stMessage);
+			}
+
+			@Override
+			public void IOError(STMessage stMessage) {
+				reportInternalError(stMessage);
+			}
+
+			@Override
+			public void internalError(STMessage stMessage) {
+				reportInternalError(stMessage);
+			}
+
+			private void reportActionTemplateError(STMessage stMessage) {
+				errorManager.toolError(
+					ErrorType.ERROR_RENDERING_ACTION_TEMPLATE_FILE,
+					actionTemplateGroupFile.fileName,
+					stMessage.toString());
+			}
+
+			private void reportInternalError(STMessage stMessage) {
+				errorManager.toolError(ErrorType.INTERNAL_ERROR, stMessage.cause, stMessage.toString());
+			}
+		};
+	}
+
+	/**
+	 * Create an error listener for action templates embedded inside a grammar's actions and semantic predicates.
+	 */
+	private STErrorListener createGrammarErrorListener(GrammarAST ast) {
+		return new STErrorListener() {
+			private final ErrorManager errorManager = ast.g.tool.errMgr;
+
+			/**
+			 * Get the STCompiletimeMesage error message content, translating the source location
+			 * according to the action token's position in the grammar.
+			 */
+			private String getSTCompiletimeErrorMessage(STCompiletimeMessage stMsg) {
+				StringWriter sw = new StringWriter();
+				PrintWriter pw = new PrintWriter(sw);
+
+				if (stMsg.token != null) {
+					int linePos = ast.getLine() + stMsg.token.getLine() - 1;
+					int charPos = stMsg.token.getCharPositionInLine();
+					if (stMsg.token.getLine() == 1) {
+						charPos += ast.getCharPositionInLine();
+					}
+					pw.print(linePos + ":" + charPos + ": ");
+				}
+
+				String msg = String.format(stMsg.error.message, stMsg.arg, stMsg.arg2);
+
+				pw.print(msg);
+
+				return sw.toString();
+			}
+
+			/**
+			 * Get the STLexerMessage error message content, translating the source location
+			 * according to the action token's position in the grammar.
+			 */
+			private String getSTLexerErrorMessage(STLexerMessage stMsg) {
+				StringWriter sw = new StringWriter();
+				PrintWriter pw = new PrintWriter(sw);
+
+				// From STLexerMessage.toString
+				RecognitionException re = (RecognitionException)stMsg.cause;
+				int linePos = ast.getLine() + re.line - 1;
+				int charPos = re.charPositionInLine;
+				if (re.line == 1) {
+					charPos += ast.getCharPositionInLine();
+				}
+				pw.print(linePos + ":" + charPos + ": ");
+
+				String msg = String.format(stMsg.error.message, stMsg.msg);
+
+				pw.print(msg);
+
+				return sw.toString();
+			}
+
+			@Override
+			public void compileTimeError(STMessage stMessage) {
+				if (stMessage instanceof STCompiletimeMessage) {
+					STCompiletimeMessage compileMessage = (STCompiletimeMessage) stMessage;
+					errorManager.grammarError(ErrorType.ERROR_COMPILING_ACTION_TEMPLATE, ast.g.fileName, ast.getToken(), getSTCompiletimeErrorMessage(compileMessage));
+				}
+				else if (stMessage instanceof STLexerMessage) {
+					STLexerMessage lexerMessage = (STLexerMessage) stMessage;
+					errorManager.grammarError(ErrorType.ERROR_COMPILING_ACTION_TEMPLATE, ast.g.fileName, ast.getToken(), getSTLexerErrorMessage(lexerMessage));
+				}
+				else {
+					errorManager.grammarError(ErrorType.ERROR_COMPILING_ACTION_TEMPLATE, ast.g.fileName, ast.getToken(), stMessage.toString());
+				}
+			}
+
+			/**
+			 * Get the STRuntimeMessage error location Coordinate.
+			 */
+			private Coordinate getSTRuntimeMessageSourceLocation(STRuntimeMessage msg) {
+				// From STRuntimeMessage.getSourceLocation
+				if (msg.ip >= 0 && msg.self != null && msg.self.impl != null) {
+					Interval I = msg.self.impl.sourceMap[msg.ip];
+					if (I == null) {
+						return null;
+					} else {
+						int i = I.a;
+						return Misc.getLineCharPosition(msg.self.impl.template, i);
+					}
+				} else {
+					return null;
+				}
+			}
+
+			/**
+			 * Get the STRuntimeMessage error message content, translating the source location
+			 * according to the action token's position in the grammar.
+			 */
+			private String getSTRuntimeErrorMessage(STRuntimeMessage stMsg) {
+				StringWriter sw = new StringWriter();
+				PrintWriter pw = new PrintWriter(sw);
+				Coordinate coord = getSTRuntimeMessageSourceLocation(stMsg);
+
+				if (coord != null) {
+					int linePos = ast.getLine() + coord.line - 1;
+					int charPos = coord.charPosition;
+					if (coord.line == 1) {
+						charPos += ast.getCharPositionInLine();
+					}
+					pw.print(linePos + ":" + charPos + ": ");
+				}
+
+				// From STMessage.toString
+				String msg = String.format(stMsg.error.message, stMsg.arg, stMsg.arg2, stMsg.arg3);
+
+				pw.print(msg);
+
+				if (stMsg.cause != null) {
+					pw.print("\nCaused by: ");
+					stMsg.cause.printStackTrace(pw);
+				}
+
+				return sw.toString();
+			}
+
+			@Override
+			public void runTimeError(STMessage stMessage) {
+				if (stMessage instanceof STRuntimeMessage) {
+					STRuntimeMessage runtimeMessage = (STRuntimeMessage) stMessage;
+					errorManager.grammarError(
+						ErrorType.ERROR_RENDERING_ACTION_TEMPLATE,
+						ast.g.fileName,
+						ast.getToken(),
+						getSTRuntimeErrorMessage(runtimeMessage));
+				} else {
+					errorManager.grammarError(
+						ErrorType.ERROR_RENDERING_ACTION_TEMPLATE,
+						ast.g.fileName,
+						ast.getToken(),
+						stMessage.toString());
+				}
+			}
+
+			@Override
+			public void IOError(STMessage stMessage) {
+				reportError(stMessage);
+			}
+
+			@Override
+			public void internalError(STMessage stMessage) {
+				reportError(stMessage);
+			}
+
+			private void reportError(STMessage stMessage) {
+				errorManager.toolError(ErrorType.INTERNAL_ERROR, stMessage.cause, stMessage.toString());
+			}
+		};
+	}
+
+	public STGroupFile loadActionTemplatesGroupFile(GrammarRootAST root) {
+		Grammar grammar = root.g;
+		ErrorManager errorManager = grammar.tool.errMgr;
+		String actionTemplatesFile = grammar.getActionTemplates();
+
 		try {
-			STGroupFile actionTemplates = new STGroupFile(fileName);
-			TreeVisitor v = new TreeVisitor(new GrammarASTAdaptor());
-			v.visit(root, new TreeVisitorAction() {
+			STGroupFile actionTemplates = new STGroupFile(actionTemplatesFile);
+			STErrorListener errorListener = createActionTemplateErrorListener(root, actionTemplates);
+
+			// Force load the action templates group file
+			actionTemplates.setListener(errorListener);
+			actionTemplates.load();
+
+			return actionTemplates;
+
+		} catch (IllegalArgumentException e) {
+			if (e.getMessage() != null && e.getMessage().startsWith("No such group file")) {
+				// Check whether this action template file came from options in the grammar file
+				GrammarAST optionAST = root.getOptionAST("actionTemplates");
+
+				if (optionAST != null && actionTemplatesFile.equals(optionAST.getToken().getText())) {
+					errorManager.grammarError(
+						ErrorType.CANNOT_FIND_ACTION_TEMPLATES_FILE_REFD_IN_GRAMMAR,
+						grammar.fileName,
+						optionAST.getToken(), actionTemplatesFile);
+				} else {
+					errorManager.toolError(
+						ErrorType.CANNOT_FIND_ACTION_TEMPLATES_FILE_GIVEN_ON_CMDLINE,
+						actionTemplatesFile,
+						grammar.name);
+				}
+
+			} else {
+				errorManager.toolError(
+					ErrorType.ERROR_READING_ACTION_TEMPLATES_FILE, e,
+					actionTemplatesFile,
+					e.getMessage());
+			}
+		} catch (STException e) {
+			errorManager.toolError(
+				ErrorType.ERROR_READING_ACTION_TEMPLATES_FILE, e,
+				actionTemplatesFile,
+				e.getMessage());
+		}
+
+		return null;
+	}
+
+	public void expandActionTemplates(GrammarRootAST root) {
+		Grammar grammar = root.g;
+		ErrorManager errorManager = grammar.tool.errMgr;
+
+		STGroupFile actionTemplates = loadActionTemplatesGroupFile(root);
+
+		if (actionTemplates != null) {
+			TreeVisitor visitor = new TreeVisitor(new GrammarASTAdaptor());
+			visitor.visit(root, new TreeVisitorAction() {
 				@Override
 				public Object pre(Object t) {
-					if (((GrammarAST) t).getType() == ANTLRParser.ACTION) {
-						return expandActionTemplate((GrammarAST) t, actionTemplates);
+					GrammarAST grammarAST = (GrammarAST) t;
+					int tokenType = grammarAST.getType();
+					if (tokenType == ANTLRParser.ACTION || tokenType == ANTLRParser.SEMPRED) {
+						return expandActionTemplate((GrammarAST) t, errorManager, actionTemplates);
 					}
 					return t;
 				}
@@ -535,25 +783,31 @@ public class GrammarTransformPipeline {
 					return t;
 				}
 			});
-		} catch (IllegalArgumentException e) {
-			if (e.getMessage() != null && e.getMessage().startsWith("No such group file")) {
-				tool.errMgr.toolError(ErrorType.CANNOT_FIND_ACTION_TEMPLATES_FILE_GIVEN_ON_CMDLINE, e, fileName, root.g.name);
-			} else {
-				tool.errMgr.toolError(ErrorType.ERROR_READING_ACTION_TEMPLATES_FILE, e, fileName, e.getMessage());
-			}
-		} catch (STException e) {
-			tool.errMgr.toolError(ErrorType.ERROR_READING_ACTION_TEMPLATES_FILE, e, fileName, e.getMessage());
 		}
 	}
 
-	public GrammarAST expandActionTemplate(GrammarAST t, STGroupFile actionTemplates) {
-		String grammarFileInfo = t.g.fileName + " " + t.getLine() + 1 + ":" + t.getCharPositionInLine();
-		String actionText = t.getText().substring(1, t.getText().length() - 1);
-		STGroupString actionTemplateGroup = new STGroupString(grammarFileInfo, "action() ::= << " + actionText + " >>");
-		actionTemplateGroup.importTemplates(actionTemplates);
+	public GrammarAST expandActionTemplate(GrammarAST ast, ErrorManager errMgr, STGroupFile actionTemplateGroupFile) {
+		// Trim the curly braces and trailing question mark
+		// from an action or semantic predicate
+		String actionText = ast.getText()
+			.substring(1,
+				ast.getType() == ANTLRParser.SEMPRED
+					? ast.getText().length() - 2
+					: ast.getText().length() - 1);
+
+		STGroupString actionTemplateGroup = new STGroupString(
+			ast.g.fileName, "action() ::= << " + actionText + " >>");
+
+		actionTemplateGroup.importTemplates(actionTemplateGroupFile);
+
+		actionTemplateGroup.setListener(createGrammarErrorListener(ast));
+
 		ST actionTemplate = actionTemplateGroup.getInstanceOf("action");
-		String expandedTemplate = actionTemplate.render();
-		t.setText(expandedTemplate);
-		return t;
+
+		if (actionTemplate != null) {
+			ast.setText(actionTemplate.render());
+		}
+
+		return ast;
 	}
 }


### PR DESCRIPTION
This is an idea about how to resolve #4067 without developing an entirely new actions language.

This PR enables users to write cross-target grammars which make use of actions, by enabling users to provide action templates as StringTemplate `.stg` group files on the command line.

By providing different action templates for each target language, users can provide a different implementation of the action logic for each target.

`Java.stg`:
```
normalizerImports() ::= <<
import java.text.Normalizer;
import java.text.Normalizer.Form;
>>
normalize(s) ::= <<Normalizer.normalize(<s>, Form.NFKC)>>
getText() ::= <<getText()>>
setText(s) ::= <<setText(<s>);>>
```

`Javascript.stg`:
```
normalizerImports() ::= ""
normalize(s) ::= <<<s>.normalize("NFKC")>>
getText() ::= "this.text"
setText(s) ::= "this.text = <s>"
```

The example below is the motivating example for me - I have a grammar that I'd like to use in both a JVM-based compiler and a VS Code extension:

`Example.g4`:
```antlr
lexer grammar Example;

@lexer::header {
<normalizerImports()>
}

ID : (ID_START ID_CONTINUE* | '_' ID_CONTINUE+) { <setText(normalize(getText()))> } ;
ID_START : [\p{XID_Start}] ;
ID_CONTINUE: [\p{XID_Continue}] ;
WS : (' '|'\n') -> skip ;
```

Thanks to my employer @opencastsoftware for sponsoring this work!