### PR TITLE
[JavaScript] Document Node.JS v16 requirement

### DIFF
--- a/runtime/JavaScript/README.md
+++ b/runtime/JavaScript/README.md
@@ -1,5 +1,9 @@
 # JavaScript target for ANTLR 4
 
+[![npm version](https://img.shields.io/npm/v/antlr4)](https://www.npmjs.com/package/antlr4)
+[![Badge showing the supported LTS versions of Node.JS in the latest NPM release](https://img.shields.io/node/v-lts/antlr4)](https://www.npmjs.com/package/antlr4)
+[![npm type definitions](https://img.shields.io/npm/types/antlr4)](https://www.npmjs.com/package/antlr4)
+
 JavaScript runtime libraries for ANTLR 4
 
 This runtime is available through npm. The package name is 'antlr4'.

--- a/runtime/JavaScript/README.md
+++ b/runtime/JavaScript/README.md
@@ -11,7 +11,7 @@ See www.antlr.org for more information on ANTLR
 See [Javascript Target](https://github.com/antlr/antlr4/blob/master/doc/javascript-target.md)
 for more information on using ANTLR in JavaScript
 
-This runtime requires node version >= 14, the first version to officially support ES semantics.
+This runtime requires node version >= 16.
 
 ANTLR 4 runtime is available in 10 target languages, and favors consistency of versioning across targets.
 As such it cannot follow recommended NPM semantic versioning.


### PR DESCRIPTION
The current `antlr4` JavaScript package requires Node.JS v16, since https://github.com/antlr/antlr4/commit/2c75e642796718273fd215b03a310d4958319bad (aka ANTLR 4.12.0).

The important line changed is:

https://github.com/antlr/antlr4/blob/ce7f5e73cd4787c5aebdc05c29d4d898d6f2d123/runtime/JavaScript/package.json#L49

**By the way, can an admin modify the release notes for https://github.com/antlr/antlr4/releases/tag/4.12.0 and stick somewhere that the javascript target now requires Node v16?** It's currently missing from the release notes.

By the way, I've also added some badges to the `runtime/JavaScript/README.md` file that automatically load data listed in the `package.json` file, which look like: [![npm version](https://img.shields.io/npm/v/antlr4)](https://www.npmjs.com/package/antlr4) [![Badge showing the supported LTS versions of Node.JS in the latest NPM release](https://img.shields.io/node/v-lts/antlr4)](https://www.npmjs.com/package/antlr4) [![npm type definitions](https://img.shields.io/npm/types/antlr4)](https://www.npmjs.com/package/antlr4)

These shields are pretty common in the Python and JavaScript/NPM eco-system[^1]

[^1]: GitHub even hosts their own badges for GitHub Actions, like [![antlr4](https://github.com/antlr/antlr4/actions/workflows/hosted.yml/badge.svg)](https://github.com/antlr/antlr4/actions/workflows/hosted.yml) is `![antlr4](https://github.com/antlr/antlr4/actions/workflows/hosted.yml/badge.svg)` 


