### PR TITLE
[Javascript] Fix broken package entrypoints

### DIFF
--- a/runtime/JavaScript/package.json
+++ b/runtime/JavaScript/package.json
@@ -3,8 +3,9 @@
   "version": "4.13.1",
   "type": "module",
   "description": "JavaScript runtime for ANTLR4",
-  "browser": "dist/antlr4.web.js",
-  "main": "dist/antlr4.node.mjs",
+  "browser": "dist/antlr4.web.mjs",
+  "main": "dist/antlr4.node.cjs",
+  "module": "dist/antlr4.node.mjs",
   "types": "src/antlr4/index.d.ts",
   "repository": "antlr/antlr4.git",
   "keywords": [


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

Currently as of 4.13.1 the entrypoint for `browser` is invalid, and `main` specifies the `esm` build instead of the `commonjs` one.

This results in commonjs based sources attempting to load esm syntax when addressing the sources using `main`.

The error in `browser` causes this error when attempting to bundle the sources:
```
[commonjs--resolver] Failed to resolve entry for package "antlr4". The package may have incorrect main/module/exports specified in its package.json.
error during build:
Error: Failed to resolve entry for package "antlr4". The package may have incorrect main/module/exports specified in its package.json.
```

### Fixes
- `browser` field updated to fix the extension
  - `"dist/antlr4.web.js"` -> `"dist/antlr4.web.mjs"`
- `main` field updated to point to the commonjs bundle
  - "dist/antlr4.node.mjs"` -> `"dist/antlr4.node.cjs"`

### Added
- `module` field to point to the esm bundle
  - `"module": "dist/antlr4.node.mjs"`

More information on `main` vs `module` can be found here: https://nodejs.org/api/packages.html#dual-commonjses-module-packages