### PR TITLE
Java: Use Token.getInputStream()

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/DefaultErrorStrategy.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/DefaultErrorStrategy.java
@@ -596,7 +596,7 @@ public class DefaultErrorStrategy implements ANTLRErrorStrategy {
 			current = lookback;
 		}
 		return
-			recognizer.getTokenFactory().create(new Pair<TokenSource, CharStream>(current.getTokenSource(), current.getTokenSource().getInputStream()), expectedTokenType, tokenText,
+			recognizer.getTokenFactory().create(new Pair<TokenSource, CharStream>(current.getTokenSource(), current.getInputStream()), expectedTokenType, tokenText,
 							Token.DEFAULT_CHANNEL,
 							-1, -1,
 							current.getLine(), current.getCharPositionInLine());

--- a/runtime/Java/src/org/antlr/v4/runtime/ParserInterpreter.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ParserInterpreter.java
@@ -412,7 +412,7 @@ public class ParserInterpreter extends Parser {
 					expectedTokenType = ime.getExpectedTokens().getMinElement(); // get any element
 				}
 				Token errToken =
-					getTokenFactory().create(new Pair<TokenSource, CharStream>(tok.getTokenSource(), tok.getTokenSource().getInputStream()),
+					getTokenFactory().create(new Pair<TokenSource, CharStream>(tok.getTokenSource(), tok.getInputStream()),
 				                             expectedTokenType, tok.getText(),
 				                             Token.DEFAULT_CHANNEL,
 				                            -1, -1, // invalid start/stop
@@ -422,7 +422,7 @@ public class ParserInterpreter extends Parser {
 			else { // NoViableAlt
 				Token tok = e.getOffendingToken();
 				Token errToken =
-					getTokenFactory().create(new Pair<TokenSource, CharStream>(tok.getTokenSource(), tok.getTokenSource().getInputStream()),
+					getTokenFactory().create(new Pair<TokenSource, CharStream>(tok.getTokenSource(), tok.getInputStream()),
 				                             Token.INVALID_TYPE, tok.getText(),
 				                             Token.DEFAULT_CHANNEL,
 				                            -1, -1, // invalid start/stop


### PR DESCRIPTION
This commit changes the Java library to obtain Token input stream directly using `Token.getInputStream()` instead of indirectly using `Token.getTokenSource().getInputStream()`.

This change improves code consistency, as the `CommonToken(Token)` constructor already uses `Token.getInputStream()` without the intermediate `getTokenSource()` call. It also avoids NPE when processing a `Token` with the `source` field set to `CommonToken.EMPTY_SOURCE`.

Fixes: https://github.com/antlr/antlr4/issues/951
