### PR TITLE
fix(TypeScript): update and add missing definition in IntervalSEt.d.ts

### DIFF
--- a/runtime/JavaScript/src/antlr4/misc/IntervalSet.d.ts
+++ b/runtime/JavaScript/src/antlr4/misc/IntervalSet.d.ts
@@ -1,13 +1,41 @@
 import {Interval} from "./Interval";
+import { Token } from "../Token";
 
-export declare class IntervalSet {
+export default class IntervalSet {
+    private intervals: Interval[] | null;
+    private readOnly: boolean;
 
-    isNil: boolean;
-    size: number;
-    minElement: number;
-    maxElement: number;
-    intervals: Interval[];
+    constructor();
 
-    contains(i: number): boolean;
-    toString(literalNames?: (string | null)[], symbolicNames?: string[], elemsAreChar?: boolean): string;
+    first(v: number): number;
+
+    addOne(v: number): void;
+
+    addRange(l: number, h: number): void;
+
+    addInterval(toAdd: Interval): void;
+
+    addSet(other: IntervalSet): IntervalSet;
+
+    private reduce(pos: number): void;
+
+    complement(start: number, stop: number): IntervalSet;
+
+    contains(item: number): boolean;
+
+    removeRange(toRemove: Interval): void;
+
+    removeOne(value: number): void;
+
+    toString(literalNames?: string[], symbolicNames?: string[], elemsAreChar?: boolean): string;
+
+    private toCharString(): string;
+
+    private toIndexString(): string;
+
+    private toTokenString(literalNames: string[], symbolicNames: string[]): string;
+
+    private elementName(literalNames: string[], symbolicNames: string[], token: number): string;
+
+    get length(): number;
 }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
In the TypeScript target, I noticed that the IntervalSet.d.ts file didn't match the code in IntervalSet.js—they really should be the same. Because of this mismatch, I ran into the error TS2339: "Property 'addRange' does not exist on type 'IntervalSet'" when I tried to use IntervalSet utilities like addOne. So, in this PR, I've made changes to ensure they are consistent.