### PR TITLE
Bugfix for Interval Set

### DIFF
--- a/runtime/Go/antlr/v4/interval_set.go
+++ b/runtime/Go/antlr/v4/interval_set.go
@@ -186,7 +186,7 @@ func (i *IntervalSet) removeRange(v Interval) {
 				//                i.intervals.splice(k, 1)
 				i.intervals = append(i.intervals[0:k], i.intervals[k+1:]...)
 				k = k - 1 // need another pass
-			} else if v.Start < ni.Stop {
+			} else if v.Start < ni.Stop && v.Start > ni.Start {
 				i.intervals[k] = NewInterval(ni.Start, v.Start)
 			} else if v.Stop < ni.Stop {
 				i.intervals[k] = NewInterval(v.Stop, ni.Stop)


### PR DESCRIPTION
I'm pretty sure this is a bug. Checked the python implementation and it looked similar. None of them have tests though.


This change is necessary or else the last `else if` will never be executed and the function returns wrong results for some cases. For example, these following tests will fail without this change, even though they are correct:

```
TestRemoveRangeSameStart() {
	i := NewIntervalSet()
	i.addInterval(antlr.NewInterval(1, 10))
	i.removeRange(antlr.NewInterval(1, 7))

	suite.Len(i.intervals, 1)
	suite.Equal(7, i.intervals[0].Start)
	suite.Equal(10, i.intervals[0].Stop)
}
```

```
TestRemoveRangeOverStartBound() {
	i := NewIntervalSet()
	i.addInterval(antlr.NewInterval(5, 15))

	i.removeRange(antlr.NewInterval(1, 10))
	suite.Len(i.intervals, 1)
	suite.Equal(10, i.intervals[0].Start)
	suite.Equal(15, i.intervals[0].Stop)
}
```

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
