### PR TITLE
[TypeScript] Add methods for BufferedTokenStream

### DIFF
--- a/runtime/JavaScript/src/antlr4/BufferedTokenStream.d.ts
+++ b/runtime/JavaScript/src/antlr4/BufferedTokenStream.d.ts
@@ -1,8 +1,26 @@
 import { TokenStream } from './TokenStream';
-import { Lexer } from "./Lexer";
+import { TokenSource } from './TokenSource';
+import { Token } from './Token';
 
 export declare class BufferedTokenStream extends TokenStream {
 
-    tokenSource: Lexer;
+    tokenSource: TokenSource;
+    tokens: Token[];
+    fetchedEof: boolean;
 
+    constructor(source: TokenSource);
+    setTokenSource(tokenSource: TokenSource): void;
+    mark(): number;
+    release(marker: number): void;
+    reset(): void;
+    seek(index: number): void;
+    consume(): void;
+    sync(i: number): boolean;
+    fetch(n: number): number;
+    LB(k: number): Token;
+    nextTokenOnChannel(i: number, channel: number): number;
+    previousTokenOnChannel(i: number, channel: number): number;
+
+    protected lazyInit(): void;
+    protected adjustSeekIndex(i: number): number;
 }


### PR DESCRIPTION
The typescript class was almost completely empty, so it was not possible to directly use the token stream in a type-safe way.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
