### PR TITLE
Restore "Obtained from string" source name.

### DIFF
--- a/runtime/Go/antlr/v4/input_stream.go
+++ b/runtime/Go/antlr/v4/input_stream.go
@@ -148,7 +148,7 @@ func (is *InputStream) GetTextFromInterval(i Interval) string {
 }
 
 func (*InputStream) GetSourceName() string {
-	return ""
+	return "Obtained from string"
 }
 
 // String returns the entire input stream as a string


### PR DESCRIPTION
This causes a fair number of diffs when importing into Google. If a way of setting the source name for string input streams was provided, then we could have the default be the empty string.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
