### PR TITLE
Add a Force Compile Property

### DIFF
--- a/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/Antlr4Mojo.java
+++ b/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/Antlr4Mojo.java
@@ -106,6 +106,12 @@ public class Antlr4Mojo extends AbstractMojo {
 	protected boolean forceATN;
 
 	/**
+	 * Skip grammar file change detect and just compile them.
+	 */
+	@Parameter(property = "antlr4.forceCompile", defaultValue = "false")
+	protected boolean forceCompile;
+
+	/**
 	 * A list of grammar options to explicitly specify to the tool. These
 	 * options are passed to the tool using the
 	 * <code>-D&lt;option&gt;=&lt;value&gt;</code> syntax.
@@ -394,7 +400,7 @@ public class Antlr4Mojo extends AbstractMojo {
         for (File grammarFile : grammarFiles) {
             String tokensFileName = grammarFile.getName().split("\\.")[0] + ".tokens";
             File outputFile = new File(outputDirectory, tokensFileName);
-            if ( (! outputFile.exists()) ||
+            if (forceCompile || (! outputFile.exists()) ||
                  outputFile.lastModified() <= grammarFile.lastModified() ||
                  dependencies.isDependencyChanged(grammarFile)) {
                 grammarFilesToProcess.add(grammarFile);


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

When I upgrade antlr to a new version, but keep the grammar files untouched, the grammar files will not be compiled but there is a warning message complaining the runtime version changed.

So I add a property forceCompile to skip the checksum and last modification date check and just re-compile the grammars.
