### PR TITLE
Upgrade ci node version

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -247,11 +247,11 @@ jobs:
         python-version: '3.x'
         architecture: 'x64'
 
-    - name: Set up Node 16
+    - name: Set up Node 20
       if: (matrix.target == 'javascript') || (matrix.target == 'typescript')
       uses: actions/setup-node@v3.6.0
       with:
-        node-version: '16'
+        node-version: '20'
 
     - name: Setup Dotnet
       if: matrix.target == 'csharp'

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/TypeScript.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/TypeScript.test.stg
@@ -1,5 +1,5 @@
-writeln(s) ::= <<console.log(<s> || '');>>
-write(s) ::= <<process.stdout.write(<s> || '');>>
+writeln(s) ::= <<console.log(<s>);>>
+write(s) ::= <<process.stdout.write(<s>);>>
 writeList(s) ::= <<console.log(<s; separator="+">);>>
 
 False() ::= "false"


### PR DESCRIPTION
node 16 is deprecated in GH, bumping to node 20
