### PR TITLE
Generate meaningful exception message on checkVersion() failure

### DIFF
--- a/runtime/Python3/src/antlr4/atn/ATNDeserializer.py
+++ b/runtime/Python3/src/antlr4/atn/ATNDeserializer.py
@@ -47,7 +47,7 @@ class ATNDeserializer (object):
     def checkVersion(self):
         version = self.readInt()
         if version != SERIALIZED_VERSION:
-            raise Exception("Could not deserialize ATN with version " + str(version) + " (expected " + str(SERIALIZED_VERSION) + ").")
+            raise Exception("Could not deserialize ATN with version {} (expected {}).".format(ord(version), SERIALIZED_VERSION))
 
     def readATN(self):
         idx = self.readInt()


### PR DESCRIPTION
Currently, loading a parser from an incompatible version results in a message like:

> Could not deserialize ATN with version  (expected 4).

(see e.g. https://github.com/antlr/antlr4/issues/4041 )

Change the exception message generation to use `ord(version)`, so it shows e.g. the string 3 instead of the character with ordinal 3, which is non-printable and the cause for the above cryptic message.