### PR TITLE
[JavaScript-runtime] Support TypeScript bundler module resolution for types

### DIFF
--- a/runtime/JavaScript/package.json
+++ b/runtime/JavaScript/package.json
@@ -52,17 +52,16 @@
   "exports": {
     ".": {
       "node": {
-        "types": "./src/antlr4/index.d.ts",
         "import": "./dist/antlr4.node.mjs",
         "require": "./dist/antlr4.node.cjs",
         "default": "./dist/antlr4.node.mjs"
       },
       "browser": {
-        "types": "./src/antlr4/index.d.ts",
         "import": "./dist/antlr4.web.mjs",
         "require": "./dist/antlr4.web.cjs",
         "default": "./dist/antlr4.web.mjs"
-      }
+      },
+      "types": "./src/antlr4/index.d.ts"
     }
   }
 }


### PR DESCRIPTION
When using the published `npm` package in my TypeScript project, TypeScript gave the error that it couldn't find the types.

This fix makes sure that the type field in the `package.json` is not in a specific exports target, which fixes the issue. The same types are exposed for both the web and node target, so they were combined in the same field.
