### PR TITLE
Remove unused function createThin()

### DIFF
--- a/runtime/Go/antlr/v4/common_token_factory.go
+++ b/runtime/Go/antlr/v4/common_token_factory.go
@@ -47,10 +47,3 @@ func (c *CommonTokenFactory) Create(source *TokenSourceCharStreamPair, ttype int
 
 	return t
 }
-
-func (c *CommonTokenFactory) createThin(ttype int, text string) Token {
-	t := NewCommonToken(nil, ttype, TokenDefaultChannel, -1, -1)
-	t.SetText(text)
-
-	return t
-}

--- a/runtime/JavaScript/src/antlr4/CommonTokenFactory.js
+++ b/runtime/JavaScript/src/antlr4/CommonTokenFactory.js
@@ -43,12 +43,6 @@ export default class CommonTokenFactory extends TokenFactory {
         }
         return t;
     }
-
-    createThin(type, text) {
-        const t = new CommonToken(null, type);
-        t.text = text;
-        return t;
-    }
 }
 
 /**

--- a/runtime/Python3/src/antlr4/CommonTokenFactory.py
+++ b/runtime/Python3/src/antlr4/CommonTokenFactory.py
@@ -53,9 +53,4 @@ class CommonTokenFactory(TokenFactory):
             t.text = source[1].getText(start,stop)
         return t
 
-    def createThin(self, type:int, text:str):
-        t = CommonToken(type=type)
-        t.text = text
-        return t
-
 CommonTokenFactory.DEFAULT = CommonTokenFactory()


### PR DESCRIPTION
Remove unused function createThin() from common_token_factory.go, CommonTokenFactory.py, CommonTokenFactory.js.

The unexported function 'antlr.createThin' is never used but has a potential bug. Using nil constant at common_token_factory.go:52, it is passed as 1st parameter in call to function 'antlr.NewCommonToken' at common_token_factory.go:52, where it is dereferenced at token.go:140.

---------

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
