### PR TITLE
[SWIFT] Add Antlr4Dynamic product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,10 @@ let package = Package(
             name: "Antlr4Static",
             type: .static,
             targets: ["Antlr4"]),
+        .library(
+            name: "Antlr4Dynamic",
+            type: .dynamic,
+            targets: ["Antlr4"]),
     ],
     targets: [
         .target(


### PR DESCRIPTION
SPM cannot always properly recognise dependency type (dynamic or static) so it would be useful to be able to explicitly specify if static or dynamic is needed.
This is the case when eg. dependency is provided not as a source code but rather as a binary and dependency is already fixed into the file.
SPM is not able to detect binary dependencies. There is also no way to specify type of binary's dependencies.

There is already Antlr4Static in Package.swift so dynamic equivalent should be added for completeness.

This PR brings back the [change](https://github.com/antlr/antlr4/pull/3669) that as introduced a year ago but was later overwritten by [dev to master merge](https://github.com/antlr/antlr4/commit/49b69bb31aa34654676a864b229a369680122470#diff-a8ff7c526b830308074a30da78f5627b54ce5a6ed6b6e21b28013057e99a5a06).  
 
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
