### PR TITLE
[WIP] Update deprecated usage for InputStream.

### DIFF
--- a/runtime/JavaScript/spec/rewriter/TokenStreamRewriterSpec.js
+++ b/runtime/JavaScript/spec/rewriter/TokenStreamRewriterSpec.js
@@ -8,7 +8,7 @@ import calc from "./generatedCode/calc.js";
  * @param {string} input 
  */
 function getRewriter(lexerClass, input) {
-    const chars = new antlr4.InputStream(input);
+    const chars = new antlr4.CharStream(input);
     const lexer = new lexerClass(chars);
     const tokens = new antlr4.CommonTokenStream(lexer);
     tokens.fill();
@@ -385,7 +385,7 @@ describe("TokenStreamRewriter", () => {
     
     it("throws an error if second replace operation overlaps the first one on the left", () => {
         // Arrange
-        const chars = new antlr4.InputStream("abcccba");
+        const chars = new antlr4.CharStream("abcccba");
         const lexer = new abc(chars);
         const tokens = new antlr4.CommonTokenStream(lexer);
         tokens.fill();

--- a/runtime/JavaScript/src/antlr4/Lexer.js
+++ b/runtime/JavaScript/src/antlr4/Lexer.js
@@ -121,7 +121,9 @@ export default class Lexer extends Recognizer {
 							this.notifyListeners(e); // report error
 							this.recover(e);
 						} else {
-							console.log(e.stack);
+                            if (this._interp.debug) {
+                                console.log(e.stack);
+                            }
 							throw e;
 						}
 					}

--- a/runtime/JavaScript/src/antlr4/index.node.js
+++ b/runtime/JavaScript/src/antlr4/index.node.js
@@ -14,7 +14,7 @@ import { default as Utils } from './utils/index.js';
 import Token from './Token.js';
 import CommonToken from './CommonToken.js';
 import InputStream from './InputStream.js';
-import CharStream from './InputStream.js';
+import CharStream from './CharStream.js';
 import FileStream from './FileStream.js';
 import CommonTokenStream from './CommonTokenStream.js';
 import Lexer from './Lexer.js';

--- a/runtime/JavaScript/src/antlr4/index.web.js
+++ b/runtime/JavaScript/src/antlr4/index.web.js
@@ -14,7 +14,7 @@ import { default as Utils } from './utils/index.js';
 import Token from './Token.js';
 import CommonToken from './CommonToken.js';
 import InputStream from './InputStream.js';
-import CharStream from './InputStream.js';
+import CharStream from './CharStream.js';
 import CommonTokenStream from './CommonTokenStream.js';
 import Lexer from './Lexer.js';
 import Parser from './Parser.js';


### PR DESCRIPTION
Fix CharStream in index files referencing deprecated InputStream instead. 
Only log exceptions (for example LexerNoViableAltException) if debug is enabled for _interp. 
There is no other way to control this console output right now, seems like missed if check.
[in progress]: unintentional exception is fired by parser along with passing it through error listener at the same time. This behavior changed 

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
