### PR TITLE
Add some methods for Go runtime

### DIFF
--- a/doc/cpp-target.md
+++ b/doc/cpp-target.md
@@ -1,6 +1,6 @@
 # C++
 
-The C++ target supports all platforms that can either run MS Visual Studio 2013 (or newer), XCode 7 (or newer) or CMake (C++11 required). All build tools can either create static or dynamic libraries, both as 64bit or 32bit arch. Additionally, XCode can create an iOS library. Also see [Antlr4 for C++ with CMake: A practical example](http://blorente.me/beyond-the-loop/Antlr-cpp-cmake/).
+The C++ target supports all platforms that can either run MS Visual Studio 2017 (or newer), XCode 7 (or newer) or CMake (C++17 required). All build tools can either create static or dynamic libraries, both as 64bit or 32bit arch. Additionally, XCode can create an iOS library. Also see [Antlr4 for C++ with CMake: A practical example](http://blorente.me/beyond-the-loop/Antlr-cpp-cmake/).
 
 ## How to create a C++ lexer or parser?
 This is pretty much the same as creating a Java lexer or parser, except you need to specify the language target, for example:

--- a/runtime/Go/antlr/README.adoc
+++ b/runtime/Go/antlr/README.adoc
@@ -10,7 +10,7 @@ Your driver code etc. should now be importing from the new release only repo for
 
 ```go
 import (
-	"github.com/antlr4-go/antlr"
+	"github.com/antlr4-go/antlr/v4"
 )
 ```
 

--- a/runtime/Go/antlr/v4/lexer.go
+++ b/runtime/Go/antlr/v4/lexer.go
@@ -25,6 +25,10 @@ type Lexer interface {
 	PushMode(int)
 	PopMode() int
 	SetType(int)
+
+	GetModeStack() IntStack
+
+	GetMode() int
 	SetMode(int)
 }
 
@@ -245,6 +249,14 @@ func (b *BaseLexer) Skip() {
 
 func (b *BaseLexer) More() {
 	b.thetype = LexerMore
+}
+
+func (b *BaseLexer) GetModeStack() IntStack {
+	return b.modeStack
+}
+
+func (b *BaseLexer) GetMode() int {
+	return b.mode
 }
 
 // SetMode changes the lexer to a new mode. The lexer will use this mode from hereon in and the rules for that mode

--- a/runtime/Go/antlr/v4/token.go
+++ b/runtime/Go/antlr/v4/token.go
@@ -192,19 +192,13 @@ func NewCommonToken(source *TokenSourceCharStreamPair, tokenType, channel, start
 
 //CommonToken.EMPTY_SOURCE = [ nil, nil ]
 
-// Constructs a New{@link CommonToken} as a copy of another {@link Token}.
-//
-// <p>
-// If {@code oldToken} is also a {@link CommonToken} instance, the newly
-// constructed token will share a reference to the {@link //text} field and
-// the {@link Pair} stored in {@link //source}. Otherwise, {@link //text} will
-// be assigned the result of calling {@link //GetText}, and {@link //source}
-// will be constructed from the result of {@link Token//GetTokenSource} and
-// {@link Token//GetInputStream}.</p>
-//
-// @param oldToken The token to copy.
-func (c *CommonToken) Clone() *CommonToken {
-	return &CommonToken{c.BaseToken}
+func NewCommonTokenFromToken(oldToken Token) *CommonToken {
+	t := NewCommonToken(oldToken.GetSource(), oldToken.GetTokenType(), oldToken.GetChannel(), oldToken.GetStart(), oldToken.GetStop())
+	t.tokenIndex = oldToken.GetTokenIndex()
+	t.line = oldToken.GetLine()
+	t.column = oldToken.GetColumn()
+	t.text = oldToken.GetText()
+	return t
 }
 
 func (c *CommonToken) SetChannel(channel int) {

--- a/runtime/Go/antlr/v4/token.go
+++ b/runtime/Go/antlr/v4/token.go
@@ -203,11 +203,22 @@ func NewCommonToken(source *TokenSourceCharStreamPair, tokenType, channel, start
 // {@link Token//GetInputStream}.</p>
 //
 // @param oldToken The token to copy.
-func (c *CommonToken) clone() *CommonToken {
-	t := NewCommonToken(c.source, c.tokenType, c.channel, c.start, c.stop)
-	t.tokenIndex = c.GetTokenIndex()
-	t.line = c.GetLine()
-	t.column = c.GetColumn()
-	t.text = c.GetText()
-	return t
+func (c *CommonToken) Clone() *CommonToken {
+	return &CommonToken{c.BaseToken}
+}
+
+func (c *CommonToken) SetChannel(channel int) {
+	c.channel = channel
+}
+
+func (c *CommonToken) SetStop(stop int) {
+	c.stop = stop
+}
+
+func (c *CommonToken) SetText(text string) {
+	c.text = text
+}
+
+func (c *CommonToken) SetTokenType(ttype int) {
+	c.tokenType = ttype
 }

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -159,7 +159,7 @@ func (v *Base<file.grammarName>Visitor) Visit<lname; format="cap">(ctx *<lname; 
 
 Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
 type <parser.name> struct {
-	<superClass; null="*antlr.BaseParser">
+	*<superClass; null="antlr.BaseParser">
 	<if(namedActions.structmembers)>
 	// Grammar author supplied members of the instance struct
 	<namedActions.structmembers>
@@ -219,7 +219,7 @@ func <parser.name; format="cap">Init() {
 func New<parser.name>(input antlr.TokenStream) *<parser.name> {
 	<parser.name; format="cap">Init()
 	this := new(<parser.name>)
-	this.BaseParser = antlr.NewBaseParser(input)
+	<if(superClass)>this.<superClass> = New<superClass>(input)<else>this.BaseParser = antlr.NewBaseParser(input)<endif>
   staticData := &<parser.grammarName; format="cap">ParserStaticData
 	this.Interpreter = antlr.NewParserATNSimulator(this, staticData.atn, staticData.decisionToDFA, staticData.PredictionContextCache)
 	this.RuleNames = staticData.RuleNames
@@ -1484,7 +1484,7 @@ var _ = unicode.IsLetter
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
 type <lexer.name> struct {
-	<if(superClass)><superClass><else>*antlr.BaseLexer<endif>
+	<if(superClass)>*<superClass><else>*antlr.BaseLexer<endif>
 	channelNames []string
 	modeNames []string
 	<if(namedActions.structmembers)>
@@ -1555,7 +1555,7 @@ func <lexer.name; format="cap">Init() {
 func New<lexer.name>(input antlr.CharStream) *<lexer.name> {
   <lexer.name; format="cap">Init()
 	l := new(<lexer.name>)
-	l.BaseLexer = antlr.NewBaseLexer(input)
+	<if(superClass)>l.<superClass> = New<superClass>(input)<else>l.BaseLexer = antlr.NewBaseLexer(input)<endif>
   staticData := &<lexer.grammarName; format="cap">LexerStaticData
 	l.Interpreter = antlr.NewLexerATNSimulator(l, staticData.atn, staticData.decisionToDFA, staticData.PredictionContextCache)
 	l.channelNames = staticData.ChannelNames


### PR DESCRIPTION
Added methods for CommonToken class:
SetChannel
SetStop
SetText    // also exists in Token (Token.SetText may be unnecessary)
SetTokenType

Added constructor for CommonToken class:
CommonToken.NewCommonTokenFromToken

Removed method in CommonToken class:
Clone

Added methods for Lexer class:
GetModeStack
GetMode


The equivalent of the NewCommonTokenFromToken constructor can also be found in the [Java CommonToken class](https://www.antlr.org/api/Java/org/antlr/v4/runtime/CommonToken.html#%3Cinit%3E(org.antlr.v4.runtime.Token)).
The NewCommonTokenFromToken constructor is similar to the clone method, in that a cloned CommonToken instance is created in both.
NewCommonTokenFromToken accepts both Token and CommonToken parameters for cloning.
This made the clone method redundant.