### PR TITLE
runtime/Cpp/cmake/antlr4-generator.cmake.in: Quote the additional dependencies argument properly

### DIFF
--- a/runtime/Cpp/cmake/antlr4-generator.cmake.in
+++ b/runtime/Cpp/cmake/antlr4-generator.cmake.in
@@ -110,8 +110,8 @@ function(antlr4_generate
     set(Antlr4_NamespaceOption "")
   endif ()
 
-  if ( (ARGC GREATER_EQUAL 7 ) AND (NOT ${ARGV6} STREQUAL "") )
-    set(Antlr4_AdditionalDependencies ${ARGV6})
+  if ( (ARGC GREATER_EQUAL 7 ) AND (NOT "${ARGV6}" STREQUAL "") )
+    set(Antlr4_AdditionalDependencies "${ARGV6}")
   else()
     set(Antlr4_AdditionalDependencies "")
   endif ()


### PR DESCRIPTION
The 6th argument takes a list of dependencies. But for a list you must quote the variable as otherwise cmake complains with:

CMake Error at XXX/antlr4-generator-config.cmake:137 (if):
  if given arguments:

    "(" "ARGC" "GREATER_EQUAL" "7" ")" "AND" "(" "NOT" "YYY/Base.g4" "ZZZ/Expressions.g4" "STREQUAL" "" ")"

  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:95 (antlr4_generate)

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
