### PR TITLE
[JavaScript] Fix incorrect this.channel access

### DIFF
--- a/runtime/JavaScript/src/antlr4/BufferedTokenStream.js
+++ b/runtime/JavaScript/src/antlr4/BufferedTokenStream.js
@@ -253,7 +253,7 @@ export default class BufferedTokenStream extends TokenStream {
 			return -1;
 		}
 		let token = this.tokens[i];
-		while (token.channel !== this.channel) {
+		while (token.channel !== channel) {
 			if (token.type === Token.EOF) {
 				return -1;
 			}


### PR DESCRIPTION
`BufferedTokenStream::nextTokenOnChannel` was accessing the field `this.channel` instead of the parameter `channel`. The buffered token stream class doesn't have a field named `channel`, so this exhausted the token buffer instead.

The bug had not been caught because it is only called from `CommonTokenStream` with parameter `this.channel`.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
