### PR TITLE
[C# target] Use Collections.EmptyList to prevent zero length allocations

### DIFF
--- a/runtime/CSharp/src/Atn/ATN.cs
+++ b/runtime/CSharp/src/Atn/ATN.cs
@@ -77,10 +77,10 @@ namespace Antlr4.Runtime.Atn
         private readonly PredictionContextCache contextCache = new PredictionContextCache();
 
         [NotNull]
-		public DFA[] decisionToDFA = new DFA[0];
+		public DFA[] decisionToDFA = Collections.EmptyList<DFA>();
 
         [NotNull]
-		public DFA[] modeToDFA = new DFA[0];
+		public DFA[] modeToDFA = Collections.EmptyList<DFA>();
 
         protected internal readonly ConcurrentDictionary<int, int> LL1Table = new ConcurrentDictionary<int, int>();
 

--- a/runtime/CSharp/src/Dfa/DFA.cs
+++ b/runtime/CSharp/src/Dfa/DFA.cs
@@ -46,7 +46,7 @@ namespace Antlr4.Runtime.Dfa
 			{
 				this.precedenceDfa = true;
 				DFAState precedenceState = new DFAState(new ATNConfigSet());
-				precedenceState.edges = new DFAState[0];
+				precedenceState.edges = Collections.EmptyList<DFAState>();
 				precedenceState.isAcceptState = false;
 				precedenceState.requiresFullContext = false;
 				this.s0 = precedenceState;

--- a/runtime/CSharp/src/LexerInterpreter.cs
+++ b/runtime/CSharp/src/LexerInterpreter.cs
@@ -33,7 +33,7 @@ namespace Antlr4.Runtime
 
         [Obsolete("Use constructor with channelNames argument")]
         public LexerInterpreter(string grammarFileName, IVocabulary vocabulary, IEnumerable<string> ruleNames, IEnumerable<string> modeNames, ATN atn, ICharStream input)
-            : this(grammarFileName, vocabulary, ruleNames, new string[0], modeNames, atn, input)
+            : this(grammarFileName, vocabulary, ruleNames, Collections.EmptyList<string>(), modeNames, atn, input)
         {
         }
 

--- a/runtime/CSharp/src/Recognizer.cs
+++ b/runtime/CSharp/src/Recognizer.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Antlr4.Runtime.Atn;
 using Antlr4.Runtime.Misc;
+using Antlr4.Runtime.Sharpen;
 
 namespace Antlr4.Runtime
 {
@@ -286,7 +287,7 @@ namespace Antlr4.Runtime
 
         public virtual void RemoveErrorListeners()
         {
-            _listeners = new IAntlrErrorListener<Symbol>[0];
+            _listeners = Collections.EmptyList<IAntlrErrorListener<Symbol>>();
         }
 
         [NotNull]

--- a/runtime/CSharp/src/Sharpen/BitSet.cs
+++ b/runtime/CSharp/src/Sharpen/BitSet.cs
@@ -9,7 +9,7 @@ namespace Antlr4.Runtime.Sharpen
 
     public class BitSet
     {
-        private static readonly ulong[] EmptyBits = new ulong[0];
+        private static readonly ulong[] EmptyBits = Collections.EmptyList<ulong>();
         private const int BitsPerElement = 8 * sizeof(ulong);
 
         private ulong[] _data = EmptyBits;

--- a/runtime/CSharp/src/Sharpen/Collections.cs
+++ b/runtime/CSharp/src/Sharpen/Collections.cs
@@ -9,7 +9,11 @@ namespace Antlr4.Runtime.Sharpen
 
     internal static class Collections
     {
-        public static T[] EmptyList<T>()
+		/// <remarks>
+		/// Available in .NET as Array.Empty but not to the net45 target.
+		/// See: https://learn.microsoft.com/dotnet/api/system.array.empty.
+		/// </remarks>
+		public static T[] EmptyList<T>()
         {
             return EmptyListImpl<T>.Instance;
         }
@@ -31,10 +35,13 @@ namespace Antlr4.Runtime.Sharpen
 
         private static class EmptyListImpl<T>
         {
-            public static readonly T[] Instance = new T[0];
-        }
+#pragma warning disable CA1825
+            // Provides a solution for CA1825.
+			public static readonly T[] Instance = new T[0];
+#pragma warning restore CA1825
+		}
 
-        private static class EmptyMapImpl<TKey, TValue>
+		private static class EmptyMapImpl<TKey, TValue>
         {
             public static readonly ReadOnlyDictionary<TKey, TValue> Instance =
                 new ReadOnlyDictionary<TKey, TValue>(new Dictionary<TKey, TValue>());

--- a/runtime/CSharp/src/Vocabulary.cs
+++ b/runtime/CSharp/src/Vocabulary.cs
@@ -16,7 +16,7 @@ namespace Antlr4.Runtime
     /// <author>Sam Harwell</author>
     public class Vocabulary : IVocabulary
     {
-        private static readonly string[] EmptyNames = new string[0];
+        private static readonly string[] EmptyNames = Collections.EmptyList<string>();
 
         /// <summary>
         /// Gets an empty


### PR DESCRIPTION
I noticed when enabling some static code analysis rules (by setting the property `<EnableNETAnalyzers>true</EnableNETAnalyzers>` in the csproj file), that [CA1825: Avoid zero-length array allocations](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825) was raised.

Because the C# solution still targets net4.5 (is that still needed? I would argue that net4.8 or netstandard2.0 should be sufficient, it is 2025 after all) the use of [`Array.Empty<T>`](https://learn.microsoft.com/dotnet/api/system.array.empty) can not be used. However, fortunately, `Collections.EmptyList<T>`  already provided a solution. I just applied them where applicable.
