### PR TITLE
Bump GitHub platform

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -336,7 +336,7 @@ jobs:
     - name: Archive artifacts
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: antlr_${{ matrix.os }}_${{ matrix.target }}
         path: antlr_${{ matrix.os }}_${{ matrix.target }}.tgz

--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          macos-12,
+          macos-15,
           ubuntu-20.04,
           windows-2022
         ]
@@ -160,7 +160,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          macos-12,
+          macos-15,
           ubuntu-20.04,
           windows-2022
         ]

--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -147,7 +147,7 @@ jobs:
     - name: Archive artifacts
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: antlr_${{ matrix.os }}_${{ matrix.compiler }}
         path: antlr_${{ matrix.os }}_${{ matrix.compiler }}.tgz

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/TypeScript.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/TypeScript.test.stg
@@ -1,5 +1,5 @@
-writeln(s) ::= <<console.log(<s> || '');>>
-write(s) ::= <<process.stdout.write(<s> || '');>>
+writeln(s) ::= <<console.log(<s>);>>
+write(s) ::= <<process.stdout.write(<s>);>>
 writeList(s) ::= <<console.log(<s; separator="+">);>>
 
 False() ::= "false"


### PR DESCRIPTION
macos-12 is deprecated on GH, see https://github.com/actions/runner-images/issues/10721
This PR upgrades our CI to use macos-15