### PR TITLE
feat: Use Go min/max builtins

### DIFF
--- a/runtime/Go/antlr/v4/tokenstream_rewriter.go
+++ b/runtime/Go/antlr/v4/tokenstream_rewriter.go
@@ -641,22 +641,3 @@ func reduceToSingleOperationPerIndex(rewrites []RewriteOperation) map[int]Rewrit
 	}
 	return m
 }
-
-/*
-	Quick fixing Go lack of overloads
-*/
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	} else {
-		return b
-	}
-}
-func min(a, b int) int {
-	if a < b {
-		return a
-	} else {
-		return b
-	}
-}


### PR DESCRIPTION
The `min` and `max` builtins are available since Go 1.21[^1]. The github.com/antlr4-go/antlr/v4 is specifying Go 1.22 in its go.mod file, so the builtins can be used.

[^1]: https://go.dev/doc/go1.21#language