### PR TITLE
fix: make package.json 'exports' work with typescript moduleResolution: 'bundler'

### DIFF
--- a/runtime/JavaScript/package.json
+++ b/runtime/JavaScript/package.json
@@ -57,7 +57,7 @@
         "require": "./dist/antlr4.node.cjs",
         "default": "./dist/antlr4.node.mjs"
       },
-      "browser": {
+      "default": {
         "types": "./src/antlr4/index.d.ts",
         "import": "./dist/antlr4.web.mjs",
         "require": "./dist/antlr4.web.cjs",


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

When importing antlr4 from a typescript project with `moduleResolution: "bundler"`, typescript will fail to resolve the .d.ts provided by antlr4. That's because typescript tries to resolve the exports with [condition](https://www.typescriptlang.org/docs/handbook/modules/reference.html#supported-features-1) `['types', 'import', 'default']` which does't match any of our declared exports.

Change the `browser` condition to `default` solves the issue. It's also recommended in Node.js [doc](https://nodejs.org/api/packages.html#conditional-exports):

> When using environment branches, always include a "default" condition where possible. Providing a "default" condition ensures that any unknown JS environments are able to use this universal implementation, which helps avoid these JS environments from having to pretend to be existing environments in order to support packages with conditional exports. For this reason, using "node" and "default" condition branches is usually preferable to using "node" and "browser" condition branches.