### PR TITLE
[PHP] fix: make BaseListener abstract by default

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/PHP/PHP.stg
@@ -97,7 +97,7 @@ use Antlr\\Antlr4\\Runtime\\Tree\\TerminalNode;
  * which can be extended to create a listener which only needs to handle a subset
  * of the available methods.
  */
-class <file.grammarName>BaseListener implements <file.grammarName>Listener
+abstract class <file.grammarName>BaseListener implements <file.grammarName>Listener
 {
 	<file.listenerNames:{lname |
 /**


### PR DESCRIPTION
The `BaseListener` does nothing by default, it should be marked as abstract to signal it's not meant to be used directly (because it makes no sense to do so) but extended.