### PR TITLE
[Cpp] Fix cpp memory leaks

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ATNDeserializationOptions.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializationOptions.cpp
@@ -14,7 +14,7 @@ ATNDeserializationOptions::ATNDeserializationOptions(ATNDeserializationOptions *
       _generateRuleBypassTransitions(options->_generateRuleBypassTransitions) {}
 
 const ATNDeserializationOptions& ATNDeserializationOptions::getDefaultOptions() {
-  static const ATNDeserializationOptions* const defaultOptions = new ATNDeserializationOptions();
+  static const std::unique_ptr<const ATNDeserializationOptions> defaultOptions = std::make_unique<const ATNDeserializationOptions>();
   return *defaultOptions;
 }
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -147,7 +147,7 @@ struct <lexer.name; format = "cap">StaticData final {
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
 static thread_local
 #endif
-<lexer.name; format = "cap">StaticData *<lexer.grammarName; format = "lower">LexerStaticData = nullptr;
+std::unique_ptr\<<lexer.name; format = "cap">StaticData> <lexer.grammarName; format = "lower">LexerStaticData = nullptr;
 
 void <lexer.grammarName; format = "lower">LexerInitialize() {
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
@@ -175,7 +175,7 @@ void <lexer.grammarName; format = "lower">LexerInitialize() {
     }
   );
   <atn>
-  <lexer.grammarName; format = "lower">LexerStaticData = staticData.release();
+  <lexer.grammarName; format = "lower">LexerStaticData = std::move(staticData);
 }
 
 }
@@ -380,7 +380,7 @@ struct <parser.name; format = "cap">StaticData final {
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
 static thread_local
 #endif
-<parser.name; format = "cap">StaticData *<parser.grammarName; format = "lower">ParserStaticData = nullptr;
+std::unique_ptr\<<parser.name; format = "cap">StaticData> <parser.grammarName; format = "lower">ParserStaticData = nullptr;
 
 void <parser.grammarName; format = "lower">ParserInitialize() {
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
@@ -402,7 +402,7 @@ void <parser.grammarName; format = "lower">ParserInitialize() {
     }
   );
   <atn>
-  <parser.grammarName; format = "lower">ParserStaticData = staticData.release();
+  <parser.grammarName; format = "lower">ParserStaticData = std::move(staticData);
 }
 
 }


### PR DESCRIPTION
This PR fixes memory leaks caused by the StaticData objects associated with the generated Parser and Lexer classes. 

Found using the CRT library in VS2022. With the demo project, it produces a leak report similar to this:
```
Detected memory leaks!
Dumping objects ->
{21126} normal block at 0x000001AAB1D11180, 32 bytes long.
 Data: <                > 00 95 CF B1 AA 01 00 00 A0 9A CF B1 AA 01 00 00 
{20999} normal block at 0x000001AAB1D141E0, 32 bytes long.
 Data: <`       `       > 60 1F D1 B1 AA 01 00 00 60 1F D1 B1 AA 01 00 00 
{20982} normal block at 0x000001AAB1D134C0, 32 bytes long.
 Data: <         1      > C0 A8 CD B1 AA 01 00 00 C0 31 D1 B1 AA 01 00 00 
{20981} normal block at 0x000001AAB1D20DF0, 128 bytes long.
 Data: <                > 00 19 D1 B1 AA 01 00 00 00 19 D1 B1 AA 01 00 00 
...<~7000 lines long>
```
Valgrind on Ubuntu produces a similarly large leak detection.

Switching the StaticData objects to be unique_ptr instead of raw pointers removes all but 1 leak.
The remaining leak is the ATNDeserializationOptions which is also fixed by a unique_ptr.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
