### PR TITLE
Add IWYU pragmas to indicate that the headers export symbols.

### DIFF
--- a/runtime/Cpp/runtime/src/antlr4-runtime.h
+++ b/runtime/Cpp/runtime/src/antlr4-runtime.h
@@ -7,6 +7,8 @@
 
 // This is the umbrella header for all ANTLR4 C++ runtime headers.
 
+// IWYU pragma: begin_exports
+
 #include "antlr4-common.h"
 
 #include "ANTLRErrorListener.h"
@@ -166,3 +168,5 @@
 #include "tree/xpath/XPathWildcardAnywhereElement.h"
 #include "tree/xpath/XPathWildcardElement.h"
 #include "internal/Synchronization.h"
+
+// IWYU pragma: end_exports


### PR DESCRIPTION
Described here https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-begin_exportsend_exports

These pragmas are not only understood by the IWYU tools, but as well clang-tidy ( https://clangd.llvm.org/design/include-cleaner#iwyu-pragmas ), so that projects using clang-tidy will not get false-positives about missing includes.