### PR TITLE
Improve Python version handling

### DIFF
--- a/runtime/Python3/src/antlr4/Lexer.py
+++ b/runtime/Python3/src/antlr4/Lexer.py
@@ -11,7 +11,7 @@
 from io import StringIO
 
 import sys
-if sys.version_info[1] > 5:
+if sys.version_info >= (3, 6):
     from typing import TextIO
 else:
     from typing.io import TextIO

--- a/runtime/Python3/src/antlr4/Parser.py
+++ b/runtime/Python3/src/antlr4/Parser.py
@@ -3,7 +3,7 @@
 # Use of this file is governed by the BSD 3-clause license that
 # can be found in the LICENSE.txt file in the project root.
 import sys
-if sys.version_info[1] > 5:
+if sys.version_info >= (3, 6):
     from typing import TextIO
 else:
     from typing.io import TextIO

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -52,7 +52,7 @@ ParserFile(file, parser, namedActions, contextSuperClass) ::= <<
 from antlr4 import *
 from io import StringIO
 import sys
-if sys.version_info[1] > 5:
+if sys.version_info >= (3, 6):
 	from typing import TextIO
 else:
 	from typing.io import TextIO
@@ -761,7 +761,7 @@ LexerFile(lexerFile, lexer, namedActions) ::= <<
 from antlr4 import *
 from io import StringIO
 import sys
-if sys.version_info[1] > 5:
+if sys.version_info >= (3, 6):
     from typing import TextIO
 else:
     from typing.io import TextIO


### PR DESCRIPTION
Checking just the second element of a version tuple is never good style, and it makes it less clear what actual versions of Python are in question.