### PR TITLE
[CSharp] Fix for #4386 -- change signatures for ReportAttemptingFullContext() and ReportContextSensitivity() to be identical to all other targets

### DIFF
--- a/runtime/CSharp/src/Atn/ParserATNSimulator.cs
+++ b/runtime/CSharp/src/Atn/ParserATNSimulator.cs
@@ -2286,7 +2286,7 @@ namespace Antlr4.Runtime.Atn
 								   ", input=" + parser.TokenStream.GetText(interval));
 			}
 			if (parser != null)
-				parser.ErrorListenerDispatch.ReportAttemptingFullContext(parser, dfa, startIndex, stopIndex, conflictingAlts, null /*configs*/);
+				parser.ErrorListenerDispatch.ReportAttemptingFullContext(parser, dfa, startIndex, stopIndex, conflictingAlts, configs);
 		}
 
 		protected virtual void ReportContextSensitivity(DFA dfa, int prediction, ATNConfigSet configs, int startIndex, int stopIndex)
@@ -2297,7 +2297,7 @@ namespace Antlr4.Runtime.Atn
 				Console.WriteLine("ReportContextSensitivity decision=" + dfa.decision + ":" + configs +
 								   ", input=" + parser.TokenStream.GetText(interval));
 			}
-			if (parser != null) parser.ErrorListenerDispatch.ReportContextSensitivity(parser, dfa, startIndex, stopIndex, prediction, null /*configs*/);
+			if (parser != null) parser.ErrorListenerDispatch.ReportContextSensitivity(parser, dfa, startIndex, stopIndex, prediction, configs);
 		}
 
 		/** If context sensitive parsing, we know it's ambiguity not conflict */

--- a/runtime/CSharp/src/BaseErrorListener.cs
+++ b/runtime/CSharp/src/BaseErrorListener.cs
@@ -28,11 +28,11 @@ namespace Antlr4.Runtime
         {
         }
 
-        public virtual void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, SimulatorState conflictState)
+        public virtual void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs)
         {
         }
 
-        public virtual void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, SimulatorState acceptState)
+        public virtual void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs)
         {
         }
     }

--- a/runtime/CSharp/src/DiagnosticErrorListener.cs
+++ b/runtime/CSharp/src/DiagnosticErrorListener.cs
@@ -85,7 +85,7 @@ namespace Antlr4.Runtime
             recognizer.NotifyErrorListeners(message);
         }
 
-        public override void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, SimulatorState conflictState)
+        public override void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs)
         {
             string format = "reportAttemptingFullContext d={0}, input='{1}'";
             string decision = GetDecisionDescription(recognizer, dfa);
@@ -94,7 +94,7 @@ namespace Antlr4.Runtime
             recognizer.NotifyErrorListeners(message);
         }
 
-        public override void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, SimulatorState acceptState)
+        public override void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs)
         {
             string format = "reportContextSensitivity d={0}, input='{1}'";
             string decision = GetDecisionDescription(recognizer, dfa);

--- a/runtime/CSharp/src/IParserErrorListener.cs
+++ b/runtime/CSharp/src/IParserErrorListener.cs
@@ -118,11 +118,11 @@ namespace Antlr4.Runtime
         /// <c>configs</c>
         /// .
         /// </param>
-        /// <param name="conflictState">
-        /// the simulator state when the SLL conflict was
-        /// detected
+        /// <param name="configs">
+        /// the ATN configuration set where the ambiguity was
+        /// identified
         /// </param>
-        void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, SimulatorState conflictState);
+        void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs);
 
         /// <summary>
         /// This method is called by the parser when a full-context prediction has a
@@ -169,10 +169,10 @@ namespace Antlr4.Runtime
         /// finally determined
         /// </param>
         /// <param name="prediction">the unambiguous result of the full-context prediction</param>
-        /// <param name="acceptState">
-        /// the simulator state when the unambiguous prediction
+        /// <param name="configs">
+        /// the ATN configuration set where the unambiguous prediction
         /// was determined
         /// </param>
-        void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, SimulatorState acceptState);
+        void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs);
     }
 }

--- a/runtime/CSharp/src/ProxyParserErrorListener.cs
+++ b/runtime/CSharp/src/ProxyParserErrorListener.cs
@@ -30,7 +30,7 @@ namespace Antlr4.Runtime
             }
         }
 
-        public virtual void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, SimulatorState conflictState)
+        public virtual void ReportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs)
         {
             foreach (IAntlrErrorListener<IToken> listener in Delegates)
             {
@@ -39,11 +39,11 @@ namespace Antlr4.Runtime
                     continue;
                 }
                 IParserErrorListener parserErrorListener = (IParserErrorListener)listener;
-                parserErrorListener.ReportAttemptingFullContext(recognizer, dfa, startIndex, stopIndex, conflictingAlts, conflictState);
+                parserErrorListener.ReportAttemptingFullContext(recognizer, dfa, startIndex, stopIndex, conflictingAlts, configs);
             }
         }
 
-        public virtual void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, SimulatorState acceptState)
+        public virtual void ReportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs)
         {
             foreach (IAntlrErrorListener<IToken> listener in Delegates)
             {
@@ -52,7 +52,7 @@ namespace Antlr4.Runtime
                     continue;
                 }
                 IParserErrorListener parserErrorListener = (IParserErrorListener)listener;
-                parserErrorListener.ReportContextSensitivity(recognizer, dfa, startIndex, stopIndex, prediction, acceptState);
+                parserErrorListener.ReportContextSensitivity(recognizer, dfa, startIndex, stopIndex, prediction, configs);
             }
         }
     }


### PR DESCRIPTION
This is a fix for #4386: fix signatures of [ReportAttemptingFullContext()](https://github.com/antlr/antlr4/blob/a27cf84839c4f794e43b83b9b922d9342367fe45/runtime/CSharp/src/DiagnosticErrorListener.cs#L88C30-L88C57) and [ReportContextSensitivity()](https://github.com/antlr/antlr4/blob/a27cf84839c4f794e43b83b9b922d9342367fe45/runtime/CSharp/src/DiagnosticErrorListener.cs#L97) for the CSharp.

In this PR, I changed the signatures for ReportAttemptingFullContext() and ReportContextSensitivity() for the CSharp runtime to be identical to that for all the other runtimes. The code before this change appears to be written with the idea of exposing the prediction context in some other way. But, it seems the idea never was thought completely out, and what was implemented was basically useless null pointers being passed around for no reason. This change exposes the ATN config sets so I can then actually create meaningful error messages and perform a better analysis of why a grammar is performing poorly. Without the change, we are left with code that doesn't work the same way as all the other targets, and doesn't really help us to figure out why a grammar is bad.

Incidentally, you may be wondering why [ReportAmbiguity()](https://github.com/antlr/antlr4/blob/a27cf84839c4f794e43b83b9b922d9342367fe45/runtime/CSharp/src/DiagnosticErrorListener.cs#L74C30-L74C45) does not have the same problem with the signature as the others. It appears that came from initial check-in of the runtime for CSharp. https://github.com/antlr/antlr4/commit/e8c4bc4b0942f755d98f1dd49b63c5b4d8ceccb8#diff-46a0f5d3e67ea8c3d1c4fe92bd6fbbe9bcdfcf01fd05b6cb8bcc4286ac532488R99 

There are no tests for this API change. In fact, there were no tests for any of the API to display diagnostic errors for CSharp. And, it's unfair to require I write all these tests from scratch at this point. It should have been done years ago, with this [a commit with just one word for the description](https://github.com/antlr/antlr4/commit/10a15804481fb8aad397bb9eba0c5e78f4b15220).