### PR TITLE
golang: Add to quick checks to PredictionContext Equals checks (they …

### DIFF
--- a/runtime/Go/antlr/v4/prediction_context.go
+++ b/runtime/Go/antlr/v4/prediction_context.go
@@ -115,6 +115,9 @@ func (p *PredictionContext) Hash() int {
 }
 
 func (p *PredictionContext) Equals(other Collectable[*PredictionContext]) bool {
+	if p == other {
+		return true
+	}
 	switch p.pcType {
 	case PredictionContextEmpty:
 		otherP := other.(*PredictionContext)
@@ -152,7 +155,7 @@ func (p *PredictionContext) SingletonEquals(other Collectable[*PredictionContext
 		return false
 	}
 	otherP := other.(*PredictionContext)
-	if otherP == nil {
+	if otherP == nil || otherP.pcType != PredictionContextSingleton {
 		return false
 	}
 


### PR DESCRIPTION
…are in use

in other runtimes):

1. If pointers are equal it's the same object
2. If we are comparing singletons both types must be singletons

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
