### PR TITLE
Fix Linux compilation issue of ProfilingATNSimulator

### DIFF
--- a/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
+++ b/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift
@@ -60,7 +60,7 @@ public class ProfilingATNSimulator: ParserATNSimulator {
         let start = ProcessInfo.processInfo.systemUptime //System.nanoTime(); // expensive but useful info
         let alt: Int = try  super.adaptivePredict(input, decision, outerContext)
         let stop = ProcessInfo.processInfo.systemUptime  //System.nanoTime();
-        decisions[decision].timeInPrediction += Int64((stop - start) * TimeInterval(NSEC_PER_SEC))
+        decisions[decision].timeInPrediction += Int64((stop - start) * TimeInterval(1_000_000_000)) // Nanoseconds per 1 Second
         decisions[decision].invocations += 1
 
         let SLL_k: Int64 = Int64(_sllStopIndex - _startIndex + 1)


### PR DESCRIPTION
* NSEC_PER_SEC is available via CDispatch bindings, which are not currently imported
* Importing them would be heavy handed compared to replacing with the constant (and leaving a comment)

-----

Compiling on Linux currently produces:

```
         [239/269] Compiling Antlr4 SetTransition.swift
         /workspace/.build/checkouts/antlr4/runtime/Swift/Sources/Antlr4/atn/ProfilingATNSimulator.swift:63:85: error: cannot find 'NSEC_PER_SEC' in scope
         decisions[decision].timeInPrediction += Int64((stop - start) * TimeInterval(NSEC_PER_SEC))
```

After fixing this, it compiles (and behaves) as expected.