### PR TITLE
Added an option to generate the context classes final.

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -79,6 +79,12 @@ $ grep MyToken T2Parser.java
 Specify the super class of parse tree internal nodes. Default is `ParserRuleContext`. Should derive from ultimately `RuleContext` at minimum.
 Java target can use `contextSuperClass=org.antlr.v4.runtime.RuleContextWithAltNum` for convenience. It adds a backing field for `altNumber`, the alt matched for the associated rule node.
 
+### `finalContextClass`
+
+If this option is set to `true` that makes the generated Context classes final on Java targets. The default is `false` for backward compatibility.
+
+Hint: Introduce a sealed superclass with the `contextSuperClass` option, for better use of Java 21 pattern matching.
+
 ### `caseInsensitive`
 
 As of 4.10, ANTLR supports case-insensitive lexers using a grammar option. For example, the parser from the following grammar:

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -785,7 +785,7 @@ CaptureNextTokenType(d) ::= "<d.varName> = _input.LA(1);"
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures)
 	::= <<
 @SuppressWarnings("CheckReturnValue")
-public static class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif> {
+public static <if(file.finalContextClass)>final <endif>class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif> {
 	<attrs:{a | public <a>;}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
 	<if(ctorAttrs)>public <struct.escapedName>(ParserRuleContext parent, int invokingState) { super(parent, invokingState); }<endif>

--- a/tool/src/org/antlr/v4/codegen/model/ParserFile.java
+++ b/tool/src/org/antlr/v4/codegen/model/ParserFile.java
@@ -22,6 +22,7 @@ public class ParserFile extends OutputFile {
 	@ModelElement public Parser parser;
 	@ModelElement public Map<String, Action> namedActions;
 	@ModelElement public ActionChunk contextSuperClass;
+	public boolean finalContextClass;
 	public String grammarName;
 
 	public ParserFile(OutputModelFactory factory, String fileName) {
@@ -38,5 +39,6 @@ public class ParserFile extends OutputFile {
 		if (g.getOptionString("contextSuperClass") != null) {
 			contextSuperClass = new ActionText(null, g.getOptionString("contextSuperClass"));
 		}
+		finalContextClass = Boolean.valueOf(g.getOptionString("finalContextClass"));
 	}
 }

--- a/tool/src/org/antlr/v4/tool/Grammar.java
+++ b/tool/src/org/antlr/v4/tool/Grammar.java
@@ -77,6 +77,7 @@ public class Grammar implements AttributeResolver {
 	static {
 		parserOptions.add("superClass");
 		parserOptions.add("contextSuperClass");
+		parserOptions.add("finalContextClass");
 		parserOptions.add("TokenLabelType");
 		parserOptions.add("tokenVocab");
 		parserOptions.add("language");


### PR DESCRIPTION
Well, I was trying to test some Java 21 features, when it hit me that the generated Context classes are not final, so I can't simply just announce a sealed super class for them.

This is a trivial fix for the issue. Other languages could benefit from this `final`-ization as well, however I'm not good enough in them, to take that responsibility.

Might be a step for #4310