### PR TITLE
Explicitly ignore unused var in TypeScript and @typescript-eslint

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -33,7 +33,8 @@ import <file.grammarName>Visitor from "./<file.grammarName>Visitor.js";
 <endif>
 
 // for running tests with parameters, TODO: discuss strategy for typed parameters in CI
-// eslint-disable-next-line no-unused-vars
+// @ts-ignore
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 type int = number;
 
 <namedActions.header>


### PR DESCRIPTION
When using some strict TypeScript options, you can't compile the code anymore because of this specific line. Unfortunately I don't know enough about the necessity of the line to help in another way, so that's why I added this simple fix.

There is another error for unused imports in the Lexer file, but I wasn't able to test that one out since that import seemed to have been changes recently. 