### PR TITLE
Add parse listener methods to Parser typescript

### DIFF
--- a/runtime/JavaScript/src/antlr4/Parser.d.ts
+++ b/runtime/JavaScript/src/antlr4/Parser.d.ts
@@ -6,6 +6,7 @@ import {ParserATNSimulator} from "./atn";
 import {Token} from "./Token";
 import {ParserRuleContext} from "./context";
 import {Printer} from "./utils";
+import {ParseTreeListener} from "./tree";
 
 export declare class Parser extends Recognizer<Token> {
 
@@ -24,6 +25,10 @@ export declare class Parser extends Recognizer<Token> {
     constructor(input: TokenStream);
     match(ttype: number): Token;
     matchWildcard(): Token;
+    getParseListeners(): ParseTreeListener[];
+    addParseListener(listener: ParseTreeListener): void;
+    removeParseListener(listener: ParseTreeListener): void;
+    removeParseListeners(): void;
     consume(): Token;
     enterRule(localctx: ParserRuleContext, state: number, ruleIndex: number): void;
     exitRule() : void;


### PR DESCRIPTION
This PR adds the four parse listener methods. The `_parseListeners` field could also be set to `ParseTreeListener[]`, but it would _technically_ be a breaking change.

I chose to use `ParseTreeListener` instead of `any` in these methods because parse listeners cannot actually be `any`; their functions are called without checking if they're defined. The current ParseTreeListener interface is the minimum requirement to avoid exceptions.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
