### PR TITLE
Split ctorAttrs from attrs in codegen model StructDecl

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -861,6 +861,7 @@ CaptureNextTokenType(d) ::= "<d.varName> = TokenStream.LA(1);"
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures,
            superClass={ParserRuleContext}) ::= <<
 public partial class <struct.escapedName> : <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
+	<ctorAttrs:{a | public <a>;}; separator="\n">
 	<attrs:{a | public <a>;}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
 	<if(ctorAttrs)>public <struct.escapedName>(ParserRuleContext parent, int invokingState) : base(parent, invokingState) { }<endif>
@@ -874,6 +875,7 @@ public partial class <struct.escapedName> : <if(contextSuperClass)><contextSuper
 	public <struct.escapedName>() { }
 	public virtual void CopyFrom(<struct.escapedName> context) {
 		base.CopyFrom(context);
+		<struct.ctorAttrs:{a | this.<a.escapedName> = context.<a.escapedName>;}; separator="\n">
 		<struct.attrs:{a | this.<a.escapedName> = context.<a.escapedName>;}; separator="\n">
 	}
 <endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -583,6 +583,7 @@ LeftRecursiveRuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs
 StructDeclHeader(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, extensionMembers) ::= <<
 class <file.exportMacro> <struct.escapedName> : public <if (contextSuperClass)><contextSuperClass><else>antlr4::ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 public:
+  <ctorAttrs: {a | <a>;}; separator = "\n">
   <attrs: {a | <a>;}; separator = "\n">
   <if (ctorAttrs)><struct.escapedName>(antlr4::ParserRuleContext *parent, size_t invokingState);<endif>
   <struct.escapedName>(antlr4::ParserRuleContext *parent, size_t invokingState<ctorAttrs: {a | , <a>}>);
@@ -624,6 +625,7 @@ size_t <parser.name>::<struct.escapedName>::getRuleIndex() const {
 <if (struct.provideCopyFrom)>
 void <parser.name>::<struct.escapedName>::copyFrom(<struct.escapedName> *ctx) {
   <if (contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif>::copyFrom(ctx);
+  <struct.ctorAttrs: {a | this-><a.escapedName> = ctx-><a.escapedName>;}; separator = "\n">
   <struct.attrs: {a | this-><a.escapedName> = ctx-><a.escapedName>;}; separator = "\n">
 }
 <endif>
@@ -1172,4 +1174,3 @@ previousContext = _localctx;
 initValue(typeName) ::= <<
 <cppTypeInitMap.(typeName)>
 >>
-

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
@@ -684,6 +684,7 @@ CaptureNextTokenType(d) ::= "<d.varName> = tokenStream.LA(1)!;"
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures)
   ::= <<
 class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif> {
+  <ctorAttrs:{a | <a>;}; separator="\n">
   <attrs:{a | <a>;}; separator="\n">
   <getters:{g | <g>}; separator="\n">
   <struct.escapedName>([ParserRuleContext? parent, int? invokingState<ctorAttrs:{a | , <a>}>]) : super(parent, invokingState)<if(struct.ctorAttrs)> {
@@ -696,6 +697,7 @@ class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><el
   @override
   void copyFrom(<if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif> ctx) {
     super.copyFrom(ctx);
+    <struct.ctorAttrs:{a | if((ctx as <struct.escapedName>).<a.escapedName> != null) this.<a.escapedName> = (ctx as <struct.escapedName>).<a.escapedName>;}; separator="\n">
     <struct.attrs:{a | if((ctx as <struct.escapedName>).<a.escapedName> != null) this.<a.escapedName> = (ctx as <struct.escapedName>).<a.escapedName>;}; separator="\n">
   }
 <endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -1121,12 +1121,22 @@ Get<a.escapedName; format="cap">() []I<a.ctxName>}; separator="\n\n">
 Set<a.escapedName; format="cap">([]I<a.ctxName>) }; separator="\n\n">
 	<endif>
 
+	<if(struct.ctorAttrs)>
+
+	<struct.ctorAttrs:{a | // Get<a.escapedName; format="cap"> returns the <a.escapedName> attribute.
+Get<a.escapedName; format="cap">() <a.type>}; separator="\n\n">
+	<endif>
 	<if(struct.attributeDecls)>
 
 	<struct.attributeDecls:{a | // Get<a.escapedName; format="cap"> returns the <a.escapedName> attribute.
 Get<a.escapedName; format="cap">() <a.type>}; separator="\n\n">
 	<endif>
 
+	<if(struct.ctorAttrs)>
+
+	<struct.ctorAttrs:{a | // Set<a.escapedName; format="cap"> sets the <a.escapedName> attribute.
+Set<a.escapedName; format="cap">(<a.type>)}; separator="\n\n">
+	<endif>
 	<if(struct.attributeDecls)>
 
 	<struct.attributeDecls:{a | // Set<a.escapedName; format="cap"> sets the <a.escapedName> attribute.
@@ -1146,6 +1156,9 @@ Set<a.escapedName; format="cap">(<a.type>)}; separator="\n\n">
 type <struct.escapedName> struct {
 	<if(contextSuperClass)>*<contextSuperClass><else>antlr.BaseParserRuleContext<endif>
 	parser antlr.Parser
+	<if(ctorAttrs)>
+	<ctorAttrs; separator="\n">
+	<endif>
 	<if(attrs)>
 	<attrs; separator="\n">
 	<endif>
@@ -1243,11 +1256,19 @@ func (s *<struct.escapedName>) GetParser() antlr.Parser { return s.parser }
 <struct.ruleContextListDecls:{a | func (s *<struct.escapedName>) Set<a.escapedName; format="cap">(v []I<a.ctxName>) { s.<a.escapedName> = v \}}; separator="\n\n">
 <endif>
 
+<if(struct.ctorAttrs)>
+
+<struct.ctorAttrs:{a | func (s *<struct.escapedName>) Get<a.escapedName; format="cap">() <a.type> { return s.<a.escapedName> \}}; separator="\n\n">
+<endif>
 <if(struct.attributeDecls)>
 
 <struct.attributeDecls:{a | func (s *<struct.escapedName>) Get<a.escapedName; format="cap">() <a.type> { return s.<a.escapedName> \}}; separator="\n\n">
 <endif>
 
+<if(struct.ctorAttrs)>
+
+<struct.ctorAttrs:{a | func (s *<struct.escapedName>) Set<a.escapedName; format="cap">(v <a.type>) { s.<a.escapedName> = v \}}; separator="\n\n">
+<endif>
 <if(struct.attributeDecls)>
 
 <struct.attributeDecls:{a | func (s *<struct.escapedName>) Set<a.escapedName; format="cap">(v <a.type>) { s.<a.escapedName> = v \}}; separator="\n\n">
@@ -1262,6 +1283,7 @@ func (s *<struct.escapedName>) GetParser() antlr.Parser { return s.parser }
 
 func (s *<struct.escapedName>) CopyAll(ctx *<struct.escapedName>) {
 	s.CopyFrom(&ctx.BaseParserRuleContext)
+	<struct.ctorAttrs:{a | s.<a.escapedName> = ctx.<a.escapedName>}; separator="\n">
 	<struct.attrs:{a | s.<a.escapedName> = ctx.<a.escapedName>}; separator="\n">
 }
 <endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -786,6 +786,7 @@ StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMe
 	::= <<
 @SuppressWarnings("CheckReturnValue")
 public static class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif> {
+	<ctorAttrs:{a | public <a>;}; separator="\n">
 	<attrs:{a | public <a>;}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
 	<if(ctorAttrs)>public <struct.escapedName>(ParserRuleContext parent, int invokingState) { super(parent, invokingState); }<endif>
@@ -798,6 +799,7 @@ public static class <struct.escapedName> extends <if(contextSuperClass)><context
 	public <struct.escapedName>() { }
 	public void copyFrom(<struct.escapedName> ctx) {
 		super.copyFrom(ctx);
+		<struct.ctorAttrs:{a | this.<a.escapedName> = ctx.<a.escapedName>;}; separator="\n">
 		<struct.attrs:{a | this.<a.escapedName> = ctx.<a.escapedName>;}; separator="\n">
 	}
 <endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg
@@ -675,6 +675,7 @@ class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><el
 	<if(struct.provideCopyFrom)> <! don't need copy unless we have subclasses !>
 	copyFrom(ctx) {
 		super.copyFrom(ctx);
+		<struct.ctorAttrs:{a | this.<a.escapedName> = ctx.<a.escapedName>;}; separator="\n">
 		<struct.attrs:{a | this.<a.escapedName> = ctx.<a.escapedName>;}; separator="\n">
 	}
 	<endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
@@ -848,8 +848,17 @@ public $<d.name>;}; separator="\n\n">
  */
 public $<d.name>;}; separator="\n\n">
 <endif>
-<if(struct.attributeDecls)>
+<if(struct.ctorAttrs)>
 <if(struct.tokenListDecls || struct.tokenDecls || struct.ruleContextDecls || struct.ruleContextListDecls)>
+
+<endif>
+	<struct.ctorAttrs : {d | /**
+ * @var <d.type><if(!d.initValue)>|null<endif> $<d.name>
+ */
+public $<d.name><if(d.initValue)> = <d.initValue><endif>;}; separator="\n\n">
+<endif>
+<if(struct.attributeDecls)>
+<if(struct.tokenListDecls || struct.tokenDecls || struct.ruleContextDecls || struct.ruleContextListDecls || struct.ctorAttrs)>
 
 <endif>
 	<struct.attributeDecls : {d | /**
@@ -949,6 +958,7 @@ class <struct.name> extends <if(contextSuperClass)><contextSuperClass><else>Pars
 	{
 		parent::copyFrom($context);
 
+		<struct.ctorAttrs:{a | $this-><a.name> = $context-><a.name>;}; separator="\n">
 		<struct.attrs:{a | $this-><a.name> = $context-><a.name>;}; separator="\n">
 	}
 <endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -668,6 +668,7 @@ class <struct.escapedName>(<if(contextSuperClass)><contextSuperClass><else>Parse
 <if(struct.provideCopyFrom)> <! don't need copy unless we have subclasses !>
     def copyFrom(self, ctx:ParserRuleContext):
         super().copyFrom(ctx)
+        <struct.ctorAttrs:{a | self.<a.escapedName> = ctx.<a.escapedName>}; separator="\n">
         <struct.attrs:{a | self.<a.escapedName> = ctx.<a.escapedName>}; separator="\n">
 
 <endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -816,6 +816,7 @@ StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMe
            superClass={ParserRuleContext}) ::= <<
 
 <accessLevelNotOpen(parser)> class <struct.escapedName>: <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
+	<ctorAttrs:{a | <accessLevelOpenOK(parser)> var <a>}; separator="\n">
 	<attrs:{a | <accessLevelOpenOK(parser)> var <a>}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
 	<! <if(ctorAttrs)> <accessLevelNotOpen(parser)> init(_ parent: ParserRuleContext,_ invokingState: Int) { super.init(parent, invokingState)  }<endif> !>
@@ -835,6 +836,7 @@ StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMe
 	override func copyFrom(_ ctx_: ParserRuleContext) {
 		super.copyFrom(ctx_)
 		let ctx = ctx_ as! <struct.escapedName>
+		<struct.ctorAttrs:{a | self.<a.escapedName> = ctx.<a.escapedName>;}; separator="\n">
 		<struct.attrs:{a | self.<a.escapedName> = ctx.<a.escapedName>;}; separator="\n">
 	}
 <endif>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -731,6 +731,7 @@ CaptureNextTokenType(d) ::= "<d.varName> = this._input.LA(1);"
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures)
 	::= <<
 export class <struct.escapedName> extends <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> implements <interfaces; separator=", "><endif> {
+	<ctorAttrs:{a | public <a>;}; separator="\n">
 	<attrs:{a | public <a>;}; separator="\n">
 	<if(struct.ctorAttrs)>
 	constructor(parser: <parser.name>, parent: ParserRuleContext, invokingState: number<struct.ctorAttrs:{a |, <a.escapedName>: <a.type>}>) {
@@ -751,6 +752,7 @@ export class <struct.escapedName> extends <if(contextSuperClass)><contextSuperCl
 <if(struct.provideCopyFrom)><! don't need copy unless we have subclasses !>
 	public copyFrom(ctx: <struct.name>): void {
 		super.copyFrom(ctx);
+		<struct.ctorAttrs:{a | this.<a.escapedName> = ctx.<a.escapedName>;}; separator="\n">
 		<struct.attrs:{a | this.<a.escapedName> = ctx.<a.escapedName>;}; separator="\n">
 	}
 <endif>

--- a/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
@@ -89,7 +89,6 @@ public class RuleFunction extends OutputModelObject {
 			Collection<Attribute> decls = r.args.attributes.values();
 			if ( decls.size()>0 ) {
 				args = new ArrayList<AttributeDecl>();
-				ruleCtx.addDecls(decls);
 				for (Attribute a : decls) {
 					args.add(new AttributeDecl(factory, a));
 				}


### PR DESCRIPTION
This helps avoid dead code in ctorAttr initialization in some script targets (namely Python3 and JavaScript).
