### PR TITLE
Fix issue with index access on set in ParserInterpreter.py

### DIFF
--- a/runtime/Python3/src/antlr4/ParserInterpreter.py
+++ b/runtime/Python3/src/antlr4/ParserInterpreter.py
@@ -108,7 +108,7 @@ class ParserInterpreter(Parser):
         tt = transition.serializationType
         if tt==Transition.EPSILON:
 
-            if self.pushRecursionContextStates[p.stateNumber] and not isinstance(transition.target, LoopEndState):
+            if p.stateNumber in self.pushRecursionContextStates and not isinstance(transition.target, LoopEndState):
                 t = self._parentContextStack[-1]
                 ctx = InterpreterRuleContext(t[0], t[1], self._ctx.ruleIndex)
                 self.pushNewRecursionContext(ctx, self.atn.ruleToStartState[p.ruleIndex].stateNumber, self._ctx.ruleIndex)


### PR DESCRIPTION
In the parserinterpreter.py file, there was an issue where an attempt was made to access a set using an index. However, sets do not support indexing, which led to an error.

This change fixes the issue by modifying the logic to access the elements of the set in a valid manner.