### PR TITLE
Improved mypy type-checking for generated Python3 files.

### DIFF
--- a/runtime/Python3/src/antlr4/CommonTokenFactory.py
+++ b/runtime/Python3/src/antlr4/CommonTokenFactory.py
@@ -14,6 +14,8 @@ class TokenFactory(object):
 
     pass
 
+from antlr4.Token import CommonToken
+from antlr4.Token import CommonToken
 class CommonTokenFactory(TokenFactory):
     __slots__ = 'copyText'
 
@@ -26,7 +28,7 @@ class CommonTokenFactory(TokenFactory):
     #
     DEFAULT = None
 
-    def __init__(self, copyText:bool=False):
+    def __init__(self, copyText:bool=False) -> None:
         # Indicates whether {@link CommonToken#setText} should be called after
         # constructing tokens to explicitly set the text. This is useful for cases
         # where the input stream might not be able to provide arbitrary substrings
@@ -43,7 +45,7 @@ class CommonTokenFactory(TokenFactory):
         #
         self.copyText = copyText
 
-    def create(self, source, type:int, text:str, channel:int, start:int, stop:int, line:int, column:int):
+    def create(self, source, type:int, text:str, channel:int, start:int, stop:int, line:int, column:int) -> CommonToken:
         t = CommonToken(source, type, channel, start, stop)
         t.line = line
         t.column = column
@@ -53,7 +55,7 @@ class CommonTokenFactory(TokenFactory):
             t.text = source[1].getText(start,stop)
         return t
 
-    def createThin(self, type:int, text:str):
+    def createThin(self, type:int, text:str) -> CommonToken:
         t = CommonToken(type=type)
         t.text = text
         return t

--- a/runtime/Python3/src/antlr4/CommonTokenStream.py
+++ b/runtime/Python3/src/antlr4/CommonTokenStream.py
@@ -37,14 +37,14 @@ from antlr4.Token import Token
 class CommonTokenStream(BufferedTokenStream):
     __slots__ = 'channel'
 
-    def __init__(self, lexer:Lexer, channel:int=Token.DEFAULT_CHANNEL):
+    def __init__(self, lexer:Lexer, channel:int=Token.DEFAULT_CHANNEL) -> None:
         super().__init__(lexer)
         self.channel = channel
 
-    def adjustSeekIndex(self, i:int):
+    def adjustSeekIndex(self, i:int) -> int:
         return self.nextTokenOnChannel(i, self.channel)
 
-    def LB(self, k:int):
+    def LB(self, k:int) -> None:
         if k==0 or (self.index-k)<0:
             return None
         i = self.index
@@ -58,7 +58,7 @@ class CommonTokenStream(BufferedTokenStream):
             return None
         return self.tokens[i]
 
-    def LT(self, k:int):
+    def LT(self, k:int) -> Optional[Token]:
         self.lazyInit()
         if k == 0:
             return None
@@ -75,7 +75,7 @@ class CommonTokenStream(BufferedTokenStream):
         return self.tokens[i]
 
     # Count EOF just once.#/
-    def getNumberOfOnChannelTokens(self):
+    def getNumberOfOnChannelTokens(self) -> int:
         n = 0
         self.fill()
         for i in range(0, len(self.tokens)):

--- a/runtime/Python3/src/antlr4/FileStream.py
+++ b/runtime/Python3/src/antlr4/FileStream.py
@@ -16,7 +16,7 @@ from antlr4.InputStream import InputStream
 class FileStream(InputStream):
     __slots__ = 'fileName'
 
-    def __init__(self, fileName:str, encoding:str='ascii', errors:str='strict'):
+    def __init__(self, fileName:str, encoding:str='ascii', errors:str='strict') -> None:
         super().__init__(self.readDataFrom(fileName, encoding, errors))
         self.fileName = fileName
 

--- a/runtime/Python3/src/antlr4/InputStream.py
+++ b/runtime/Python3/src/antlr4/InputStream.py
@@ -14,38 +14,38 @@ from antlr4.Token import Token
 class InputStream (object):
     __slots__ = ('name', 'strdata', '_index', 'data', '_size')
 
-    def __init__(self, data: str):
+    def __init__(self, data: str) -> None:
         self.name = "<empty>"
         self.strdata = data
         self._loadString()
 
-    def _loadString(self):
+    def _loadString(self) -> None:
         self._index = 0
         self.data = [ord(c) for c in self.strdata]
         self._size = len(self.data)
 
     @property
-    def index(self):
+    def index(self) -> int:
         return self._index
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self._size
 
     # Reset the stream so that it's in the same state it was
     #  when the object was created *except* the data array is not
     #  touched.
     #
-    def reset(self):
+    def reset(self) -> None:
         self._index = 0
 
-    def consume(self):
+    def consume(self) -> None:
         if self._index >= self._size:
             assert self.LA(1) == Token.EOF
             raise Exception("cannot consume EOF")
         self._index += 1
 
-    def LA(self, offset: int):
+    def LA(self, offset: int) -> int:
         if offset==0:
             return 0 # undefined
         if offset<0:
@@ -55,11 +55,11 @@ class InputStream (object):
             return Token.EOF
         return self.data[pos]
 
-    def LT(self, offset: int):
+    def LT(self, offset: int) -> int:
         return self.LA(offset)
 
     # mark/release do nothing; we have entire buffer
-    def mark(self):
+    def mark(self) -> int:
         return -1
 
     def release(self, marker: int):
@@ -68,14 +68,14 @@ class InputStream (object):
     # consume() ahead until p==_index; can't just set p=_index as we must
     # update line and column. If we seek backwards, just set p
     #
-    def seek(self, _index: int):
+    def seek(self, _index: int) -> None:
         if _index<=self._index:
             self._index = _index # just jump; don't update stream state (line, ...)
             return
         # seek forward
         self._index = min(_index, self._size)
 
-    def getText(self, start :int, stop: int):
+    def getText(self, start :int, stop: int) -> str:
         if stop >= self._size:
             stop = self._size-1
         if start >= self._size:
@@ -83,5 +83,5 @@ class InputStream (object):
         else:
             return self.strdata[start:stop+1]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.strdata

--- a/runtime/Python3/src/antlr4/IntervalSet.py
+++ b/runtime/Python3/src/antlr4/IntervalSet.py
@@ -10,20 +10,21 @@ from antlr4.Token import Token
 # need forward declarations
 IntervalSet = None
 
+from typing import Iterator
 class IntervalSet(object):
     __slots__ = ('intervals', 'readonly')
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.intervals = None
         self.readonly = False
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator:
         if self.intervals is not None:
             for i in self.intervals:
                 for c in i:
                     yield c
 
-    def __getitem__(self, item):
+    def __getitem__(self, item) -> int:
         i = 0
         for k in self:
             if i==item:
@@ -32,10 +33,10 @@ class IntervalSet(object):
                 i += 1
         return Token.INVALID_TYPE
 
-    def addOne(self, v:int):
+    def addOne(self, v:int) -> None:
         self.addRange(range(v, v+1))
 
-    def addRange(self, v:range):
+    def addRange(self, v:range) -> None:
         if self.intervals is None:
             self.intervals = list()
             self.intervals.append(v)
@@ -60,13 +61,13 @@ class IntervalSet(object):
             # greater than any existing
             self.intervals.append(v)
 
-    def addSet(self, other:IntervalSet):
+    def addSet(self, other:IntervalSet) -> IntervalSet:
         if other.intervals is not None:
             for i in other.intervals:
                 self.addRange(i)
         return self
 
-    def reduce(self, k:int):
+    def reduce(self, k:int) -> None:
         # only need to reduce if k is not the last
         if k<len(self.intervals)-1:
             l = self.intervals[k]
@@ -79,23 +80,23 @@ class IntervalSet(object):
                 self.intervals[k] = range(l.start, r.stop)
                 self.intervals.pop(k+1)
 
-    def complement(self, start, stop):
+    def complement(self, start, stop) -> IntervalSet:
         result = IntervalSet()
         result.addRange(range(start,stop+1))
         for i in self.intervals:
             result.removeRange(i)
         return result
 
-    def __contains__(self, item):
+    def __contains__(self, item) -> bool:
         if self.intervals is None:
             return False
         else:
             return any(item in i for i in self.intervals)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return sum(len(i) for i in self.intervals)
 
-    def removeRange(self, v):
+    def removeRange(self, v) -> None:
         if v.start==v.stop-1:
             self.removeOne(v.start)
         elif self.intervals is not None:
@@ -122,7 +123,7 @@ class IntervalSet(object):
                     self.intervals[k] = range(v.stop, i.stop)
                 k += 1
 
-    def removeOne(self, v):
+    def removeOne(self, v) -> None:
         if self.intervals is not None:
             k = 0
             for i in self.intervals:
@@ -150,7 +151,7 @@ class IntervalSet(object):
                 k += 1
 
 
-    def toString(self, literalNames:list, symbolicNames:list):
+    def toString(self, literalNames:list, symbolicNames:list) -> str:
         if self.intervals is None:
             return "{}"
         with StringIO() as buf:
@@ -167,7 +168,7 @@ class IntervalSet(object):
                 buf.write("}")
             return buf.getvalue()
 
-    def elementName(self, literalNames:list, symbolicNames:list, a:int):
+    def elementName(self, literalNames:list, symbolicNames:list, a:int) -> str:
         if a==Token.EOF:
             return "<EOF>"
         elif a==Token.EPSILON:

--- a/runtime/Python3/src/antlr4/LL1Analyzer.py
+++ b/runtime/Python3/src/antlr4/LL1Analyzer.py
@@ -13,6 +13,7 @@ from antlr4.atn.ATNState import ATNState, RuleStopState
 from antlr4.atn.Transition import WildcardTransition, NotSetTransition, AbstractPredicateTransition, RuleTransition
 
 
+from antlr4.IntervalSet import IntervalSet
 class LL1Analyzer (object):
     __slots__ = 'atn'
 
@@ -21,7 +22,7 @@ class LL1Analyzer (object):
     #/
     HIT_PRED = Token.INVALID_TYPE
 
-    def __init__(self, atn:ATN):
+    def __init__(self, atn:ATN) -> None:
         self.atn = atn
 
     #*
@@ -34,7 +35,7 @@ class LL1Analyzer (object):
     # @param s the ATN state
     # @return the expected symbols for each outgoing transition of {@code s}.
     #/
-    def getDecisionLookahead(self, s:ATNState):
+    def getDecisionLookahead(self, s:ATNState) -> None:
         if s is None:
             return None
 
@@ -70,7 +71,7 @@ class LL1Analyzer (object):
     # @return The set of tokens that can follow {@code s} in the ATN in the
     # specified {@code ctx}.
     #/
-    def LOOK(self, s:ATNState, stopState:ATNState=None, ctx:RuleContext=None):
+    def LOOK(self, s:ATNState, stopState:ATNState=None, ctx:RuleContext=None) -> IntervalSet:
         r = IntervalSet()
         seeThruPreds = True # ignore preds; get all lookahead
         lookContext = PredictionContextFromRuleContext(s.atn, ctx) if ctx is not None else None
@@ -108,7 +109,7 @@ class LL1Analyzer (object):
     # is {@code null}.
     #/
     def _LOOK(self, s:ATNState, stopState:ATNState , ctx:PredictionContext, look:IntervalSet, lookBusy:set,
-                     calledRuleStack:set, seeThruPreds:bool, addEOF:bool):
+                     calledRuleStack:set, seeThruPreds:bool, addEOF:bool) -> None:
         c = ATNConfig(s, 0, ctx)
 
         if c in lookBusy:

--- a/runtime/Python3/src/antlr4/Lexer.py
+++ b/runtime/Python3/src/antlr4/Lexer.py
@@ -43,14 +43,14 @@ class Lexer(Recognizer, TokenSource):
     MIN_CHAR_VALUE = 0x0000
     MAX_CHAR_VALUE = 0x10FFFF
 
-    def __init__(self, input:InputStream, output:TextIO = sys.stdout):
+    def __init__(self, input:InputStream, output:TextIO = sys.stdout) -> None:
         super().__init__()
         self._input = input
         self._output = output
         self._factory = CommonTokenFactory.DEFAULT
         self._tokenFactorySourcePair = (self, input)
 
-        self._interp = None # child classes must populate this
+        self._interp : Optional[ATNSimulator] = None # child classes must populate this
 
         # The goal of all lexer rules/methods is to create a token object.
         #  self is an instance variable as multiple rules may collaborate to
@@ -91,7 +91,7 @@ class Lexer(Recognizer, TokenSource):
         self._text = None
 
 
-    def reset(self):
+    def reset(self) -> None:
         # wack Lexer state variables
         if self._input is not None:
             self._input.seek(0) # rewind the input
@@ -163,22 +163,22 @@ class Lexer(Recognizer, TokenSource):
     #  if token==null at end of any token rule, it creates one for you
     #  and emits it.
     #/
-    def skip(self):
+    def skip(self) -> None:
         self._type = self.SKIP
 
-    def more(self):
+    def more(self) -> None:
         self._type = self.MORE
 
-    def mode(self, m:int):
+    def mode(self, m:int) -> None:
         self._mode = m
 
-    def pushMode(self, m:int):
+    def pushMode(self, m:int) -> None:
         if self._interp.debug:
             print("pushMode " + str(m), file=self._output)
         self._modeStack.append(self._mode)
         self.mode(m)
 
-    def popMode(self):
+    def popMode(self) -> int:
         if len(self._modeStack)==0:
             raise Exception("Empty Stack")
         if self._interp.debug:
@@ -192,7 +192,7 @@ class Lexer(Recognizer, TokenSource):
         return self._input
 
     @inputStream.setter
-    def inputStream(self, input:InputStream):
+    def inputStream(self, input:InputStream) -> None:
         self._input = None
         self._tokenFactorySourcePair = (self, self._input)
         self.reset()
@@ -208,7 +208,7 @@ class Lexer(Recognizer, TokenSource):
     #  and getToken (to push tokens into a list and pull from that list
     #  rather than a single variable as self implementation does).
     #/
-    def emitToken(self, token:Token):
+    def emitToken(self, token:Token) -> None:
         self._token = token
 
     # The standard method called to automatically emit a token at the
@@ -232,11 +232,11 @@ class Lexer(Recognizer, TokenSource):
         return eof
 
     @property
-    def type(self):
+    def type(self) -> int:
         return self._type
 
     @type.setter
-    def type(self, type:int):
+    def type(self, type:int) -> None:
         self._type = type
 
     @property
@@ -244,7 +244,7 @@ class Lexer(Recognizer, TokenSource):
         return self._interp.line
 
     @line.setter
-    def line(self, line:int):
+    def line(self, line:int) -> None:
         self._interp.line = line
 
     @property
@@ -252,7 +252,7 @@ class Lexer(Recognizer, TokenSource):
         return self._interp.column
 
     @column.setter
-    def column(self, column:int):
+    def column(self, column:int) -> None:
         self._interp.column = column
 
     # What is the index of the current character of lookahead?#/
@@ -271,13 +271,13 @@ class Lexer(Recognizer, TokenSource):
     # Set the complete text of self token; it wipes any previous
     #  changes to the text.
     @text.setter
-    def text(self, txt:str):
+    def text(self, txt:str) -> None:
         self._text = txt
 
     # Return a list of all Token objects in input char stream.
     #  Forces load of all tokens. Does not include EOF token.
     #/
-    def getAllTokens(self):
+    def getAllTokens(self) -> list:
         tokens = []
         t = self.nextToken()
         while t.type!=Token.EOF:
@@ -285,7 +285,7 @@ class Lexer(Recognizer, TokenSource):
             t = self.nextToken()
         return tokens
 
-    def notifyListeners(self, e:LexerNoViableAltException):
+    def notifyListeners(self, e:LexerNoViableAltException) -> None:
         start = self._tokenStartCharIndex
         stop = self._input.index
         text = self._input.getText(start, stop)
@@ -299,7 +299,7 @@ class Lexer(Recognizer, TokenSource):
                 buf.write(self.getErrorDisplayForChar(c))
             return buf.getvalue()
 
-    def getErrorDisplayForChar(self, c:str):
+    def getErrorDisplayForChar(self, c:str) -> str:
         if ord(c[0])==Token.EOF:
             return "<EOF>"
         elif c=='\n':
@@ -311,7 +311,7 @@ class Lexer(Recognizer, TokenSource):
         else:
             return c
 
-    def getCharErrorDisplay(self, c:str):
+    def getCharErrorDisplay(self, c:str) -> str:
         return "'" + self.getErrorDisplayForChar(c) + "'"
 
     # Lexers can normally match any char in it's vocabulary after matching
@@ -319,7 +319,7 @@ class Lexer(Recognizer, TokenSource):
     #  it all works out.  You can instead use the rule invocation stack
     #  to do sophisticated error recovery if you are in a fragment rule.
     #/
-    def recover(self, re:RecognitionException):
+    def recover(self, re:RecognitionException) -> None:
         if self._input.LA(1) != Token.EOF:
             if isinstance(re, LexerNoViableAltException):
                     # skip a char and try again

--- a/runtime/Python3/src/antlr4/ListTokenSource.py
+++ b/runtime/Python3/src/antlr4/ListTokenSource.py
@@ -32,7 +32,7 @@ class ListTokenSource(TokenSource):
     #
     # @exception NullPointerException if {@code tokens} is {@code null}
     #
-    def __init__(self, tokens:list, sourceName:str=None):
+    def __init__(self, tokens:list, sourceName:str=None) -> None:
         if tokens is None:
             raise ReferenceError("tokens cannot be null")
         self.tokens = tokens
@@ -51,7 +51,7 @@ class ListTokenSource(TokenSource):
     # {@inheritDoc}
     #
     @property
-    def column(self):
+    def column(self) -> int:
         if self.pos < len(self.tokens):
             return self.tokens[self.pos].column
         elif self.eofToken is not None:
@@ -96,7 +96,7 @@ class ListTokenSource(TokenSource):
     # {@inheritDoc}
     #
     @property
-    def line(self):
+    def line(self) -> int:
         if self.pos < len(self.tokens):
             return self.tokens[self.pos].line
         elif self.eofToken is not None:
@@ -120,7 +120,7 @@ class ListTokenSource(TokenSource):
     #
     # {@inheritDoc}
     #
-    def getInputStream(self):
+    def getInputStream(self) -> None:
         if self.pos < len(self.tokens):
             return self.tokens[self.pos].getInputStream()
         elif self.eofToken is not None:
@@ -134,7 +134,7 @@ class ListTokenSource(TokenSource):
     #
     # {@inheritDoc}
     #
-    def getSourceName(self):
+    def getSourceName(self) -> str:
         if self.sourceName is not None:
             return self.sourceName
         inputStream = self.getInputStream()

--- a/runtime/Python3/src/antlr4/Parser.py
+++ b/runtime/Python3/src/antlr4/Parser.py
@@ -25,13 +25,13 @@ from antlr4.tree.Tree import ParseTreeListener, TerminalNode, ErrorNode
 class TraceListener(ParseTreeListener):
     __slots__ = '_parser'
 
-    def __init__(self, parser):
+    def __init__(self, parser) -> None:
         self._parser = parser
 
-    def enterEveryRule(self, ctx):
+    def enterEveryRule(self, ctx) -> None:
         print("enter   " + self._parser.ruleNames[ctx.getRuleIndex()] + ", LT(1)=" + self._parser._input.LT(1).text, file=self._parser._output)
 
-    def visitTerminal(self, node):
+    def visitTerminal(self, node) -> None:
 
         print("consume " + str(node.symbol) + " rule " + self._parser.ruleNames[self._parser._ctx.getRuleIndex()], file=self._parser._output)
 
@@ -39,11 +39,12 @@ class TraceListener(ParseTreeListener):
         pass
 
 
-    def exitEveryRule(self, ctx):
+    def exitEveryRule(self, ctx) -> None:
         print("exit    " + self._parser.ruleNames[ctx.getRuleIndex()] + ", LT(1)=" + self._parser._input.LT(1).text, file=self._parser._output)
 
 
 # self is all the parsing support code essentially; most of it is error recovery stuff.#
+from antlr4.atn.ATN import ATN
 class Parser (Recognizer):
     __slots__ = (
         '_input', '_output', '_errHandler', '_precedenceStack', '_ctx',
@@ -57,11 +58,11 @@ class Parser (Recognizer):
     #
     bypassAltsAtnCache = dict()
 
-    def __init__(self, input:TokenStream, output:TextIO = sys.stdout):
+    def __init__(self, input:TokenStream, output:TextIO = sys.stdout) -> None:
         super().__init__()
         # The input stream.
-        self._input = None
-        self._output = output
+        self._input : Optional[TokenStream] = None
+        self._output : TextIO = output
         # The error handling strategy for the parser. The default value is a new
         # instance of {@link DefaultErrorStrategy}.
         self._errHandler = DefaultErrorStrategy()
@@ -69,7 +70,7 @@ class Parser (Recognizer):
         self._precedenceStack.append(0)
         # The {@link ParserRuleContext} object for the currently executing rule.
         # self is always non-null during the parsing process.
-        self._ctx = None
+        self._ctx : Optional[ParserRuleContext] = None
         # Specifies whether or not the parser should construct a parse tree during
         # the parsing process. The default value is {@code true}.
         self.buildParseTrees = True
@@ -78,17 +79,17 @@ class Parser (Recognizer):
         # later call to {@link #setTrace}{@code (false)}. The listener itself is
         # implemented as a parser listener so self field is not directly used by
         # other parser methods.
-        self._tracer = None
+        self._tracer :TraceListener = None
         # The list of {@link ParseTreeListener} listeners registered to receive
         # events during the parse.
-        self._parseListeners = None
+        self._parseListeners : ParseTreeListener = None
         # The number of syntax errors reported during parsing. self value is
         # incremented each time {@link #notifyErrorListeners} is called.
-        self._syntaxErrors = 0
+        self._syntaxErrors :notifyErrorListeners = 0
         self.setInputStream(input)
 
     # reset the parser's state#
-    def reset(self):
+    def reset(self) -> None:
         if self._input is not None:
             self._input.seek(0)
         self._errHandler.reset(self)
@@ -160,7 +161,7 @@ class Parser (Recognizer):
 
         return t
 
-    def getParseListeners(self):
+    def getParseListeners(self) -> list | None:
         return list() if self._parseListeners is None else self._parseListeners
 
     # Registers {@code listener} to receive events during the parsing process.
@@ -191,7 +192,7 @@ class Parser (Recognizer):
     #
     # @throws NullPointerException if {@code} listener is {@code null}
     #
-    def addParseListener(self, listener:ParseTreeListener):
+    def addParseListener(self, listener:ParseTreeListener) -> None:
         if listener is None:
             raise ReferenceError("listener")
         if self._parseListeners is None:
@@ -205,18 +206,18 @@ class Parser (Recognizer):
     # listener, self method does nothing.</p>
     # @param listener the listener to remove
     #
-    def removeParseListener(self, listener:ParseTreeListener):
+    def removeParseListener(self, listener:ParseTreeListener) -> None:
         if self._parseListeners is not None:
             self._parseListeners.remove(listener)
             if len(self._parseListeners)==0:
                     self._parseListeners = None
 
     # Remove all parse listeners.
-    def removeParseListeners(self):
+    def removeParseListeners(self) -> None:
         self._parseListeners = None
 
     # Notify any parse listeners of an enter rule event.
-    def triggerEnterRuleEvent(self):
+    def triggerEnterRuleEvent(self) -> None:
         if self._parseListeners is not None:
             for listener in self._parseListeners:
                 listener.enterEveryRule(self._ctx)
@@ -227,7 +228,7 @@ class Parser (Recognizer):
     #
     # @see #addParseListener
     #
-    def triggerExitRuleEvent(self):
+    def triggerExitRuleEvent(self) -> None:
         if self._parseListeners is not None:
             # reverse order walk of listeners
             for listener in reversed(self._parseListeners):
@@ -240,14 +241,14 @@ class Parser (Recognizer):
     #
     # @see #notifyErrorListeners
     #
-    def getNumberOfSyntaxErrors(self):
+    def getNumberOfSyntaxErrors(self) -> int:
         return self._syntaxErrors
 
     def getTokenFactory(self):
         return self._input.tokenSource._factory
 
     # Tell our token source and error strategy about a new way to create tokens.#
-    def setTokenFactory(self, factory:TokenFactory):
+    def setTokenFactory(self, factory:TokenFactory) -> None:
         self._input.tokenSource._factory = factory
 
     # The ATN with bypass alternatives is expensive to create so we create it
@@ -256,7 +257,7 @@ class Parser (Recognizer):
     # @throws UnsupportedOperationException if the current parser does not
     # implement the {@link #getSerializedATN()} method.
     #
-    def getATNWithBypassAlts(self):
+    def getATNWithBypassAlts(self) -> ATN:
         serializedAtn = self.getSerializedATN()
         if serializedAtn is None:
             raise UnsupportedOperationException("The current parser does not support an ATN with bypass alternatives.")
@@ -294,17 +295,17 @@ class Parser (Recognizer):
     def getInputStream(self):
         return self.getTokenStream()
 
-    def setInputStream(self, input:InputStream):
+    def setInputStream(self, input:InputStream) -> None:
         self.setTokenStream(input)
 
     def getTokenStream(self):
         return self._input
 
     # Set the token stream and reset the parser.#
-    def setTokenStream(self, input:TokenStream):
-        self._input = None
+    def setTokenStream(self, input:TokenStream) -> None:
+        self._input : Optional[TokenStream] = None
         self.reset()
-        self._input = input
+        self._input: TokenStream = input
 
     # Match needs to return the current input symbol, which gets put
     #  into the label for the associated token ref; e.g., x=ID.
@@ -312,7 +313,7 @@ class Parser (Recognizer):
     def getCurrentToken(self):
         return self._input.LT(1)
 
-    def notifyErrorListeners(self, msg:str, offendingToken:Token = None, e:RecognitionException = None):
+    def notifyErrorListeners(self, msg:str, offendingToken:Token = None, e:RecognitionException = None) -> None:
         if offendingToken is None:
             offendingToken = self.getCurrentToken()
         self._syntaxErrors += 1
@@ -360,7 +361,7 @@ class Parser (Recognizer):
                         listener.visitTerminal(node)
         return o
 
-    def addContextToParseTree(self):
+    def addContextToParseTree(self) -> None:
         # add current context to parent if we have a parent
         if self._ctx.parentCtx is not None:
             self._ctx.parentCtx.addChild(self._ctx)
@@ -368,7 +369,7 @@ class Parser (Recognizer):
     # Always called by generated parsers upon entry to a rule. Access field
     # {@link #_ctx} get the current context.
     #
-    def enterRule(self, localctx:ParserRuleContext , state:int , ruleIndex:int):
+    def enterRule(self, localctx:ParserRuleContext , state:int , ruleIndex:int) -> None:
         self.state = state
         self._ctx = localctx
         self._ctx.start = self._input.LT(1)
@@ -377,7 +378,7 @@ class Parser (Recognizer):
         if self._parseListeners  is not None:
             self.triggerEnterRuleEvent()
 
-    def exitRule(self):
+    def exitRule(self) -> None:
         self._ctx.stop = self._input.LT(-1)
         # trigger event on _ctx, before it reverts to parent
         if self._parseListeners is not None:
@@ -385,7 +386,7 @@ class Parser (Recognizer):
         self.state = self._ctx.invokingState
         self._ctx = self._ctx.parentCtx
 
-    def enterOuterAlt(self, localctx:ParserRuleContext, altNum:int):
+    def enterOuterAlt(self, localctx:ParserRuleContext, altNum:int) -> None:
         localctx.setAltNumber(altNum)
         # if we have new localctx, make sure we replace existing ctx
         # that is previous child of parse tree
@@ -400,13 +401,13 @@ class Parser (Recognizer):
     # @return The precedence level for the top-most precedence rule, or -1 if
     # the parser context is not nested within a precedence rule.
     #
-    def getPrecedence(self):
+    def getPrecedence(self) -> int:
         if len(self._precedenceStack)==0:
             return -1
         else:
             return self._precedenceStack[-1]
 
-    def enterRecursionRule(self, localctx:ParserRuleContext, state:int, ruleIndex:int, precedence:int):
+    def enterRecursionRule(self, localctx:ParserRuleContext, state:int, ruleIndex:int, precedence:int) -> None:
         self.state = state
         self._precedenceStack.append(precedence)
         self._ctx = localctx
@@ -417,7 +418,7 @@ class Parser (Recognizer):
     #
     # Like {@link #enterRule} but for recursive rules.
     #
-    def pushNewRecursionContext(self, localctx:ParserRuleContext, state:int, ruleIndex:int):
+    def pushNewRecursionContext(self, localctx:ParserRuleContext, state:int, ruleIndex:int) -> None:
         previous = self._ctx
         previous.parentCtx = localctx
         previous.invokingState = state
@@ -431,7 +432,7 @@ class Parser (Recognizer):
         if self._parseListeners is not None:
             self.triggerEnterRuleEvent() # simulates rule entry for left-recursive rules
 
-    def unrollRecursionContexts(self, parentCtx:ParserRuleContext):
+    def unrollRecursionContexts(self, parentCtx:ParserRuleContext) -> None:
         self._precedenceStack.pop()
         self._ctx.stop = self._input.LT(-1)
         retCtx = self._ctx # save current ctx (return value)
@@ -450,7 +451,7 @@ class Parser (Recognizer):
             # add return ctx into invoking rule's tree
             parentCtx.addChild(retCtx)
 
-    def getInvokingContext(self, ruleIndex:int):
+    def getInvokingContext(self, ruleIndex:int) -> None:
         ctx = self._ctx
         while ctx is not None:
             if ctx.getRuleIndex() == ruleIndex:
@@ -459,10 +460,10 @@ class Parser (Recognizer):
         return None
 
 
-    def precpred(self, localctx:RuleContext , precedence:int):
+    def precpred(self, localctx:RuleContext , precedence:int) -> bool:
         return precedence >= self._precedenceStack[-1]
 
-    def inContext(self, context:str):
+    def inContext(self, context:str) -> bool:
         # TODO: useful in parser?
         return False
 
@@ -480,7 +481,7 @@ class Parser (Recognizer):
     # @return {@code true} if {@code symbol} can follow the current state in
     # the ATN, otherwise {@code false}.
     #
-    def isExpectedToken(self, symbol:int):
+    def isExpectedToken(self, symbol:int) -> bool:
         atn = self._interp.atn
         ctx = self._ctx
         s = atn.states[self.state]
@@ -518,7 +519,7 @@ class Parser (Recognizer):
         return atn.nextTokens(s)
 
     # Get a rule's index (i.e., {@code RULE_ruleName} field) or -1 if not found.#
-    def getRuleIndex(self, ruleName:str):
+    def getRuleIndex(self, ruleName:str) -> int:
         ruleIndex = self.getRuleIndexMap().get(ruleName, None)
         if ruleIndex is not None:
             return ruleIndex
@@ -532,7 +533,7 @@ class Parser (Recognizer):
     #
     #  this is very useful for error messages.
     #
-    def getRuleInvocationStack(self, p:RuleContext=None):
+    def getRuleInvocationStack(self, p:RuleContext=None) -> list:
         if p is None:
             p = self._ctx
         stack = list()
@@ -547,11 +548,11 @@ class Parser (Recognizer):
         return stack
 
     # For debugging and other purposes.#
-    def getDFAStrings(self):
+    def getDFAStrings(self) -> list:
         return [ str(dfa) for dfa in self._interp.decisionToDFA]
 
     # For debugging and other purposes.#
-    def dumpDFA(self):
+    def dumpDFA(self) -> None:
         seenOne = False
         for i in range(0, len(self._interp.decisionToDFA)):
             dfa = self._interp.decisionToDFA[i]
@@ -569,7 +570,7 @@ class Parser (Recognizer):
     # During a parse is sometimes useful to listen in on the rule entry and exit
     #  events as well as token matches. self is for quick and dirty debugging.
     #
-    def setTrace(self, trace:bool):
+    def setTrace(self, trace:bool) -> None:
         if not trace:
             self.removeParseListener(self._tracer)
             self._tracer = None

--- a/runtime/Python3/src/antlr4/ParserInterpreter.py
+++ b/runtime/Python3/src/antlr4/ParserInterpreter.py
@@ -31,6 +31,7 @@ from antlr4.atn.Transition import Transition
 from antlr4.error.Errors import RecognitionException, UnsupportedOperationException, FailedPredicateException
 
 
+from antlr4.ParserRuleContext import InterpreterRuleContext
 class ParserInterpreter(Parser):
     __slots__ = (
         'grammarFileName', 'atn', 'tokenNames', 'ruleNames', 'decisionToDFA',
@@ -38,7 +39,7 @@ class ParserInterpreter(Parser):
         'pushRecursionContextStates'
     )
 
-    def __init__(self, grammarFileName:str, tokenNames:list, ruleNames:list, atn:ATN, input:TokenStream):
+    def __init__(self, grammarFileName:str, tokenNames:list, ruleNames:list, atn:ATN, input:TokenStream) -> None:
         super().__init__(input)
         self.grammarFileName = grammarFileName
         self.atn = atn
@@ -58,7 +59,7 @@ class ParserInterpreter(Parser):
         self._interp = ParserATNSimulator(self, atn, self.decisionToDFA, self.sharedContextCache)
 
     # Begin parsing at startRuleIndex#
-    def parse(self, startRuleIndex:int):
+    def parse(self, startRuleIndex:int) -> InterpreterRuleContext:
         startRuleStartState = self.atn.ruleToStartState[startRuleIndex]
         rootContext = InterpreterRuleContext(None, ATNState.INVALID_STATE_NUMBER, startRuleIndex)
         if startRuleStartState.isPrecedenceRule:
@@ -89,14 +90,14 @@ class ParserInterpreter(Parser):
                     self._errHandler.reportError(self, e)
                     self._errHandler.recover(self, e)
 
-    def enterRecursionRule(self, localctx:ParserRuleContext, state:int, ruleIndex:int, precedence:int):
+    def enterRecursionRule(self, localctx:ParserRuleContext, state:int, ruleIndex:int, precedence:int) -> None:
         self._parentContextStack.append((self._ctx, localctx.invokingState))
         super().enterRecursionRule(localctx, state, ruleIndex, precedence)
 
     def getATNState(self):
         return self.atn.states[self.state]
 
-    def visitState(self, p:ATNState):
+    def visitState(self, p:ATNState) -> None:
         edge = 0
         if len(p.transitions) > 1:
             self._errHandler.sync(self)
@@ -157,7 +158,7 @@ class ParserInterpreter(Parser):
 
         self.state = transition.target.stateNumber
 
-    def visitRuleStopState(self, p:ATNState):
+    def visitRuleStopState(self, p:ATNState) -> None:
         ruleStartState = self.atn.ruleToStartState[p.ruleIndex]
         if ruleStartState.isPrecedenceRule:
             parentContext = self._parentContextStack.pop()

--- a/runtime/Python3/src/antlr4/ParserRuleContext.py
+++ b/runtime/Python3/src/antlr4/ParserRuleContext.py
@@ -30,12 +30,16 @@ from antlr4.Token import Token
 from antlr4.tree.Tree import ParseTreeListener, ParseTree, TerminalNodeImpl, ErrorNodeImpl, TerminalNode, \
     INVALID_INTERVAL
 
-# need forward declaration
-ParserRuleContext = None
+from typing import Optional
 
+# need forward declaration
+
+from typing import Iterator
+from antlr4.tree.Tree import ErrorNodeImpl
+from antlr4.tree.Tree import TerminalNodeImpl
 class ParserRuleContext(RuleContext):
     __slots__ = ('children', 'start', 'stop', 'exception')
-    def __init__(self, parent:ParserRuleContext = None, invokingStateNumber:int = None ):
+    def __init__(self, parent:Optional["ParserRuleContext"] = None, invokingStateNumber:Optional[int] = None ) -> None:
         super().__init__(parent, invokingStateNumber)
         #* If we are debugging or building a parse tree for a visitor,
         #  we need to track all of the tokens and rule invocations associated
@@ -43,12 +47,12 @@ class ParserRuleContext(RuleContext):
         #  operation because we don't the need to track the details about
         #  how we parse this rule.
         #/
-        self.children = None
-        self.start = None
-        self.stop = None
+        self.children : Optional[ParseTree] = None
+        self.start: Optional[ParseTree] = None
+        self.stop : Optional[ParseTree]= None
         # The exception that forced this rule to return. If the rule successfully
         # completed, this is {@code null}.
-        self.exception = None
+        self.exception : Optional[Exception] = None 
 
     #* COPY a ctx (I'm deliberately not using copy constructor)#/
     #
@@ -60,11 +64,11 @@ class ParserRuleContext(RuleContext):
     # to the generic XContext so this function must copy those nodes to
     # the YContext as well else they are lost!
     #/
-    def copyFrom(self, ctx:ParserRuleContext):
+    def copyFrom(self, ctx:"ParserRuleContext") -> None:
         # from RuleContext
         self.parentCtx = ctx.parentCtx
         self.invokingState = ctx.invokingState
-        self.children = None
+        self.children : ParseTree = None
         self.start = ctx.start
         self.stop = ctx.stop
 
@@ -95,23 +99,23 @@ class ParserRuleContext(RuleContext):
     #  we entered a rule. If we have # label, we will need to remove
     #  generic ruleContext object.
     #/
-    def removeLastChild(self):
+    def removeLastChild(self) -> None:
         if self.children is not None:
             del self.children[len(self.children)-1]
 
-    def addTokenNode(self, token:Token):
+    def addTokenNode(self, token:Token) -> TerminalNodeImpl:
         node = TerminalNodeImpl(token)
         self.addChild(node)
         node.parentCtx = self
         return node
 
-    def addErrorNode(self, badToken:Token):
+    def addErrorNode(self, badToken:Token) -> ErrorNodeImpl:
         node = ErrorNodeImpl(badToken)
         self.addChild(node)
         node.parentCtx = self
         return node
 
-    def getChild(self, i:int, ttype:type = None):
+    def getChild(self, i:int, ttype:type = None) -> None:
         if ttype is None:
             return self.children[i] if len(self.children)>i else None
         else:
@@ -123,14 +127,14 @@ class ParserRuleContext(RuleContext):
                 i -= 1
             return None
 
-    def getChildren(self, predicate = None):
+    def getChildren(self, predicate = None) -> Iterator:
         if self.children is not None:
             for child in self.children:
                 if predicate is not None and not predicate(child):
                     continue
                 yield child
 
-    def getToken(self, ttype:int, i:int):
+    def getToken(self, ttype:int, i:int) -> None:
         for child in self.getChildren():
             if not isinstance(child, TerminalNode):
                 continue
@@ -141,7 +145,7 @@ class ParserRuleContext(RuleContext):
             i -= 1
         return None
 
-    def getTokens(self, ttype:int ):
+    def getTokens(self, ttype:int ) -> list:
         if self.getChildren() is None:
             return []
         tokens = []
@@ -156,7 +160,7 @@ class ParserRuleContext(RuleContext):
     def getTypedRuleContext(self, ctxType:type, i:int):
         return self.getChild(i, ctxType)
 
-    def getTypedRuleContexts(self, ctxType:type):
+    def getTypedRuleContexts(self, ctxType:type) -> list:
         children = self.getChildren()
         if children is None:
             return []
@@ -167,10 +171,10 @@ class ParserRuleContext(RuleContext):
             contexts.append(child)
         return contexts
 
-    def getChildCount(self):
+    def getChildCount(self) -> int:
         return len(self.children) if self.children else 0
 
-    def getSourceInterval(self):
+    def getSourceInterval(self) -> tuple:
         if self.start is None or self.stop is None:
             return INVALID_INTERVAL
         else:
@@ -181,6 +185,6 @@ RuleContext.EMPTY = ParserRuleContext()
 
 class InterpreterRuleContext(ParserRuleContext):
 
-    def __init__(self, parent:ParserRuleContext, invokingStateNumber:int, ruleIndex:int):
+    def __init__(self, parent:ParserRuleContext, invokingStateNumber:int, ruleIndex:int) -> None:
         super().__init__(parent, invokingStateNumber)
         self.ruleIndex = ruleIndex

--- a/runtime/Python3/src/antlr4/Recognizer.py
+++ b/runtime/Python3/src/antlr4/Recognizer.py
@@ -16,12 +16,12 @@ class Recognizer(object):
     tokenTypeMapCache = dict()
     ruleIndexMapCache = dict()
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._listeners = [ ConsoleErrorListener.INSTANCE ]
-        self._interp = None
+        self._interp : Optional[ATNSimulator] = None 
         self._stateNumber = -1
 
-    def extractVersion(self, version):
+    def extractVersion(self, version) -> tuple:
         pos = version.find(".")
         major = version[0:pos]
         version = version[pos+1:]
@@ -33,23 +33,23 @@ class Recognizer(object):
         minor = version[0:pos]
         return major, minor
 
-    def checkVersion(self, toolVersion):
+    def checkVersion(self, toolVersion) -> None:
         runtimeVersion = "4.13.0"
         rvmajor, rvminor = self.extractVersion(runtimeVersion)
         tvmajor, tvminor = self.extractVersion(toolVersion)
         if rvmajor!=tvmajor or rvminor!=tvminor:
             print("ANTLR runtime and generated code versions disagree: "+runtimeVersion+"!="+toolVersion)
 
-    def addErrorListener(self, listener):
+    def addErrorListener(self, listener) -> None:
         self._listeners.append(listener)
 
-    def removeErrorListener(self, listener):
+    def removeErrorListener(self, listener) -> None:
         self._listeners.remove(listener)
 
-    def removeErrorListeners(self):
+    def removeErrorListeners(self) -> None:
         self._listeners = []
 
-    def getTokenTypeMap(self):
+    def getTokenTypeMap(self) -> zip:
         tokenNames = self.getTokenNames()
         if tokenNames is None:
             from antlr4.error.Errors import UnsupportedOperationException
@@ -65,7 +65,7 @@ class Recognizer(object):
     #
     # <p>Used for XPath and tree pattern compilation.</p>
     #
-    def getRuleIndexMap(self):
+    def getRuleIndexMap(self) -> zip:
         ruleNames = self.getRuleNames()
         if ruleNames is None:
             from antlr4.error.Errors import UnsupportedOperationException
@@ -76,7 +76,7 @@ class Recognizer(object):
             self.ruleIndexMapCache[ruleNames] = result
         return result
 
-    def getTokenType(self, tokenName:str):
+    def getTokenType(self, tokenName:str) -> int:
         ttype = self.getTokenTypeMap().get(tokenName, None)
         if ttype is not None:
             return ttype
@@ -104,7 +104,7 @@ class Recognizer(object):
     # feature when necessary. For example, see
     # {@link DefaultErrorStrategy#getTokenErrorDisplay}.
     #
-    def getTokenErrorDisplay(self, t:Token):
+    def getTokenErrorDisplay(self, t:Token) -> str:
         if t is None:
             return "<no token>"
         s = t.text
@@ -118,19 +118,19 @@ class Recognizer(object):
         s = s.replace("\t","\\t")
         return "'" + s + "'"
 
-    def getErrorListenerDispatch(self):
+    def getErrorListenerDispatch(self) -> ProxyErrorListener:
         return ProxyErrorListener(self._listeners)
 
     # subclass needs to override these if there are sempreds or actions
     # that the ATN interp needs to execute
-    def sempred(self, localctx:RuleContext, ruleIndex:int, actionIndex:int):
+    def sempred(self, localctx:RuleContext, ruleIndex:int, actionIndex:int) -> bool:
         return True
 
-    def precpred(self, localctx:RuleContext , precedence:int):
+    def precpred(self, localctx:RuleContext , precedence:int) -> bool:
         return True
 
     @property
-    def state(self):
+    def state(self) -> int:
         return self._stateNumber
 
     # Indicate that the recognizer has changed internal state that is
@@ -141,7 +141,7 @@ class Recognizer(object):
     #  configuration information.
 
     @state.setter
-    def state(self, atnState:int):
+    def state(self, atnState:int) -> None:
         self._stateNumber = atnState
 
 del RecognitionException

--- a/runtime/Python3/src/antlr4/RuleContext.py
+++ b/runtime/Python3/src/antlr4/RuleContext.py
@@ -27,47 +27,45 @@
 from io import StringIO
 from antlr4.tree.Tree import RuleNode, INVALID_INTERVAL, ParseTreeVisitor
 from antlr4.tree.Trees import Trees
+from typing import Optional
 
-# need forward declarations
-RuleContext = None
-Parser = None
-
+from typing import Iterator
 class RuleContext(RuleNode):
     __slots__ = ('parentCtx', 'invokingState')
     EMPTY = None
 
-    def __init__(self, parent:RuleContext=None, invokingState:int=-1):
+    def __init__(self, parent:Optional["RuleContext"]=None, invokingState:int=-1) -> None:
         super().__init__()
         # What context invoked this rule?
-        self.parentCtx = parent
+        self.parentCtx: Optional[RuleContext] = parent
         # What state invoked the rule associated with this context?
         #  The "return address" is the followState of invokingState
         #  If parent is null, this should be -1.
         self.invokingState = invokingState
 
 
-    def depth(self):
+    def depth(self) -> int:
         n = 0
         p = self
         while p is not None:
-            p = p.parentCtx
+            p:Optional[RuleContext] = p.parentCtx
             n += 1
         return n
 
     # A context is empty if there is no invoking state; meaning nobody call
     #  current context.
-    def isEmpty(self):
+    def isEmpty(self) -> bool:
         return self.invokingState == -1
 
     # satisfy the ParseTree / SyntaxTree interface
 
-    def getSourceInterval(self):
+    def getSourceInterval(self) -> tuple:
         return INVALID_INTERVAL
 
-    def getRuleContext(self):
+    def getRuleContext(self) -> RuleContext:
         return self
 
-    def getPayload(self):
+    def getPayload(self) -> RuleContext:
         return self
 
    # Return the combined text of all child nodes. This method only considers
@@ -77,7 +75,7 @@ class RuleContext(RuleNode):
     #  added to the parse trees, they will not appear in the output of this
     #  method.
     #/
-    def getText(self):
+    def getText(self) -> str:
         if self.getChildCount() == 0:
             return ""
         with StringIO() as builder:
@@ -85,7 +83,7 @@ class RuleContext(RuleNode):
                 builder.write(child.getText())
             return builder.getvalue()
 
-    def getRuleIndex(self):
+    def getRuleIndex(self) -> int:
         return -1
 
     # For rule associated with this parse tree internal node, return
@@ -94,7 +92,7 @@ class RuleContext(RuleNode):
     # a subclass of ParserRuleContext with backing field and set
     # option contextSuperClass.
     # to set it.
-    def getAltNumber(self):
+    def getAltNumber(self) -> int:
         return 0 # should use ATN.INVALID_ALT_NUMBER but won't compile
 
     # Set the outer alternative number for this context node. Default
@@ -105,13 +103,13 @@ class RuleContext(RuleNode):
     def setAltNumber(self, altNumber:int):
         pass
 
-    def getChild(self, i:int):
+    def getChild(self, i:int) -> None:
         return None
 
-    def getChildCount(self):
+    def getChildCount(self) -> int:
         return 0
 
-    def getChildren(self):
+    def getChildren(self) -> Iterator:
         for c in []:
             yield c
 
@@ -173,7 +171,7 @@ class RuleContext(RuleNode):
    # Print out a whole tree, not just a node, in LISP format
    #  (root child1 .. childN). Print just a node if this is a leaf.
    #
-    def toStringTree(self, ruleNames:list=None, recog:Parser=None):
+    def toStringTree(self, ruleNames:list=None, recog:Optional["Parser"]=None):
         return Trees.toStringTree(self, ruleNames=ruleNames, recog=recog)
    #  }
    #
@@ -182,7 +180,7 @@ class RuleContext(RuleNode):
    #      return toStringTree((List<String>)null);
    #  }
    #
-    def __str__(self):
+    def __str__(self) -> str:
         return self.toString(None, None)
 
    #  @Override

--- a/runtime/Python3/src/antlr4/Token.py
+++ b/runtime/Python3/src/antlr4/Token.py
@@ -33,7 +33,7 @@ class Token (object):
 
     HIDDEN_CHANNEL = 1
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.source = None
         self.type = None # token type of the token
         self.channel = None # The parser ignores everything not on DEFAULT_CHANNEL
@@ -57,7 +57,7 @@ class Token (object):
     # of the token.
 
     @text.setter
-    def text(self, text:str):
+    def text(self, text:str) -> None:
         self._text = text
 
 
@@ -73,7 +73,7 @@ class CommonToken(Token):
     # {@link #source} for tokens that do not have a source.
     EMPTY_SOURCE = (None, None)
 
-    def __init__(self, source:tuple = EMPTY_SOURCE, type:int = None, channel:int=Token.DEFAULT_CHANNEL, start:int=-1, stop:int=-1):
+    def __init__(self, source:tuple = EMPTY_SOURCE, type:int = None, channel:int=Token.DEFAULT_CHANNEL, start:int=-1, stop:int=-1) -> None:
         super().__init__()
         self.source = source
         self.type = type
@@ -99,7 +99,7 @@ class CommonToken(Token):
     #
     # @param oldToken The token to copy.
      #
-    def clone(self):
+    def clone(self) -> CommonToken:
         t = CommonToken(self.source, self.type, self.channel, self.start, self.stop)
         t.tokenIndex = self.tokenIndex
         t.line = self.line
@@ -108,7 +108,7 @@ class CommonToken(Token):
         return t
 
     @property
-    def text(self):
+    def text(self) -> str | None:
         if self._text is not None:
             return self._text
         input = self.getInputStream()
@@ -121,10 +121,10 @@ class CommonToken(Token):
             return "<EOF>"
 
     @text.setter
-    def text(self, text:str):
+    def text(self, text:str) -> None:
         self._text = text
 
-    def __str__(self):
+    def __str__(self) -> str:
         with StringIO() as buf:
             buf.write("[@")
             buf.write(str(self.tokenIndex))

--- a/runtime/Python3/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python3/src/antlr4/TokenStreamRewriter.py
@@ -17,7 +17,7 @@ class TokenStreamRewriter(object):
     PROGRAM_INIT_SIZE = 100
     MIN_TOKEN_INDEX = 0
 
-    def __init__(self, tokens):
+    def __init__(self, tokens) -> None:
         """
         :type  tokens: antlr4.BufferedTokenStream.BufferedTokenStream
         :param tokens:
@@ -31,48 +31,48 @@ class TokenStreamRewriter(object):
     def getTokenStream(self):
         return self.tokens
 
-    def rollback(self, instruction_index, program_name):
+    def rollback(self, instruction_index, program_name) -> None:
         ins = self.programs.get(program_name, None)
         if ins:
             self.programs[program_name] = ins[self.MIN_TOKEN_INDEX: instruction_index]
 
-    def deleteProgram(self, program_name=DEFAULT_PROGRAM_NAME):
+    def deleteProgram(self, program_name=DEFAULT_PROGRAM_NAME) -> None:
         self.rollback(self.MIN_TOKEN_INDEX, program_name)
 
-    def insertAfterToken(self, token, text, program_name=DEFAULT_PROGRAM_NAME):
+    def insertAfterToken(self, token, text, program_name=DEFAULT_PROGRAM_NAME) -> None:
         self.insertAfter(token.tokenIndex, text, program_name)
 
-    def insertAfter(self, index, text, program_name=DEFAULT_PROGRAM_NAME):
+    def insertAfter(self, index, text, program_name=DEFAULT_PROGRAM_NAME) -> None:
         op = self.InsertAfterOp(self.tokens, index + 1, text)
         rewrites = self.getProgram(program_name)
         op.instructionIndex = len(rewrites)
         rewrites.append(op)
 
-    def insertBeforeIndex(self, index, text):
+    def insertBeforeIndex(self, index, text) -> None:
         self.insertBefore(self.DEFAULT_PROGRAM_NAME, index, text)
 
-    def insertBeforeToken(self, token, text, program_name=DEFAULT_PROGRAM_NAME):
+    def insertBeforeToken(self, token, text, program_name=DEFAULT_PROGRAM_NAME) -> None:
         self.insertBefore(program_name, token.tokenIndex, text)
 
-    def insertBefore(self, program_name, index, text):
+    def insertBefore(self, program_name, index, text) -> None:
         op = self.InsertBeforeOp(self.tokens, index, text)
         rewrites = self.getProgram(program_name)
         op.instructionIndex = len(rewrites)
         rewrites.append(op)
 
-    def replaceIndex(self, index, text):
+    def replaceIndex(self, index, text) -> None:
         self.replace(self.DEFAULT_PROGRAM_NAME, index, index, text)
 
-    def replaceRange(self, from_idx, to_idx, text):
+    def replaceRange(self, from_idx, to_idx, text) -> None:
         self.replace(self.DEFAULT_PROGRAM_NAME, from_idx, to_idx, text)
 
-    def replaceSingleToken(self, token, text):
+    def replaceSingleToken(self, token, text) -> None:
         self.replace(self.DEFAULT_PROGRAM_NAME, token.tokenIndex, token.tokenIndex, text)
 
-    def replaceRangeTokens(self, from_token, to_token, text, program_name=DEFAULT_PROGRAM_NAME):
+    def replaceRangeTokens(self, from_token, to_token, text, program_name=DEFAULT_PROGRAM_NAME) -> None:
         self.replace(program_name, from_token.tokenIndex, to_token.tokenIndex, text)
 
-    def replace(self, program_name, from_idx, to_idx, text):
+    def replace(self, program_name, from_idx, to_idx, text) -> None:
         if any((from_idx > to_idx, from_idx < 0, to_idx < 0, to_idx >= len(self.tokens.tokens))):
             raise ValueError(
                 'replace: range invalid: {}..{}(size={})'.format(from_idx, to_idx, len(self.tokens.tokens)))
@@ -81,13 +81,13 @@ class TokenStreamRewriter(object):
         op.instructionIndex = len(rewrites)
         rewrites.append(op)
 
-    def deleteToken(self, token):
+    def deleteToken(self, token) -> None:
         self.delete(self.DEFAULT_PROGRAM_NAME, token, token)
 
-    def deleteIndex(self, index):
+    def deleteIndex(self, index) -> None:
         self.delete(self.DEFAULT_PROGRAM_NAME, index, index)
 
-    def delete(self, program_name, from_idx, to_idx):
+    def delete(self, program_name, from_idx, to_idx) -> None:
         if isinstance(from_idx, Token):
             self.replace(program_name, from_idx.tokenIndex, to_idx.tokenIndex, "")
         else:
@@ -96,7 +96,7 @@ class TokenStreamRewriter(object):
     def lastRewriteTokenIndex(self, program_name=DEFAULT_PROGRAM_NAME):
         return self.lastRewriteTokenIndexes.get(program_name, -1)
 
-    def setLastRewriteTokenIndex(self, program_name, i):
+    def setLastRewriteTokenIndex(self, program_name, i) -> None:
         self.lastRewriteTokenIndexes[program_name] = i
 
     def getProgram(self, program_name):
@@ -137,7 +137,7 @@ class TokenStreamRewriter(object):
 
         return buf.getvalue()
 
-    def _reduceToSingleOperationPerIndex(self, rewrites):
+    def _reduceToSingleOperationPerIndex(self, rewrites) -> dict:
         # Walk replaces
         for i, rop in enumerate(rewrites):
             if any((rop is None, not isinstance(rop, TokenStreamRewriter.ReplaceOp))):

--- a/runtime/Python3/src/antlr4/_pygrun.py
+++ b/runtime/Python3/src/antlr4/_pygrun.py
@@ -26,7 +26,7 @@ def beautify_lisp_string(in_string):
     return out_string
 
 
-def main():
+def main() -> None:
 
     #############################################################
     # parse options

--- a/runtime/Python3/src/antlr4/atn/ATN.py
+++ b/runtime/Python3/src/antlr4/atn/ATN.py
@@ -11,6 +11,9 @@ from antlr4.atn.ATNType import ATNType
 from antlr4.atn.ATNState import ATNState, DecisionState
 
 
+from antlr4.IntervalSet import IntervalSet
+from antlr4.IntervalSet import IntervalSet
+from antlr4.IntervalSet import IntervalSet
 class ATN(object):
     __slots__ = (
         'grammarType', 'maxTokenType', 'states', 'decisionToState',
@@ -21,7 +24,7 @@ class ATN(object):
     INVALID_ALT_NUMBER = 0
 
     # Used for runtime deserialization of ATNs from strings#/
-    def __init__(self, grammarType:ATNType , maxTokenType:int ):
+    def __init__(self, grammarType:ATNType , maxTokenType:int ) -> None:
         # The type of the ATN.
         self.grammarType = grammarType
         # The maximum value for any symbol recognized by a transition in the ATN.
@@ -51,7 +54,7 @@ class ATN(object):
     #  If {@code ctx} is null, the set of tokens will not include what can follow
     #  the rule surrounding {@code s}. In other words, the set will be
     #  restricted to tokens reachable staying within {@code s}'s rule.
-    def nextTokensInContext(self, s:ATNState, ctx:RuleContext):
+    def nextTokensInContext(self, s:ATNState, ctx:RuleContext) -> IntervalSet:
         from antlr4.LL1Analyzer import LL1Analyzer
         anal = LL1Analyzer(self)
         return anal.LOOK(s, ctx=ctx)
@@ -66,19 +69,19 @@ class ATN(object):
         s.nextTokenWithinRule.readonly = True
         return s.nextTokenWithinRule
 
-    def nextTokens(self, s:ATNState, ctx:RuleContext = None):
+    def nextTokens(self, s:ATNState, ctx:RuleContext = None) -> IntervalSet:
         if ctx==None:
             return self.nextTokensNoContext(s)
         else:
             return self.nextTokensInContext(s, ctx)
 
-    def addState(self, state:ATNState):
+    def addState(self, state:ATNState) -> None:
         if state is not None:
             state.atn = self
             state.stateNumber = len(self.states)
         self.states.append(state)
 
-    def removeState(self, state:ATNState):
+    def removeState(self, state:ATNState) -> None:
         self.states[state.stateNumber] = None # just free mem, don't shift states in list
 
     def defineDecisionState(self, s:DecisionState):
@@ -86,7 +89,7 @@ class ATN(object):
         s.decision = len(self.decisionToState)-1
         return s.decision
 
-    def getDecisionState(self, decision:int):
+    def getDecisionState(self, decision:int) -> None:
         if len(self.decisionToState)==0:
             return None
         else:
@@ -110,7 +113,7 @@ class ATN(object):
     # @throws IllegalArgumentException if the ATN does not contain a state with
     # number {@code stateNumber}
     #/
-    def getExpectedTokens(self, stateNumber:int, ctx:RuleContext ):
+    def getExpectedTokens(self, stateNumber:int, ctx:RuleContext ) -> IntervalSet:
         if stateNumber < 0 or stateNumber >= len(self.states):
             raise Exception("Invalid state number.")
         s = self.states[stateNumber]

--- a/runtime/Python3/src/antlr4/atn/ATNConfig.py
+++ b/runtime/Python3/src/antlr4/atn/ATNConfig.py
@@ -17,8 +17,8 @@ from antlr4.atn.ATNState import ATNState, DecisionState
 from antlr4.atn.LexerActionExecutor import LexerActionExecutor
 from antlr4.atn.SemanticContext import SemanticContext
 
-# need a forward declaration
-ATNConfig = None
+# TODO: Do we need this?
+class ATNConfig: pass
 
 class ATNConfig(object):
     __slots__ = (
@@ -26,7 +26,7 @@ class ATNConfig(object):
         'precedenceFilterSuppressed'
     )
 
-    def __init__(self, state:ATNState=None, alt:int=None, context:PredictionContext=None, semantic:SemanticContext=None, config:ATNConfig=None):
+    def __init__(self, state:ATNState=None, alt:int=None, context:PredictionContext=None, semantic:SemanticContext=None, config:ATNConfig=None) -> None:
         if config is not None:
             if state is None:
                 state = config.state
@@ -63,7 +63,7 @@ class ATNConfig(object):
     #  the same state, they predict the same alternative, and
     #  syntactic/semantic contexts are the same.
     #/
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, ATNConfig):
@@ -75,13 +75,13 @@ class ATNConfig(object):
                 and self.semanticContext==other.semanticContext \
                 and self.precedenceFilterSuppressed==other.precedenceFilterSuppressed
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.state.stateNumber, self.alt, self.context, self.semanticContext))
 
-    def hashCodeForConfigSet(self):
+    def hashCodeForConfigSet(self) -> int:
         return hash((self.state.stateNumber, self.alt, hash(self.semanticContext)))
 
-    def equalsForConfigSet(self, other):
+    def equalsForConfigSet(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, ATNConfig):
@@ -91,7 +91,7 @@ class ATNConfig(object):
                 and self.alt==other.alt \
                 and self.semanticContext==other.semanticContext
 
-    def __str__(self):
+    def __str__(self) -> str:
         with StringIO() as buf:
             buf.write('(')
             buf.write(str(self.state))
@@ -110,14 +110,15 @@ class ATNConfig(object):
             buf.write(')')
             return buf.getvalue()
 
+# CHW: WRONG
 # need a forward declaration
-LexerATNConfig = None
+#LexerATNConfig = None
 
 class LexerATNConfig(ATNConfig):
     __slots__ = ('lexerActionExecutor', 'passedThroughNonGreedyDecision')
 
     def __init__(self, state:ATNState, alt:int=None, context:PredictionContext=None, semantic:SemanticContext=SemanticContext.NONE,
-                 lexerActionExecutor:LexerActionExecutor=None, config:LexerATNConfig=None):
+                 lexerActionExecutor:LexerActionExecutor=None, config:"LexerATNConfig"=None) -> None:
         super().__init__(state=state, alt=alt, context=context, semantic=semantic, config=config)
         if config is not None:
             if lexerActionExecutor is None:
@@ -126,12 +127,12 @@ class LexerATNConfig(ATNConfig):
         self.lexerActionExecutor = lexerActionExecutor
         self.passedThroughNonGreedyDecision = False if config is None else self.checkNonGreedyDecision(config, state)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.state.stateNumber, self.alt, self.context,
                 self.semanticContext, self.passedThroughNonGreedyDecision,
                 self.lexerActionExecutor))
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, LexerATNConfig):
@@ -144,16 +145,16 @@ class LexerATNConfig(ATNConfig):
 
 
 
-    def hashCodeForConfigSet(self):
+    def hashCodeForConfigSet(self) -> int:
         return hash(self)
 
 
 
-    def equalsForConfigSet(self, other):
+    def equalsForConfigSet(self, other) -> bool:
         return self==other
 
 
 
-    def checkNonGreedyDecision(self, source:LexerATNConfig, target:ATNState):
+    def checkNonGreedyDecision(self, source:"LexerATNConfig", target:ATNState):
         return source.passedThroughNonGreedyDecision \
             or isinstance(target, DecisionState) and target.nonGreedy

--- a/runtime/Python3/src/antlr4/atn/ATNConfigSet.py
+++ b/runtime/Python3/src/antlr4/atn/ATNConfigSet.py
@@ -19,6 +19,7 @@ from io import StringIO
 
 ATNSimulator = None
 
+from typing import Iterator
 class ATNConfigSet(object):
     __slots__ = (
         'configLookup', 'fullCtx', 'readonly', 'configs', 'uniqueAlt',
@@ -33,7 +34,7 @@ class ATNConfigSet(object):
     # the number of objects associated with ATNConfigs. The other solution is to
     # use a hash table that lets us specify the equals/hashcode operation.
 
-    def __init__(self, fullCtx:bool=True):
+    def __init__(self, fullCtx:bool=True) -> None:
         # All configs but hashed by (s, i, _, pi) not including context. Wiped out
         # when we go readonly as this set becomes a DFA state.
         self.configLookup = dict()
@@ -62,7 +63,7 @@ class ATNConfigSet(object):
 
         self.cachedHashCode = -1
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator:
         return self.configs.__iter__()
 
     # Adding a new config means merging contexts with existing configs for
@@ -74,7 +75,7 @@ class ATNConfigSet(object):
     # <p>This method updates {@link #dipsIntoOuterContext} and
     # {@link #hasSemanticContext} when necessary.</p>
     #/
-    def add(self, config:ATNConfig, mergeCache=None):
+    def add(self, config:ATNConfig, mergeCache=None) -> bool:
         if self.readonly:
             raise Exception("This set is readonly")
         if config.semanticContext is not SemanticContext.NONE:
@@ -113,16 +114,16 @@ class ATNConfigSet(object):
             l.append(config)
         return config
 
-    def getStates(self):
+    def getStates(self) -> set:
         return set(c.state for c in self.configs)
 
-    def getPredicates(self):
+    def getPredicates(self) -> list:
         return list(cfg.semanticContext for cfg in self.configs if cfg.semanticContext!=SemanticContext.NONE)
 
     def get(self, i:int):
         return self.configs[i]
 
-    def optimizeConfigs(self, interpreter:ATNSimulator):
+    def optimizeConfigs(self, interpreter:ATNSimulator) -> None:
         if self.readonly:
             raise IllegalStateException("This set is readonly")
         if len(self.configs)==0:
@@ -130,12 +131,12 @@ class ATNConfigSet(object):
         for config in self.configs:
             config.context = interpreter.getCachedContext(config.context)
 
-    def addAll(self, coll:list):
+    def addAll(self, coll:list) -> bool:
         for c in coll:
             self.add(c)
         return False
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, ATNConfigSet):
@@ -151,23 +152,23 @@ class ATNConfigSet(object):
 
         return same
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         if self.readonly:
             if self.cachedHashCode == -1:
                 self.cachedHashCode = self.hashConfigs()
             return self.cachedHashCode
         return self.hashConfigs()
 
-    def hashConfigs(self):
+    def hashConfigs(self) -> int:
         return reduce(lambda h, cfg: hash((h, cfg)), self.configs, 0)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.configs)
 
-    def isEmpty(self):
+    def isEmpty(self) -> bool:
         return len(self.configs)==0
 
-    def __contains__(self, config):
+    def __contains__(self, config) -> bool:
         if self.configLookup is None:
             raise UnsupportedOperationException("This method is not implemented for readonly sets.")
         h = config.hashCodeForConfigSet()
@@ -178,18 +179,18 @@ class ATNConfigSet(object):
                     return True
         return False
 
-    def clear(self):
+    def clear(self) -> None:
         if self.readonly:
             raise IllegalStateException("This set is readonly")
         self.configs.clear()
         self.cachedHashCode = -1
         self.configLookup.clear()
 
-    def setReadonly(self, readonly:bool):
+    def setReadonly(self, readonly:bool) -> None:
         self.readonly = readonly
         self.configLookup = None # can't mod, no need for lookup cache
 
-    def __str__(self):
+    def __str__(self) -> str:
         with StringIO() as buf:
             buf.write(str_list(self.configs))
             if self.hasSemanticContext:
@@ -208,5 +209,5 @@ class ATNConfigSet(object):
 
 class OrderedATNConfigSet(ATNConfigSet):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()

--- a/runtime/Python3/src/antlr4/atn/ATNDeserializationOptions.py
+++ b/runtime/Python3/src/antlr4/atn/ATNDeserializationOptions.py
@@ -10,12 +10,12 @@ class ATNDeserializationOptions(object):
 
     defaultOptions = None
 
-    def __init__(self, copyFrom:ATNDeserializationOptions = None):
+    def __init__(self, copyFrom:ATNDeserializationOptions = None) -> None:
         self.readonly = False
         self.verifyATN = True if copyFrom is None else copyFrom.verifyATN
         self.generateRuleBypassTransitions = False if copyFrom is None else copyFrom.generateRuleBypassTransitions
 
-    def __setattr__(self, key, value):
+    def __setattr__(self, key: str, value: bool) -> None:
         if key!="readonly" and self.readonly:
             raise Exception("The object is read only.")
         super(type(self), self).__setattr__(key,value)

--- a/runtime/Python3/src/antlr4/atn/ATNDeserializer.py
+++ b/runtime/Python3/src/antlr4/atn/ATNDeserializer.py
@@ -14,15 +14,17 @@ from antlr4.atn.ATNDeserializationOptions import ATNDeserializationOptions
 
 SERIALIZED_VERSION = 4
 
+from antlr4.atn.ATN import ATN
+from antlr4.atn.ATN import ATN
 class ATNDeserializer (object):
     __slots__ = ('deserializationOptions', 'data', 'pos')
 
-    def __init__(self, options : ATNDeserializationOptions = None):
+    def __init__(self, options : ATNDeserializationOptions = None) -> None:
         if options is None:
             options = ATNDeserializationOptions.defaultOptions
         self.deserializationOptions = options
 
-    def deserialize(self, data : [int]):
+    def deserialize(self, data : [int]) -> ATN:
         self.data = data
         self.pos = 0
         self.checkVersion()
@@ -44,18 +46,18 @@ class ATNDeserializer (object):
             self.verifyATN(atn)
         return atn
 
-    def checkVersion(self):
+    def checkVersion(self) -> None:
         version = self.readInt()
         if version != SERIALIZED_VERSION:
             raise Exception("Could not deserialize ATN with version " + str(version) + " (expected " + str(SERIALIZED_VERSION) + ").")
 
-    def readATN(self):
+    def readATN(self) -> ATN:
         idx = self.readInt()
         grammarType = ATNType.fromOrdinal(idx)
         maxTokenType = self.readInt()
         return ATN(grammarType, maxTokenType)
 
-    def readStates(self, atn:ATN):
+    def readStates(self, atn:ATN) -> None:
         loopBackStateNumbers = []
         endStateNumbers = []
         nstates = self.readInt()
@@ -93,7 +95,7 @@ class ATNDeserializer (object):
             stateNumber = self.readInt()
             atn.states[stateNumber].isPrecedenceRule = True
 
-    def readRules(self, atn:ATN):
+    def readRules(self, atn:ATN) -> None:
         nrules = self.readInt()
         if atn.grammarType == ATNType.LEXER:
             atn.ruleToTokenType = [0] * nrules
@@ -114,13 +116,13 @@ class ATNDeserializer (object):
             atn.ruleToStopState[state.ruleIndex] = state
             atn.ruleToStartState[state.ruleIndex].stopState = state
 
-    def readModes(self, atn:ATN):
+    def readModes(self, atn:ATN) -> None:
         nmodes = self.readInt()
         for i in range(0, nmodes):
             s = self.readInt()
             atn.modeToStartState.append(atn.states[s])
 
-    def readSets(self, atn:ATN, sets:list):
+    def readSets(self, atn:ATN, sets:list) -> None:
         m = self.readInt()
         for i in range(0, m):
             iset = IntervalSet()
@@ -134,7 +136,7 @@ class ATNDeserializer (object):
                 i2 = self.readInt()
                 iset.addRange(range(i1, i2 + 1)) # range upper limit is exclusive
 
-    def readEdges(self, atn:ATN, sets:list):
+    def readEdges(self, atn:ATN, sets:list) -> None:
         nedges = self.readInt()
         for i in range(0, nedges):
             src = self.readInt()
@@ -181,7 +183,7 @@ class ATNDeserializer (object):
                     if isinstance(target, StarLoopEntryState):
                         target.loopBackState = state
 
-    def readDecisions(self, atn:ATN):
+    def readDecisions(self, atn:ATN) -> None:
         ndecisions = self.readInt()
         for i in range(0, ndecisions):
             s = self.readInt()
@@ -189,7 +191,7 @@ class ATNDeserializer (object):
             atn.decisionToState.append(decState)
             decState.decision = i
 
-    def readLexerActions(self, atn:ATN):
+    def readLexerActions(self, atn:ATN) -> None:
         if atn.grammarType == ATNType.LEXER:
             count = self.readInt()
             atn.lexerActions = [ None ] * count
@@ -200,7 +202,7 @@ class ATNDeserializer (object):
                 lexerAction = self.lexerActionFactory(actionType, data1, data2)
                 atn.lexerActions[i] = lexerAction
 
-    def generateRuleBypassTransitions(self, atn:ATN):
+    def generateRuleBypassTransitions(self, atn:ATN) -> None:
 
         count = len(atn.ruleToStartState)
         atn.ruleToTokenType = [ 0 ] * count
@@ -210,7 +212,7 @@ class ATNDeserializer (object):
         for i in range(0, count):
             self.generateRuleBypassTransition(atn, i)
 
-    def generateRuleBypassTransition(self, atn:ATN, idx:int):
+    def generateRuleBypassTransition(self, atn:ATN, idx:int) -> None:
 
         bypassStart = BasicBlockStartState()
         bypassStart.ruleIndex = idx
@@ -268,7 +270,7 @@ class ATNDeserializer (object):
         bypassStart.addTransition(EpsilonTransition(matchState))
 
 
-    def stateIsEndStateFor(self, state:ATNState, idx:int):
+    def stateIsEndStateFor(self, state:ATNState, idx:int) -> None:
         if state.ruleIndex != idx:
             return None
         if not isinstance(state, StarLoopEntryState):
@@ -292,7 +294,7 @@ class ATNDeserializer (object):
     #
     # @param atn The ATN.
     #
-    def markPrecedenceDecisions(self, atn:ATN):
+    def markPrecedenceDecisions(self, atn:ATN) -> None:
         for state in atn.states:
             if not isinstance(state, StarLoopEntryState):
                 continue
@@ -308,7 +310,7 @@ class ATNDeserializer (object):
                             isinstance(maybeLoopEndState.transitions[0].target, RuleStopState):
                         state.isPrecedenceDecision = True
 
-    def verifyATN(self, atn:ATN):
+    def verifyATN(self, atn:ATN) -> None:
         if not self.deserializationOptions.verifyATN:
             return
         # verify assumptions
@@ -355,7 +357,7 @@ class ATNDeserializer (object):
             else:
                 self.checkCondition(len(state.transitions) <= 1 or isinstance(state, RuleStopState))
 
-    def checkCondition(self, condition:bool, message=None):
+    def checkCondition(self, condition:bool, message=None) -> None:
         if not condition:
             if message is None:
                 message = "IllegalState"

--- a/runtime/Python3/src/antlr4/atn/ATNSimulator.py
+++ b/runtime/Python3/src/antlr4/atn/ATNSimulator.py
@@ -9,6 +9,8 @@ from antlr4.atn.ATNConfigSet import ATNConfigSet
 from antlr4.dfa.DFAState import DFAState
 
 
+from antlr4.PredictionContext import SingletonPredictionContext
+from antlr4.PredictionContext import ArrayPredictionContext
 class ATNSimulator(object):
     __slots__ = ('atn', 'sharedContextCache', '__dict__')
 
@@ -36,11 +38,11 @@ class ATNSimulator(object):
     #  more time I think and doesn't save on the overall footprint
     #  so it's not worth the complexity.</p>
     #/
-    def __init__(self, atn:ATN, sharedContextCache:PredictionContextCache):
+    def __init__(self, atn:ATN, sharedContextCache:PredictionContextCache) -> None:
         self.atn = atn
         self.sharedContextCache = sharedContextCache
 
-    def getCachedContext(self, context:PredictionContext):
+    def getCachedContext(self, context:PredictionContext) -> SingletonPredictionContext | None | ArrayPredictionContext:
         if self.sharedContextCache is None:
             return context
         visited = dict()

--- a/runtime/Python3/src/antlr4/atn/ATNState.py
+++ b/runtime/Python3/src/antlr4/atn/ATNState.py
@@ -106,7 +106,7 @@ class ATNState(object):
 
     INVALID_STATE_NUMBER = -1
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Which ATN are we in?
         self.atn = None
         self.stateNumber = ATNState.INVALID_STATE_NUMBER
@@ -118,22 +118,22 @@ class ATNState(object):
         # Used to cache lookahead during parsing, not used during construction
         self.nextTokenWithinRule = None
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return self.stateNumber
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return isinstance(other, ATNState) and self.stateNumber==other.stateNumber
 
-    def onlyHasEpsilonTransitions(self):
+    def onlyHasEpsilonTransitions(self) -> bool:
         return self.epsilonOnlyTransitions
 
-    def isNonGreedyExitState(self):
+    def isNonGreedyExitState(self) -> bool:
         return False
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.stateNumber)
 
-    def addTransition(self, trans:Transition, index:int=-1):
+    def addTransition(self, trans:Transition, index:int=-1) -> None:
         if len(self.transitions)==0:
             self.epsilonOnlyTransitions = trans.isEpsilon
         elif self.epsilonOnlyTransitions != trans.isEpsilon:
@@ -146,14 +146,14 @@ class ATNState(object):
 
 class BasicState(ATNState):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.BASIC
 
 
 class DecisionState(ATNState):
     __slots__ = ('decision', 'nonGreedy')
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.decision = -1
         self.nonGreedy = False
@@ -162,13 +162,13 @@ class DecisionState(ATNState):
 class BlockStartState(DecisionState):
     __slots__ = 'endState'
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.endState = None
 
 class BasicBlockStartState(BlockStartState):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.BLOCK_START
 
@@ -176,7 +176,7 @@ class BasicBlockStartState(BlockStartState):
 class BlockEndState(ATNState):
     __slots__ = 'startState'
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.BLOCK_END
         self.startState = None
@@ -188,14 +188,14 @@ class BlockEndState(ATNState):
 #
 class RuleStopState(ATNState):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.RULE_STOP
 
 class RuleStartState(ATNState):
     __slots__ = ('stopState', 'isPrecedenceRule')
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.RULE_START
         self.stopState = None
@@ -206,7 +206,7 @@ class RuleStartState(ATNState):
 #
 class PlusLoopbackState(DecisionState):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.PLUS_LOOP_BACK
 
@@ -218,7 +218,7 @@ class PlusLoopbackState(DecisionState):
 class PlusBlockStartState(BlockStartState):
     __slots__ = 'loopBackState'
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.PLUS_BLOCK_START
         self.loopBackState = None
@@ -226,13 +226,13 @@ class PlusBlockStartState(BlockStartState):
 # The block that begins a closure loop.
 class StarBlockStartState(BlockStartState):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.STAR_BLOCK_START
 
 class StarLoopbackState(ATNState):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.STAR_LOOP_BACK
 
@@ -240,7 +240,7 @@ class StarLoopbackState(ATNState):
 class StarLoopEntryState(DecisionState):
     __slots__ = ('loopBackState', 'isPrecedenceDecision')
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.STAR_LOOP_ENTRY
         self.loopBackState = None
@@ -251,7 +251,7 @@ class StarLoopEntryState(DecisionState):
 class LoopEndState(ATNState):
     __slots__ = 'loopBackState'
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.LOOP_END
         self.loopBackState = None
@@ -259,6 +259,6 @@ class LoopEndState(ATNState):
 # The Tokens rule start state linking to each lexer rule start state */
 class TokensStartState(DecisionState):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stateType = self.TOKEN_START

--- a/runtime/Python3/src/antlr4/atn/ATNType.py
+++ b/runtime/Python3/src/antlr4/atn/ATNType.py
@@ -13,5 +13,5 @@ class ATNType(IntEnum):
     PARSER = 1
 
     @classmethod
-    def fromOrdinal(cls, i:int):
+    def fromOrdinal(cls, i:int) -> "ATNType":
         return cls._value2member_map_[i]

--- a/runtime/Python3/src/antlr4/atn/LexerATNSimulator.py
+++ b/runtime/Python3/src/antlr4/atn/LexerATNSimulator.py
@@ -36,19 +36,18 @@ from antlr4.error.Errors import LexerNoViableAltException, UnsupportedOperationE
 class SimState(object):
     __slots__ = ('index', 'line', 'column', 'dfaState')
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.reset()
 
-    def reset(self):
+    def reset(self) -> None:
         self.index = -1
         self.line = 0
         self.column = -1
         self.dfaState = None
 
-# need forward declaration
-Lexer = None
-LexerATNSimulator = None
-
+from antlr4.atn.ATNConfig import LexerATNConfig
+from antlr4.atn.ATNConfigSet import OrderedATNConfigSet
+from antlr4.dfa.DFAState import DFAState
 class LexerATNSimulator(ATNSimulator):
     __slots__ = (
         'decisionToDFA', 'recog', 'startIndex', 'line', 'column', 'mode',
@@ -63,7 +62,7 @@ class LexerATNSimulator(ATNSimulator):
 
     ERROR = None
 
-    def __init__(self, recog:Lexer, atn:ATN, decisionToDFA:list, sharedContextCache:PredictionContextCache):
+    def __init__(self, recog:Lexer, atn:ATN, decisionToDFA:list, sharedContextCache:PredictionContextCache) -> None:
         super().__init__(atn, sharedContextCache)
         self.decisionToDFA = decisionToDFA
         self.recog = recog
@@ -85,13 +84,13 @@ class LexerATNSimulator(ATNSimulator):
         self.prevAccept = SimState()
 
 
-    def copyState(self, simulator:LexerATNSimulator ):
+    def copyState(self, simulator:"LexerATNSimulator" ) -> None:
         self.column = simulator.column
         self.line = simulator.line
         self.mode = simulator.mode
         self.startIndex = simulator.startIndex
 
-    def match(self, input:InputStream , mode:int):
+    def match(self, input:InputStream , mode:int) -> int:
         self.mode = mode
         mark = input.mark()
         try:
@@ -105,14 +104,14 @@ class LexerATNSimulator(ATNSimulator):
         finally:
             input.release(mark)
 
-    def reset(self):
+    def reset(self) -> None:
         self.prevAccept.reset()
         self.startIndex = -1
         self.line = 1
         self.column = 0
         self.mode = self.DEFAULT_MODE
 
-    def matchATN(self, input:InputStream):
+    def matchATN(self, input:InputStream) -> int:
         startState = self.atn.modeToStartState[self.mode]
 
         if LexerATNSimulator.debug:
@@ -134,7 +133,7 @@ class LexerATNSimulator(ATNSimulator):
 
         return predict
 
-    def execATN(self, input:InputStream, ds0:DFAState):
+    def execATN(self, input:InputStream, ds0:DFAState) -> int:
         if LexerATNSimulator.debug:
             print("start state closure=" + str(ds0.configs))
 
@@ -203,7 +202,7 @@ class LexerATNSimulator(ATNSimulator):
     # @return The existing target DFA state for the given input symbol
     # {@code t}, or {@code null} if the target state for this edge is not
     # already cached
-    def getExistingTargetState(self, s:DFAState, t:int):
+    def getExistingTargetState(self, s:DFAState, t:int) -> None:
         if s.edges is None or t < self.MIN_DFA_EDGE or t > self.MAX_DFA_EDGE:
             return None
 
@@ -223,7 +222,7 @@ class LexerATNSimulator(ATNSimulator):
     # @return The computed target DFA state for the given input symbol
     # {@code t}. If {@code t} does not lead to a valid DFA state, this method
     # returns {@link #ERROR}.
-    def computeTargetState(self, input:InputStream, s:DFAState, t:int):
+    def computeTargetState(self, input:InputStream, s:DFAState, t:int) -> DFAState | None:
         reach = OrderedATNConfigSet()
 
         # if we don't find an existing DFA state
@@ -242,7 +241,7 @@ class LexerATNSimulator(ATNSimulator):
         # Add an edge from s to target DFA found/created for reach
         return self.addDFAEdge(s, t, cfgs=reach)
 
-    def failOrAccept(self, prevAccept:SimState , input:InputStream, reach:ATNConfigSet, t:int):
+    def failOrAccept(self, prevAccept:SimState , input:InputStream, reach:ATNConfigSet, t:int) -> int:
         if self.prevAccept.dfaState is not None:
             lexerActionExecutor = prevAccept.dfaState.lexerActionExecutor
             self.accept(input, lexerActionExecutor, self.startIndex, prevAccept.index, prevAccept.line, prevAccept.column)
@@ -256,7 +255,7 @@ class LexerATNSimulator(ATNSimulator):
     # Given a starting configuration set, figure out all ATN configurations
     #  we can reach upon input {@code t}. Parameter {@code reach} is a return
     #  parameter.
-    def getReachableConfigSet(self, input:InputStream, closure:ATNConfigSet, reach:ATNConfigSet, t:int):
+    def getReachableConfigSet(self, input:InputStream, closure:ATNConfigSet, reach:ATNConfigSet, t:int) -> None:
         # this is used to skip processing for configs which have a lower priority
         # than a config that already reached an accept state for the same rule
         skipAlt = ATN.INVALID_ALT_NUMBER
@@ -282,7 +281,7 @@ class LexerATNSimulator(ATNSimulator):
                         # the one that just reached an accept state.
                         skipAlt = cfg.alt
 
-    def accept(self, input:InputStream, lexerActionExecutor:LexerActionExecutor, startIndex:int, index:int, line:int, charPos:int):
+    def accept(self, input:InputStream, lexerActionExecutor:LexerActionExecutor, startIndex:int, index:int, line:int, charPos:int) -> None:
         if LexerATNSimulator.debug:
             print("ACTION", lexerActionExecutor)
 
@@ -294,13 +293,13 @@ class LexerATNSimulator(ATNSimulator):
         if lexerActionExecutor is not None and self.recog is not None:
             lexerActionExecutor.execute(self.recog, input, startIndex)
 
-    def getReachableTarget(self, trans:Transition, t:int):
+    def getReachableTarget(self, trans:Transition, t:int) -> None:
         if trans.matches(t, 0, self.MAX_CHAR_VALUE):
             return trans.target
         else:
             return None
 
-    def computeStartState(self, input:InputStream, p:ATNState):
+    def computeStartState(self, input:InputStream, p:ATNState) -> OrderedATNConfigSet:
         initialContext = PredictionContext.EMPTY
         configs = OrderedATNConfigSet()
         for i in range(0,len(p.transitions)):
@@ -318,7 +317,7 @@ class LexerATNSimulator(ATNSimulator):
     # @return {@code true} if an accept state is reached, otherwise
     # {@code false}.
     def closure(self, input:InputStream, config:LexerATNConfig, configs:ATNConfigSet, currentAltReachedAcceptState:bool,
-                speculative:bool, treatEofAsEpsilon:bool):
+                speculative:bool, treatEofAsEpsilon:bool) -> bool:
         if LexerATNSimulator.debug:
             print("closure(" + str(config) + ")")
 
@@ -362,7 +361,7 @@ class LexerATNSimulator(ATNSimulator):
 
     # side-effect: can alter configs.hasSemanticContext
     def getEpsilonTarget(self, input:InputStream, config:LexerATNConfig, t:Transition, configs:ATNConfigSet,
-                                           speculative:bool, treatEofAsEpsilon:bool):
+                                           speculative:bool, treatEofAsEpsilon:bool) -> LexerATNConfig | None:
         c = None
         if t.serializationType==Transition.RULE:
                 newContext = SingletonPredictionContext.create(config.context, t.followState.stateNumber)
@@ -448,7 +447,7 @@ class LexerATNSimulator(ATNSimulator):
     # @return {@code true} if the specified predicate evaluates to
     # {@code true}.
     #/
-    def evaluatePredicate(self, input:InputStream, ruleIndex:int, predIndex:int, speculative:bool):
+    def evaluatePredicate(self, input:InputStream, ruleIndex:int, predIndex:int, speculative:bool) -> bool:
         # assume true if no recognizer was provided
         if self.recog is None:
             return True
@@ -469,7 +468,7 @@ class LexerATNSimulator(ATNSimulator):
             input.seek(index)
             input.release(marker)
 
-    def captureSimState(self, settings:SimState, input:InputStream, dfaState:DFAState):
+    def captureSimState(self, settings:SimState, input:InputStream, dfaState:DFAState) -> None:
         settings.index = input.index
         settings.line = self.line
         settings.column = self.column
@@ -549,7 +548,7 @@ class LexerATNSimulator(ATNSimulator):
         # index is first lookahead char, don't include.
         return input.getText(self.startIndex, input.index-1)
 
-    def consume(self, input:InputStream):
+    def consume(self, input:InputStream) -> None:
         curChar = input.LA(1)
         if curChar==ord('\n'):
             self.line += 1
@@ -558,7 +557,7 @@ class LexerATNSimulator(ATNSimulator):
             self.column += 1
         input.consume()
 
-    def getTokenName(self, t:int):
+    def getTokenName(self, t:int) -> str:
         if t==-1:
             return "EOF"
         else:

--- a/runtime/Python3/src/antlr4/atn/LexerAction.py
+++ b/runtime/Python3/src/antlr4/atn/LexerAction.py
@@ -6,10 +6,6 @@
 
 from enum import IntEnum
 
-# need forward declaration
-Lexer = None
-
-
 class LexerActionType(IntEnum):
 
     CHANNEL = 0     #The type of a {@link LexerChannelAction} action.
@@ -24,14 +20,14 @@ class LexerActionType(IntEnum):
 class LexerAction(object):
     __slots__ = ('actionType', 'isPositionDependent')
 
-    def __init__(self, action:LexerActionType):
+    def __init__(self, action:LexerActionType) -> None:
         self.actionType = action
         self.isPositionDependent = False
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.actionType)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return self is other
 
 
@@ -45,13 +41,13 @@ class LexerSkipAction(LexerAction):
     # Provides a singleton instance of this parameterless lexer action.
     INSTANCE = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(LexerActionType.SKIP)
 
-    def execute(self, lexer:Lexer):
+    def execute(self, lexer:Lexer) -> None:
         lexer.skip()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "skip"
 
 LexerSkipAction.INSTANCE = LexerSkipAction()
@@ -61,17 +57,17 @@ LexerSkipAction.INSTANCE = LexerSkipAction()
 class LexerTypeAction(LexerAction):
     __slots__ = 'type'
 
-    def __init__(self, type:int):
+    def __init__(self, type:int) -> None:
         super().__init__(LexerActionType.TYPE)
         self.type = type
 
-    def execute(self, lexer:Lexer):
+    def execute(self, lexer:Lexer) -> None:
         lexer.type = self.type
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.actionType, self.type))
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, LexerTypeAction):
@@ -79,7 +75,7 @@ class LexerTypeAction(LexerAction):
         else:
             return self.type == other.type
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "type(" + str(self.type) + ")"
 
 
@@ -88,19 +84,19 @@ class LexerTypeAction(LexerAction):
 class LexerPushModeAction(LexerAction):
     __slots__ = 'mode'
 
-    def __init__(self, mode:int):
+    def __init__(self, mode:int) -> None:
         super().__init__(LexerActionType.PUSH_MODE)
         self.mode = mode
 
     # <p>This action is implemented by calling {@link Lexer#pushMode} with the
     # value provided by {@link #getMode}.</p>
-    def execute(self, lexer:Lexer):
+    def execute(self, lexer:Lexer) -> None:
         lexer.pushMode(self.mode)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.actionType, self.mode))
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, LexerPushModeAction):
@@ -108,7 +104,7 @@ class LexerPushModeAction(LexerAction):
         else:
             return self.mode == other.mode
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "pushMode(" + str(self.mode) + ")"
 
 
@@ -120,14 +116,14 @@ class LexerPopModeAction(LexerAction):
 
     INSTANCE = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(LexerActionType.POP_MODE)
 
     # <p>This action is implemented by calling {@link Lexer#popMode}.</p>
-    def execute(self, lexer:Lexer):
+    def execute(self, lexer:Lexer) -> None:
         lexer.popMode()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "popMode"
 
 LexerPopModeAction.INSTANCE = LexerPopModeAction()
@@ -140,14 +136,14 @@ class LexerMoreAction(LexerAction):
 
     INSTANCE = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(LexerActionType.MORE)
 
     # <p>This action is implemented by calling {@link Lexer#popMode}.</p>
-    def execute(self, lexer:Lexer):
+    def execute(self, lexer:Lexer) -> None:
         lexer.more()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "more"
 
 LexerMoreAction.INSTANCE = LexerMoreAction()
@@ -157,19 +153,19 @@ LexerMoreAction.INSTANCE = LexerMoreAction()
 class LexerModeAction(LexerAction):
     __slots__ = 'mode'
 
-    def __init__(self, mode:int):
+    def __init__(self, mode:int) -> None:
         super().__init__(LexerActionType.MODE)
         self.mode = mode
 
     # <p>This action is implemented by calling {@link Lexer#mode} with the
     # value provided by {@link #getMode}.</p>
-    def execute(self, lexer:Lexer):
+    def execute(self, lexer:Lexer) -> None:
         lexer.mode(self.mode)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.actionType, self.mode))
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, LexerModeAction):
@@ -177,7 +173,7 @@ class LexerModeAction(LexerAction):
         else:
             return self.mode == other.mode
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "mode(" + str(self.mode) + ")"
 
 # Executes a custom lexer action by calling {@link Recognizer#action} with the
@@ -200,7 +196,7 @@ class LexerCustomAction(LexerAction):
     # @param actionIndex The action index to use for calls to
     # {@link Recognizer#action}.
     #/
-    def __init__(self, ruleIndex:int, actionIndex:int):
+    def __init__(self, ruleIndex:int, actionIndex:int) -> None:
         super().__init__(LexerActionType.CUSTOM)
         self.ruleIndex = ruleIndex
         self.actionIndex = actionIndex
@@ -208,13 +204,13 @@ class LexerCustomAction(LexerAction):
 
     # <p>Custom actions are implemented by calling {@link Lexer#action} with the
     # appropriate rule and action indexes.</p>
-    def execute(self, lexer:Lexer):
+    def execute(self, lexer:Lexer) -> None:
         lexer.action(None, self.ruleIndex, self.actionIndex)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.actionType, self.ruleIndex, self.actionIndex))
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, LexerCustomAction):
@@ -229,19 +225,19 @@ class LexerChannelAction(LexerAction):
 
     # Constructs a new {@code channel} action with the specified channel value.
     # @param channel The channel value to pass to {@link Lexer#setChannel}.
-    def __init__(self, channel:int):
+    def __init__(self, channel:int) -> None:
         super().__init__(LexerActionType.CHANNEL)
         self.channel = channel
 
     # <p>This action is implemented by calling {@link Lexer#setChannel} with the
     # value provided by {@link #getChannel}.</p>
-    def execute(self, lexer:Lexer):
+    def execute(self, lexer:Lexer) -> None:
         lexer._channel = self.channel
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.actionType, self.channel))
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, LexerChannelAction):
@@ -249,7 +245,7 @@ class LexerChannelAction(LexerAction):
         else:
             return self.channel == other.channel
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "channel(" + str(self.channel) + ")"
 
 # This implementation of {@link LexerAction} is used for tracking input offsets
@@ -274,7 +270,7 @@ class LexerIndexedCustomAction(LexerAction):
     # executed.
     # @param action The lexer action to execute at a particular offset in the
     # input {@link CharStream}.
-    def __init__(self, offset:int, action:LexerAction):
+    def __init__(self, offset:int, action:LexerAction) -> None:
         super().__init__(action.actionType)
         self.offset = offset
         self.action = action
@@ -282,14 +278,14 @@ class LexerIndexedCustomAction(LexerAction):
 
     # <p>This method calls {@link #execute} on the result of {@link #getAction}
     # using the provided {@code lexer}.</p>
-    def execute(self, lexer:Lexer):
+    def execute(self, lexer:Lexer) -> None:
         # assume the input stream position was properly set by the calling code
         self.action.execute(lexer)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.actionType, self.offset, self.action))
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, LexerIndexedCustomAction):

--- a/runtime/Python3/src/antlr4/atn/LexerActionExecutor.py
+++ b/runtime/Python3/src/antlr4/atn/LexerActionExecutor.py
@@ -22,7 +22,7 @@ LexerActionExecutor = None
 class LexerActionExecutor(object):
     __slots__ = ('lexerActions', 'hashCode')
 
-    def __init__(self, lexerActions:list=list()):
+    def __init__(self, lexerActions:list=list()) -> None:
         self.lexerActions = lexerActions
         # Caches the result of {@link #hashCode} since the hash code is an element
         # of the performance-critical {@link LexerATNConfig#hashCode} operation.
@@ -43,7 +43,7 @@ class LexerActionExecutor(object):
     # @return A {@link LexerActionExecutor} for executing the combine actions
     # of {@code lexerActionExecutor} and {@code lexerAction}.
     @staticmethod
-    def append(lexerActionExecutor:LexerActionExecutor , lexerAction:LexerAction ):
+    def append(lexerActionExecutor:LexerActionExecutor , lexerAction:LexerAction ) -> LexerActionExecutor:
         if lexerActionExecutor is None:
             return LexerActionExecutor([ lexerAction ])
 
@@ -78,7 +78,7 @@ class LexerActionExecutor(object):
     # @return A {@link LexerActionExecutor} which stores input stream offsets
     # for all position-dependent lexer actions.
     #/
-    def fixOffsetBeforeMatch(self, offset:int):
+    def fixOffsetBeforeMatch(self, offset:int) -> LexerActionExecutor:
         updatedLexerActions = None
         for i in range(0, len(self.lexerActions)):
             if self.lexerActions[i].isPositionDependent and not isinstance(self.lexerActions[i], LexerIndexedCustomAction):
@@ -110,7 +110,7 @@ class LexerActionExecutor(object):
     # {@link IntStream#seek} to set the {@code input} position to the beginning
     # of the token.
     #/
-    def execute(self, lexer:Lexer, input:InputStream, startIndex:int):
+    def execute(self, lexer:Lexer, input:InputStream, startIndex:int) -> None:
         requiresSeek = False
         stopIndex = input.index
         try:
@@ -128,10 +128,10 @@ class LexerActionExecutor(object):
             if requiresSeek:
                 input.seek(stopIndex)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return self.hashCode
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif not isinstance(other, LexerActionExecutor):

--- a/runtime/Python3/src/antlr4/atn/ParserATNSimulator.py
+++ b/runtime/Python3/src/antlr4/atn/ParserATNSimulator.py
@@ -254,6 +254,14 @@ from antlr4.dfa.DFAState import DFAState, PredPrediction
 from antlr4.error.Errors import NoViableAltException
 
 
+from antlr4.atn.ATNConfig import ATNConfig
+from antlr4.atn.ATNConfig import ATNConfig
+from antlr4.atn.ATNConfigSet import ATNConfigSet
+from antlr4.atn.ATNConfigSet import ATNConfigSet
+from antlr4.atn.ATNConfigSet import ATNConfigSet
+from antlr4.atn.ATNConfigSet import ATNConfigSet
+from antlr4.atn.ATNConfigSet import ATNConfigSet
+from antlr4.dfa.DFAState import DFAState
 class ParserATNSimulator(ATNSimulator):
     __slots__ = (
         'parser', 'decisionToDFA', 'predictionMode', '_input', '_startIndex',
@@ -266,7 +274,7 @@ class ParserATNSimulator(ATNSimulator):
     retry_debug = False
 
 
-    def __init__(self, parser:Parser, atn:ATN, decisionToDFA:list, sharedContextCache:PredictionContextCache):
+    def __init__(self, parser:Parser, atn:ATN, decisionToDFA:list, sharedContextCache:PredictionContextCache) -> None:
         super().__init__(atn, sharedContextCache)
         self.parser = parser
         self.decisionToDFA = decisionToDFA
@@ -291,7 +299,7 @@ class ParserATNSimulator(ATNSimulator):
     def reset(self):
         pass
 
-    def adaptivePredict(self, input:TokenStream, decision:int, outerContext:ParserRuleContext):
+    def adaptivePredict(self, input:TokenStream, decision:int, outerContext:ParserRuleContext) -> int:
         if ParserATNSimulator.debug or ParserATNSimulator.trace_atn_sim:
             print("adaptivePredict decision " + str(decision) +
                                    " exec LA(1)==" + self.getLookaheadName(input) +
@@ -383,7 +391,7 @@ class ParserATNSimulator(ATNSimulator):
     #    conflict
     #    conflict + preds
     #
-    def execATN(self, dfa:DFA, s0:DFAState, input:TokenStream, startIndex:int, outerContext:ParserRuleContext ):
+    def execATN(self, dfa:DFA, s0:DFAState, input:TokenStream, startIndex:int, outerContext:ParserRuleContext ) -> int:
         if ParserATNSimulator.debug or ParserATNSimulator.trace_atn_sim:
             print("execATN decision " + str(dfa.decision) +
                     ", DFA state " + str(s0) +
@@ -478,7 +486,7 @@ class ParserATNSimulator(ATNSimulator):
     # {@code t}, or {@code null} if the target state for this edge is not
     # already cached
     #
-    def getExistingTargetState(self, previousD:DFAState, t:int):
+    def getExistingTargetState(self, previousD:DFAState, t:int) -> None:
         edges = previousD.edges
         if edges is None or t + 1 < 0 or t + 1 >= len(edges):
             return None
@@ -497,7 +505,7 @@ class ParserATNSimulator(ATNSimulator):
     # {@code t}. If {@code t} does not lead to a valid DFA state, this method
     # returns {@link #ERROR}.
     #
-    def computeTargetState(self, dfa:DFA, previousD:DFAState, t:int):
+    def computeTargetState(self, dfa:DFA, previousD:DFAState, t:int) -> DFAState:
         reach = self.computeReachSet(previousD.configs, t, False)
         if reach is None:
             self.addDFAEdge(dfa, previousD, t, self.ERROR)
@@ -537,7 +545,7 @@ class ParserATNSimulator(ATNSimulator):
         D = self.addDFAEdge(dfa, previousD, t, D)
         return D
 
-    def predicateDFAState(self, dfaState:DFAState, decisionState:DecisionState):
+    def predicateDFAState(self, dfaState:DFAState, decisionState:DecisionState) -> None:
         # We need to test all predicates, even in DFA states that
         # uniquely predict alternative.
         nalts = len(decisionState.transitions)
@@ -559,7 +567,7 @@ class ParserATNSimulator(ATNSimulator):
                                          s0:ATNConfigSet,
                                          input:TokenStream,
                                          startIndex:int,
-                                         outerContext:ParserRuleContext):
+                                         outerContext:ParserRuleContext) -> int:
         if ParserATNSimulator.debug or ParserATNSimulator.trace_atn_sim:
             print("execATNWithFullContext", str(s0))
         fullCtx = True
@@ -658,7 +666,7 @@ class ParserATNSimulator(ATNSimulator):
 
         return predictedAlt
 
-    def computeReachSet(self, closure:ATNConfigSet, t:int, fullCtx:bool):
+    def computeReachSet(self, closure:ATNConfigSet, t:int, fullCtx:bool) -> ATNConfigSet | None:
         if ParserATNSimulator.debug:
             print("in computeReachSet, starting closure: " + str(closure))
 
@@ -791,7 +799,7 @@ class ParserATNSimulator(ATNSimulator):
     # rule stop state, otherwise return a new configuration set containing only
     # the configurations from {@code configs} which are in a rule stop state
     #
-    def removeAllConfigsNotInRuleStopState(self, configs:ATNConfigSet, lookToEndOfRule:bool):
+    def removeAllConfigsNotInRuleStopState(self, configs:ATNConfigSet, lookToEndOfRule:bool) -> ATNConfigSet:
         if PredictionMode.allConfigsInRuleStopStates(configs):
             return configs
         result = ATNConfigSet(configs.fullCtx)
@@ -806,7 +814,7 @@ class ParserATNSimulator(ATNSimulator):
                     result.add(ATNConfig(state=endOfRuleState, config=config), self.mergeCache)
         return result
 
-    def computeStartState(self, p:ATNState, ctx:RuleContext, fullCtx:bool):
+    def computeStartState(self, p:ATNState, ctx:RuleContext, fullCtx:bool) -> ATNConfigSet:
         # always at least the implicit call to start rule
         initialContext = PredictionContextFromRuleContext(self.atn, ctx)
         configs = ATNConfigSet(fullCtx)
@@ -878,7 +886,7 @@ class ParserATNSimulator(ATNSimulator):
     # for a precedence DFA at a particular precedence level (determined by
     # calling {@link Parser#getPrecedence}).
     #
-    def applyPrecedenceFilter(self, configs:ATNConfigSet):
+    def applyPrecedenceFilter(self, configs:ATNConfigSet) -> ATNConfigSet:
         statesFromAlt1 = dict()
         configSet = ATNConfigSet(configs.fullCtx)
         for config in configs:
@@ -915,7 +923,7 @@ class ParserATNSimulator(ATNSimulator):
 
         return configSet
 
-    def getReachableTarget(self, trans:Transition, ttype:int):
+    def getReachableTarget(self, trans:Transition, ttype:int) -> None:
         if trans.matches(ttype, 0, self.atn.maxTokenType):
             return trans.target
         else:
@@ -953,7 +961,7 @@ class ParserATNSimulator(ATNSimulator):
             print("getPredsForAmbigAlts result " + str_list(altToPred))
         return altToPred
 
-    def getPredicatePredictions(self, ambigAlts:set, altToPred:list):
+    def getPredicatePredictions(self, ambigAlts:set, altToPred:list) -> list | None:
         pairs = []
         containsPredicate = False
         for i in range(1, len(altToPred)):
@@ -1015,7 +1023,7 @@ class ParserATNSimulator(ATNSimulator):
     # {@link ATN#INVALID_ALT_NUMBER} if a suitable alternative was not
     # identified and {@link #adaptivePredict} should report an error instead.
     #
-    def getSynValidOrSemInvalidAltThatFinishedDecisionEntryRule(self, configs:ATNConfigSet, outerContext:ParserRuleContext):
+    def getSynValidOrSemInvalidAltThatFinishedDecisionEntryRule(self, configs:ATNConfigSet, outerContext:ParserRuleContext) -> int:
         semValidConfigs, semInvalidConfigs = self.splitAccordingToSemanticValidity(configs, outerContext)
         alt = self.getAltThatFinishedDecisionEntryRule(semValidConfigs)
         if alt!=ATN.INVALID_ALT_NUMBER: # semantically/syntactically viable path exists
@@ -1027,7 +1035,7 @@ class ParserATNSimulator(ATNSimulator):
                 return alt
         return ATN.INVALID_ALT_NUMBER
 
-    def getAltThatFinishedDecisionEntryRule(self, configs:ATNConfigSet):
+    def getAltThatFinishedDecisionEntryRule(self, configs:ATNConfigSet) -> int:
         alts = set()
         for c in configs:
             if c.reachesIntoOuterContext>0 or (isinstance(c.state, RuleStopState) and c.context.hasEmptyPath() ):
@@ -1046,7 +1054,7 @@ class ParserATNSimulator(ATNSimulator):
     #  Assumption: the input stream has been restored to the starting point
     #  prediction, which is where predicates need to evaluate.
     #
-    def splitAccordingToSemanticValidity(self, configs:ATNConfigSet, outerContext:ParserRuleContext):
+    def splitAccordingToSemanticValidity(self, configs:ATNConfigSet, outerContext:ParserRuleContext) -> tuple[ATNConfigSet, ATNConfigSet]:
         succeeded = ATNConfigSet(configs.fullCtx)
         failed = ATNConfigSet(configs.fullCtx)
         for c in configs:
@@ -1066,7 +1074,7 @@ class ParserATNSimulator(ATNSimulator):
     #  then we stop at the first predicate that evaluates to true. This
     #  includes pairs with null predicates.
     #
-    def evalSemanticContext(self, predPredictions:list, outerContext:ParserRuleContext, complete:bool):
+    def evalSemanticContext(self, predPredictions:list, outerContext:ParserRuleContext, complete:bool) -> set:
         predictions = set()
         for pair in predPredictions:
             if pair.pred is SemanticContext.NONE:
@@ -1094,13 +1102,13 @@ class ParserATNSimulator(ATNSimulator):
     #     ambig detection thought :(
     #
 
-    def closure(self, config:ATNConfig, configs:ATNConfigSet, closureBusy:set, collectPredicates:bool, fullCtx:bool, treatEofAsEpsilon:bool):
+    def closure(self, config:ATNConfig, configs:ATNConfigSet, closureBusy:set, collectPredicates:bool, fullCtx:bool, treatEofAsEpsilon:bool) -> None:
         initialDepth = 0
         self.closureCheckingStopState(config, configs, closureBusy, collectPredicates,
                                  fullCtx, initialDepth, treatEofAsEpsilon)
 
 
-    def closureCheckingStopState(self, config:ATNConfig, configs:ATNConfigSet, closureBusy:set, collectPredicates:bool, fullCtx:bool, depth:int, treatEofAsEpsilon:bool):
+    def closureCheckingStopState(self, config:ATNConfig, configs:ATNConfigSet, closureBusy:set, collectPredicates:bool, fullCtx:bool, depth:int, treatEofAsEpsilon:bool) -> None:
         if ParserATNSimulator.trace_atn_sim:
             print("closure(" + str(config) + ")")
 
@@ -1142,7 +1150,7 @@ class ParserATNSimulator(ATNSimulator):
         self.closure_(config, configs, closureBusy, collectPredicates, fullCtx, depth, treatEofAsEpsilon)
 
     # Do the actual work of walking epsilon edges#
-    def closure_(self, config:ATNConfig, configs:ATNConfigSet, closureBusy:set, collectPredicates:bool, fullCtx:bool, depth:int, treatEofAsEpsilon:bool):
+    def closure_(self, config:ATNConfig, configs:ATNConfigSet, closureBusy:set, collectPredicates:bool, fullCtx:bool, depth:int, treatEofAsEpsilon:bool) -> None:
         p = config.state
         # optimization
         if not p.epsilonOnlyTransitions:
@@ -1282,7 +1290,7 @@ class ParserATNSimulator(ATNSimulator):
     #
     # @since 4.6
     #
-    def canDropLoopEntryEdgeInLeftRecursiveRule(self, config):
+    def canDropLoopEntryEdgeInLeftRecursiveRule(self, config) -> bool:
         # return False
         p = config.state
         # First check to see if we are in StarLoopEntryState generated during
@@ -1347,7 +1355,7 @@ class ParserATNSimulator(ATNSimulator):
         return True
 
 
-    def getRuleName(self, index:int):
+    def getRuleName(self, index:int) -> str:
         if self.parser is not None and index>=0:
             return self.parser.ruleNames[index]
         else:
@@ -1371,19 +1379,19 @@ class ParserATNSimulator(ATNSimulator):
     epsilonTargetMethods[Transition.SET] = lambda sim, config, t, collectPredicates, inContext, fullCtx, treatEofAsEpsilon: \
         ATNConfig(state=t.target, config=config) if treatEofAsEpsilon and t.matches(Token.EOF, 0, 1) else None
 
-    def getEpsilonTarget(self, config:ATNConfig, t:Transition, collectPredicates:bool, inContext:bool, fullCtx:bool, treatEofAsEpsilon:bool):
+    def getEpsilonTarget(self, config:ATNConfig, t:Transition, collectPredicates:bool, inContext:bool, fullCtx:bool, treatEofAsEpsilon:bool) -> None:
         m = self.epsilonTargetMethods.get(t.serializationType, None)
         if m is None:
             return None
         else:
             return m(self, config, t, collectPredicates, inContext, fullCtx, treatEofAsEpsilon)
 
-    def actionTransition(self, config:ATNConfig, t:ActionTransition):
+    def actionTransition(self, config:ATNConfig, t:ActionTransition) -> ATNConfig:
         if ParserATNSimulator.debug:
             print("ACTION edge " + str(t.ruleIndex) + ":" + str(t.actionIndex))
         return ATNConfig(state=t.target, config=config)
 
-    def precedenceTransition(self, config:ATNConfig, pt:PrecedencePredicateTransition,  collectPredicates:bool, inContext:bool, fullCtx:bool):
+    def precedenceTransition(self, config:ATNConfig, pt:PrecedencePredicateTransition,  collectPredicates:bool, inContext:bool, fullCtx:bool) -> ATNConfig | None:
         if ParserATNSimulator.debug:
             print("PRED (collectPredicates=" + str(collectPredicates) + ") " +
                     str(pt.precedence) + ">=_p, ctx dependent=true")
@@ -1413,7 +1421,7 @@ class ParserATNSimulator(ATNSimulator):
             print("config from pred transition=" + str(c))
         return c
 
-    def predTransition(self, config:ATNConfig, pt:PredicateTransition, collectPredicates:bool, inContext:bool, fullCtx:bool):
+    def predTransition(self, config:ATNConfig, pt:PredicateTransition, collectPredicates:bool, inContext:bool, fullCtx:bool) -> ATNConfig | None:
         if ParserATNSimulator.debug:
             print("PRED (collectPredicates=" + str(collectPredicates) + ") " + str(pt.ruleIndex) +
                     ":" + str(pt.predIndex) + ", ctx dependent=" + str(pt.isCtxDependent))
@@ -1443,7 +1451,7 @@ class ParserATNSimulator(ATNSimulator):
             print("config from pred transition=" + str(c))
         return c
 
-    def ruleTransition(self, config:ATNConfig, t:RuleTransition):
+    def ruleTransition(self, config:ATNConfig, t:RuleTransition) -> ATNConfig:
         if ParserATNSimulator.debug:
             print("CALL rule " + self.getRuleName(t.target.ruleIndex) + ", ctx=" + str(config.context))
         returnState = t.followState
@@ -1490,7 +1498,7 @@ class ParserATNSimulator(ATNSimulator):
      # that we still need to pursue.
     #
 
-    def getConflictingAltsOrUniqueAlt(self, configs:ATNConfigSet):
+    def getConflictingAltsOrUniqueAlt(self, configs:ATNConfigSet) -> set | None:
         conflictingAlts = None
         if configs.uniqueAlt!= ATN.INVALID_ALT_NUMBER:
             conflictingAlts = set()
@@ -1499,7 +1507,7 @@ class ParserATNSimulator(ATNSimulator):
             conflictingAlts = configs.conflictingAlts
         return conflictingAlts
 
-    def getTokenName(self, t:int):
+    def getTokenName(self, t:int) -> str:
         if t==Token.EOF:
             return "EOF"
         if self.parser is not None and \
@@ -1513,14 +1521,14 @@ class ParserATNSimulator(ATNSimulator):
         else:
             return str(t)
 
-    def getLookaheadName(self, input:TokenStream):
+    def getLookaheadName(self, input:TokenStream) -> str:
         return self.getTokenName(input.LA(1))
 
     # Used for debugging in adaptivePredict around execATN but I cut
     #  it out for clarity now that alg. works well. We can leave this
     #  "dead" code for a bit.
     #
-    def dumpDeadEndConfigs(self, nvae:NoViableAltException):
+    def dumpDeadEndConfigs(self, nvae:NoViableAltException) -> None:
         print("dead end configs: ")
         for c in nvae.getDeadEndConfigs():
             trans = "no edges"
@@ -1533,10 +1541,10 @@ class ParserATNSimulator(ATNSimulator):
                     trans = ("~" if neg else "")+"Set "+ str(t.set)
             print(c.toString(self.parser, True) + ":" + trans, file=sys.stderr)
 
-    def noViableAlt(self, input:TokenStream, outerContext:ParserRuleContext, configs:ATNConfigSet, startIndex:int):
+    def noViableAlt(self, input:TokenStream, outerContext:ParserRuleContext, configs:ATNConfigSet, startIndex:int) -> NoViableAltException:
         return NoViableAltException(self.parser, input, input.get(startIndex), input.LT(1), configs, outerContext)
 
-    def getUniqueAlt(self, configs:ATNConfigSet):
+    def getUniqueAlt(self, configs:ATNConfigSet) -> int:
         alt = ATN.INVALID_ALT_NUMBER
         for c in configs:
             if alt == ATN.INVALID_ALT_NUMBER:
@@ -1565,7 +1573,7 @@ class ParserATNSimulator(ATNSimulator):
     # otherwise this method returns the result of calling {@link #addDFAState}
     # on {@code to}
     #
-    def addDFAEdge(self, dfa:DFA, from_:DFAState, t:int, to:DFAState):
+    def addDFAEdge(self, dfa:DFA, from_:DFAState, t:int, to:DFAState) -> None:
         if ParserATNSimulator.debug:
             print("EDGE " + str(from_) + " -> " + str(to) + " upon " + self.getTokenName(t))
 
@@ -1621,14 +1629,14 @@ class ParserATNSimulator(ATNSimulator):
         dfa.states[D] = D
         return D
 
-    def reportAttemptingFullContext(self, dfa:DFA, conflictingAlts:set, configs:ATNConfigSet, startIndex:int, stopIndex:int):
+    def reportAttemptingFullContext(self, dfa:DFA, conflictingAlts:set, configs:ATNConfigSet, startIndex:int, stopIndex:int) -> None:
         if ParserATNSimulator.debug or ParserATNSimulator.retry_debug:
             print("reportAttemptingFullContext decision=" + str(dfa.decision) + ":" + str(configs) +
                                ", input=" + self.parser.getTokenStream().getText(startIndex, stopIndex))
         if self.parser is not None:
             self.parser.getErrorListenerDispatch().reportAttemptingFullContext(self.parser, dfa, startIndex, stopIndex, conflictingAlts, configs)
 
-    def reportContextSensitivity(self, dfa:DFA, prediction:int, configs:ATNConfigSet, startIndex:int, stopIndex:int):
+    def reportContextSensitivity(self, dfa:DFA, prediction:int, configs:ATNConfigSet, startIndex:int, stopIndex:int) -> None:
         if ParserATNSimulator.debug or ParserATNSimulator.retry_debug:
             print("reportContextSensitivity decision=" + str(dfa.decision) + ":" + str(configs) +
                                ", input=" + self.parser.getTokenStream().getText(startIndex, stopIndex))
@@ -1637,7 +1645,7 @@ class ParserATNSimulator(ATNSimulator):
 
     # If context sensitive parsing, we know it's ambiguity not conflict#
     def reportAmbiguity(self, dfa:DFA, D:DFAState, startIndex:int, stopIndex:int,
-                                   exact:bool, ambigAlts:set, configs:ATNConfigSet ):
+                                   exact:bool, ambigAlts:set, configs:ATNConfigSet ) -> None:
         if ParserATNSimulator.debug or ParserATNSimulator.retry_debug:
 #			ParserATNPathFinder finder = new ParserATNPathFinder(parser, atn);
 #			int i = 1;

--- a/runtime/Python3/src/antlr4/atn/PredictionMode.py
+++ b/runtime/Python3/src/antlr4/atn/PredictionMode.py
@@ -173,7 +173,7 @@ class PredictionMode(Enum):
     # {@link ATNConfigSet} will merge everything ignoring predicates.</p>
     #
     @classmethod
-    def hasSLLConflictTerminatingPrediction(cls, mode:PredictionMode, configs:ATNConfigSet):
+    def hasSLLConflictTerminatingPrediction(cls, mode:PredictionMode, configs:ATNConfigSet) -> bool:
         # Configs in rule stop states indicate reaching the end of the decision
         # rule (local context) or end of start rule (full context). If all
         # configs meet this condition, then none of the configurations is able
@@ -209,7 +209,7 @@ class PredictionMode(Enum):
     # @return {@code true} if any configuration in {@code configs} is in a
     # {@link RuleStopState}, otherwise {@code false}
     @classmethod
-    def hasConfigInRuleStopState(cls, configs:ATNConfigSet):
+    def hasConfigInRuleStopState(cls, configs:ATNConfigSet) -> bool:
         return any(isinstance(cfg.state, RuleStopState) for cfg in configs)
 
     # Checks if all configurations in {@code configs} are in a
@@ -221,7 +221,7 @@ class PredictionMode(Enum):
     # @return {@code true} if all configurations in {@code configs} are in a
     # {@link RuleStopState}, otherwise {@code false}
     @classmethod
-    def allConfigsInRuleStopStates(cls, configs:ATNConfigSet):
+    def allConfigsInRuleStopStates(cls, configs:ATNConfigSet) -> bool:
         return all(isinstance(cfg.state, RuleStopState) for cfg in configs)
 
     #
@@ -366,7 +366,7 @@ class PredictionMode(Enum):
     # {@code A={{1,2}}} or {@code {{1,2},{1,2}}}, etc...</p>
     #
     @classmethod
-    def resolvesToJustOneViableAlt(cls, altsets:list):
+    def resolvesToJustOneViableAlt(cls, altsets:list) -> int:
         return cls.getSingleViableAlt(altsets)
 
     #
@@ -378,7 +378,7 @@ class PredictionMode(Enum):
     # {@link BitSet#cardinality cardinality} &gt; 1, otherwise {@code false}
     #
     @classmethod
-    def allSubsetsConflict(cls, altsets:list):
+    def allSubsetsConflict(cls, altsets:list) -> bool:
         return not cls.hasNonConflictingAltSet(altsets)
 
     #
@@ -390,7 +390,7 @@ class PredictionMode(Enum):
     # {@link BitSet#cardinality cardinality} 1, otherwise {@code false}
     #
     @classmethod
-    def hasNonConflictingAltSet(cls, altsets:list):
+    def hasNonConflictingAltSet(cls, altsets:list) -> bool:
         return any(len(alts) == 1 for alts in altsets)
 
     #
@@ -402,7 +402,7 @@ class PredictionMode(Enum):
     # {@link BitSet#cardinality cardinality} &gt; 1, otherwise {@code false}
     #
     @classmethod
-    def hasConflictingAltSet(cls, altsets:list):
+    def hasConflictingAltSet(cls, altsets:list) -> bool:
         return any(len(alts) > 1 for alts in altsets)
 
     #
@@ -413,7 +413,7 @@ class PredictionMode(Enum):
     # others, otherwise {@code false}
     #
     @classmethod
-    def allSubsetsEqual(cls, altsets:list):
+    def allSubsetsEqual(cls, altsets:list) -> bool:
         if not altsets:
             return True
         first = next(iter(altsets))
@@ -427,7 +427,7 @@ class PredictionMode(Enum):
     # @param altsets a collection of alternative subsets
     #
     @classmethod
-    def getUniqueAlt(cls, altsets:list):
+    def getUniqueAlt(cls, altsets:list) -> int:
         all = cls.getAlts(altsets)
         if len(all)==1:
             return next(iter(all))
@@ -474,7 +474,7 @@ class PredictionMode(Enum):
     # </pre>
     #
     @classmethod
-    def getStateToAltMap(cls, configs:ATNConfigSet):
+    def getStateToAltMap(cls, configs:ATNConfigSet) -> dict:
         m = dict()
         for c in configs:
             alts = m.get(c.state, None)
@@ -485,11 +485,11 @@ class PredictionMode(Enum):
         return m
 
     @classmethod
-    def hasStateAssociatedWithOneAlt(cls, configs:ATNConfigSet):
+    def hasStateAssociatedWithOneAlt(cls, configs:ATNConfigSet) -> bool:
         return any(len(alts) == 1 for alts in cls.getStateToAltMap(configs).values())
 
     @classmethod
-    def getSingleViableAlt(cls, altsets:list):
+    def getSingleViableAlt(cls, altsets:list) -> int:
         viableAlts = set()
         for alts in altsets:
             minAlt = min(alts)

--- a/runtime/Python3/src/antlr4/atn/Transition.py
+++ b/runtime/Python3/src/antlr4/atn/Transition.py
@@ -56,7 +56,7 @@ class Transition (object):
 
     serializationTypes = dict()
 
-    def __init__(self, target:ATNState):
+    def __init__(self, target:ATNState) -> None:
         # The target of this transition.
         if target is None:
             raise Exception("target cannot be null.")
@@ -70,27 +70,27 @@ class Transition (object):
 class AtomTransition(Transition):
     __slots__ = ('label_', 'serializationType')
 
-    def __init__(self, target:ATNState, label:int):
+    def __init__(self, target:ATNState, label:int) -> None:
         super().__init__(target)
         self.label_ = label # The token type or character value; or, signifies special label.
         self.label = self.makeLabel()
         self.serializationType = self.ATOM
 
-    def makeLabel(self):
+    def makeLabel(self) -> IntervalSet:
         s = IntervalSet()
         s.addOne(self.label_)
         return s
 
-    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
+    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int) -> bool:
         return self.label_ == symbol
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.label_)
 
 class RuleTransition(Transition):
     __slots__ = ('ruleIndex', 'precedence', 'followState', 'serializationType')
 
-    def __init__(self, ruleStart:RuleStartState, ruleIndex:int, precedence:int, followState:ATNState):
+    def __init__(self, ruleStart:RuleStartState, ruleIndex:int, precedence:int, followState:ATNState) -> None:
         super().__init__(ruleStart)
         self.ruleIndex = ruleIndex # ptr to the rule definition object for this rule ref
         self.precedence = precedence
@@ -98,56 +98,57 @@ class RuleTransition(Transition):
         self.serializationType = self.RULE
         self.isEpsilon = True
 
-    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
+    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int) -> bool:
         return False
 
 
 class EpsilonTransition(Transition):
     __slots__ = ('serializationType', 'outermostPrecedenceReturn')
 
-    def __init__(self, target, outermostPrecedenceReturn=-1):
+    def __init__(self, target: "ATNState", outermostPrecedenceReturn: int=-1) -> None:
         super(EpsilonTransition, self).__init__(target)
         self.serializationType = self.EPSILON
         self.isEpsilon = True
         self.outermostPrecedenceReturn = outermostPrecedenceReturn
 
-    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
+    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int) -> bool:
         return False
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "epsilon"
 
+from antlr4.IntervalSet import IntervalSet
 class RangeTransition(Transition):
     __slots__ = ('serializationType', 'start', 'stop')
 
-    def __init__(self, target:ATNState, start:int, stop:int):
+    def __init__(self, target:ATNState, start:int, stop:int) -> None:
         super().__init__(target)
         self.serializationType = self.RANGE
         self.start = start
         self.stop = stop
         self.label = self.makeLabel()
 
-    def makeLabel(self):
+    def makeLabel(self) -> IntervalSet:
         s = IntervalSet()
         s.addRange(range(self.start, self.stop + 1))
         return s
 
-    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
+    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int) -> bool:
         return symbol >= self.start and symbol <= self.stop
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "'" + chr(self.start) + "'..'" + chr(self.stop) + "'"
 
 class AbstractPredicateTransition(Transition):
 
-    def __init__(self, target:ATNState):
+    def __init__(self, target:ATNState) -> None:
         super().__init__(target)
 
 
 class PredicateTransition(AbstractPredicateTransition):
     __slots__ = ('serializationType', 'ruleIndex', 'predIndex', 'isCtxDependent')
 
-    def __init__(self, target:ATNState, ruleIndex:int, predIndex:int, isCtxDependent:bool):
+    def __init__(self, target:ATNState, ruleIndex:int, predIndex:int, isCtxDependent:bool) -> None:
         super().__init__(target)
         self.serializationType = self.PREDICATE
         self.ruleIndex = ruleIndex
@@ -155,19 +156,19 @@ class PredicateTransition(AbstractPredicateTransition):
         self.isCtxDependent = isCtxDependent # e.g., $i ref in pred
         self.isEpsilon = True
 
-    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
+    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int) -> bool:
         return False
 
-    def getPredicate(self):
+    def getPredicate(self) -> Predicate:
         return Predicate(self.ruleIndex, self.predIndex, self.isCtxDependent)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "pred_" + str(self.ruleIndex) + ":" + str(self.predIndex)
 
 class ActionTransition(Transition):
     __slots__ = ('serializationType', 'ruleIndex', 'actionIndex', 'isCtxDependent')
 
-    def __init__(self, target:ATNState, ruleIndex:int, actionIndex:int=-1, isCtxDependent:bool=False):
+    def __init__(self, target:ATNState, ruleIndex:int, actionIndex:int=-1, isCtxDependent:bool=False) -> None:
         super().__init__(target)
         self.serializationType = self.ACTION
         self.ruleIndex = ruleIndex
@@ -175,17 +176,17 @@ class ActionTransition(Transition):
         self.isCtxDependent = isCtxDependent # e.g., $i ref in pred
         self.isEpsilon = True
 
-    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
+    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int) -> bool:
         return False
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "action_"+self.ruleIndex+":"+self.actionIndex
 
 # A transition containing a set of values.
 class SetTransition(Transition):
     __slots__ = 'serializationType'
 
-    def __init__(self, target:ATNState, set:IntervalSet):
+    def __init__(self, target:ATNState, set:IntervalSet) -> None:
         super().__init__(target)
         self.serializationType = self.SET
         if set is not None:
@@ -194,58 +195,58 @@ class SetTransition(Transition):
             self.label = IntervalSet()
             self.label.addRange(range(Token.INVALID_TYPE, Token.INVALID_TYPE + 1))
 
-    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
+    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int) -> bool:
         return symbol in self.label
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.label)
 
 class NotSetTransition(SetTransition):
 
-    def __init__(self, target:ATNState, set:IntervalSet):
+    def __init__(self, target:ATNState, set:IntervalSet) -> None:
         super().__init__(target, set)
         self.serializationType = self.NOT_SET
 
-    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
+    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int) -> bool:
         return symbol >= minVocabSymbol \
             and symbol <= maxVocabSymbol \
             and not super(type(self), self).matches(symbol, minVocabSymbol, maxVocabSymbol)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '~' + super(type(self), self).__str__()
 
 
 class WildcardTransition(Transition):
     __slots__ = 'serializationType'
 
-    def __init__(self, target:ATNState):
+    def __init__(self, target:ATNState) -> None:
         super().__init__(target)
         self.serializationType = self.WILDCARD
 
-    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
+    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int) -> bool:
         return symbol >= minVocabSymbol and symbol <= maxVocabSymbol
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "."
 
 
 class PrecedencePredicateTransition(AbstractPredicateTransition):
     __slots__ = ('serializationType', 'precedence')
 
-    def __init__(self, target:ATNState, precedence:int):
+    def __init__(self, target:ATNState, precedence:int) -> None:
         super().__init__(target)
         self.serializationType = self.PRECEDENCE
         self.precedence = precedence
         self.isEpsilon = True
 
-    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
+    def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int) -> bool:
         return False
 
 
-    def getPredicate(self):
+    def getPredicate(self) -> PrecedencePredicate:
         return PrecedencePredicate(self.precedence)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.precedence + " >= _p"
 
 

--- a/runtime/Python3/src/antlr4/dfa/DFA.py
+++ b/runtime/Python3/src/antlr4/dfa/DFA.py
@@ -13,7 +13,7 @@ from antlr4.error.Errors import IllegalStateException
 class DFA(object):
     __slots__ = ('atnStartState', 'decision', '_states', 's0', 'precedenceDfa')
 
-    def __init__(self, atnStartState:DecisionState, decision:int=0):
+    def __init__(self, atnStartState:DecisionState, decision:int=0) -> None:
         # From which ATN state did we create this DFA?
         self.atnStartState = atnStartState
         self.decision = decision
@@ -45,7 +45,7 @@ class DFA(object):
     # @throws IllegalStateException if this is not a precedence DFA.
     # @see #isPrecedenceDfa()
 
-    def getPrecedenceStartState(self, precedence:int):
+    def getPrecedenceStartState(self, precedence:int) -> None:
         if not self.precedenceDfa:
             raise IllegalStateException("Only precedence DFAs may contain a precedence start state.")
 
@@ -63,7 +63,7 @@ class DFA(object):
     # @throws IllegalStateException if this is not a precedence DFA.
     # @see #isPrecedenceDfa()
     #
-    def setPrecedenceStartState(self, precedence:int, startState:DFAState):
+    def setPrecedenceStartState(self, precedence:int, startState:DFAState) -> None:
         if not self.precedenceDfa:
             raise IllegalStateException("Only precedence DFAs may contain a precedence start state.")
 
@@ -94,7 +94,7 @@ class DFA(object):
     # @param precedenceDfa {@code true} if this is a precedence DFA; otherwise,
     # {@code false}
 
-    def setPrecedenceDfa(self, precedenceDfa:bool):
+    def setPrecedenceDfa(self, precedenceDfa:bool) -> None:
         if self.precedenceDfa != precedenceDfa:
             self._states = dict()
             if precedenceDfa:
@@ -108,24 +108,24 @@ class DFA(object):
             self.precedenceDfa = precedenceDfa
 
     @property
-    def states(self):
+    def states(self) -> dict:
         return self._states
 
     # Return a list of all states in this DFA, ordered by state number.
     def sortedStates(self):
         return sorted(self._states.keys(), key=lambda state: state.stateNumber)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.toString(None)
 
-    def toString(self, literalNames:list=None, symbolicNames:list=None):
+    def toString(self, literalNames:list=None, symbolicNames:list=None) -> str:
         if self.s0 is None:
             return ""
         from antlr4.dfa.DFASerializer import DFASerializer
         serializer = DFASerializer(self,literalNames,symbolicNames)
         return str(serializer)
 
-    def toLexerString(self):
+    def toLexerString(self) -> str:
         if self.s0 is None:
             return ""
         from antlr4.dfa.DFASerializer import LexerDFASerializer

--- a/runtime/Python3/src/antlr4/dfa/DFASerializer.py
+++ b/runtime/Python3/src/antlr4/dfa/DFASerializer.py
@@ -14,12 +14,12 @@ from antlr4.dfa.DFAState import DFAState
 class DFASerializer(object):
     __slots__ = ('dfa', 'literalNames', 'symbolicNames')
 
-    def __init__(self, dfa:DFA, literalNames:list=None, symbolicNames:list=None):
+    def __init__(self, dfa:DFA, literalNames:list=None, symbolicNames:list=None) -> None:
         self.dfa = dfa
         self.literalNames = literalNames
         self.symbolicNames = symbolicNames
 
-    def __str__(self):
+    def __str__(self) -> None:
         if self.dfa.s0 is None:
             return None
         with StringIO() as buf:
@@ -43,7 +43,7 @@ class DFASerializer(object):
             else:
                 return output
 
-    def getEdgeLabel(self, i:int):
+    def getEdgeLabel(self, i:int) -> str:
         if i==0:
             return "EOF"
         if self.literalNames is not None and i<=len(self.literalNames):
@@ -53,7 +53,7 @@ class DFASerializer(object):
         else:
             return str(i-1)
 
-    def getStateString(self, s:DFAState):
+    def getStateString(self, s:DFAState) -> str:
         n = s.stateNumber
         baseStateStr = ( ":" if s.isAcceptState else "") + "s" + str(n) + ( "^" if s.requiresFullContext else "")
         if s.isAcceptState:
@@ -66,8 +66,8 @@ class DFASerializer(object):
 
 class LexerDFASerializer(DFASerializer):
 
-    def __init__(self, dfa:DFA):
+    def __init__(self, dfa:DFA) -> None:
         super().__init__(dfa, None)
 
-    def getEdgeLabel(self, i:int):
+    def getEdgeLabel(self, i:int) -> str:
         return "'" + chr(i) + "'"

--- a/runtime/Python3/src/antlr4/dfa/DFAState.py
+++ b/runtime/Python3/src/antlr4/dfa/DFAState.py
@@ -13,11 +13,11 @@ from antlr4.atn.SemanticContext import SemanticContext
 class PredPrediction(object):
     __slots__ = ('alt', 'pred')
 
-    def __init__(self, pred:SemanticContext, alt:int):
+    def __init__(self, pred:SemanticContext, alt:int) -> None:
         self.alt = alt
         self.pred = pred
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "(" + str(self.pred) + ", " + str(self.alt) +  ")"
 
 # A DFA state represents a set of possible ATN configurations.
@@ -50,7 +50,7 @@ class DFAState(object):
         'lexerActionExecutor', 'requiresFullContext', 'predicates'
     )
 
-    def __init__(self, stateNumber:int=-1, configs:ATNConfigSet=ATNConfigSet()):
+    def __init__(self, stateNumber:int=-1, configs:ATNConfigSet=ATNConfigSet()) -> None:
         self.stateNumber = stateNumber
         self.configs = configs
         # {@code edges[symbol]} points to target of symbol. Shift up by 1 so (-1)
@@ -84,12 +84,12 @@ class DFAState(object):
 
     # Get the set of all alts mentioned by all ATN configurations in this
     #  DFA state.
-    def getAltSet(self):
+    def getAltSet(self) -> set | None:
         if self.configs is not None:
             return set(cfg.alt for cfg in self.configs) or None
         return None
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.configs)
 
     # Two {@link DFAState} instances are equal if their ATN configuration sets
@@ -103,7 +103,7 @@ class DFAState(object):
     # {@link ParserATNSimulator#addDFAState} we need to know if any other state
     # exists that has this exact set of ATN configurations. The
     # {@link #stateNumber} is irrelevant.</p>
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         # compare set of ATN configurations in this set with other
         if self is other:
             return True
@@ -112,7 +112,7 @@ class DFAState(object):
         else:
             return self.configs==other.configs
 
-    def __str__(self):
+    def __str__(self) -> str:
         with StringIO() as buf:
             buf.write(str(self.stateNumber))
             buf.write(":")

--- a/runtime/Python3/src/antlr4/error/DiagnosticErrorListener.py
+++ b/runtime/Python3/src/antlr4/error/DiagnosticErrorListener.py
@@ -31,12 +31,12 @@ from antlr4.error.ErrorListener import ErrorListener
 
 class DiagnosticErrorListener(ErrorListener):
 
-    def __init__(self, exactOnly:bool=True):
+    def __init__(self, exactOnly:bool=True) -> None:
         # whether all ambiguities or only exact ambiguities are reported.
         self.exactOnly = exactOnly
 
     def reportAmbiguity(self, recognizer:Parser, dfa:DFA, startIndex:int,
-                       stopIndex:int, exact:bool, ambigAlts:set, configs:ATNConfigSet):
+                       stopIndex:int, exact:bool, ambigAlts:set, configs:ATNConfigSet) -> None:
         if self.exactOnly and not exact:
             return
 
@@ -52,7 +52,7 @@ class DiagnosticErrorListener(ErrorListener):
 
 
     def reportAttemptingFullContext(self, recognizer:Parser, dfa:DFA, startIndex:int,
-                       stopIndex:int, conflictingAlts:set, configs:ATNConfigSet):
+                       stopIndex:int, conflictingAlts:set, configs:ATNConfigSet) -> None:
         with StringIO() as buf:
             buf.write("reportAttemptingFullContext d=")
             buf.write(self.getDecisionDescription(recognizer, dfa))
@@ -62,7 +62,7 @@ class DiagnosticErrorListener(ErrorListener):
             recognizer.notifyErrorListeners(buf.getvalue())
 
     def reportContextSensitivity(self, recognizer:Parser, dfa:DFA, startIndex:int,
-                       stopIndex:int, prediction:int, configs:ATNConfigSet):
+                       stopIndex:int, prediction:int, configs:ATNConfigSet) -> None:
         with StringIO() as buf:
             buf.write("reportContextSensitivity d=")
             buf.write(self.getDecisionDescription(recognizer, dfa))
@@ -71,7 +71,7 @@ class DiagnosticErrorListener(ErrorListener):
             buf.write("'")
             recognizer.notifyErrorListeners(buf.getvalue())
 
-    def getDecisionDescription(self, recognizer:Parser, dfa:DFA):
+    def getDecisionDescription(self, recognizer:Parser, dfa:DFA) -> str:
         decision = dfa.decision
         ruleIndex = dfa.atnStartState.ruleIndex
 
@@ -96,7 +96,7 @@ class DiagnosticErrorListener(ErrorListener):
     # @return Returns {@code reportedAlts} if it is not {@code null}, otherwise
     # returns the set of alternatives represented in {@code configs}.
     #
-    def getConflictingAlts(self, reportedAlts:set, configs:ATNConfigSet):
+    def getConflictingAlts(self, reportedAlts:set, configs:ATNConfigSet) -> set:
         if reportedAlts is not None:
             return reportedAlts
 

--- a/runtime/Python3/src/antlr4/error/ErrorListener.py
+++ b/runtime/Python3/src/antlr4/error/ErrorListener.py
@@ -42,31 +42,31 @@ class ConsoleErrorListener(ErrorListener):
     # line <em>line</em>:<em>charPositionInLine</em> <em>msg</em>
     # </pre>
     #
-    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
+    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e) -> None:
         print("line " + str(line) + ":" + str(column) + " " + msg, file=sys.stderr)
 
 ConsoleErrorListener.INSTANCE = ConsoleErrorListener()
 
 class ProxyErrorListener(ErrorListener):
 
-    def __init__(self, delegates):
+    def __init__(self, delegates) -> None:
         super().__init__()
         if delegates is None:
             raise ReferenceError("delegates")
         self.delegates = delegates
 
-    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
+    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e) -> None:
         for delegate in self.delegates:
             delegate.syntaxError(recognizer, offendingSymbol, line, column, msg, e)
 
-    def reportAmbiguity(self, recognizer, dfa, startIndex, stopIndex, exact, ambigAlts, configs):
+    def reportAmbiguity(self, recognizer, dfa, startIndex, stopIndex, exact, ambigAlts, configs) -> None:
         for delegate in self.delegates:
             delegate.reportAmbiguity(recognizer, dfa, startIndex, stopIndex, exact, ambigAlts, configs)
 
-    def reportAttemptingFullContext(self, recognizer, dfa, startIndex, stopIndex, conflictingAlts, configs):
+    def reportAttemptingFullContext(self, recognizer, dfa, startIndex, stopIndex, conflictingAlts, configs) -> None:
         for delegate in self.delegates:
             delegate.reportAttemptingFullContext(recognizer, dfa, startIndex, stopIndex, conflictingAlts, configs)
 
-    def reportContextSensitivity(self, recognizer, dfa, startIndex, stopIndex, prediction, configs):
+    def reportContextSensitivity(self, recognizer, dfa, startIndex, stopIndex, prediction, configs) -> None:
         for delegate in self.delegates:
             delegate.reportContextSensitivity(recognizer, dfa, startIndex, stopIndex, prediction, configs)

--- a/runtime/Python3/src/antlr4/error/ErrorStrategy.py
+++ b/runtime/Python3/src/antlr4/error/ErrorStrategy.py
@@ -38,9 +38,10 @@ class ErrorStrategy(object):
 # This is the default implementation of {@link ANTLRErrorStrategy} used for
 # error reporting and recovery in ANTLR parsers.
 #
+from antlr4.IntervalSet import IntervalSet
 class DefaultErrorStrategy(ErrorStrategy):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # Indicates whether the error strategy is currently "recovering from an
         # error". This is used to suppress reporting multiple error messages while
@@ -63,7 +64,7 @@ class DefaultErrorStrategy(ErrorStrategy):
 
     # <p>The default implementation simply calls {@link #endErrorCondition} to
     # ensure that the handler is not in error recovery mode.</p>
-    def reset(self, recognizer:Parser):
+    def reset(self, recognizer:Parser) -> None:
         self.endErrorCondition(recognizer)
 
     #
@@ -72,10 +73,10 @@ class DefaultErrorStrategy(ErrorStrategy):
     #
     # @param recognizer the parser instance
     #
-    def beginErrorCondition(self, recognizer:Parser):
+    def beginErrorCondition(self, recognizer:Parser) -> None:
         self.errorRecoveryMode = True
 
-    def inErrorRecoveryMode(self, recognizer:Parser):
+    def inErrorRecoveryMode(self, recognizer:Parser) -> bool:
         return self.errorRecoveryMode
 
     #
@@ -84,7 +85,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     #
     # @param recognizer
     #
-    def endErrorCondition(self, recognizer:Parser):
+    def endErrorCondition(self, recognizer:Parser) -> None:
         self.errorRecoveryMode = False
         self.lastErrorStates = None
         self.lastErrorIndex = -1
@@ -94,7 +95,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     #
     # <p>The default implementation simply calls {@link #endErrorCondition}.</p>
     #
-    def reportMatch(self, recognizer:Parser):
+    def reportMatch(self, recognizer:Parser) -> None:
         self.endErrorCondition(recognizer)
 
     #
@@ -116,7 +117,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     # the exception</li>
     # </ul>
     #
-    def reportError(self, recognizer:Parser, e:RecognitionException):
+    def reportError(self, recognizer:Parser, e:RecognitionException) -> None:
        # if we've already reported an error and have not matched a token
        # yet successfully, don't report any errors.
         if self.inErrorRecoveryMode(recognizer):
@@ -139,7 +140,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     # until we find one in the resynchronization set--loosely the set of tokens
     # that can follow the current rule.</p>
     #
-    def recover(self, recognizer:Parser, e:RecognitionException):
+    def recover(self, recognizer:Parser, e:RecognitionException) -> None:
         if self.lastErrorIndex==recognizer.getInputStream().index \
             and self.lastErrorStates is not None \
             and recognizer.state in self.lastErrorStates:
@@ -201,7 +202,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     # some reason speed is suffering for you, you can turn off this
     # functionality by simply overriding this method as a blank { }.</p>
     #
-    def sync(self, recognizer:Parser):
+    def sync(self, recognizer:Parser) -> None:
         # If already recovering, don't try to sync
         if self.inErrorRecoveryMode(recognizer):
             return
@@ -248,7 +249,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     # @param recognizer the parser instance
     # @param e the recognition exception
     #
-    def reportNoViableAlternative(self, recognizer:Parser, e:NoViableAltException):
+    def reportNoViableAlternative(self, recognizer:Parser, e:NoViableAltException) -> None:
         tokens = recognizer.getTokenStream()
         if tokens is not None:
             if e.startToken.type==Token.EOF:
@@ -269,7 +270,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     # @param recognizer the parser instance
     # @param e the recognition exception
     #
-    def reportInputMismatch(self, recognizer:Parser, e:InputMismatchException):
+    def reportInputMismatch(self, recognizer:Parser, e:InputMismatchException) -> None:
         msg = "mismatched input " + self.getTokenErrorDisplay(e.offendingToken) \
               + " expecting " + e.getExpectedTokens().toString(recognizer.literalNames, recognizer.symbolicNames)
         recognizer.notifyErrorListeners(msg, e.offendingToken, e)
@@ -283,7 +284,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     # @param recognizer the parser instance
     # @param e the recognition exception
     #
-    def reportFailedPredicate(self, recognizer, e):
+    def reportFailedPredicate(self, recognizer, e) -> None:
         ruleName = recognizer.ruleNames[recognizer._ctx.getRuleIndex()]
         msg = "rule " + ruleName + " " + e.message
         recognizer.notifyErrorListeners(msg, e.offendingToken, e)
@@ -305,7 +306,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     #
     # @param recognizer the parser instance
     #
-    def reportUnwantedToken(self, recognizer:Parser):
+    def reportUnwantedToken(self, recognizer:Parser) -> None:
         if self.inErrorRecoveryMode(recognizer):
             return
 
@@ -333,7 +334,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     #
     # @param recognizer the parser instance
     #
-    def reportMissingToken(self, recognizer:Parser):
+    def reportMissingToken(self, recognizer:Parser) -> None:
         if self.inErrorRecoveryMode(recognizer):
             return
         self.beginErrorCondition(recognizer)
@@ -423,7 +424,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     # @return {@code true} if single-token insertion is a viable recovery
     # strategy for the current mismatched input, otherwise {@code false}
     #
-    def singleTokenInsertion(self, recognizer:Parser):
+    def singleTokenInsertion(self, recognizer:Parser) -> bool:
         currentSymbolType = recognizer.getTokenStream().LA(1)
         # if current token is consistent with what could come after current
         # ATN state, then we know we're missing a token; error recovery
@@ -456,7 +457,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     # deletion successfully recovers from the mismatched input, otherwise
     # {@code null}
     #
-    def singleTokenDeletion(self, recognizer:Parser):
+    def singleTokenDeletion(self, recognizer:Parser) -> None:
         nextTokenType = recognizer.getTokenStream().LA(2)
         expecting = self.getExpectedTokens(recognizer)
         if nextTokenType in expecting:
@@ -524,7 +525,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     #  your token objects because you don't have to go modify your lexer
     #  so that it creates a new Java type.
     #
-    def getTokenErrorDisplay(self, t:Token):
+    def getTokenErrorDisplay(self, t:Token) -> str:
         if t is None:
             return "<no token>"
         s = t.text
@@ -535,7 +536,7 @@ class DefaultErrorStrategy(ErrorStrategy):
                 s = "<" + str(t.type) + ">"
         return self.escapeWSAndQuote(s)
 
-    def escapeWSAndQuote(self, s:str):
+    def escapeWSAndQuote(self, s:str) -> str:
         s = s.replace("\n","\\n")
         s = s.replace("\r","\\r")
         s = s.replace("\t","\\t")
@@ -633,7 +634,7 @@ class DefaultErrorStrategy(ErrorStrategy):
     #  Like Grosch I implement context-sensitive FOLLOW sets that are combined
     #  at run-time upon error to avoid overhead during parsing.
     #
-    def getErrorRecoverySet(self, recognizer:Parser):
+    def getErrorRecoverySet(self, recognizer:Parser) -> IntervalSet:
         atn = recognizer._interp.atn
         ctx = recognizer._ctx
         recoverSet = IntervalSet()
@@ -648,7 +649,7 @@ class DefaultErrorStrategy(ErrorStrategy):
         return recoverSet
 
     # Consume tokens until one matches the given token set.#
-    def consumeUntil(self, recognizer:Parser, set_:set):
+    def consumeUntil(self, recognizer:Parser, set_:set) -> None:
         ttype = recognizer.getTokenStream().LA(1)
         while ttype != Token.EOF and not ttype in set_:
             recognizer.consume()
@@ -689,7 +690,7 @@ class BailErrorStrategy(DefaultErrorStrategy):
     #  rule function catches.  Use {@link Exception#getCause()} to get the
     #  original {@link RecognitionException}.
     #
-    def recover(self, recognizer:Parser, e:RecognitionException):
+    def recover(self, recognizer:Parser, e:RecognitionException) -> None:
         context = recognizer._ctx
         while context is not None:
             context.exception = e
@@ -699,7 +700,7 @@ class BailErrorStrategy(DefaultErrorStrategy):
     # Make sure we don't attempt to recover inline; if the parser
     #  successfully recovers, it won't throw an exception.
     #
-    def recoverInline(self, recognizer:Parser):
+    def recoverInline(self, recognizer:Parser) -> None:
         self.recover(recognizer, InputMismatchException(recognizer))
 
     # Make sure we don't attempt to recover from problems in subrules.#

--- a/runtime/Python3/src/antlr4/error/Errors.py
+++ b/runtime/Python3/src/antlr4/error/Errors.py
@@ -2,30 +2,21 @@
 # Use of this file is governed by the BSD 3-clause license that
 # can be found in the LICENSE.txt file in the project root.
 #
-
-# need forward declaration
-Token = None
-Lexer = None
-Parser = None
-TokenStream = None
-ATNConfigSet = None
-ParserRulecontext = None
-PredicateTransition = None
-BufferedTokenStream = None
+from typing import Optional
 
 class UnsupportedOperationException(Exception):
 
-    def __init__(self, msg:str):
+    def __init__(self, msg:str) -> None:
         super().__init__(msg)
 
 class IllegalStateException(Exception):
 
-    def __init__(self, msg:str):
+    def __init__(self, msg:str) -> None:
         super().__init__(msg)
 
 class CancellationException(IllegalStateException):
 
-    def __init__(self, msg:str):
+    def __init__(self, msg:str) -> None:
         super().__init__(msg)
 
 # The root of the ANTLR exception hierarchy. In general, ANTLR tracks just
@@ -41,16 +32,16 @@ from antlr4.Recognizer import Recognizer
 class RecognitionException(Exception):
 
 
-    def __init__(self, message:str=None, recognizer:Recognizer=None, input:InputStream=None, ctx:ParserRulecontext=None):
+    def __init__(self, message:Optional[str]=None, recognizer:Optional[Recognizer]=None, input:Optional[InputStream]=None, ctx:Optional[ParserRuleContext]=None) -> None:
         super().__init__(message)
-        self.message = message
-        self.recognizer = recognizer
-        self.input = input
-        self.ctx = ctx
+        self.message: Optional[str] = message
+        self.recognizer: Optional[Recognizer] = recognizer
+        self.input: Optional[InputStream] = input
+        self.ctx: Optional[ParserRuleContext] = ctx
         # The current {@link Token} when an error occurred. Since not all streams
         # support accessing symbols by index, we have to track the {@link Token}
         # instance itself.
-        self.offendingToken = None
+        self.offendingToken:Optional[Token] = None
         # Get the ATN state number the parser was in at the time the error
         # occurred. For {@link NoViableAltException} and
         # {@link LexerNoViableAltException} exceptions, this is the
@@ -72,7 +63,7 @@ class RecognitionException(Exception):
     # @return The set of token types that could potentially follow the current
     # state in the ATN, or {@code null} if the information is not available.
     #/
-    def getExpectedTokens(self):
+    def getExpectedTokens(self) -> None:
         if self.recognizer is not None:
             return self.recognizer.atn.getExpectedTokens(self.offendingState, self.ctx)
         else:
@@ -81,13 +72,14 @@ class RecognitionException(Exception):
 
 class LexerNoViableAltException(RecognitionException):
 
-    def __init__(self, lexer:Lexer, input:InputStream, startIndex:int, deadEndConfigs:ATNConfigSet):
+    def __init__(self, lexer:Lexer, input:InputStream, startIndex:int, deadEndConfigs:ATNConfigSet) -> None:
+        # FIX: This needs types
         super().__init__(message=None, recognizer=lexer, input=input, ctx=None)
         self.startIndex = startIndex
         self.deadEndConfigs = deadEndConfigs
         self.message = ""
 
-    def __str__(self):
+    def __str__(self) -> str:
         symbol = ""
         if self.startIndex >= 0 and self.startIndex < self.input.size:
             symbol = self.input.getText(self.startIndex, self.startIndex)
@@ -102,7 +94,7 @@ class LexerNoViableAltException(RecognitionException):
 class NoViableAltException(RecognitionException):
 
     def __init__(self, recognizer:Parser, input:TokenStream=None, startToken:Token=None,
-                    offendingToken:Token=None, deadEndConfigs:ATNConfigSet=None, ctx:ParserRuleContext=None):
+                    offendingToken:Token=None, deadEndConfigs:ATNConfigSet=None, ctx:ParserRuleContext=None) -> None:
         if ctx is None:
             ctx = recognizer._ctx
         if offendingToken is None:
@@ -126,7 +118,7 @@ class NoViableAltException(RecognitionException):
 #
 class InputMismatchException(RecognitionException):
 
-    def __init__(self, recognizer:Parser):
+    def __init__(self, recognizer:Parser) -> None:
         super().__init__(recognizer=recognizer, input=recognizer.getInputStream(), ctx=recognizer._ctx)
         self.offendingToken = recognizer.getCurrentToken()
 
@@ -138,7 +130,7 @@ class InputMismatchException(RecognitionException):
 
 class FailedPredicateException(RecognitionException):
 
-    def __init__(self, recognizer:Parser, predicate:str=None, message:str=None):
+    def __init__(self, recognizer:Parser, predicate:str=None, message:str=None) -> None:
         super().__init__(message=self.formatMessage(predicate,message), recognizer=recognizer,
                          input=recognizer.getInputStream(), ctx=recognizer._ctx)
         s = recognizer._interp.atn.states[recognizer.state]
@@ -153,7 +145,7 @@ class FailedPredicateException(RecognitionException):
         self.predicate = predicate
         self.offendingToken = recognizer.getCurrentToken()
 
-    def formatMessage(self, predicate:str, message:str):
+    def formatMessage(self, predicate:str, message:str) -> str:
         if message is not None:
             return message
         else:
@@ -163,11 +155,3 @@ class ParseCancellationException(CancellationException):
 
     pass
 
-del Token
-del Lexer
-del Parser
-del TokenStream
-del ATNConfigSet
-del ParserRulecontext
-del PredicateTransition
-del BufferedTokenStream

--- a/runtime/Python3/src/antlr4/tree/Chunk.py
+++ b/runtime/Python3/src/antlr4/tree/Chunk.py
@@ -10,11 +10,11 @@ class Chunk(object):
 class TagChunk(Chunk):
     __slots__ = ('tag', 'label')
 
-    def __init__(self, tag:str, label:str=None):
+    def __init__(self, tag:str, label:str=None) -> None:
         self.tag = tag
         self.label = label
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.label is None:
             return self.tag
         else:
@@ -23,8 +23,8 @@ class TagChunk(Chunk):
 class TextChunk(Chunk):
     __slots__ = 'text'
 
-    def __init__(self, text:str):
+    def __init__(self, text:str) -> None:
         self.text = text
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "'" + self.text + "'"

--- a/runtime/Python3/src/antlr4/tree/ParseTreeMatch.py
+++ b/runtime/Python3/src/antlr4/tree/ParseTreeMatch.py
@@ -30,7 +30,7 @@ class ParseTreeMatch(object):
     # @exception IllegalArgumentException if {@code pattern} is {@code null}
     # @exception IllegalArgumentException if {@code labels} is {@code null}
     #
-    def __init__(self, tree:ParseTree, pattern:ParseTreePattern, labels:dict, mismatchedNode:ParseTree):
+    def __init__(self, tree:ParseTree, pattern:ParseTreePattern, labels:dict, mismatchedNode:ParseTree) -> None:
         if tree is None:
             raise Exception("tree cannot be null")
         if pattern is None:
@@ -58,7 +58,7 @@ class ParseTreeMatch(object):
     # @return The last {@link ParseTree} to match a tag with the specified
     # label, or {@code null} if no parse tree matched a tag with the label.
     #
-    def get(self, label:str):
+    def get(self, label:str) -> None:
         parseTrees = self.labels.get(label, None)
         if parseTrees is None or len(parseTrees)==0:
             return None
@@ -88,7 +88,7 @@ class ParseTreeMatch(object):
     # the specified {@code label}. If no nodes matched the label, an empty list
     # is returned.
     #
-    def getAll(self, label:str):
+    def getAll(self, label:str) -> list:
         nodes = self.labels.get(label, None)
         if nodes is None:
             return list()
@@ -102,13 +102,13 @@ class ParseTreeMatch(object):
     # @return {@code true} if the match operation succeeded; otherwise,
     # {@code false}.
     #
-    def succeeded(self):
+    def succeeded(self) -> bool:
         return self.mismatchedNode is None
 
     #
     # {@inheritDoc}
     #
-    def __str__(self):
+    def __str__(self) -> str:
         with StringIO() as buf:
             buf.write("Match ")
             buf.write("succeeded" if self.succeeded() else "failed")

--- a/runtime/Python3/src/antlr4/tree/ParseTreePattern.py
+++ b/runtime/Python3/src/antlr4/tree/ParseTreePattern.py
@@ -25,7 +25,7 @@ class ParseTreePattern(object):
     # tree pattern.
     # @param patternTree The tree pattern in {@link ParseTree} form.
     #
-    def __init__(self, matcher:ParseTreePatternMatcher, pattern:str, patternRuleIndex:int , patternTree:ParseTree):
+    def __init__(self, matcher:ParseTreePatternMatcher, pattern:str, patternRuleIndex:int , patternTree:ParseTree) -> None:
         self.matcher = matcher
         self.patternRuleIndex = patternRuleIndex
         self.pattern = pattern
@@ -62,7 +62,7 @@ class ParseTreePattern(object):
     # successful matches. Unsuccessful matches are omitted from the result,
     # regardless of the reason for the failure.
     #
-    def findAll(self, tree:ParseTree, xpath:str):
+    def findAll(self, tree:ParseTree, xpath:str) -> list:
         subtrees = XPath.findAll(tree, xpath, self.matcher.parser)
         matches = list()
         for t in subtrees:

--- a/runtime/Python3/src/antlr4/tree/ParseTreePatternMatcher.py
+++ b/runtime/Python3/src/antlr4/tree/ParseTreePatternMatcher.py
@@ -80,7 +80,7 @@ ParseTreePattern = None
 
 class CannotInvokeStartRule(Exception):
 
-    def __init__(self, e:Exception):
+    def __init__(self, e:Exception) -> None:
         super().__init__(e)
 
 class StartRuleDoesNotConsumeFullPattern(Exception):
@@ -88,6 +88,7 @@ class StartRuleDoesNotConsumeFullPattern(Exception):
     pass
 
 
+from antlr4.tree.ParseTreeMatch import ParseTreeMatch
 class ParseTreePatternMatcher(object):
     __slots__ = ('lexer', 'parser', 'start', 'stop', 'escape')
 
@@ -95,7 +96,7 @@ class ParseTreePatternMatcher(object):
     # {@link Parser} object. The lexer input stream is altered for tokenizing
     # the tree patterns. The parser is used as a convenient mechanism to get
     # the grammar name, plus token, rule names.
-    def __init__(self, lexer:Lexer, parser:Parser):
+    def __init__(self, lexer:Lexer, parser:Parser) -> None:
         self.lexer = lexer
         self.parser = parser
         self.start = "<"
@@ -112,7 +113,7 @@ class ParseTreePatternMatcher(object):
     # @exception IllegalArgumentException if {@code start} is {@code null} or empty.
     # @exception IllegalArgumentException if {@code stop} is {@code null} or empty.
     #
-    def setDelimiters(self, start:str, stop:str, escapeLeft:str):
+    def setDelimiters(self, start:str, stop:str, escapeLeft:str) -> None:
         if start is None or len(start)==0:
             raise Exception("start cannot be null or empty")
         if stop is None or len(stop)==0:
@@ -129,7 +130,7 @@ class ParseTreePatternMatcher(object):
     # Does {@code pattern} matched as rule patternRuleIndex match tree? Pass in a
     #  compiled pattern instead of a string representation of a tree pattern.
     #
-    def matchesPattern(self, tree:ParseTree, pattern:ParseTreePattern):
+    def matchesPattern(self, tree:ParseTree, pattern:ParseTreePattern) -> bool:
         mismatchedNode = self.matchImpl(tree, pattern.patternTree, dict())
         return mismatchedNode is None
 
@@ -138,7 +139,7 @@ class ParseTreePatternMatcher(object):
     # {@code tree} and return a {@link ParseTreeMatch} object that contains the
     # matched elements, or the node at which the match failed.
     #
-    def matchRuleIndex(self, tree:ParseTree, pattern:str, patternRuleIndex:int):
+    def matchRuleIndex(self, tree:ParseTree, pattern:str, patternRuleIndex:int) -> ParseTreeMatch:
         p = self.compileTreePattern(pattern, patternRuleIndex)
         return self.matchPattern(tree, p)
 
@@ -148,7 +149,7 @@ class ParseTreePatternMatcher(object):
     # node at which the match failed. Pass in a compiled pattern instead of a
     # string representation of a tree pattern.
     #
-    def matchPattern(self, tree:ParseTree, pattern:ParseTreePattern):
+    def matchPattern(self, tree:ParseTree, pattern:ParseTreePattern) -> ParseTreeMatch:
         labels = dict()
         mismatchedNode = self.matchImpl(tree, pattern.patternTree, labels)
         from antlr4.tree.ParseTreeMatch import ParseTreeMatch
@@ -158,7 +159,7 @@ class ParseTreePatternMatcher(object):
     # For repeated use of a tree pattern, compile it to a
     # {@link ParseTreePattern} using this method.
     #
-    def compileTreePattern(self, pattern:str, patternRuleIndex:int):
+    def compileTreePattern(self, pattern:str, patternRuleIndex:int) -> ParseTreePattern:
         tokenList = self.tokenize(pattern)
         tokenSrc = ListTokenSource(tokenList)
         tokens = CommonTokenStream(tokenSrc)
@@ -256,7 +257,7 @@ class ParseTreePatternMatcher(object):
         # if nodes aren't both tokens or both rule nodes, can't match
         return tree
 
-    def map(self, labels, label, tree):
+    def map(self, labels, label, tree) -> None:
         v = labels.get(label, None)
         if v is None:
             v = list()
@@ -264,7 +265,7 @@ class ParseTreePatternMatcher(object):
         v.append(tree)
 
     # Is {@code t} {@code (expr <expr>)} subtree?#
-    def getRuleTagToken(self, tree:ParseTree):
+    def getRuleTagToken(self, tree:ParseTree) -> None:
         if isinstance( tree, RuleNode ):
             if tree.getChildCount()==1 and isinstance(tree.getChild(0), TerminalNode ):
                 c = tree.getChild(0)
@@ -272,7 +273,7 @@ class ParseTreePatternMatcher(object):
                     return c.symbol
         return None
 
-    def tokenize(self, pattern:str):
+    def tokenize(self, pattern:str) -> list:
         # split pattern into chunks: sea (raw input) and islands (<ID>, <expr>)
         chunks = self.split(pattern)
 
@@ -303,7 +304,7 @@ class ParseTreePatternMatcher(object):
         return tokens
 
     # Split {@code <ID> = <e:expr> ;} into 4 chunks for tokenizing by {@link #tokenize}.#
-    def split(self, pattern:str):
+    def split(self, pattern:str) -> list:
         p = 0
         n = len(pattern)
         chunks = list()

--- a/runtime/Python3/src/antlr4/tree/RuleTagToken.py
+++ b/runtime/Python3/src/antlr4/tree/RuleTagToken.py
@@ -26,7 +26,7 @@ class RuleTagToken(Token):
     # @exception IllegalArgumentException if {@code ruleName} is {@code null}
     # or empty.
 
-    def __init__(self, ruleName:str, bypassTokenType:int, label:str=None):
+    def __init__(self, ruleName:str, bypassTokenType:int, label:str=None) -> None:
         if ruleName is None or len(ruleName)==0:
             raise Exception("ruleName cannot be null or empty.")
         self.source = None

--- a/runtime/Python3/src/antlr4/tree/TokenTagToken.py
+++ b/runtime/Python3/src/antlr4/tree/TokenTagToken.py
@@ -22,7 +22,7 @@ class TokenTagToken(CommonToken):
     # @param label The label associated with the token tag, or {@code null} if
     # the token tag is unlabeled.
     #
-    def __init__(self, tokenName:str, type:int, label:str=None):
+    def __init__(self, tokenName:str, type:int, label:str=None) -> None:
         super().__init__(type=type)
         self.tokenName = tokenName
         self.label = label
@@ -43,5 +43,5 @@ class TokenTagToken(CommonToken):
     # <p>The implementation for {@link TokenTagToken} returns a string of the form
     # {@code tokenName:type}.</p>
     #
-    def __str__(self):
+    def __str__(self) -> str:
         return self.tokenName + ":" + str(self.type)

--- a/runtime/Python3/src/antlr4/tree/Tree.py
+++ b/runtime/Python3/src/antlr4/tree/Tree.py
@@ -12,15 +12,19 @@ from antlr4.Token import Token
 INVALID_INTERVAL = (-1, -2)
 
 class Tree(object):
+    __slots__ = []
     pass
 
 class SyntaxTree(Tree):
+    __slots__ = []
     pass
 
 class ParseTree(SyntaxTree):
+    __slots__ = []
     pass
 
 class RuleNode(ParseTree):
+    __slots__ = []
     pass
 
 class TerminalNode(ParseTree):
@@ -52,13 +56,13 @@ class ParseTreeVisitor(object):
     def visitErrorNode(self, node):
         return self.defaultResult()
 
-    def defaultResult(self):
+    def defaultResult(self) -> None:
         return None
 
     def aggregateResult(self, aggregate, nextResult):
         return nextResult
 
-    def shouldVisitNextChild(self, node, currentResult):
+    def shouldVisitNextChild(self, node, currentResult) -> bool:
         return True
 
 ParserRuleContext = None
@@ -82,13 +86,13 @@ del ParserRuleContext
 class TerminalNodeImpl(TerminalNode):
     __slots__ = ('parentCtx', 'symbol')
 
-    def __init__(self, symbol:Token):
+    def __init__(self, symbol:Token) -> None:
         self.parentCtx = None
         self.symbol = symbol
-    def __setattr__(self, key, value):
+    def __setattr__(self, key, value) -> None:
         super().__setattr__(key, value)
 
-    def getChild(self, i:int):
+    def getChild(self, i:int) -> None:
         return None
 
     def getSymbol(self):
@@ -100,13 +104,13 @@ class TerminalNodeImpl(TerminalNode):
     def getPayload(self):
         return self.symbol
 
-    def getSourceInterval(self):
+    def getSourceInterval(self) -> tuple:
         if self.symbol is None:
             return INVALID_INTERVAL
         tokenIndex = self.symbol.tokenIndex
         return (tokenIndex, tokenIndex)
 
-    def getChildCount(self):
+    def getChildCount(self) -> int:
         return 0
 
     def accept(self, visitor:ParseTreeVisitor):
@@ -115,7 +119,7 @@ class TerminalNodeImpl(TerminalNode):
     def getText(self):
         return self.symbol.text
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.symbol.type == Token.EOF:
             return "<EOF>"
         else:
@@ -129,7 +133,7 @@ class TerminalNodeImpl(TerminalNode):
 
 class ErrorNodeImpl(TerminalNodeImpl,ErrorNode):
 
-    def __init__(self, token:Token):
+    def __init__(self, token:Token) -> None:
         super().__init__(token)
 
     def accept(self, visitor:ParseTreeVisitor):
@@ -140,7 +144,7 @@ class ParseTreeWalker(object):
 
     DEFAULT = None
 
-    def walk(self, listener:ParseTreeListener, t:ParseTree):
+    def walk(self, listener:ParseTreeListener, t:ParseTree) -> None:
         """
 	    Performs a walk on the given parse tree starting at the root and going down recursively
 	    with depth-first search. On each node, {@link ParseTreeWalker#enterRule} is called before
@@ -166,7 +170,7 @@ class ParseTreeWalker(object):
     # {@link RuleContext}-specific event. First we trigger the generic and then
     # the rule specific. We to them in reverse order upon finishing the node.
     #
-    def enterRule(self, listener:ParseTreeListener, r:RuleNode):
+    def enterRule(self, listener:ParseTreeListener, r:RuleNode) -> None:
         """
 	    Enters a grammar rule by first triggering the generic event {@link ParseTreeListener#enterEveryRule}
 	    then by triggering the event specific to the given parse tree node
@@ -177,7 +181,7 @@ class ParseTreeWalker(object):
         listener.enterEveryRule(ctx)
         ctx.enterRule(listener)
 
-    def exitRule(self, listener:ParseTreeListener, r:RuleNode):
+    def exitRule(self, listener:ParseTreeListener, r:RuleNode) -> None:
         """
 	    Exits a grammar rule by first triggering the event specific to the given parse tree node
 	    then by triggering the generic event {@link ParseTreeListener#exitEveryRule}

--- a/runtime/Python3/src/antlr4/tree/Trees.py
+++ b/runtime/Python3/src/antlr4/tree/Trees.py
@@ -38,7 +38,7 @@ class Trees(object):
             return buf.getvalue()
 
     @classmethod
-    def getNodeText(cls, t:Tree, ruleNames:list=None, recog:Parser=None):
+    def getNodeText(cls, t:Tree, ruleNames:list=None, recog:Parser=None) -> str:
         if recog is not None:
             ruleNames = recog.ruleNames
         if ruleNames is not None:
@@ -60,14 +60,14 @@ class Trees(object):
 
     # Return ordered list of all children of this node
     @classmethod
-    def getChildren(cls, t:Tree):
+    def getChildren(cls, t:Tree) -> list:
         return [ t.getChild(i) for i in range(0, t.getChildCount()) ]
 
     # Return a list of all ancestors of this node.  The first node of
     #  list is the root and the last is the parent of this node.
     #
     @classmethod
-    def getAncestors(cls, t:Tree):
+    def getAncestors(cls, t:Tree) -> list:
         ancestors = []
         t = t.getParent()
         while t is not None:
@@ -76,21 +76,21 @@ class Trees(object):
         return ancestors
 
     @classmethod
-    def findAllTokenNodes(cls, t:ParseTree, ttype:int):
+    def findAllTokenNodes(cls, t:ParseTree, ttype:int) -> list:
         return cls.findAllNodes(t, ttype, True)
 
     @classmethod
-    def findAllRuleNodes(cls, t:ParseTree, ruleIndex:int):
+    def findAllRuleNodes(cls, t:ParseTree, ruleIndex:int) -> list:
         return cls.findAllNodes(t, ruleIndex, False)
 
     @classmethod
-    def findAllNodes(cls, t:ParseTree, index:int, findTokens:bool):
+    def findAllNodes(cls, t:ParseTree, index:int, findTokens:bool) -> list:
         nodes = []
         cls._findAllNodes(t, index, findTokens, nodes)
         return nodes
 
     @classmethod
-    def _findAllNodes(cls, t:ParseTree, index:int, findTokens:bool, nodes:list):
+    def _findAllNodes(cls, t:ParseTree, index:int, findTokens:bool, nodes:list) -> None:
         from antlr4.ParserRuleContext import ParserRuleContext
         # check this node (the root) first
         if findTokens and isinstance(t, TerminalNode):
@@ -104,7 +104,7 @@ class Trees(object):
             cls._findAllNodes(t.getChild(i), index, findTokens, nodes)
 
     @classmethod
-    def descendants(cls, t:ParseTree):
+    def descendants(cls, t:ParseTree) -> list:
         nodes = [t]
         for i in range(0, t.getChildCount()):
             nodes.extend(cls.descendants(t.getChild(i)))

--- a/runtime/Python3/src/antlr4/xpath/XPath.py
+++ b/runtime/Python3/src/antlr4/xpath/XPath.py
@@ -66,12 +66,12 @@ class XPath(object):
     WILDCARD = "*" # word not operator/separator
     NOT = "!" # word for invert operator
 
-    def __init__(self, parser:Parser, path:str):
+    def __init__(self, parser:Parser, path:str) -> None:
         self.parser = parser
         self.path = path
         self.elements = self.split(path)
 
-    def split(self, path:str):
+    def split(self, path:str) -> list:
         input = InputStream(path)
         lexer = XPathLexer(input)
         def recover(self, e):
@@ -124,7 +124,7 @@ class XPath(object):
     # element. {@code anywhere} is {@code true} if {@code //} precedes the
     # word.
     #
-    def getXPathElement(self, wordToken:Token, anywhere:bool):
+    def getXPathElement(self, wordToken:Token, anywhere:bool) -> XPathRuleAnywhereElement | XPathRuleElement | XPathTokenAnywhereElement | XPathTokenElement | XPathWildcardAnywhereElement | XPathWildcardElement:
         if wordToken.type==Token.EOF:
             raise Exception("Missing path element at end of path")
 
@@ -156,7 +156,7 @@ class XPath(object):
 
 
     @staticmethod
-    def findAll(tree:ParseTree, xpath:str, parser:Parser):
+    def findAll(tree:ParseTree, xpath:str, parser:Parser) -> list:
         p = XPath(parser, xpath)
         return p.evaluate(tree)
 
@@ -165,7 +165,7 @@ class XPath(object):
     # path. The root {@code /} is relative to the node passed to
     # {@link #evaluate}.
     #
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t:ParseTree) -> list:
         dummyRoot = ParserRuleContext()
         dummyRoot.children = [t] # don't set t's parent.
 
@@ -191,11 +191,11 @@ class XPath(object):
 
 class XPathElement(object):
 
-    def __init__(self, nodeName:str):
+    def __init__(self, nodeName:str) -> None:
         self.nodeName = nodeName
         self.invert = False
 
-    def __str__(self):
+    def __str__(self) -> str:
         return type(self).__name__ + "[" + ("!" if self.invert else "") + self.nodeName + "]"
 
 
@@ -205,51 +205,51 @@ class XPathElement(object):
 #
 class XPathRuleAnywhereElement(XPathElement):
 
-    def __init__(self, ruleName:str, ruleIndex:int):
+    def __init__(self, ruleName:str, ruleIndex:int) -> None:
         super().__init__(ruleName)
         self.ruleIndex = ruleIndex
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t:ParseTree) -> filter:
         # return all ParserRuleContext descendants of t that match ruleIndex (or do not match if inverted)
         return filter(lambda c: isinstance(c, ParserRuleContext) and (self.invert ^ (c.getRuleIndex() == self.ruleIndex)), Trees.descendants(t))
 
 class XPathRuleElement(XPathElement):
 
-    def __init__(self, ruleName:str, ruleIndex:int):
+    def __init__(self, ruleName:str, ruleIndex:int) -> None:
         super().__init__(ruleName)
         self.ruleIndex = ruleIndex
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t:ParseTree) -> filter:
         # return all ParserRuleContext children of t that match ruleIndex (or do not match if inverted)
         return filter(lambda c: isinstance(c, ParserRuleContext) and (self.invert ^ (c.getRuleIndex() == self.ruleIndex)), Trees.getChildren(t))
 
 class XPathTokenAnywhereElement(XPathElement):
 
-    def __init__(self, ruleName:str, tokenType:int):
+    def __init__(self, ruleName:str, tokenType:int) -> None:
         super().__init__(ruleName)
         self.tokenType = tokenType
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t:ParseTree) -> filter:
         # return all TerminalNode descendants of t that match tokenType (or do not match if inverted)
         return filter(lambda c: isinstance(c, TerminalNode) and (self.invert ^ (c.symbol.type == self.tokenType)), Trees.descendants(t))
 
 class XPathTokenElement(XPathElement):
 
-    def __init__(self, ruleName:str, tokenType:int):
+    def __init__(self, ruleName:str, tokenType:int) -> None:
         super().__init__(ruleName)
         self.tokenType = tokenType
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t:ParseTree) -> filter:
         # return all TerminalNode children of t that match tokenType (or do not match if inverted)
         return filter(lambda c: isinstance(c, TerminalNode) and (self.invert ^ (c.symbol.type == self.tokenType)), Trees.getChildren(t))
 
 
 class XPathWildcardAnywhereElement(XPathElement):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(XPath.WILDCARD)
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t:ParseTree) -> list:
         if self.invert:
             return list() # !* is weird but valid (empty)
         else:
@@ -258,11 +258,11 @@ class XPathWildcardAnywhereElement(XPathElement):
 
 class XPathWildcardElement(XPathElement):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(XPath.WILDCARD)
 
 
-    def evaluate(self, t:ParseTree):
+    def evaluate(self, t:ParseTree) -> list:
         if self.invert:
             return list() # !* is weird but valid (empty)
         else:

--- a/runtime/Python3/src/antlr4/xpath/XPathLexer.py
+++ b/runtime/Python3/src/antlr4/xpath/XPathLexer.py
@@ -8,7 +8,7 @@ else:
     from typing.io import TextIO
 
 
-def serializedATN():
+def serializedATN() -> list[int]:
     return [
         4,0,8,50,6,-1,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,
         6,7,6,2,7,7,7,1,0,1,0,1,0,1,1,1,1,1,2,1,2,1,3,1,3,1,4,1,4,5,4,29,
@@ -61,7 +61,7 @@ class XPathLexer(Lexer):
 
     grammarFileName = "XPathLexer.g4"
 
-    def __init__(self, input=None, output:TextIO = sys.stdout):
+    def __init__(self, input=None, output:TextIO = sys.stdout) -> None:
         super().__init__(input, output)
         self.checkVersion("4.11.2-SNAPSHOT")
         self._interp = LexerATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
@@ -69,7 +69,7 @@ class XPathLexer(Lexer):
         self._predicates = None
 
 
-    def action(self, localctx:RuleContext, ruleIndex:int, actionIndex:int):
+    def action(self, localctx:RuleContext, ruleIndex:int, actionIndex:int) -> None:
         if self._actions is None:
             actions = dict()
             actions[4] = self.ID_action 
@@ -81,7 +81,7 @@ class XPathLexer(Lexer):
             raise Exception("No registered action for:" + str(ruleIndex))
 
 
-    def ID_action(self, localctx:RuleContext , actionIndex:int):
+    def ID_action(self, localctx:RuleContext , actionIndex:int) -> None:
         if actionIndex == 0:
 
                             char = self.text[0]

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -53,9 +53,10 @@ from antlr4 import *
 from io import StringIO
 import sys
 if sys.version_info[1] > 5:
-	from typing import TextIO
+	from typing import List, TextIO, Dict, Any
 else:
-	from typing.io import TextIO
+	from typing.io import List, TextIO, Dict, Any
+from typing import Optional
 
 <namedActions.header>
 <parser>
@@ -217,11 +218,11 @@ def sempred(self, localctx:RuleContext, ruleIndex:int, predIndex:int):
 >>
 
 parser_ctor(p) ::= <<
-def __init__(self, input:TokenStream, output:TextIO = sys.stdout):
+def __init__(self, input:TokenStream, output:TextIO = sys.stdout) -> None:
     super().__init__(input, output)
     self.checkVersion("<file.ANTLRVersion>")
     self._interp = ParserATNSimulator(self, self.atn, self.decisionsToDFA, self.sharedContextCache)
-    self._predicates = None
+    self._predicates : Dict[int, Any] = dict()
 
 >>
 
@@ -262,8 +263,7 @@ RuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,namedActions,fina
 <ruleCtx>
 
 <altLabelCtxs:{l | <altLabelCtxs.(l)>}; separator="\n">
-
-def <currentRule.escapedName>(self<currentRule.args:{a | , <a.escapedName><if(a.type)>:<a.type><endif>}>):
+def <currentRule.escapedName>(self<currentRule.args:{a | , <a.escapedName><if(a.type)>:<a.type><endif>}>) -> <currentRule.ctxType>:
 
     localctx = <parser.name>.<currentRule.ctxType>(self, self._ctx, self.state<currentRule.args:{a | , <a.escapedName>}>)
     self.enterRule(localctx, <currentRule.startState>, self.RULE_<currentRule.name>)
@@ -295,7 +295,7 @@ LeftRecursiveRuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,
 <ruleCtx>
 <altLabelCtxs:{l | <altLabelCtxs.(l)>}; separator="\n">
 
-def <currentRule.escapedName>(self, _p:int=0<if(currentRule.args)>, <args:{a | , <a>}><endif>):
+def <currentRule.escapedName>(self, _p:int=0<if(currentRule.args)>, <args:{a | , <a>}><endif>) -> <currentRule.ctxType>:
     _parentctx = self._ctx
     _parentState = self.state
     localctx = <parser.name>.<currentRule.ctxType>(self, self._ctx, _parentState<args:{a | , <a.escapedName>}>)
@@ -606,7 +606,7 @@ def <t.name>_list(self):
 >>
 
 ContextTokenListIndexedGetterDecl(t)  ::= <<
-def <t.escapedName>(self, i:int=None):
+def <t.escapedName>(self, i:Optional[int]=None):
     if i is None:
         return self.getTokens(<parser.name>.<t.name>)
     else:
@@ -627,7 +627,7 @@ def <r.name>_list(self):
 >>
 
 ContextRuleListIndexedGetterDecl(r)   ::= <<
-def <r.escapedName>(self, i:int=None):
+def <r.escapedName>(self, i:Optional[int]=None):
     if i is None:
         return self.getTypedRuleContexts(<parser.name>.<r.ctxName>)
     else:
@@ -652,11 +652,11 @@ CaptureNextTokenType(d) ::= "<d.varName> = self._input.LA(1)"
 
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures) ::= <<
 class <struct.escapedName>(<if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>):
-    __slots__ = 'parser'
+    __slots__ = [ 'parser', <struct.attrs:{a | '<a.escapedName>'}; separator=","> ]
 
-    def __init__(self, parser, parent:ParserRuleContext=None, invokingState:int=-1<struct.ctorAttrs:{a | , <a.escapedName><if(a.type)>:<a.type><endif>=None}>):
+    def __init__(self, parser, parent:Optional[ParserRuleContext]=None, invokingState:int=-1<struct.ctorAttrs:{a | , <a.escapedName><if(a.type)>:<a.type><endif>=None}>):
         super().__init__(parent, invokingState)
-        self.parser = parser
+        self.parser : Parser = parser
         <attrs:{a | <a>}; separator="\n">
         <struct.ctorAttrs:{a | self.<a.escapedName> = <a.escapedName>}; separator="\n">
 
@@ -762,9 +762,9 @@ from antlr4 import *
 from io import StringIO
 import sys
 if sys.version_info[1] > 5:
-    from typing import TextIO
+    from typing import List, TextIO, Dict, Any
 else:
-    from typing.io import TextIO
+    from typing.io import List, TextIO, Dict, Any
 
 <namedActions.header>
 
@@ -813,12 +813,12 @@ class <lexer.name>(<if(superClass)><superClass><else>Lexer<endif>):
 
     grammarFileName = "<lexer.grammarFileName>"
 
-    def __init__(self, input=None, output:TextIO = sys.stdout):
+    def __init__(self, input=None, output:TextIO = sys.stdout) -> None:
         super().__init__(input, output)
         self.checkVersion("<lexerFile.ANTLRVersion>")
         self._interp = LexerATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
         self._actions = None
-        self._predicates = None
+        self._predicates : Dict[int, Any] = dict()
 
     <namedActions.members>
 
@@ -827,7 +827,7 @@ class <lexer.name>(<if(superClass)><superClass><else>Lexer<endif>):
 >>
 
 SerializedATN(model) ::= <<
-def serializedATN():
+def serializedATN()  -> List[int]:
     return [
         <model.serialized: {s | <s>}; separator=",", wrap>
     ]


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
Antlr4's generated code for Python3 target had some misuse of __slots__. All the base objects were not using slots so derived objects from them didn't correctly enforce slots. __slots__ were added to base objects. Additionally, a number of forward declarations were made as class_name = None, this causes issues with mypy when checking code. Imports and other forward declarations were added to correct this. Furthermore, return types and argument types were added to functions within runtime to contribute to mypy type checking.  Emitted code was verified by generating a parser for java8 using python 3.11