### PR TITLE
Upgrade to go 1.21, replace golang.org/x/exp/slices with slices

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -265,11 +265,11 @@ jobs:
       with:
         sdk: 2.12.1
 
-    - name: Setup Go 1.19
+    - name: Setup Go 1.21
       if: matrix.target == 'go'
       uses: actions/setup-go@v3.3.1
       with:
-        go-version: '^1.19'
+        go-version: '^1.21'
 
     - name: Setup Swift
       if: matrix.target == 'swift'

--- a/runtime/Go/antlr/v4/go.mod
+++ b/runtime/Go/antlr/v4/go.mod
@@ -1,5 +1,3 @@
 module github.com/antlr4-go/antlr/v4
 
-go 1.20
-
-require golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
+go 1.21

--- a/runtime/Go/antlr/v4/go.sum
+++ b/runtime/Go/antlr/v4/go.sum
@@ -1,4 +1,0 @@
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
-golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
-golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/runtime/Go/antlr/v4/lexer_action_executor.go
+++ b/runtime/Go/antlr/v4/lexer_action_executor.go
@@ -4,7 +4,7 @@
 
 package antlr
 
-import "golang.org/x/exp/slices"
+import "slices"
 
 // Represents an executor for a sequence of lexer actions which traversed during
 // the Matching operation of a lexer rule (token).


### PR DESCRIPTION
Upgrade to go 1.21 to use `slices` package instead of `golang.org/x/exp/slices` package.

In the [antlr4-go/antlr](https://github.com/antlr4-go/antlr) project, the go version declared in [go.mod](https://github.com/antlr4-go/antlr/blob/main/go.mod) is already 1.22.