### PR TITLE
Include `<chrono>` for high_resolution_clock

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
@@ -10,6 +10,7 @@
 #include "support/CPPUtils.h"
 
 #include "atn/ProfilingATNSimulator.h"
+#include <chrono>
 
 using namespace antlr4;
 using namespace antlr4::atn;


### PR DESCRIPTION
I am a member of Microsoft vcpkg, due to there are new changes merged by microsoft/STL#5105, which revealed a conformance issue in `antlr4`. It must add include `<chrono>` to fix this error.

Compiler error with this STL change:
```
D:\b\antlr4\src\4.13.2-0987b822d0.clean\runtime\Cpp\runtime\src\atn\ProfilingATNSimulator.cpp(38): error C2653: 'high_resolution_clock': is not a class or namespace name
```