### PR TITLE
[Cpp] Fix compiler warning in 32 bit build

### DIFF
--- a/runtime/Cpp/runtime/src/atn/PredictionContextMergeCacheOptions.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionContextMergeCacheOptions.h
@@ -53,7 +53,7 @@ namespace atn {
 
     bool hasClearEveryN() const { return getClearEveryN() != 0; }
 
-    PredictionContextMergeCacheOptions& setClearEveryN(uint64_t clearEveryN) {
+    PredictionContextMergeCacheOptions& setClearEveryN(size_t clearEveryN) {
       _clearEveryN = clearEveryN;
       return *this;
     }
@@ -64,7 +64,7 @@ namespace atn {
 
   private:
     size_t _maxSize = std::numeric_limits<size_t>::max();
-    uint64_t _clearEveryN = 1;
+    size_t _clearEveryN = 1;
   };
 
 }  // namespace atn


### PR DESCRIPTION
In 32 bit mode, `size_t` is smaller than `uint64_t`, so the type mismatch causes a compiler warning in `PredictionContextMergeCacheOptions::getClearEveryN()`.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
