### PR TITLE
Add "override" before EOF in TS

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -135,7 +135,7 @@ export default class <parser.name> extends <superClass; null="Parser"> {
 	<if(parser.tokens)>
 	<parser.tokens:{k | public static readonly <k> = <parser.tokens.(k)>;}; separator="\n", wrap, anchor>
 	<endif>
-	public static readonly EOF = Token.EOF;
+	public static override readonly EOF = Token.EOF;
 	<parser.rules:{r | public static readonly RULE_<r.name> = <r.index>;}; separator="\n", wrap, anchor>
 	public static readonly literalNames: (string | null)[] = [ <parser.literalNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];
 	public static readonly symbolicNames: (string | null)[] = [ <parser.symbolicNames:{t | <t>}; null="null", separator=", ", wrap, anchor> ];


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

Currently, when targeting TS, ANTLR will generate a parser file with this code:
<img width="1035" alt="image" src="https://github.com/antlr/antlr4/assets/2680243/dd102889-464e-4556-ba86-7d6fac974ac8">

This PR adds the override keyword to fix this issue.
