### PR TITLE
Applying CA1834 - Use StringBuilder.Append(char) for single character strings

### DIFF
--- a/runtime/CSharp/src/Atn/ATNConfig.cs
+++ b/runtime/CSharp/src/Atn/ATNConfig.cs
@@ -220,18 +220,18 @@ namespace Antlr4.Runtime.Atn
 			buf.Append(state);
 			if (showAlt)
 			{
-				buf.Append(",");
+				buf.Append(',');
 				buf.Append(alt);
 			}
 			if (context != null)
 			{
 				buf.Append(",[");
 				buf.Append(context.ToString());
-				buf.Append("]");
+				buf.Append(']');
 			}
 			if (semanticContext != null && semanticContext != SemanticContext.Empty.Instance)
 			{
-				buf.Append(",");
+				buf.Append(',');
 				buf.Append(semanticContext);
 			}
 			if (OuterContextDepth > 0)

--- a/runtime/CSharp/src/Atn/ArrayPredictionContext.cs
+++ b/runtime/CSharp/src/Atn/ArrayPredictionContext.cs
@@ -2,123 +2,124 @@
  * Use of this file is governed by the BSD 3-clause license that
  * can be found in the LICENSE.txt file in the project root.
  */
+using Antlr4.Runtime.Sharpen;
 using System;
 using System.Text;
-using Antlr4.Runtime.Sharpen;
 
 namespace Antlr4.Runtime.Atn
 {
 
 
-	#pragma warning disable 0659 // 'class' overrides Object.Equals(object o) but does not override Object.GetHashCode()
-	public class ArrayPredictionContext : PredictionContext
-	{
-		/** Parent can be null only if full ctx mode and we make an array
+#pragma warning disable 0659 // 'class' overrides Object.Equals(object o) but does not override Object.GetHashCode()
+    public class ArrayPredictionContext : PredictionContext
+    {
+        /** Parent can be null only if full ctx mode and we make an array
 		 *  from {@link #EMPTY} and non-empty. We merge {@link #EMPTY} by using null parent and
 		 *  returnState == {@link #EMPTY_RETURN_STATE}.
 		 */
-		public readonly PredictionContext[] parents;
+        public readonly PredictionContext[] parents;
 
-		/** Sorted for merge, no duplicates; if present,
+        /** Sorted for merge, no duplicates; if present,
 		 *  {@link #EMPTY_RETURN_STATE} is always last.
 		 */
-		public readonly int[] returnStates;
+        public readonly int[] returnStates;
 
-		public ArrayPredictionContext(SingletonPredictionContext a)
-			: this(new PredictionContext[] { a.parent }, new int[] { a.returnState })
-		{
-		}
+        public ArrayPredictionContext(SingletonPredictionContext a)
+            : this(new PredictionContext[] { a.parent }, new int[] { a.returnState })
+        {
+        }
 
-		public ArrayPredictionContext(PredictionContext[] parents, int[] returnStates)
-			: base(CalculateHashCode(parents, returnStates))
-		{
-			//		System.err.println("CREATE ARRAY: "+Arrays.toString(parents)+", "+Arrays.toString(returnStates));
-			this.parents = parents;
-			this.returnStates = returnStates;
-		}
+        public ArrayPredictionContext(PredictionContext[] parents, int[] returnStates)
+            : base(CalculateHashCode(parents, returnStates))
+        {
+            //		System.err.println("CREATE ARRAY: "+Arrays.toString(parents)+", "+Arrays.toString(returnStates));
+            this.parents = parents;
+            this.returnStates = returnStates;
+        }
 
-		public override bool IsEmpty
-		{
-			get
-			{
-				// since EMPTY_RETURN_STATE can only appear in the last position, we
-				// don't need to verify that size==1
-				return returnStates[0] == EMPTY_RETURN_STATE;
-			}
-		}
+        public override bool IsEmpty
+        {
+            get
+            {
+                // since EMPTY_RETURN_STATE can only appear in the last position, we
+                // don't need to verify that size==1
+                return returnStates[0] == EMPTY_RETURN_STATE;
+            }
+        }
 
-		public override int Size
-		{
-			get
-			{
-				return returnStates.Length;
-			}
-		}
+        public override int Size
+        {
+            get
+            {
+                return returnStates.Length;
+            }
+        }
 
-		public override PredictionContext GetParent(int index)
-		{
-			return parents[index];
-		}
+        public override PredictionContext GetParent(int index)
+        {
+            return parents[index];
+        }
 
-		public override int GetReturnState(int index)
-		{
-			return returnStates[index];
-		}
+        public override int GetReturnState(int index)
+        {
+            return returnStates[index];
+        }
 
-		//	@Override
-		//	public int findReturnState(int returnState) {
-		//		return Arrays.binarySearch(returnStates, returnState);
-		//	}
+        //	@Override
+        //	public int findReturnState(int returnState) {
+        //		return Arrays.binarySearch(returnStates, returnState);
+        //	}
 
-		public override bool Equals(Object o)
-		{
-			if (this == o)
-			{
-				return true;
-			}
-			else if (!(o is ArrayPredictionContext))
-			{
-				return false;
-			}
+        public override bool Equals(Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            else if (!(o is ArrayPredictionContext))
+            {
+                return false;
+            }
 
-			if (this.GetHashCode() != o.GetHashCode())
-			{
-				return false; // can't be same if hash is different
-			}
+            if (this.GetHashCode() != o.GetHashCode())
+            {
+                return false; // can't be same if hash is different
+            }
 
-			ArrayPredictionContext a = (ArrayPredictionContext)o;
-			return Arrays.Equals(returnStates, a.returnStates) &&
-				   Arrays.Equals(parents, a.parents);
-		}
+            ArrayPredictionContext a = (ArrayPredictionContext)o;
+            return Arrays.Equals(returnStates, a.returnStates) &&
+                   Arrays.Equals(parents, a.parents);
+        }
 
 
-		public override String ToString()
-		{
-			if (IsEmpty)
-				return "[]";
-			StringBuilder buf = new StringBuilder();
-			buf.Append("[");
-			for (int i = 0; i < returnStates.Length; i++)
-			{
-				if (i > 0) buf.Append(", ");
-				if (returnStates[i] == EMPTY_RETURN_STATE)
-				{
-					buf.Append("$");
-					continue;
-				}
-				buf.Append(returnStates[i]);
-				if (parents[i] != null)
-				{
-					buf.Append(' ');
-					buf.Append(parents[i].ToString());
-				}
-				else {
-					buf.Append("null");
-				}
-			}
-			buf.Append("]");
-			return buf.ToString();
-		}
-	}
+        public override String ToString()
+        {
+            if (IsEmpty)
+                return "[]";
+            StringBuilder buf = new StringBuilder();
+            buf.Append('[');
+            for (int i = 0; i < returnStates.Length; i++)
+            {
+                if (i > 0) buf.Append(", ");
+                if (returnStates[i] == EMPTY_RETURN_STATE)
+                {
+                    buf.Append('$');
+                    continue;
+                }
+                buf.Append(returnStates[i]);
+                if (parents[i] != null)
+                {
+                    buf.Append(' ');
+                    buf.Append(parents[i].ToString());
+                }
+                else
+                {
+                    buf.Append("null");
+                }
+            }
+            buf.Append(']');
+            return buf.ToString();
+        }
+    }
 
 }

--- a/runtime/CSharp/src/Atn/PredictionContext.cs
+++ b/runtime/CSharp/src/Atn/PredictionContext.cs
@@ -498,7 +498,7 @@ namespace Antlr4.Runtime.Atn
 				PredictionContext p = this;
 				int stateNumber = currentState;
 				StringBuilder localBuffer = new StringBuilder();
-				localBuffer.Append("[");
+				localBuffer.Append('[');
 				while (!p.IsEmpty && p != stop)
 				{
 					int index = 0;
@@ -548,7 +548,7 @@ namespace Antlr4.Runtime.Atn
 					stateNumber = p.GetReturnState(index);
 					p = p.GetParent(index);
 				}
-				localBuffer.Append("]");
+				localBuffer.Append(']');
 				result.Add(localBuffer.ToString());
 				if (last)
 				{

--- a/runtime/CSharp/src/Dfa/DFASerializer.cs
+++ b/runtime/CSharp/src/Dfa/DFASerializer.cs
@@ -66,7 +66,7 @@ namespace Antlr4.Runtime.Dfa
 						{
 							buf.Append(GetStateString(s));
 							String label = GetEdgeLabel(i);
-							buf.Append("-");
+							buf.Append('-');
 							buf.Append(label);
 							buf.Append("->");
 							buf.Append(GetStateString(t));

--- a/runtime/CSharp/src/Dfa/DFAState.cs
+++ b/runtime/CSharp/src/Dfa/DFAState.cs
@@ -148,7 +148,7 @@ namespace Antlr4.Runtime.Dfa
 		public override String ToString()
 		{
 			StringBuilder buf = new StringBuilder();
-			buf.Append(stateNumber).Append(":").Append(configSet);
+			buf.Append(stateNumber).Append(':').Append(configSet);
 			if (isAcceptState)
 			{
 				buf.Append("=>");

--- a/runtime/CSharp/src/Misc/IntervalSet.cs
+++ b/runtime/CSharp/src/Misc/IntervalSet.cs
@@ -622,7 +622,7 @@ namespace Antlr4.Runtime.Misc
             }
             if (this.Count > 1)
             {
-                buf.Append("{");
+                buf.Append('{');
             }
 
             bool first = true;
@@ -644,7 +644,7 @@ namespace Antlr4.Runtime.Misc
                     {
                         if (elemAreChar)
                         {
-                            buf.Append("'").Append((char)a).Append("'");
+                            buf.Append('\'').Append((char)a).Append('\'');
                         }
                         else
                         {
@@ -656,7 +656,7 @@ namespace Antlr4.Runtime.Misc
                 {
                     if (elemAreChar)
                     {
-                        buf.Append("'").Append((char)a).Append("'..'").Append((char)b).Append("'");
+                        buf.Append('\'').Append((char)a).Append("'..'").Append((char)b).Append('\'');
                     }
                     else
                     {
@@ -666,7 +666,7 @@ namespace Antlr4.Runtime.Misc
             }
             if (this.Count > 1)
             {
-                buf.Append("}");
+                buf.Append('}');
             }
             return buf.ToString();
         }
@@ -680,7 +680,7 @@ namespace Antlr4.Runtime.Misc
             }
             if (this.Count > 1)
             {
-                buf.Append("{");
+                buf.Append('{');
             }
 
             bool first = true;
@@ -710,7 +710,7 @@ namespace Antlr4.Runtime.Misc
             }
             if (this.Count > 1)
             {
-                buf.Append("}");
+                buf.Append('}');
             }
             return buf.ToString();
         }

--- a/runtime/CSharp/src/Parser.cs
+++ b/runtime/CSharp/src/Parser.cs
@@ -1101,7 +1101,7 @@ namespace Antlr4.Runtime
 				sb.Append (", ");
 			}
 			sb.Length = sb.Length - 2;
-			sb.Append ("]");
+			sb.Append (']');
 			return sb.ToString ();
 		}
 

--- a/runtime/CSharp/src/RuleContext.cs
+++ b/runtime/CSharp/src/RuleContext.cs
@@ -291,7 +291,7 @@ namespace Antlr4.Runtime
         {
             StringBuilder buf = new StringBuilder();
             Antlr4.Runtime.RuleContext p = this;
-            buf.Append("[");
+            buf.Append('[');
             while (p != null && p != stop)
             {
                 if (ruleNames == null)
@@ -309,11 +309,11 @@ namespace Antlr4.Runtime
                 }
                 if (p.Parent != null && (ruleNames != null || !p.Parent.IsEmpty))
                 {
-                    buf.Append(" ");
+                    buf.Append(' ');
                 }
                 p = p.Parent;
             }
-            buf.Append("]");
+            buf.Append(']');
             return buf.ToString();
         }
     }

--- a/runtime/CSharp/src/Tree/Trees.cs
+++ b/runtime/CSharp/src/Tree/Trees.cs
@@ -57,7 +57,7 @@ namespace Antlr4.Runtime.Tree
                 return s;
             }
             StringBuilder buf = new StringBuilder();
-            buf.Append("(");
+            buf.Append('(');
             s = Utils.EscapeWhitespace(GetNodeText(t, ruleNames), false);
             buf.Append(s);
             buf.Append(' ');
@@ -69,7 +69,7 @@ namespace Antlr4.Runtime.Tree
                 }
                 buf.Append(ToStringTree(t.GetChild(i), ruleNames));
             }
-            buf.Append(")");
+            buf.Append(')');
             return buf.ToString();
         }
 


### PR DESCRIPTION
Optimize StringBuilder Usage by Applying CA1834

[CA1834: Use StringBuilder.Append(char) for single-character strings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1834)
