### PR TITLE
Update README.md to include Go support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## Versioning
 
 ANTLR 4 supports 10 target languages
-(Cpp, CSharp, Dart, Java, JavaScript, PHP, Python3, Swift, TypeScript),
+(Cpp, CSharp, Dart, Go, Java, JavaScript, PHP, Python3, Swift, TypeScript),
 and ensuring consistency across these targets is a unique and highly valuable feature.
 To ensure proper support of this feature, each release of ANTLR is a complete release of the tool and the 10 runtimes, all with the same version.
 As such, ANTLR versioning does not strictly follow semver semantics:


### PR DESCRIPTION
The doc says it supports 10 languages but enumerates only 9, forgetting Go.
