### PR TITLE
[JS] Fix Parser.getSourceName returning undefined

### DIFF
--- a/runtime/JavaScript/src/antlr4/Parser.js
+++ b/runtime/JavaScript/src/antlr4/Parser.js
@@ -603,14 +603,8 @@ export default class Parser extends Recognizer {
         }
     }
 
-    /*
-        "			printer = function() {\r\n" +
-        "				this.println = function(s) { document.getElementById('output') += s + '\\n'; }\r\n" +
-        "				this.print = function(s) { document.getElementById('output') += s; }\r\n" +
-        "			};\r\n" +
-        */
     getSourceName() {
-        return this._input.sourceName;
+        return this._input.getSourceName();
     }
 
     /**


### PR DESCRIPTION
`Parser.getSourceName` was expecting a field `sourceName` on `TokenStream`, but that doesn't exist on any `TokenStream` implementation. This commit fixes the bug by calling `getSourceName`, which *is* defined on `BufferedTokenStream`.

This commit also removes some nearby commented-out code that didn't make any sense.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
