### PR TITLE
depricate some methods

### DIFF
--- a/runtime/JavaScript/src/antlr4/Lexer.d.ts
+++ b/runtime/JavaScript/src/antlr4/Lexer.d.ts
@@ -22,7 +22,9 @@ export declare class Lexer extends Recognizer<number> {
     nextToken(): Token;
     skip(): void;
     more(): void;
-    more(m: number): void;
+    setMode(m: number): void;
+    getMode(): number;
+    getModeStack(): number[];
     pushMode(m: number): void;
     popMode(): number;
     emitToken(token: Token): void;

--- a/runtime/JavaScript/src/antlr4/Lexer.js
+++ b/runtime/JavaScript/src/antlr4/Lexer.js
@@ -169,8 +169,24 @@ export default class Lexer extends Recognizer {
 		this._type = Lexer.MORE;
 	}
 
+    /**
+     * @deprecated since ANTLR 4.13.2; use setMode instead
+     */
 	mode(m) {
+		console.warn("Calling deprecated method in Lexer class: mode(...)");
+		setMode(m);
+	}
+
+	setMode(m) {
 		this._mode = m;
+	}
+
+	getMode() {
+		return this._mode;
+	}
+
+	getModeStack() {
+		return this._modeStack;
 	}
 
 	pushMode(m) {
@@ -178,7 +194,7 @@ export default class Lexer extends Recognizer {
 			console.log("pushMode " + m);
 		}
 		this._modeStack.push(this._mode);
-		this.mode(m);
+		this.setMode(m);
 	}
 
 	popMode() {
@@ -188,7 +204,7 @@ export default class Lexer extends Recognizer {
 		if (this._interp.debug) {
 			console.log("popMode back to " + this._modeStack.slice(0, -1));
 		}
-		this.mode(this._modeStack.pop());
+		this.setMode(this._modeStack.pop());
 		return this._mode;
 	}
 
@@ -252,7 +268,7 @@ export default class Lexer extends Recognizer {
 		const stop = this._input.index;
 		const text = this._input.getText(start, stop);
 		const msg = "token recognition error at: '" + this.getErrorDisplay(text) + "'";
-		const listener = this.getErrorListenerDispatch();
+		const listener = this.getErrorListener();
 		listener.syntaxError(this, null, this._tokenStartLine,
 				this._tokenStartColumn, msg, e);
 	}

--- a/runtime/JavaScript/src/antlr4/Parser.d.ts
+++ b/runtime/JavaScript/src/antlr4/Parser.d.ts
@@ -6,6 +6,7 @@ import {ParserATNSimulator} from "./atn";
 import {Token} from "./Token";
 import {ParserRuleContext} from "./context";
 import {Printer} from "./utils";
+import {ParseTreeListener} from "./tree";
 
 export declare class Parser extends Recognizer<Token> {
 
@@ -24,6 +25,10 @@ export declare class Parser extends Recognizer<Token> {
     constructor(input: TokenStream);
     match(ttype: number): Token;
     matchWildcard(): Token;
+    getParseListeners(): ParseTreeListener[];
+    addParseListener(listener: ParseTreeListener): void;
+    removeParseListener(listener: ParseTreeListener): void;
+    removeParseListeners(): void;
     consume(): Token;
     enterRule(localctx: ParserRuleContext, state: number, ruleIndex: number): void;
     exitRule() : void;

--- a/runtime/JavaScript/src/antlr4/Parser.js
+++ b/runtime/JavaScript/src/antlr4/Parser.js
@@ -314,7 +314,7 @@ export default class Parser extends Recognizer {
         this._syntaxErrors += 1;
         const line = offendingToken.line;
         const column = offendingToken.column;
-        const listener = this.getErrorListenerDispatch();
+        const listener = this.getErrorListener();
         listener.syntaxError(this, offendingToken, line, column, msg, err);
     }
 

--- a/runtime/JavaScript/src/antlr4/Recognizer.d.ts
+++ b/runtime/JavaScript/src/antlr4/Recognizer.d.ts
@@ -6,4 +6,7 @@ export declare class Recognizer<TSymbol> {
 
     removeErrorListeners(): void;
     addErrorListener(listener: ErrorListener<TSymbol>): void;
+    getErrorListener(): ErrorListener<TSymbol>;
+    getLiteralNames(): string[];
+    getSymbolicNames(): string[];
 }

--- a/runtime/JavaScript/src/antlr4/Recognizer.js
+++ b/runtime/JavaScript/src/antlr4/Recognizer.js
@@ -126,7 +126,15 @@ export default class Recognizer {
         return "'" + s + "'";
     }
 
+    /**
+     * @deprecated since ANTLR 4.13.2; use getErrorListener instead
+     */
     getErrorListenerDispatch() {
+        console.warn("Calling deprecated method in Recognizer class: getErrorListenerDispatch()");
+        return this.getErrorListener();
+    }
+
+    getErrorListener() {
         return new ProxyErrorListener(this._listeners);
     }
 

--- a/runtime/JavaScript/src/antlr4/Token.d.ts
+++ b/runtime/JavaScript/src/antlr4/Token.d.ts
@@ -1,9 +1,10 @@
-import {CharStream} from "./CharStream";
+import { TokenSource } from "./TokenSource";
+import { CharStream } from "./CharStream";
 
 export declare class Token {
 
+    static INVALID_TYPE: number;
     static EOF: number;
-    
     static DEFAULT_CHANNEL: number;
     static HIDDEN_CHANNEL: number;
 
@@ -18,5 +19,6 @@ export declare class Token {
 
     clone(): Token;
     cloneWithType(type: number): Token;
+    getTokenSource(): TokenSource;
     getInputStream(): CharStream;
 }

--- a/runtime/JavaScript/src/antlr4/action/LexerModeAction.js
+++ b/runtime/JavaScript/src/antlr4/action/LexerModeAction.js
@@ -20,7 +20,7 @@ export default class LexerModeAction extends LexerAction {
      * value provided by {@link //getMode}.</p>
      */
     execute(lexer) {
-        lexer.mode(this.mode);
+        lexer.setMode(this.mode);
     }
 
     updateHashCode(hash) {

--- a/runtime/JavaScript/src/antlr4/atn/ParserATNSimulator.js
+++ b/runtime/JavaScript/src/antlr4/atn/ParserATNSimulator.js
@@ -1702,7 +1702,7 @@ export default class ParserATNSimulator extends ATNSimulator {
                                ", input=" + this.parser.getTokenStream().getText(interval));
         }
         if (this.parser!==null) {
-            this.parser.getErrorListenerDispatch().reportAttemptingFullContext(this.parser, dfa, startIndex, stopIndex, conflictingAlts, configs);
+            this.parser.getErrorListener().reportAttemptingFullContext(this.parser, dfa, startIndex, stopIndex, conflictingAlts, configs);
         }
     }
 
@@ -1713,7 +1713,7 @@ export default class ParserATNSimulator extends ATNSimulator {
                                ", input=" + this.parser.getTokenStream().getText(interval));
         }
         if (this.parser!==null) {
-            this.parser.getErrorListenerDispatch().reportContextSensitivity(this.parser, dfa, startIndex, stopIndex, prediction, configs);
+            this.parser.getErrorListener().reportContextSensitivity(this.parser, dfa, startIndex, stopIndex, prediction, configs);
         }
     }
 
@@ -1726,7 +1726,7 @@ export default class ParserATNSimulator extends ATNSimulator {
                                ", input=" + this.parser.getTokenStream().getText(interval));
         }
         if (this.parser!==null) {
-            this.parser.getErrorListenerDispatch().reportAmbiguity(this.parser, dfa, startIndex, stopIndex, exact, ambigAlts, configs);
+            this.parser.getErrorListener().reportAmbiguity(this.parser, dfa, startIndex, stopIndex, exact, ambigAlts, configs);
         }
     }
 }


### PR DESCRIPTION
**Added TypeScript members:**
- Lexer.setMode()
- Lexer.getMode()
- Lexer.getModeStack()
- Recognizer.getErrorListener()
- Recognizer.getLiteralNames()
- Recognizer.getSymbolicNames()
- Token.INVALID_TYPE
- Token.getTokenSource()

Removed (fixed) TypeScript member:
- Lexer.more(m: number)

Added JavaScript members:
- Lexer.setMode()
- Lexer.getMode()
- Lexer.getModeStack()
- Recognizer.getErrorListener()

Depricated JavaScript members:
- Lexer.mode(...)
- Recognizer.getErrorListenerDispatch()
