### PR TITLE
[Cpp] Use target_include_dirs for cmake targets

### DIFF
--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -7,7 +7,9 @@ if (NOT ANTLR_BUILD_SHARED AND NOT ANTLR_BUILD_STATIC)
   message(FATAL_ERROR "Options ANTLR_BUILD_SHARED and ANTLR_BUILD_STATIC can't both be OFF")
 endif()
 
-include_directories(
+set(libantlrcpp_INCLUDE_INSTALL_DIR "include/antlr4-runtime")
+
+set(libantlrcpp_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/runtime/src
   ${PROJECT_SOURCE_DIR}/runtime/src/atn
   ${PROJECT_SOURCE_DIR}/runtime/src/dfa
@@ -34,9 +36,15 @@ file(GLOB libantlrcpp_SRC
 
 if (ANTLR_BUILD_SHARED)
   add_library(antlr4_shared SHARED ${libantlrcpp_SRC})
+  target_include_directories(antlr4_shared PUBLIC 
+    "$<BUILD_INTERFACE:${libantlrcpp_INCLUDE_DIRS}>" 
+    "$<INSTALL_INTERFACE:${libantlrcpp_INCLUDE_INSTALL_DIR}>")
 endif()
 if (ANTLR_BUILD_STATIC)
   add_library(antlr4_static STATIC ${libantlrcpp_SRC})
+  target_include_directories(antlr4_static PUBLIC 
+    "$<BUILD_INTERFACE:${libantlrcpp_INCLUDE_DIRS}>" 
+    "$<INSTALL_INTERFACE:${libantlrcpp_INCLUDE_INSTALL_DIR}>")
 endif()
 
 if (CMAKE_HOST_UNIX)
@@ -185,7 +193,7 @@ if (TARGET antlr4_static)
 endif()
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/runtime/src/"
-        DESTINATION "include/antlr4-runtime"
+        DESTINATION "${libantlrcpp_INCLUDE_INSTALL_DIR}"
         COMPONENT dev
         FILES_MATCHING PATTERN "*.h"
         )


### PR DESCRIPTION
Use target_include_dirs to attach include directories to targets. This allows setting include directories for the `INSTALL_INTERFACE` which will get exported into `antlr4-targets.cmake`.

`antlr4-targets.cmake` will now have an `INTERFACE_INCLUDE_DIRECTORIES` property set like so:
```
set_target_properties(antlr4_shared PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "ANTLR4CPP_EXPORTS"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/antlr4-runtime"
)
```
When downstream users pull in antlr4-runtime using `find_package(antlr4-runtime)`, the imported targets `antlr4_static` and `antlr4_shared` will automatically pick up the appropriate include directories instead of needing to manually use `ANTLR4_INCLUDE_DIR`.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
