### PR TITLE
Add LexerNoViableAltException typescript class

### DIFF
--- a/runtime/JavaScript/src/antlr4/error/LexerNoViableAltException.d.ts
+++ b/runtime/JavaScript/src/antlr4/error/LexerNoViableAltException.d.ts
@@ -1,0 +1,13 @@
+import {ATNConfigSet} from "../atn";
+import {Recognizer} from "../Recognizer";
+import { Token } from "../Token";
+import {RecognitionException} from "./RecognitionException";
+
+export declare class LexerNoViableAltException extends RecognitionException {
+
+    deadEndConfigs: ATNConfigSet;
+
+    constructor(recognizer: Recognizer<any>);
+
+    startIndex: number;
+}

--- a/runtime/JavaScript/src/antlr4/error/index.d.ts
+++ b/runtime/JavaScript/src/antlr4/error/index.d.ts
@@ -1,4 +1,5 @@
 export * from './RecognitionException';
+export * from './LexerNoViableAltException';
 export * from './NoViableAltException';
 export * from './FailedPredicateException';
 export * from './InputMismatchException';


### PR DESCRIPTION
Currently I am using  latest antlr package from npm `"antlr4": "^4.13.2"` and I don't know how to check if an exception is the proposed class without importing js sources.

