### PR TITLE
Band-Aid "go vet" error with Go codegen template

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -432,8 +432,10 @@ errorExit:
 	<finallyAction>
 	<endif>
 	p.ExitRule()
+	if false {
+		goto errorExit // Trick to prevent compiler error if the label is not used
+	}
 	return localctx
-	goto errorExit // Trick to prevent compiler error if the label is not used
 }
 >>
 
@@ -500,8 +502,10 @@ func (p *<parser.name>) <currentRule.escapedName>(_p int<args:{a | , <a.escapedN
 	<finallyAction>
 	<endif>
 	p.UnrollRecursionContexts(_parentctx)
+	if false {
+		goto errorExit // Trick to prevent compiler error if the label is not used
+	}
 	return localctx
-	goto errorExit // Trick to prevent compiler error if the label is not used
 }
 >>
 


### PR DESCRIPTION
Resolves https://github.com/antlr/antlr4/issues/4439

This may not work forever. If it ever stops working, then we can switch to using a `const` variable, as  that is how Rob Pike & Co. intend for debugging-logic to work. Refer to the following issue:

https://github.com/golang/go/issues/16370