### PR TITLE
[Target: Cpp] fix Duplicate using namespace lines.

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -111,8 +111,6 @@ private:
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass = {Lexer}) ::= <<
 
-using namespace antlr4;
-
 namespace {
 
 struct <lexer.name; format = "cap">StaticData final {


### PR DESCRIPTION
A simple bug in the ANTLR4 code generator for C++.

If we generate a lexical analyzer for any ANTLR4 grammar using target C++, then we can see that the ANTLR4 code generator duplicates "using namespace std;" twice, which is not logical behavior.

For example, if we have a small grammar:
```
grammar main;

mainRule: token+;
Token: 'token';
```

Now let's try to generate a parser for this grammar:
```
antlr4 main.g4 -Dlanguage=Cpp
```

Then we will get a lexical file in the likeness:
```cpp
#include "MainLexer.h"

using namespace antlr4;

using namespace antlr4;
```

📛 Issue: https://github.com/antlr/antlr4/issues/4733