### PR TITLE
Update PredictionContext.cpp

### DIFF
--- a/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
@@ -358,9 +358,9 @@ Ref<const PredictionContext> PredictionContext::mergeArrays(Ref<const ArrayPredi
       // same payload (stack tops are equal), must yield merged singleton
       size_t payload = a->returnStates[i];
       // $+$ = $
-      bool both$ = payload == EMPTY_RETURN_STATE && !parentA && !parentB;
+      bool both_dollar = payload == EMPTY_RETURN_STATE && !parentA && !parentB;
       bool ax_ax = (parentA && parentB) && *parentA == *parentB; // ax+ax -> ax
-      if (both$ || ax_ax) {
+      if (both_dollar || ax_ax) {
         mergedParents[k] = parentA; // choose left
         mergedReturnStates[k] = payload;
       } else { // ax+ay -> a'[x,y]


### PR DESCRIPTION
On an x86_64 machine with Ubuntu 22.04 I found this warning with clang 14.0:

`INFO: From Compiling runtime/Cpp/runtime/src/atn/PredictionContext.cpp:
external/antlr4/runtime/Cpp/runtime/src/atn/PredictionContext.cpp:361:16: warning: '$' in identifier [-Wdollar-in-identifier-extension]
      bool both$ = payload == EMPTY_RETURN_STATE && !parentA && !parentB;
               ^
external/antlr4/runtime/Cpp/runtime/src/atn/PredictionContext.cpp:363:15: warning: '$' in identifier [-Wdollar-in-identifier-extension]
      if (both$ || ax_ax) {
              ^`
So I replaced the dollar sign by `_dollar`

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
