### PR TITLE
Drop unstable golang.org/x/exp dependency

### DIFF
--- a/runtime/Go/antlr/v4/go.mod
+++ b/runtime/Go/antlr/v4/go.mod
@@ -1,5 +1,3 @@
 module github.com/antlr4-go/antlr/v4
 
 go 1.20
-
-require golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc

--- a/runtime/Go/antlr/v4/go.sum
+++ b/runtime/Go/antlr/v4/go.sum
@@ -1,4 +1,0 @@
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
-golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
-golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/runtime/Go/antlr/v4/lexer_action_executor.go
+++ b/runtime/Go/antlr/v4/lexer_action_executor.go
@@ -4,8 +4,6 @@
 
 package antlr
 
-import "golang.org/x/exp/slices"
-
 // Represents an executor for a sequence of lexer actions which traversed during
 // the Matching operation of a lexer rule (token).
 //
@@ -167,7 +165,10 @@ func (l *LexerActionExecutor) Equals(other interface{}) bool {
 	if len(l.lexerActions) != len(othert.lexerActions) {
 		return false
 	}
-	return slices.EqualFunc(l.lexerActions, othert.lexerActions, func(i, j LexerAction) bool {
-		return i.Equals(j)
-	})
+	for i := range l.lexerActions {
+		if !l.lexerActions[i].Equals(othert.lexerActions[i]) {
+			return false
+		}
+	}
+	return true
 }

--- a/runtime/Go/antlr/v4/prediction_context.go
+++ b/runtime/Go/antlr/v4/prediction_context.go
@@ -6,7 +6,6 @@ package antlr
 
 import (
 	"fmt"
-	"golang.org/x/exp/slices"
 	"strconv"
 )
 
@@ -138,13 +137,25 @@ func (p *PredictionContext) ArrayEquals(o Collectable[*PredictionContext]) bool 
 	if p.cachedHash != other.Hash() {
 		return false // can't be same if hash is different
 	}
-	
+	if len(p.returnStates) != len(other.returnStates) {
+		return false
+	}
+	if len(p.parents) != len(other.parents) {
+		return false
+	}
 	// Must compare the actual array elements and not just the array address
 	//
-	return slices.Equal(p.returnStates, other.returnStates) &&
-		slices.EqualFunc(p.parents, other.parents, func(x, y *PredictionContext) bool {
-			return x.Equals(y)
-		})
+	for i := range p.returnStates {
+		if p.returnStates[i] != other.returnStates[i] {
+			return false
+		}
+	}
+	for i := range p.parents {
+		if !p.parents[i].Equals(other.parents[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func (p *PredictionContext) SingletonEquals(other Collectable[*PredictionContext]) bool {


### PR DESCRIPTION
This PR replaces the only two uses of the `golang.org/x/exp` dependency with an inlined slice equality check.

The golang.org/x/exp module is [explicitly unstable](https://pkg.go.dev/golang.org/x/exp#section-readme), so it is beneficial to avoid depending on it in ways that pass those dependencies on to downstream users.