### PR TITLE
[TS] Add property versions of raw fields to TS

### DIFF
--- a/runtime/JavaScript/src/antlr4/Lexer.d.ts
+++ b/runtime/JavaScript/src/antlr4/Lexer.d.ts
@@ -7,7 +7,11 @@ export declare class Lexer extends Recognizer<number> {
 
     static DEFAULT_MODE: number;
 
+    /**
+     * Use inputStream property instead
+     */
     _input: CharStream;
+    inputStream: CharStream;
     _interp: LexerATNSimulator;
     text: string;
     line: number;
@@ -15,7 +19,11 @@ export declare class Lexer extends Recognizer<number> {
     _tokenStartCharIndex: number;
     _tokenStartLine: number;
     _tokenStartColumn: number;
+    /**
+     * Use type property instead
+     */
     _type: number;
+    type: number;
 
     constructor(input: CharStream);
     reset(): void;


### PR DESCRIPTION
JS properties exist for the `_type` and `_input` fields, but they aren't present in the typescript definition file. This commit adds those properties.

The commit adds doc comments pointing developers toward the corresponding properties. I don't know if there's a deprication process for removing the old fields. `inputStream`'s setter function does a reset of the lexer, but otherwise the properties are normal.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
