### PR TITLE
Removed classpath flag for alias antlr4 and grun

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -156,8 +156,8 @@ It's also a good idea to put this in your `.bash_profile` or whatever your start
 
 3. Create aliases for the ANTLR Tool, and `TestRig`.
 ```
-$ alias antlr4='java -Xmx500M -cp "/usr/local/lib/antlr-4.13.1-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
-$ alias grun='java -Xmx500M -cp "/usr/local/lib/antlr-4.13.1-complete.jar:$CLASSPATH" org.antlr.v4.gui.TestRig'
+$ alias antlr4='java -Xmx500M org.antlr.v4.Tool'
+$ alias grun='java -Xmx500M org.antlr.v4.gui.TestRig'
 ```
 
 ### WINDOWS


### PR DESCRIPTION
I removed the -cp flag for the aliases as it included the antlr jar location that has already been included in the classpath in step 2. This caused some confusion for me, as I am somewhat unsure what exactly it would contribute to specify it twice.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
