### PR TITLE
Add override specifier to typescript copyfrom codegen

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -749,7 +749,7 @@ export class <struct.escapedName> extends <if(contextSuperClass)><contextSuperCl
     	return <parser.name>.RULE_<struct.derivedFromName>;
 	}
 <if(struct.provideCopyFrom)><! don't need copy unless we have subclasses !>
-	public copyFrom(ctx: <struct.name>): void {
+	public override copyFrom(ctx: <struct.name>): void {
 		super.copyFrom(ctx);
 		<struct.attrs:{a | this.<a.escapedName> = ctx.<a.escapedName>;}; separator="\n">
 	}


### PR DESCRIPTION
Required for `"noImplicitOverride": true` typescript setting.

I couldn't figure out how to add a test for this situation in the typescript test file. It only happens if a rule context class has a subclass.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
