### PR TITLE
fix(JS: ErrorListener types)

### DIFF
--- a/runtime/JavaScript/src/antlr4/error/DiagnosticErrorListener.d.ts
+++ b/runtime/JavaScript/src/antlr4/error/DiagnosticErrorListener.d.ts
@@ -1,16 +1,3 @@
-import {ATNConfigSet} from "../atn";
-import {BitSet} from "../misc/BitSet";
-import {DFA} from "../dfa";
 import {ErrorListener} from "./ErrorListener";
-import {Recognizer} from "../Recognizer";
-import {RecognitionException} from "./RecognitionException";
 
-export declare class DiagnosticErrorListener<TSymbol> implements ErrorListener<TSymbol> {
-    reportAmbiguity(recognizer: Recognizer<TSymbol>, dfa: DFA, startIndex: number, stopIndex: number, exact: boolean, ambigAlts: BitSet, configs: ATNConfigSet): void;
-    
-    reportAttemptingFullContext(recognizer: Recognizer<TSymbol>, dfa: DFA, startIndex: number, stopIndex: number, conflictingAlts: BitSet, configs: ATNConfigSet): void;
-    
-    reportContextSensitivity(recognizer: Recognizer<TSymbol>, dfa: DFA, startIndex: number, stopIndex: number, prediction: number, configs: ATNConfigSet): void;
-
-    syntaxError(recognizer: Recognizer<TSymbol>, offendingSymbol: TSymbol, line: number, column: number, msg: string, e: RecognitionException | undefined): void;
-}
+export declare class DiagnosticErrorListener<TSymbol> extends ErrorListener<TSymbol> {}

--- a/runtime/JavaScript/src/antlr4/error/DiagnosticErrorListener.d.ts
+++ b/runtime/JavaScript/src/antlr4/error/DiagnosticErrorListener.d.ts
@@ -1,9 +1,16 @@
+import {ATNConfigSet} from "../atn";
+import {BitSet} from "../misc/BitSet";
+import {DFA} from "../dfa";
 import {ErrorListener} from "./ErrorListener";
 import {Recognizer} from "../Recognizer";
 import {RecognitionException} from "./RecognitionException";
 
 export declare class DiagnosticErrorListener<TSymbol> implements ErrorListener<TSymbol> {
+    reportAmbiguity(recognizer: Recognizer<TSymbol>, dfa: DFA, startIndex: number, stopIndex: number, exact: boolean, ambigAlts: BitSet, configs: ATNConfigSet): void;
+    
+    reportAttemptingFullContext(recognizer: Recognizer<TSymbol>, dfa: DFA, startIndex: number, stopIndex: number, conflictingAlts: BitSet, configs: ATNConfigSet): void;
+    
+    reportContextSensitivity(recognizer: Recognizer<TSymbol>, dfa: DFA, startIndex: number, stopIndex: number, prediction: number, configs: ATNConfigSet): void;
 
     syntaxError(recognizer: Recognizer<TSymbol>, offendingSymbol: TSymbol, line: number, column: number, msg: string, e: RecognitionException | undefined): void;
-
 }

--- a/runtime/JavaScript/src/antlr4/error/ErrorListener.d.ts
+++ b/runtime/JavaScript/src/antlr4/error/ErrorListener.d.ts
@@ -1,6 +1,15 @@
-import {Recognizer} from "../Recognizer";
-import {RecognitionException} from "./RecognitionException";
+import { ATNConfigSet } from "../atn";
+import { BitSet } from '../misc/BitSet';
+import { DFA } from "../dfa";
+import { Recognizer } from "../Recognizer";
+import { RecognitionException } from "./RecognitionException";
 
 export declare class ErrorListener<TSymbol> {
+    reportAmbiguity(recognizer: Recognizer<TSymbol>, dfa: DFA, startIndex: number, stopIndex: number, exact: boolean, ambigAlts: BitSet, configs: ATNConfigSet): void;
+    
+    reportAttemptingFullContext(recognizer: Recognizer<TSymbol>, dfa: DFA, startIndex: number, stopIndex: number, conflictingAlts: BitSet, configs: ATNConfigSet): void;
+    
+    reportContextSensitivity(recognizer: Recognizer<TSymbol>, dfa: DFA, startIndex: number, stopIndex: number, prediction: number, configs: ATNConfigSet): void;
+    
     syntaxError(recognizer: Recognizer<TSymbol>, offendingSymbol: TSymbol, line: number, column: number, msg: string, e: RecognitionException | undefined): void;
 }

--- a/runtime/JavaScript/src/antlr4/misc/BitSet.d.ts
+++ b/runtime/JavaScript/src/antlr4/misc/BitSet.d.ts
@@ -1,0 +1,30 @@
+export declare class BitSet {
+    private data: Uint32Array;
+    readonly length: number;
+    
+    constructor();
+
+    set(index: number): void;
+
+    get(index: number): number;
+
+    clear(index: number): void;
+
+    or(set: BitSet): void;
+
+    values(): Array<number>;
+
+    minValue(): number;
+
+    hashCode(): number;
+
+    equals(): boolean;
+
+    toString(): string;
+
+    _resize(index: number): void;
+
+    static _checkIndex(index: number): void;
+
+    static _bitCount(l: number): number; 
+}

--- a/runtime/JavaScript/src/antlr4/misc/BitSet.d.ts
+++ b/runtime/JavaScript/src/antlr4/misc/BitSet.d.ts
@@ -1,16 +1,8 @@
 export declare class BitSet {
-    private data: Uint32Array;
+    // write methods are not exposed based on this conversation https://github.com/antlr/antlr4/pull/4731#discussion_r1847139040
     readonly length: number;
-    
-    constructor();
-
-    set(index: number): void;
 
     get(index: number): number;
-
-    clear(index: number): void;
-
-    or(set: BitSet): void;
 
     values(): Array<number>;
 
@@ -21,10 +13,6 @@ export declare class BitSet {
     equals(): boolean;
 
     toString(): string;
-
-    _resize(index: number): void;
-
-    static _checkIndex(index: number): void;
 
     static _bitCount(l: number): number; 
 }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

Fixes: https://github.com/antlr/antlr4/issues/4730

Updates TypeScript declaration file for `ErrorListener`. Additionally updates `DiagnosticErrorListener` that implements `ErrorListener` and adds a declaration file for `BitSet` class (`BitSet.d.ts`).

