### PR TITLE
runtime(go): minimum requirement go1.18

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          macos-12,
+          macos-13,
           ubuntu-20.04,
           windows-2022
         ]
@@ -160,7 +160,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          macos-12,
+          macos-13,
           ubuntu-20.04,
           windows-2022
         ]

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/GoRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/GoRunner.java
@@ -142,6 +142,11 @@ public class GoRunner extends RuntimeRunner {
 		//
 		Exception ex = null;
 		if (cachedGoSum == null) {
+			// We need to write an empty go.sum file because `go mod tidy` may not generate it if there is no dependency.
+			// Or it will casue `java.io.FileNotFoundException` when readFile below
+			//
+			writeFile(getTempDirPath(), "go.sum", "");
+
 			try {
 				Processor.run(new String[]{getRuntimeToolPath(), "mod", "tidy"}, getTempDirPath(), environment);
 			} catch (InterruptedException | IOException e) {

--- a/runtime/Go/antlr/v4/go.mod
+++ b/runtime/Go/antlr/v4/go.mod
@@ -1,5 +1,3 @@
 module github.com/antlr4-go/antlr/v4
 
-go 1.20
-
-require golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
+go 1.18

--- a/runtime/Go/antlr/v4/go.sum
+++ b/runtime/Go/antlr/v4/go.sum
@@ -1,4 +1,0 @@
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
-golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
-golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/runtime/Go/antlr/v4/lexer_action_executor.go
+++ b/runtime/Go/antlr/v4/lexer_action_executor.go
@@ -4,8 +4,6 @@
 
 package antlr
 
-import "golang.org/x/exp/slices"
-
 // Represents an executor for a sequence of lexer actions which traversed during
 // the Matching operation of a lexer rule (token).
 //
@@ -167,7 +165,10 @@ func (l *LexerActionExecutor) Equals(other interface{}) bool {
 	if len(l.lexerActions) != len(othert.lexerActions) {
 		return false
 	}
-	return slices.EqualFunc(l.lexerActions, othert.lexerActions, func(i, j LexerAction) bool {
-		return i.Equals(j)
-	})
+	for i, v := range l.lexerActions {
+		if !v.Equals(othert.lexerActions[i]) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
golang.org/x/exp,
which requires newer go version,
is too heavy for previous implementation.

may duplicated with #4688 #4356 #4294, related #4663

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
