### PR TITLE
Fix "chrono" C++ library not being included on Windows

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
@@ -10,6 +10,7 @@
 #include "support/CPPUtils.h"
 
 #include "atn/ProfilingATNSimulator.h"
+#include <chrono>
 
 using namespace antlr4;
 using namespace antlr4::atn;


### PR DESCRIPTION
On Linux, the build is successful because this library is usually included in the headers by default. But on Windows, when using Visual Studio (at least VS 2022 Community - the version I tested this on), the build fails because the "chrono" library is not included by default.

To avoid troubling new Windows adopters of this C++ runtime, it would be good to include this in the code!

(Adding this line does not break builds on Linux, and does not cause any warnings on Windows or Linux! - I tested it on both Windows and Linux)

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
