### PR TITLE
Fix removeOne for internal set

### DIFF
--- a/runtime/Go/antlr/v4/interval_set.go
+++ b/runtime/Go/antlr/v4/interval_set.go
@@ -199,7 +199,7 @@ func (i *IntervalSet) removeRange(v Interval) {
 func (i *IntervalSet) removeOne(v int) {
 	if i.intervals != nil {
 		for k := 0; k < len(i.intervals); k++ {
-			ki := i.intervals[k]
+			ki := &i.intervals[k]
 			// intervals i ordered
 			if v < ki.Start {
 				return


### PR DESCRIPTION
Here, in go, if we assign a slice position to a variable, we'll have a copy.

ki.Start = v + 1, on line 218, was just modifying a copy, which is not what was intended to be done here.

If we get the reference as done in the change, we'll modify `ki.Start`properly. Another option would be to reasign the copy to the array position. Either way, this should be fixed.

Simple test which would fail:

```
func (suite *IIntervalSetTestSuite) TestRemoveOne() {
	i := NewIntervalSet()
	i.addInterval(antlr.NewInterval(5, 10))

	i.removeOne(7)

	suite.Len(i.intervals, 2)
	suite.Equal(5, i.intervals[0].Start)
	suite.Equal(7, i.intervals[0].Stop)
	suite.Equal(8, i.intervals[1].Start)
	suite.Equal(10, i.intervals[1].Stop)
}
```

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
