### PR TITLE
fix: suppress more "this-escape" warnings from JDK 21

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Java/Java.stg
@@ -356,6 +356,7 @@ case <f.ruleIndex>:
 >>
 
 parser_ctor(p) ::= <<
+@SuppressWarnings("this-escape")
 public <p.name>(TokenStream input) {
 	super(input);
 	_interp = new ParserATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);


### PR DESCRIPTION
This is a followup to 851ddee4 and PR #4486. Parser constructor needs a similar pragma.

Signed-off-by: combolek <4743344+combolek@users.noreply.github.com>
