### PR TITLE
Bump GitHub action

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -336,7 +336,7 @@ jobs:
     - name: Archive artifacts
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: antlr_${{ matrix.os }}_${{ matrix.target }}
         path: antlr_${{ matrix.os }}_${{ matrix.target }}.tgz

--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -147,7 +147,7 @@ jobs:
     - name: Archive artifacts
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: antlr_${{ matrix.os }}_${{ matrix.compiler }}
         path: antlr_${{ matrix.os }}_${{ matrix.compiler }}.tgz

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/TypeScript.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/TypeScript.test.stg
@@ -1,5 +1,5 @@
-writeln(s) ::= <<console.log(<s> || '');>>
-write(s) ::= <<process.stdout.write(<s> || '');>>
+writeln(s) ::= <<console.log(<s>);>>
+write(s) ::= <<process.stdout.write(<s>);>>
 writeList(s) ::= <<console.log(<s; separator="+">);>>
 
 False() ::= "false"


### PR DESCRIPTION
Mandatory bump of actions/upload-artifact, see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/