### PR TITLE
typo

### DIFF
--- a/tool/src/org/antlr/v4/gui/Interpreter.java
+++ b/tool/src/org/antlr/v4/gui/Interpreter.java
@@ -62,7 +62,7 @@ public class Interpreter {
 
 	public Interpreter(String[] args) throws Exception {
 		if ( args.length < 2 ) {
-			System.err.println("java org.antlr.v4.gui.Intrepreter [X.g4|XParser.g4 XLexer.g4] startRuleName\n" +
+			System.err.println("java org.antlr.v4.gui.Interpreter [X.g4|XParser.g4 XLexer.g4] startRuleName\n" +
 					"  [-tokens] [-tree] [-gui] [-encoding encodingname]\n" +
 					"  [-trace] [-profile filename.csv] [input-filename(s)]");
 			System.err.println("Omitting input-filename makes rig read from stdin.");


### PR DESCRIPTION
Ok, my first contribution to antlr. So what's the deal? I don't like running antlr through python, but I needed to download it anyway to figure out how to run antlr4-parse. Maybe that should be somewhere in the docs, because now it only says to use python... So I needed to do that, and then it said,

java org.antlr.v4.gui.Intrepreter [X.g4|XParser.g4 XLexer.g4] startRuleName
  [-tokens] [-tree] [-gui] [-encoding encodingname]
  [-trace] [-profile filename.csv] [input-filename(s)]
Omitting input-filename makes rig read from stdin.

Ok, good! Tx python!

So I tried that, and then it didn't work because the class name is not Intrepreter but Interpreter. So everyone who copies this from the terminal just like I did because he or she whats to be able to run the tools directly and not through python will fail... So I fixed that, so now it says,

java org.antlr.v4.gui.Interpreter [X.g4|XParser.g4 XLexer.g4] startRuleName
  [-tokens] [-tree] [-gui] [-encoding encodingname]
  [-trace] [-profile filename.csv] [input-filename(s)]
Omitting input-filename makes rig read from stdin.

Ok that's it!

Kind regards,
Ondrej

P.S, Tx for the antlr-parse tool, and the Cxx 14 grammar.  I needed that to figure out parse traces from the C++ grammar... So I am going to gave a look at that now, Tx!