### PR TITLE
Mark all generated C# classes with [GeneratedCode] attribute

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/CSharp/CSharp.stg
@@ -860,6 +860,8 @@ CaptureNextTokenType(d) ::= "<d.varName> = TokenStream.LA(1);"
 
 StructDecl(struct,ctorAttrs,attrs,getters,dispatchMethods,interfaces,extensionMembers,signatures,
            superClass={ParserRuleContext}) ::= <<
+[System.CodeDom.Compiler.GeneratedCode("ANTLR", "<file.ANTLRVersion>")]
+[System.CLSCompliant(false)]
 public partial class <struct.escapedName> : <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)>, <interfaces; separator=", "><endif> {
 	<attrs:{a | public <a>;}; separator="\n">
 	<getters:{g | <g>}; separator="\n">
@@ -883,6 +885,8 @@ public partial class <struct.escapedName> : <if(contextSuperClass)><contextSuper
 >>
 
 AltLabelStructDecl(struct,attrs,getters,dispatchMethods) ::= <<
+[System.CodeDom.Compiler.GeneratedCode("ANTLR", "<file.ANTLRVersion>")]
+[System.CLSCompliant(false)]
 public partial class <struct.escapedName> : <currentRule.name; format="cap">Context {
 	<attrs:{a | public <a>;}; separator="\n">
 	<getters:{g | <g>}; separator="\n">


### PR DESCRIPTION
Hi,

we use ANTLR to generate a C# parser for our grammar and we run for each build static code analysis and for obvious reasons we exclude generated code, including the generated ANTLR classes. For ANTLR generated code we have to manually exclude the generated namespace from the inspection, because not all of the generated classes are marked with [[GeneratedCode]](https://learn.microsoft.com/en-us/dotnet/api/system.codedom.compiler.generatedcodeattribute) attribute, none of the public nested classes are, only the top level parent ones for Parser/Visitor are marked as generated.

We are using NDepend and JetBrains InspectCode to analyse the code. With the changes to the CSharp target template I propose in this PR no further work has to be done to exclude ANTLR generated code from the inspection as both tools understand that attribute, as do probably any other C# static analysis tools.


