### PR TITLE
[CSharp] Fir for #4386

### DIFF
--- a/doc/go-target.md
+++ b/doc/go-target.md
@@ -78,7 +78,7 @@ If you are already using the repo and import `github.com/antlr4-go/antlr/v4` the
 using the standard.
 
 ```shell
-go get -u get github.com/antlr4-go/antlr
+go get -u github.com/antlr4-go/antlr
 ```
 
 If you have not yet upgraded existing projects to the `/v4` module path, consult the section *Upgrading to v4

--- a/runtime/CSharp/src/Atn/ParserATNSimulator.cs
+++ b/runtime/CSharp/src/Atn/ParserATNSimulator.cs
@@ -2286,7 +2286,7 @@ namespace Antlr4.Runtime.Atn
 								   ", input=" + parser.TokenStream.GetText(interval));
 			}
 			if (parser != null)
-				parser.ErrorListenerDispatch.ReportAttemptingFullContext(parser, dfa, startIndex, stopIndex, conflictingAlts, null /*configs*/);
+				parser.ErrorListenerDispatch.ReportAttemptingFullContext(parser, dfa, startIndex, stopIndex, conflictingAlts, configs);
 		}
 
 		protected virtual void ReportContextSensitivity(DFA dfa, int prediction, ATNConfigSet configs, int startIndex, int stopIndex)
@@ -2297,7 +2297,7 @@ namespace Antlr4.Runtime.Atn
 				Console.WriteLine("ReportContextSensitivity decision=" + dfa.decision + ":" + configs +
 								   ", input=" + parser.TokenStream.GetText(interval));
 			}
-			if (parser != null) parser.ErrorListenerDispatch.ReportContextSensitivity(parser, dfa, startIndex, stopIndex, prediction, null /*configs*/);
+			if (parser != null) parser.ErrorListenerDispatch.ReportContextSensitivity(parser, dfa, startIndex, stopIndex, prediction, configs);
 		}
 
 		/** If context sensitive parsing, we know it's ambiguity not conflict */

--- a/runtime/CSharp/src/BaseErrorListener.cs
+++ b/runtime/CSharp/src/BaseErrorListener.cs
@@ -28,11 +28,11 @@ namespace Antlr4.Runtime
         {
         }
 
-        public virtual void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, SimulatorState conflictState)
+        public virtual void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs)
         {
         }
 
-        public virtual void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, SimulatorState acceptState)
+        public virtual void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs)
         {
         }
     }

--- a/runtime/CSharp/src/DiagnosticErrorListener.cs
+++ b/runtime/CSharp/src/DiagnosticErrorListener.cs
@@ -85,7 +85,7 @@ namespace Antlr4.Runtime
             recognizer.NotifyErrorListeners(message);
         }
 
-        public override void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, SimulatorState conflictState)
+        public override void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs)
         {
             string format = "reportAttemptingFullContext d={0}, input='{1}'";
             string decision = GetDecisionDescription(recognizer, dfa);
@@ -94,7 +94,7 @@ namespace Antlr4.Runtime
             recognizer.NotifyErrorListeners(message);
         }
 
-        public override void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, SimulatorState acceptState)
+        public override void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs)
         {
             string format = "reportContextSensitivity d={0}, input='{1}'";
             string decision = GetDecisionDescription(recognizer, dfa);

--- a/runtime/CSharp/src/IParserErrorListener.cs
+++ b/runtime/CSharp/src/IParserErrorListener.cs
@@ -122,7 +122,7 @@ namespace Antlr4.Runtime
         /// the simulator state when the SLL conflict was
         /// detected
         /// </param>
-        void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, SimulatorState conflictState);
+        void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs);
 
         /// <summary>
         /// This method is called by the parser when a full-context prediction has a
@@ -173,6 +173,6 @@ namespace Antlr4.Runtime
         /// the simulator state when the unambiguous prediction
         /// was determined
         /// </param>
-        void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, SimulatorState acceptState);
+        void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs);
     }
 }

--- a/runtime/CSharp/src/ProxyParserErrorListener.cs
+++ b/runtime/CSharp/src/ProxyParserErrorListener.cs
@@ -30,7 +30,7 @@ namespace Antlr4.Runtime
             }
         }
 
-        public virtual void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, SimulatorState conflictState)
+        public virtual void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs)
         {
             foreach (IAntlrErrorListener<IToken> listener in Delegates)
             {
@@ -39,11 +39,11 @@ namespace Antlr4.Runtime
                     continue;
                 }
                 IParserErrorListener parserErrorListener = (IParserErrorListener)listener;
-                parserErrorListener.ReportAttemptingFullContext(recognizer, dfa, startIndex, stopIndex, conflictingAlts, conflictState);
+                parserErrorListener.ReportAttemptingFullContext(recognizer, dfa, startIndex, stopIndex, conflictingAlts, configs);
             }
         }
 
-        public virtual void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, SimulatorState acceptState)
+        public virtual void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs)
         {
             foreach (IAntlrErrorListener<IToken> listener in Delegates)
             {
@@ -52,7 +52,7 @@ namespace Antlr4.Runtime
                     continue;
                 }
                 IParserErrorListener parserErrorListener = (IParserErrorListener)listener;
-                parserErrorListener.ReportContextSensitivity(recognizer, dfa, startIndex, stopIndex, prediction, acceptState);
+                parserErrorListener.ReportContextSensitivity(recognizer, dfa, startIndex, stopIndex, prediction, configs);
             }
         }
     }

--- a/runtime/Python2/src/antlr4/xpath/XPath.py
+++ b/runtime/Python2/src/antlr4/xpath/XPath.py
@@ -66,12 +66,12 @@ class XPath(object):
     WILDCARD = "*" # word not operator/separator
     NOT = "!" # word for invert operator
 
-    def __init__(self, parser:Parser, path:str):
+    def __init__(self, parser, path):
         self.parser = parser
         self.path = path
         self.elements = self.split(path)
 
-    def split(self, path:str):
+    def split(self, path):
         input = InputStream(path)
         lexer = XPathLexer(input)
         def recover(self, e):
@@ -124,7 +124,7 @@ class XPath(object):
     # element. {@code anywhere} is {@code true} if {@code //} precedes the
     # word.
     #
-    def getXPathElement(self, wordToken:Token, anywhere:bool):
+    def getXPathElement(self, wordToken, anywhere):
         if wordToken.type==Token.EOF:
             raise Exception("Missing path element at end of path")
 
@@ -156,7 +156,7 @@ class XPath(object):
 
 
     @staticmethod
-    def findAll(tree:ParseTree, xpath:str, parser:Parser):
+    def findAll(tree, xpath, parser):
         p = XPath(parser, xpath)
         return p.evaluate(tree)
 
@@ -165,7 +165,7 @@ class XPath(object):
     # path. The root {@code /} is relative to the node passed to
     # {@link #evaluate}.
     #
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         dummyRoot = ParserRuleContext()
         dummyRoot.children = [t] # don't set t's parent.
 
@@ -191,7 +191,7 @@ class XPath(object):
 
 class XPathElement(object):
 
-    def __init__(self, nodeName:str):
+    def __init__(self, nodeName):
         self.nodeName = nodeName
         self.invert = False
 
@@ -205,41 +205,41 @@ class XPathElement(object):
 #
 class XPathRuleAnywhereElement(XPathElement):
 
-    def __init__(self, ruleName:str, ruleIndex:int):
+    def __init__(self, ruleName, ruleIndexint):
         super().__init__(ruleName)
         self.ruleIndex = ruleIndex
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         # return all ParserRuleContext descendants of t that match ruleIndex (or do not match if inverted)
         return filter(lambda c: isinstance(c, ParserRuleContext) and (self.invert ^ (c.getRuleIndex() == self.ruleIndex)), Trees.descendants(t))
 
 class XPathRuleElement(XPathElement):
 
-    def __init__(self, ruleName:str, ruleIndex:int):
+    def __init__(self, ruleName, ruleIndex):
         super().__init__(ruleName)
         self.ruleIndex = ruleIndex
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         # return all ParserRuleContext children of t that match ruleIndex (or do not match if inverted)
         return filter(lambda c: isinstance(c, ParserRuleContext) and (self.invert ^ (c.getRuleIndex() == self.ruleIndex)), Trees.getChildren(t))
 
 class XPathTokenAnywhereElement(XPathElement):
 
-    def __init__(self, ruleName:str, tokenType:int):
+    def __init__(self, ruleName, tokenType):
         super().__init__(ruleName)
         self.tokenType = tokenType
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         # return all TerminalNode descendants of t that match tokenType (or do not match if inverted)
         return filter(lambda c: isinstance(c, TerminalNode) and (self.invert ^ (c.symbol.type == self.tokenType)), Trees.descendants(t))
 
 class XPathTokenElement(XPathElement):
 
-    def __init__(self, ruleName:str, tokenType:int):
+    def __init__(self, ruleName, tokenType):
         super().__init__(ruleName)
         self.tokenType = tokenType
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         # return all TerminalNode children of t that match tokenType (or do not match if inverted)
         return filter(lambda c: isinstance(c, TerminalNode) and (self.invert ^ (c.symbol.type == self.tokenType)), Trees.getChildren(t))
 
@@ -249,7 +249,7 @@ class XPathWildcardAnywhereElement(XPathElement):
     def __init__(self):
         super().__init__(XPath.WILDCARD)
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         if self.invert:
             return list() # !* is weird but valid (empty)
         else:
@@ -262,7 +262,7 @@ class XPathWildcardElement(XPathElement):
         super().__init__(XPath.WILDCARD)
 
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t):
         if self.invert:
             return list() # !* is weird but valid (empty)
         else:


### PR DESCRIPTION
This is a fix for #4386.

In this PR, I changed the signatures for ReportAttemptingFullContext() and ReportContextSensitivity() for the CSharp target to be identical to that for all the other targets. It seems that the code before this change was written with the idea to implement exposing the prediction context in another way, but it never got completed and never worked. This change exposes the ATN config sets so one can use them to create meaningful error messages and perform a better analysis of why a grammar is performing poorly.

There are no tests for this API change. In fact, there was no test for any of the API to display diagnostic errors, and it's unfair to require I write all these tests from scratch at this point. It should have been done years ago, with this [a commit with just one word for the description](https://github.com/antlr/antlr4/commit/10a15804481fb8aad397bb9eba0c5e78f4b15220).