### PR TITLE
fix: tweak word antrl to antlr

### DIFF
--- a/runtime/Cpp/cmake/README.md
+++ b/runtime/Cpp/cmake/README.md
@@ -34,7 +34,7 @@ set(ANTLR4_WITH_STATIC_CRT OFF)
 
 # add external build for antlrcpp
 include(ExternalAntlr4Cpp)
-# add antrl4cpp artifacts to project environment
+# add antlr4cpp artifacts to project environment
 include_directories(${ANTLR4_INCLUDE_DIRS})
 
 # set variable pointing to the antlr tool that supports C++


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
