### PR TITLE
Move GetText(), SetText(), and String() from CommonToken to BaseToken

### DIFF
--- a/runtime/Go/antlr/v4/token.go
+++ b/runtime/Go/antlr/v4/token.go
@@ -104,6 +104,25 @@ func (b *BaseToken) GetSource() *TokenSourceCharStreamPair {
 	return b.source
 }
 
+func (b *BaseToken) GetText() string {
+	if b.text != "" {
+		return b.text
+	}
+	input := b.GetInputStream()
+	if input == nil {
+		return ""
+	}
+	n := input.Size()
+	if b.GetStart() < n && b.GetStop() < n {
+		return input.GetTextFromInterval(NewInterval(b.GetStart(), b.GetStop()))
+	}
+	return "<EOF>"
+}
+
+func (b *BaseToken) SetText(text string) {
+	b.text = text
+}
+
 func (b *BaseToken) GetTokenIndex() int {
 	return b.tokenIndex
 }
@@ -118,6 +137,28 @@ func (b *BaseToken) GetTokenSource() TokenSource {
 
 func (b *BaseToken) GetInputStream() CharStream {
 	return b.source.charStream
+}
+
+func (b *BaseToken) String() string {
+	txt := b.GetText()
+	if txt != "" {
+		txt = strings.Replace(txt, "\n", "\\n", -1)
+		txt = strings.Replace(txt, "\r", "\\r", -1)
+		txt = strings.Replace(txt, "\t", "\\t", -1)
+	} else {
+		txt = "<no text>"
+	}
+
+	var ch string
+	if b.GetChannel() > 0 {
+		ch = ",channel=" + strconv.Itoa(b.GetChannel())
+	} else {
+		ch = ""
+	}
+
+	return "[@" + strconv.Itoa(b.GetTokenIndex()) + "," + strconv.Itoa(b.GetStart()) + ":" + strconv.Itoa(b.GetStop()) + "='" +
+		txt + "',<" + strconv.Itoa(b.GetTokenType()) + ">" +
+		ch + "," + strconv.Itoa(b.GetLine()) + ":" + strconv.Itoa(b.GetColumn()) + "]"
 }
 
 type CommonToken struct {
@@ -169,45 +210,4 @@ func (c *CommonToken) clone() *CommonToken {
 	t.column = c.GetColumn()
 	t.text = c.GetText()
 	return t
-}
-
-func (c *CommonToken) GetText() string {
-	if c.text != "" {
-		return c.text
-	}
-	input := c.GetInputStream()
-	if input == nil {
-		return ""
-	}
-	n := input.Size()
-	if c.start < n && c.stop < n {
-		return input.GetTextFromInterval(NewInterval(c.start, c.stop))
-	}
-	return "<EOF>"
-}
-
-func (c *CommonToken) SetText(text string) {
-	c.text = text
-}
-
-func (c *CommonToken) String() string {
-	txt := c.GetText()
-	if txt != "" {
-		txt = strings.Replace(txt, "\n", "\\n", -1)
-		txt = strings.Replace(txt, "\r", "\\r", -1)
-		txt = strings.Replace(txt, "\t", "\\t", -1)
-	} else {
-		txt = "<no text>"
-	}
-
-	var ch string
-	if c.channel > 0 {
-		ch = ",channel=" + strconv.Itoa(c.channel)
-	} else {
-		ch = ""
-	}
-
-	return "[@" + strconv.Itoa(c.tokenIndex) + "," + strconv.Itoa(c.start) + ":" + strconv.Itoa(c.stop) + "='" +
-		txt + "',<" + strconv.Itoa(c.tokenType) + ">" +
-		ch + "," + strconv.Itoa(c.line) + ":" + strconv.Itoa(c.column) + "]"
 }


### PR DESCRIPTION
This change means that BaseToken satisfies the Token interface.

The recent addition of the String() function to the Token interface means that any custom BaseToken derivatives no longer satisfy the Token interface. Rather than forcing them all to implement their own String() function, put the CommonToken String function (plus GetText and SetText) into the BaseToken.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
