### PR TITLE
Use 'override' in virtual methods of derived classes.

### DIFF
--- a/runtime/Cpp/runtime/src/ANTLRFileStream.h
+++ b/runtime/Cpp/runtime/src/ANTLRFileStream.h
@@ -21,7 +21,7 @@ namespace antlr4 {
 
     // Assumes a file name encoded in UTF-8 and file content in the same encoding (with or w/o BOM).
     virtual void loadFromFile(const std::string &fileName);
-    virtual std::string getSourceName() const override;
+    std::string getSourceName() const override;
 
   private:
     std::string _fileName; // UTF-8 encoded file name.

--- a/runtime/Cpp/runtime/src/ANTLRInputStream.h
+++ b/runtime/Cpp/runtime/src/ANTLRInputStream.h
@@ -46,8 +46,8 @@ namespace antlr4 {
     /// when the object was created *except* the data array is not
     /// touched.
     virtual void reset();
-    virtual void consume() override;
-    virtual size_t LA(ssize_t i) override;
+    void consume() override;
+    size_t LA(ssize_t i) override;
     virtual size_t LT(ssize_t i);
 
     /// <summary>
@@ -55,22 +55,22 @@ namespace antlr4 {
     ///  last symbol has been read.  The index is the index of char to
     ///  be returned from LA(1).
     /// </summary>
-    virtual size_t index() override;
-    virtual size_t size() override;
+    size_t index() override;
+    size_t size() override;
 
     /// <summary>
     /// mark/release do nothing; we have entire buffer </summary>
-    virtual ssize_t mark() override;
-    virtual void release(ssize_t marker) override;
+    ssize_t mark() override;
+    void release(ssize_t marker) override;
 
     /// <summary>
     /// consume() ahead until p==index; can't just set p=index as we must
     ///  update line and charPositionInLine. If we seek backwards, just set p
     /// </summary>
-    virtual void seek(size_t index) override;
-    virtual std::string getText(const misc::Interval &interval) override;
-    virtual std::string getSourceName() const override;
-    virtual std::string toString() const override;
+    void seek(size_t index) override;
+    std::string getText(const misc::Interval &interval) override;
+    std::string getSourceName() const override;
+    std::string toString() const override;
 
   private:
     void InitializeInstanceFields();

--- a/runtime/Cpp/runtime/src/BailErrorStrategy.h
+++ b/runtime/Cpp/runtime/src/BailErrorStrategy.h
@@ -45,15 +45,15 @@ namespace antlr4 {
     ///  original <seealso cref="RecognitionException"/>.
     /// </summary>
   public:
-    virtual void recover(Parser *recognizer, std::exception_ptr e) override;
+    void recover(Parser *recognizer, std::exception_ptr e) override;
 
     /// Make sure we don't attempt to recover inline; if the parser
     ///  successfully recovers, it won't throw an exception.
-    virtual Token* recoverInline(Parser *recognizer) override;
+    Token* recoverInline(Parser *recognizer) override;
 
     /// <summary>
     /// Make sure we don't attempt to recover from problems in subrules. </summary>
-    virtual void sync(Parser *recognizer) override;
+    void sync(Parser *recognizer) override;
   };
 
 } // namespace antlr4

--- a/runtime/Cpp/runtime/src/BaseErrorListener.h
+++ b/runtime/Cpp/runtime/src/BaseErrorListener.h
@@ -20,16 +20,16 @@ namespace antlr4 {
    */
   class ANTLR4CPP_PUBLIC BaseErrorListener : public ANTLRErrorListener {
 
-    virtual void syntaxError(Recognizer *recognizer, Token * offendingSymbol, size_t line, size_t charPositionInLine,
+    void syntaxError(Recognizer *recognizer, Token * offendingSymbol, size_t line, size_t charPositionInLine,
       const std::string &msg, std::exception_ptr e) override;
 
-    virtual void reportAmbiguity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex, bool exact,
+    void reportAmbiguity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex, bool exact,
       const antlrcpp::BitSet &ambigAlts, atn::ATNConfigSet *configs) override;
 
-    virtual void reportAttemptingFullContext(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
+    void reportAttemptingFullContext(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
       const antlrcpp::BitSet &conflictingAlts, atn::ATNConfigSet *configs) override;
 
-    virtual void reportContextSensitivity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
+    void reportContextSensitivity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
       size_t prediction, atn::ATNConfigSet *configs) override;
   };
 

--- a/runtime/Cpp/runtime/src/BufferedTokenStream.h
+++ b/runtime/Cpp/runtime/src/BufferedTokenStream.h
@@ -28,24 +28,24 @@ namespace antlr4 {
 
     BufferedTokenStream& operator = (const BufferedTokenStream& other) = delete;
 
-    virtual TokenSource* getTokenSource() const override;
-    virtual size_t index() override;
-    virtual ssize_t mark() override;
+    TokenSource* getTokenSource() const override;
+    size_t index() override;
+    ssize_t mark() override;
 
-    virtual void release(ssize_t marker) override;
+    void release(ssize_t marker) override;
     virtual void reset();
-    virtual void seek(size_t index) override;
+    void seek(size_t index) override;
 
-    virtual size_t size() override;
-    virtual void consume() override;
+    size_t size() override;
+    void consume() override;
 
-    virtual Token* get(size_t i) const override;
+    Token* get(size_t i) const override;
 
     /// Get all tokens from start..stop inclusively.
     virtual std::vector<Token *> get(size_t start, size_t stop);
 
-    virtual size_t LA(ssize_t i) override;
-    virtual Token* LT(ssize_t k) override;
+    size_t LA(ssize_t i) override;
+    Token* LT(ssize_t k) override;
 
     /// Reset this token stream by setting its token source.
     virtual void setTokenSource(TokenSource *tokenSource);
@@ -85,11 +85,11 @@ namespace antlr4 {
     /// </summary>
     virtual std::vector<Token *> getHiddenTokensToLeft(size_t tokenIndex);
 
-    virtual std::string getSourceName() const override;
-    virtual std::string getText() override;
-    virtual std::string getText(const misc::Interval &interval) override;
-    virtual std::string getText(RuleContext *ctx) override;
-    virtual std::string getText(Token *start, Token *stop) override;
+    std::string getSourceName() const override;
+    std::string getText() override;
+    std::string getText(const misc::Interval &interval) override;
+    std::string getText(RuleContext *ctx) override;
+    std::string getText(Token *start, Token *stop) override;
 
     /// Get all tokens from lexer until EOF.
     virtual void fill();

--- a/runtime/Cpp/runtime/src/CharStream.h
+++ b/runtime/Cpp/runtime/src/CharStream.h
@@ -13,7 +13,7 @@ namespace antlr4 {
   /// A source of characters for an ANTLR lexer.
   class ANTLR4CPP_PUBLIC CharStream : public IntStream {
   public:
-    virtual ~CharStream();
+    ~CharStream() override;
 
     /// This method returns the text for a range of characters within this input
     /// stream. This method is guaranteed to not throw an exception if the

--- a/runtime/Cpp/runtime/src/CommonToken.h
+++ b/runtime/Cpp/runtime/src/CommonToken.h
@@ -111,7 +111,7 @@ namespace antlr4 {
      */
     CommonToken(Token *oldToken);
 
-    virtual size_t getType() const override;
+    size_t getType() const override;
 
     /**
      * Explicitly set the text for this token. If {code text} is not
@@ -122,33 +122,33 @@ namespace antlr4 {
      * should be obtained from the input along with the start and stop indexes
      * of the token.
      */
-    virtual void setText(const std::string &text) override;
-    virtual std::string getText() const override;
+    void setText(const std::string &text) override;
+    std::string getText() const override;
 
-    virtual void setLine(size_t line) override;
-    virtual size_t getLine() const override;
+    void setLine(size_t line) override;
+    size_t getLine() const override;
 
-    virtual size_t getCharPositionInLine() const override;
-    virtual void setCharPositionInLine(size_t charPositionInLine) override;
+    size_t getCharPositionInLine() const override;
+    void setCharPositionInLine(size_t charPositionInLine) override;
 
-    virtual size_t getChannel() const override;
-    virtual void setChannel(size_t channel) override;
+    size_t getChannel() const override;
+    void setChannel(size_t channel) override;
 
-    virtual void setType(size_t type) override;
+    void setType(size_t type) override;
 
-    virtual size_t getStartIndex() const override;
+    size_t getStartIndex() const override;
     virtual void setStartIndex(size_t start);
 
-    virtual size_t getStopIndex() const override;
+    size_t getStopIndex() const override;
     virtual void setStopIndex(size_t stop);
 
-    virtual size_t getTokenIndex() const override;
-    virtual void setTokenIndex(size_t index) override;
+    size_t getTokenIndex() const override;
+    void setTokenIndex(size_t index) override;
 
-    virtual TokenSource *getTokenSource() const override;
-    virtual CharStream *getInputStream() const override;
+    TokenSource *getTokenSource() const override;
+    CharStream *getInputStream() const override;
 
-    virtual std::string toString() const override;
+    std::string toString() const override;
 
     virtual std::string toString(Recognizer *r) const;
   private:

--- a/runtime/Cpp/runtime/src/CommonTokenFactory.h
+++ b/runtime/Cpp/runtime/src/CommonTokenFactory.h
@@ -65,10 +65,10 @@ namespace antlr4 {
      */
     CommonTokenFactory();
 
-    virtual std::unique_ptr<CommonToken> create(std::pair<TokenSource*, CharStream*> source, size_t type,
+    std::unique_ptr<CommonToken> create(std::pair<TokenSource*, CharStream*> source, size_t type,
       const std::string &text, size_t channel, size_t start, size_t stop, size_t line, size_t charPositionInLine) override;
 
-    virtual std::unique_ptr<CommonToken> create(size_t type, const std::string &text) override;
+    std::unique_ptr<CommonToken> create(size_t type, const std::string &text) override;
   };
 
 } // namespace antlr4

--- a/runtime/Cpp/runtime/src/CommonTokenStream.h
+++ b/runtime/Cpp/runtime/src/CommonTokenStream.h
@@ -55,7 +55,7 @@ namespace antlr4 {
      */
     CommonTokenStream(TokenSource *tokenSource, size_t channel);
 
-    virtual Token* LT(ssize_t k) override;
+    Token* LT(ssize_t k) override;
 
     /// Count EOF just once.
     virtual int getNumberOfOnChannelTokens();
@@ -70,9 +70,9 @@ namespace antlr4 {
      */
     size_t channel;
 
-    virtual ssize_t adjustSeekIndex(size_t i) override;
+    ssize_t adjustSeekIndex(size_t i) override;
 
-    virtual Token* LB(size_t k) override;
+    Token* LB(size_t k) override;
 
   };
 

--- a/runtime/Cpp/runtime/src/ConsoleErrorListener.h
+++ b/runtime/Cpp/runtime/src/ConsoleErrorListener.h
@@ -28,7 +28,7 @@ namespace antlr4 {
      * line <em>line</em>:<em>charPositionInLine</em> <em>msg</em>
      * </pre>
      */
-    virtual void syntaxError(Recognizer *recognizer, Token * offendingSymbol, size_t line, size_t charPositionInLine,
+    void syntaxError(Recognizer *recognizer, Token * offendingSymbol, size_t line, size_t charPositionInLine,
                              const std::string &msg, std::exception_ptr e) override;
   };
 

--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.h
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.h
@@ -18,7 +18,7 @@ namespace antlr4 {
   public:
     DefaultErrorStrategy();
     DefaultErrorStrategy(DefaultErrorStrategy const& other) = delete;
-    virtual ~DefaultErrorStrategy();
+    ~DefaultErrorStrategy() override;
 
     DefaultErrorStrategy& operator = (DefaultErrorStrategy const& other) = delete;
 
@@ -49,7 +49,7 @@ namespace antlr4 {
     /// ensure that the handler is not in error recovery mode.
     /// </summary>
   public:
-    virtual void reset(Parser *recognizer) override;
+    void reset(Parser *recognizer) override;
 
     /// <summary>
     /// This method is called to enter error recovery mode when a recognition
@@ -63,7 +63,7 @@ namespace antlr4 {
     /// {@inheritDoc}
     /// </summary>
   public:
-    virtual bool inErrorRecoveryMode(Parser *recognizer) override;
+    bool inErrorRecoveryMode(Parser *recognizer) override;
 
     /// <summary>
     /// This method is called to leave error recovery mode after recovering from
@@ -79,7 +79,7 @@ namespace antlr4 {
     /// The default implementation simply calls <seealso cref="#endErrorCondition"/>.
     /// </summary>
   public:
-    virtual void reportMatch(Parser *recognizer) override;
+    void reportMatch(Parser *recognizer) override;
 
     /// {@inheritDoc}
     /// <p/>
@@ -98,7 +98,7 @@ namespace antlr4 {
     /// <li>All other types: calls <seealso cref="Parser#notifyErrorListeners"/> to report
     /// the exception</li>
     /// </ul>
-    virtual void reportError(Parser *recognizer, const RecognitionException &e) override;
+    void reportError(Parser *recognizer, const RecognitionException &e) override;
 
     /// <summary>
     /// {@inheritDoc}
@@ -107,7 +107,7 @@ namespace antlr4 {
     /// until we find one in the resynchronization set--loosely the set of tokens
     /// that can follow the current rule.
     /// </summary>
-    virtual void recover(Parser *recognizer, std::exception_ptr e) override;
+    void recover(Parser *recognizer, std::exception_ptr e) override;
 
     /**
      * The default implementation of {@link ANTLRErrorStrategy#sync} makes sure
@@ -155,7 +155,7 @@ namespace antlr4 {
      * some reason speed is suffering for you, you can turn off this
      * functionality by simply overriding this method as a blank { }.</p>
      */
-    virtual void sync(Parser *recognizer) override;
+    void sync(Parser *recognizer) override;
 
     /// <summary>
     /// This is called by <seealso cref="#reportError"/> when the exception is a
@@ -278,7 +278,7 @@ namespace antlr4 {
      * is in the set of tokens that can follow the {@code ')'} token reference
      * in rule {@code atom}. It can assume that you forgot the {@code ')'}.
      */
-    virtual Token* recoverInline(Parser *recognizer) override;
+    Token* recoverInline(Parser *recognizer) override;
 
     /// <summary>
     /// This method implements the single-token insertion inline error recovery

--- a/runtime/Cpp/runtime/src/DiagnosticErrorListener.h
+++ b/runtime/Cpp/runtime/src/DiagnosticErrorListener.h
@@ -52,13 +52,13 @@ namespace antlr4 {
     /// {@code false} to report all ambiguities. </param>
     DiagnosticErrorListener(bool exactOnly);
 
-    virtual void reportAmbiguity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex, bool exact,
+    void reportAmbiguity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex, bool exact,
       const antlrcpp::BitSet &ambigAlts, atn::ATNConfigSet *configs) override;
 
-    virtual void reportAttemptingFullContext(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
+    void reportAttemptingFullContext(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
       const antlrcpp::BitSet &conflictingAlts, atn::ATNConfigSet *configs) override;
 
-    virtual void reportContextSensitivity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
+    void reportContextSensitivity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
       size_t prediction, atn::ATNConfigSet *configs) override;
 
   protected:

--- a/runtime/Cpp/runtime/src/Exceptions.h
+++ b/runtime/Cpp/runtime/src/Exceptions.h
@@ -16,14 +16,14 @@ namespace antlr4 {
   public:
     RuntimeException(const std::string &msg = "");
 
-    virtual const char* what() const noexcept override;
+    const char* what() const noexcept override;
   };
 
   class ANTLR4CPP_PUBLIC IllegalStateException : public RuntimeException {
   public:
     IllegalStateException(const std::string &msg = "") : RuntimeException(msg) {}
     IllegalStateException(IllegalStateException const&) = default;
-    ~IllegalStateException();
+    ~IllegalStateException() override;
     IllegalStateException& operator=(IllegalStateException const&) = default;
   };
 
@@ -31,7 +31,7 @@ namespace antlr4 {
   public:
     IllegalArgumentException(IllegalArgumentException const&) = default;
     IllegalArgumentException(const std::string &msg = "") : RuntimeException(msg) {}
-    ~IllegalArgumentException();
+    ~IllegalArgumentException() override;
     IllegalArgumentException& operator=(IllegalArgumentException const&) = default;
   };
 
@@ -39,7 +39,7 @@ namespace antlr4 {
   public:
     NullPointerException(const std::string &msg = "") : RuntimeException(msg) {}
     NullPointerException(NullPointerException const&) = default;
-    ~NullPointerException();
+    ~NullPointerException() override;
     NullPointerException& operator=(NullPointerException const&) = default;
   };
 
@@ -47,7 +47,7 @@ namespace antlr4 {
   public:
     IndexOutOfBoundsException(const std::string &msg = "") : RuntimeException(msg) {}
     IndexOutOfBoundsException(IndexOutOfBoundsException const&) = default;
-    ~IndexOutOfBoundsException();
+    ~IndexOutOfBoundsException() override;
     IndexOutOfBoundsException& operator=(IndexOutOfBoundsException const&) = default;
   };
 
@@ -55,7 +55,7 @@ namespace antlr4 {
   public:
     UnsupportedOperationException(const std::string &msg = "") : RuntimeException(msg) {}
     UnsupportedOperationException(UnsupportedOperationException const&) = default;
-    ~UnsupportedOperationException();
+    ~UnsupportedOperationException() override;
     UnsupportedOperationException& operator=(UnsupportedOperationException const&) = default;
 
   };
@@ -64,7 +64,7 @@ namespace antlr4 {
   public:
     EmptyStackException(const std::string &msg = "") : RuntimeException(msg) {}
     EmptyStackException(EmptyStackException const&) = default;
-    ~EmptyStackException();
+    ~EmptyStackException() override;
     EmptyStackException& operator=(EmptyStackException const&) = default;
   };
 
@@ -77,14 +77,14 @@ namespace antlr4 {
   public:
     IOException(const std::string &msg = "");
 
-    virtual const char* what() const noexcept override;
+    const char* what() const noexcept override;
   };
 
   class ANTLR4CPP_PUBLIC CancellationException : public IllegalStateException {
   public:
     CancellationException(const std::string &msg = "") : IllegalStateException(msg) {}
     CancellationException(CancellationException const&) = default;
-    ~CancellationException();
+    ~CancellationException() override;
     CancellationException& operator=(CancellationException const&) = default;
   };
 
@@ -92,7 +92,7 @@ namespace antlr4 {
   public:
     ParseCancellationException(const std::string &msg = "") : CancellationException(msg) {}
     ParseCancellationException(ParseCancellationException const&) = default;
-    ~ParseCancellationException();
+    ~ParseCancellationException() override;
     ParseCancellationException& operator=(ParseCancellationException const&) = default;
   };
 

--- a/runtime/Cpp/runtime/src/InputMismatchException.h
+++ b/runtime/Cpp/runtime/src/InputMismatchException.h
@@ -17,7 +17,7 @@ namespace antlr4 {
   public:
     InputMismatchException(Parser *recognizer);
     InputMismatchException(InputMismatchException const&) = default;
-    ~InputMismatchException();
+    ~InputMismatchException() override;
     InputMismatchException& operator=(InputMismatchException const&) = default;
   };
 

--- a/runtime/Cpp/runtime/src/InterpreterRuleContext.h
+++ b/runtime/Cpp/runtime/src/InterpreterRuleContext.h
@@ -35,7 +35,7 @@ namespace antlr4 {
      */
     InterpreterRuleContext(ParserRuleContext *parent, size_t invokingStateNumber, size_t ruleIndex);
 
-    virtual size_t getRuleIndex() const override;
+    size_t getRuleIndex() const override;
 
   protected:
     /** This is the backing field for {@link #getRuleIndex}. */

--- a/runtime/Cpp/runtime/src/Lexer.h
+++ b/runtime/Cpp/runtime/src/Lexer.h
@@ -77,12 +77,12 @@ namespace antlr4 {
 
     Lexer();
     Lexer(CharStream *input);
-    virtual ~Lexer() {}
+    ~Lexer() override {}
 
     virtual void reset();
 
     /// Return a token from this source; i.e., match a token on the char stream.
-    virtual std::unique_ptr<Token> nextToken() override;
+    std::unique_ptr<Token> nextToken() override;
 
     /// Instruct the lexer to skip creating a token for current lexer rule
     /// and look for another token.  nextToken() knows to keep looking when
@@ -100,14 +100,14 @@ namespace antlr4 {
       this->_factory = factory;
     }
 
-    virtual TokenFactory<CommonToken>* getTokenFactory() override;
+    TokenFactory<CommonToken>* getTokenFactory() override;
 
     /// Set the char stream and reset the lexer
-    virtual void setInputStream(IntStream *input) override;
+    void setInputStream(IntStream *input) override;
 
-    virtual std::string getSourceName() override;
+    std::string getSourceName() override;
 
-    virtual CharStream* getInputStream() override;
+    CharStream* getInputStream() override;
 
     /// By default does not support multiple emits per nextToken invocation
     /// for efficiency reasons. Subclasses can override this method, nextToken,
@@ -124,9 +124,9 @@ namespace antlr4 {
 
     virtual Token* emitEOF();
 
-    virtual size_t getLine() const override;
+    size_t getLine() const override;
 
-    virtual size_t getCharPositionInLine() override;
+    size_t getCharPositionInLine() override;
 
     virtual void setLine(size_t line);
 

--- a/runtime/Cpp/runtime/src/LexerInterpreter.h
+++ b/runtime/Cpp/runtime/src/LexerInterpreter.h
@@ -18,15 +18,15 @@ namespace antlr4 {
                      const std::vector<std::string> &ruleNames, const std::vector<std::string> &channelNames,
                      const std::vector<std::string> &modeNames, const atn::ATN &atn, CharStream *input);
 
-    ~LexerInterpreter();
+    ~LexerInterpreter() override;
 
-    virtual const atn::ATN& getATN() const override;
-    virtual std::string getGrammarFileName() const override;
-    virtual const std::vector<std::string>& getRuleNames() const override;
-    virtual const std::vector<std::string>& getChannelNames() const override;
-    virtual const std::vector<std::string>& getModeNames() const override;
+    const atn::ATN& getATN() const override;
+    std::string getGrammarFileName() const override;
+    const std::vector<std::string>& getRuleNames() const override;
+    const std::vector<std::string>& getChannelNames() const override;
+    const std::vector<std::string>& getModeNames() const override;
 
-    virtual const dfa::Vocabulary& getVocabulary() const override;
+    const dfa::Vocabulary& getVocabulary() const override;
 
   protected:
     const std::string _grammarFileName;

--- a/runtime/Cpp/runtime/src/ListTokenSource.h
+++ b/runtime/Cpp/runtime/src/ListTokenSource.h
@@ -68,18 +68,18 @@ namespace antlr4 {
     /// <exception cref="NullPointerException"> if {@code tokens} is {@code null} </exception>
     ListTokenSource(std::vector<std::unique_ptr<Token>> tokens_, const std::string &sourceName_);
 
-    virtual size_t getCharPositionInLine() override;
-    virtual std::unique_ptr<Token> nextToken() override;
-    virtual size_t getLine() const override;
-    virtual CharStream* getInputStream() override;
-    virtual std::string getSourceName() override;
+    size_t getCharPositionInLine() override;
+    std::unique_ptr<Token> nextToken() override;
+    size_t getLine() const override;
+    CharStream* getInputStream() override;
+    std::string getSourceName() override;
 
     template<typename T1>
     void setTokenFactory(TokenFactory<T1> *factory) {
       this->_factory = factory;
     }
 
-    virtual TokenFactory<CommonToken>* getTokenFactory() override;
+    TokenFactory<CommonToken>* getTokenFactory() override;
 
   private:
     void InitializeInstanceFields();

--- a/runtime/Cpp/runtime/src/NoViableAltException.h
+++ b/runtime/Cpp/runtime/src/NoViableAltException.h
@@ -20,7 +20,7 @@ namespace antlr4 {
     NoViableAltException(Parser *recognizer); // LL(1) error
     NoViableAltException(Parser *recognizer, TokenStream *input,Token *startToken,
       Token *offendingToken, atn::ATNConfigSet *deadEndConfigs, ParserRuleContext *ctx, bool deleteConfigs);
-    ~NoViableAltException();
+    ~NoViableAltException() override;
     
     virtual Token* getStartToken() const;
     virtual atn::ATNConfigSet* getDeadEndConfigs() const;

--- a/runtime/Cpp/runtime/src/Parser.h
+++ b/runtime/Cpp/runtime/src/Parser.h
@@ -21,12 +21,12 @@ namespace antlr4 {
     class TraceListener : public tree::ParseTreeListener {
     public:
       TraceListener(Parser *outerInstance);
-      virtual ~TraceListener();
+      ~TraceListener() override;
 
-      virtual void enterEveryRule(ParserRuleContext *ctx) override;
-      virtual void visitTerminal(tree::TerminalNode *node) override;
-      virtual void visitErrorNode(tree::ErrorNode *node) override;
-      virtual void exitEveryRule(ParserRuleContext *ctx) override;
+      void enterEveryRule(ParserRuleContext *ctx) override;
+      void visitTerminal(tree::TerminalNode *node) override;
+      void visitErrorNode(tree::ErrorNode *node) override;
+      void exitEveryRule(ParserRuleContext *ctx) override;
 
     private:
       Parser *const outerInstance;
@@ -36,16 +36,16 @@ namespace antlr4 {
     public:
       static TrimToSizeListener INSTANCE;
 
-      virtual ~TrimToSizeListener();
+      ~TrimToSizeListener() override;
 
-      virtual void enterEveryRule(ParserRuleContext *ctx) override;
-      virtual void visitTerminal(tree::TerminalNode *node) override;
-      virtual void visitErrorNode(tree::ErrorNode *node) override;
-      virtual void exitEveryRule(ParserRuleContext *ctx) override;
+      void enterEveryRule(ParserRuleContext *ctx) override;
+      void visitTerminal(tree::TerminalNode *node) override;
+      void visitErrorNode(tree::ErrorNode *node) override;
+      void exitEveryRule(ParserRuleContext *ctx) override;
     };
 
     Parser(TokenStream *input);
-    virtual ~Parser();
+    ~Parser() override;
 
     /// reset the parser's state
     virtual void reset();
@@ -193,7 +193,7 @@ namespace antlr4 {
     /// <seealso cref= #notifyErrorListeners </seealso>
     virtual size_t getNumberOfSyntaxErrors();
 
-    virtual TokenFactory<CommonToken>* getTokenFactory() override;
+    TokenFactory<CommonToken>* getTokenFactory() override;
 
     /// <summary>
     /// Tell our token source and error strategy about a new way to create tokens. </summary>
@@ -229,7 +229,7 @@ namespace antlr4 {
     virtual Ref<ANTLRErrorStrategy> getErrorHandler();
     virtual void setErrorHandler(Ref<ANTLRErrorStrategy> const& handler);
 
-    virtual IntStream* getInputStream() override;
+    IntStream* getInputStream() override;
     void setInputStream(IntStream *input) override;
 
     virtual TokenStream* getTokenStream();
@@ -297,7 +297,7 @@ namespace antlr4 {
     virtual ParserRuleContext* getInvokingContext(size_t ruleIndex);
     virtual ParserRuleContext* getContext();
     virtual void setContext(ParserRuleContext *ctx);
-    virtual bool precpred(RuleContext *localctx, int precedence) override;
+    bool precpred(RuleContext *localctx, int precedence) override;
     virtual bool inContext(const std::string &context);
 
     /// <summary>

--- a/runtime/Cpp/runtime/src/ParserInterpreter.h
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.h
@@ -32,21 +32,21 @@ namespace antlr4 {
   public:
     ParserInterpreter(const std::string &grammarFileName, const dfa::Vocabulary &vocabulary,
                       const std::vector<std::string> &ruleNames, const atn::ATN &atn, TokenStream *input);
-    ~ParserInterpreter();
+    ~ParserInterpreter() override;
 
-    virtual void reset() override;
+    void reset() override;
 
-    virtual const atn::ATN& getATN() const override;
+    const atn::ATN& getATN() const override;
 
-    virtual const dfa::Vocabulary& getVocabulary() const override;
+    const dfa::Vocabulary& getVocabulary() const override;
 
-    virtual const std::vector<std::string>& getRuleNames() const override;
-    virtual std::string getGrammarFileName() const override;
+    const std::vector<std::string>& getRuleNames() const override;
+    std::string getGrammarFileName() const override;
 
     /// Begin parsing at startRuleIndex
     virtual ParserRuleContext* parse(size_t startRuleIndex);
 
-    virtual void enterRecursionRule(ParserRuleContext *localctx, size_t state, size_t ruleIndex, int precedence) override;
+    void enterRecursionRule(ParserRuleContext *localctx, size_t state, size_t ruleIndex, int precedence) override;
 
 
     /** Override this parser interpreters normal decision-making process

--- a/runtime/Cpp/runtime/src/ParserRuleContext.h
+++ b/runtime/Cpp/runtime/src/ParserRuleContext.h
@@ -123,7 +123,7 @@ namespace antlr4 {
       return contexts;
     }
 
-    virtual misc::Interval getSourceInterval() override;
+    misc::Interval getSourceInterval() override;
 
     /**
      * Get the initial token in this context.

--- a/runtime/Cpp/runtime/src/ProxyErrorListener.h
+++ b/runtime/Cpp/runtime/src/ProxyErrorListener.h
@@ -25,13 +25,13 @@ namespace antlr4 {
     void syntaxError(Recognizer *recognizer, Token *offendingSymbol, size_t line, size_t charPositionInLine,
                      const std::string &msg, std::exception_ptr e) override;
 
-    virtual void reportAmbiguity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex, bool exact,
+    void reportAmbiguity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex, bool exact,
                                  const antlrcpp::BitSet &ambigAlts, atn::ATNConfigSet *configs) override;
 
-    virtual void reportAttemptingFullContext(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
+    void reportAttemptingFullContext(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
       const antlrcpp::BitSet &conflictingAlts, atn::ATNConfigSet *configs) override;
 
-    virtual void reportContextSensitivity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
+    void reportContextSensitivity(Parser *recognizer, const dfa::DFA &dfa, size_t startIndex, size_t stopIndex,
                                           size_t prediction, atn::ATNConfigSet *configs) override;
   };
 

--- a/runtime/Cpp/runtime/src/RecognitionException.h
+++ b/runtime/Cpp/runtime/src/RecognitionException.h
@@ -34,7 +34,7 @@ namespace antlr4 {
     RecognitionException(const std::string &message, Recognizer *recognizer, IntStream *input,
                          ParserRuleContext *ctx, Token *offendingToken = nullptr);
     RecognitionException(RecognitionException const&) = default;
-    ~RecognitionException();
+    ~RecognitionException() override;
     RecognitionException& operator=(RecognitionException const&) = default;
 
     /// Get the ATN state number the parser was in at the time the error

--- a/runtime/Cpp/runtime/src/RuleContext.h
+++ b/runtime/Cpp/runtime/src/RuleContext.h
@@ -80,9 +80,9 @@ namespace antlr4 {
 
     // satisfy the ParseTree / SyntaxTree interface
 
-    virtual misc::Interval getSourceInterval() override;
+    misc::Interval getSourceInterval() override;
 
-    virtual std::string getText() override;
+    std::string getText() override;
 
     virtual size_t getRuleIndex() const;
 
@@ -107,14 +107,14 @@ namespace antlr4 {
      */
     virtual void setAltNumber(size_t altNumber);
 
-    virtual std::any accept(tree::ParseTreeVisitor *visitor) override;
+    std::any accept(tree::ParseTreeVisitor *visitor) override;
 
     /// <summary>
     /// Print out a whole tree, not just a node, in LISP format
     ///  (root child1 .. childN). Print just a node if this is a leaf.
     ///  We have to know the recognizer so we can get rule names.
     /// </summary>
-    virtual std::string toStringTree(Parser *recog, bool pretty = false) override;
+    std::string toStringTree(Parser *recog, bool pretty = false) override;
 
     /// <summary>
     /// Print out a whole tree, not just a node, in LISP format
@@ -122,8 +122,8 @@ namespace antlr4 {
     /// </summary>
     virtual std::string toStringTree(std::vector<std::string> &ruleNames, bool pretty = false);
 
-    virtual std::string toStringTree(bool pretty = false) override;
-    virtual std::string toString() override;
+    std::string toStringTree(bool pretty = false) override;
+    std::string toString() override;
     std::string toString(Recognizer *recog);
     std::string toString(const std::vector<std::string> &ruleNames);
 

--- a/runtime/Cpp/runtime/src/RuleContextWithAltNum.h
+++ b/runtime/Cpp/runtime/src/RuleContextWithAltNum.h
@@ -25,8 +25,8 @@ namespace antlr4 {
     RuleContextWithAltNum();
     RuleContextWithAltNum(ParserRuleContext *parent, int invokingStateNumber);
 
-    virtual size_t getAltNumber() const override;
-    virtual void setAltNumber(size_t altNum) override;
+    size_t getAltNumber() const override;
+    void setAltNumber(size_t altNum) override;
   };
 
 } // namespace antlr4

--- a/runtime/Cpp/runtime/src/TokenStream.h
+++ b/runtime/Cpp/runtime/src/TokenStream.h
@@ -22,7 +22,7 @@ namespace antlr4 {
     /// </summary>
     /// <seealso cref= IntStream#LA </seealso>
   public:
-    virtual ~TokenStream();
+    ~TokenStream() override;
 
     virtual Token* LT(ssize_t k) = 0;
 

--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.h
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.h
@@ -186,7 +186,7 @@ namespace antlr4 {
     public:
       InsertBeforeOp(TokenStreamRewriter *outerInstance, size_t index, const std::string& text);
 
-      virtual size_t execute(std::string *buf) override;
+      size_t execute(std::string *buf) override;
     };
 
     class ReplaceOp : public RewriteOperation {
@@ -197,8 +197,8 @@ namespace antlr4 {
       size_t lastIndex;
 
       ReplaceOp(TokenStreamRewriter *outerInstance, size_t from, size_t to, const std::string& text);
-      virtual size_t execute(std::string *buf) override;
-      virtual std::string toString() override;
+      size_t execute(std::string *buf) override;
+      std::string toString() override;
 
     private:
       void InitializeInstanceFields();

--- a/runtime/Cpp/runtime/src/UnbufferedTokenStream.h
+++ b/runtime/Cpp/runtime/src/UnbufferedTokenStream.h
@@ -14,22 +14,22 @@ namespace antlr4 {
     UnbufferedTokenStream(TokenSource *tokenSource);
     UnbufferedTokenStream(TokenSource *tokenSource, int bufferSize);
     UnbufferedTokenStream(const UnbufferedTokenStream& other) = delete;
-    virtual ~UnbufferedTokenStream();
+    ~UnbufferedTokenStream() override;
 
     UnbufferedTokenStream& operator = (const UnbufferedTokenStream& other) = delete;
 
-    virtual Token* get(size_t i) const override;
-    virtual Token* LT(ssize_t i) override;
-    virtual size_t LA(ssize_t i) override;
+    Token* get(size_t i) const override;
+    Token* LT(ssize_t i) override;
+    size_t LA(ssize_t i) override;
 
-    virtual TokenSource* getTokenSource() const override;
+    TokenSource* getTokenSource() const override;
 
-    virtual std::string getText(const misc::Interval &interval) override;
-    virtual std::string getText() override;
-    virtual std::string getText(RuleContext *ctx) override;
-    virtual std::string getText(Token *start, Token *stop) override;
+    std::string getText(const misc::Interval &interval) override;
+    std::string getText() override;
+    std::string getText(RuleContext *ctx) override;
+    std::string getText(Token *start, Token *stop) override;
 
-    virtual void consume() override;
+    void consume() override;
 
     /// <summary>
     /// Return a marker that we can release later.
@@ -38,12 +38,12 @@ namespace antlr4 {
     /// protection against misuse where {@code seek()} is called on a mark or
     /// {@code release()} is called in the wrong order.
     /// </summary>
-    virtual ssize_t mark() override;
-    virtual void release(ssize_t marker) override;
-    virtual size_t index() override;
-    virtual void seek(size_t index) override;
-    virtual size_t size() override;
-    virtual std::string getSourceName() const override;
+    ssize_t mark() override;
+    void release(ssize_t marker) override;
+    size_t index() override;
+    void seek(size_t index) override;
+    size_t size() override;
+    std::string getSourceName() const override;
 
   protected:
     /// Make sure we have 'need' elements from current position p. Last valid

--- a/runtime/Cpp/runtime/src/WritableToken.h
+++ b/runtime/Cpp/runtime/src/WritableToken.h
@@ -11,7 +11,7 @@ namespace antlr4 {
 
   class ANTLR4CPP_PUBLIC WritableToken : public Token {
   public:
-    virtual ~WritableToken();
+    ~WritableToken() override;
     virtual void setText(const std::string &text) = 0;
     virtual void setType(size_t ttype) = 0;
     virtual void setLine(size_t line) = 0;

--- a/runtime/Cpp/runtime/src/atn/ActionTransition.h
+++ b/runtime/Cpp/runtime/src/atn/ActionTransition.h
@@ -24,11 +24,11 @@ namespace atn {
 
     ActionTransition(ATNState *target, size_t ruleIndex, size_t actionIndex, bool isCtxDependent);
 
-    virtual bool isEpsilon() const override;
+    bool isEpsilon() const override;
 
-    virtual bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
+    bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
 
-    virtual std::string toString() const override;
+    std::string toString() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/AtomTransition.h
+++ b/runtime/Cpp/runtime/src/atn/AtomTransition.h
@@ -23,10 +23,10 @@ namespace atn {
 
     AtomTransition(ATNState *target, size_t label);
 
-    virtual misc::IntervalSet label() const override;
-    virtual bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
+    misc::IntervalSet label() const override;
+    bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
 
-    virtual std::string toString() const override;
+    std::string toString() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/DecisionState.h
+++ b/runtime/Cpp/runtime/src/atn/DecisionState.h
@@ -24,7 +24,7 @@ namespace atn {
     int decision = -1;
     bool nonGreedy = false;
 
-    virtual std::string toString() const override;
+    std::string toString() const override;
 
   protected:
     using ATNState::ATNState;

--- a/runtime/Cpp/runtime/src/atn/EpsilonTransition.h
+++ b/runtime/Cpp/runtime/src/atn/EpsilonTransition.h
@@ -29,10 +29,10 @@ namespace atn {
      */
     size_t outermostPrecedenceReturn() const;
 
-    virtual bool isEpsilon() const override;
-    virtual bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
+    bool isEpsilon() const override;
+    bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
 
-    virtual std::string toString() const override;
+    std::string toString() const override;
 
   private:
     const size_t _outermostPrecedenceReturn; // A rule index.

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
@@ -26,7 +26,7 @@ namespace atn {
     const Ref<const LexerActionExecutor>& getLexerActionExecutor() const { return _lexerActionExecutor; }
     bool hasPassedThroughNonGreedyDecision() const { return _passedThroughNonGreedyDecision; }
 
-    virtual size_t hashCode() const override;
+    size_t hashCode() const override;
 
     bool operator==(const LexerATNConfig& other) const;
 

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
@@ -73,13 +73,13 @@ namespace atn {
   public:
     LexerATNSimulator(const ATN &atn, std::vector<dfa::DFA> &decisionToDFA, PredictionContextCache &sharedContextCache);
     LexerATNSimulator(Lexer *recog, const ATN &atn, std::vector<dfa::DFA> &decisionToDFA, PredictionContextCache &sharedContextCache);
-    virtual ~LexerATNSimulator() = default;
+    ~LexerATNSimulator() override = default;
 
     virtual void copyState(LexerATNSimulator *simulator);
     virtual size_t match(CharStream *input, size_t mode);
-    virtual void reset() override;
+    void reset() override;
 
-    virtual void clearDFA() override;
+    void clearDFA() override;
 
   protected:
     virtual size_t matchATN(CharStream *input);

--- a/runtime/Cpp/runtime/src/atn/NotSetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/NotSetTransition.h
@@ -18,9 +18,9 @@ namespace atn {
 
     NotSetTransition(ATNState *target, misc::IntervalSet set);
 
-    virtual bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
+    bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
 
-    virtual std::string toString() const override;
+    std::string toString() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
@@ -257,8 +257,8 @@ namespace atn {
                        PredictionContextCache &sharedContextCache,
                        const ParserATNSimulatorOptions &options);
 
-    virtual void reset() override;
-    virtual void clearDFA() override;
+    void reset() override;
+    void clearDFA() override;
     virtual size_t adaptivePredict(TokenStream *input, size_t decision, ParserRuleContext *outerContext);
 
     static const bool TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT;

--- a/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.h
@@ -15,7 +15,7 @@ namespace atn {
   public:
     explicit ProfilingATNSimulator(Parser *parser);
 
-    virtual size_t adaptivePredict(TokenStream *input, size_t decision, ParserRuleContext *outerContext) override;
+    size_t adaptivePredict(TokenStream *input, size_t decision, ParserRuleContext *outerContext) override;
 
     virtual std::vector<DecisionInfo> getDecisionInfo() const;
     virtual dfa::DFAState* getCurrentState() const;
@@ -43,16 +43,16 @@ namespace atn {
     /// </summary>
     size_t conflictingAltResolvedBySLL = 0;
 
-    virtual dfa::DFAState* getExistingTargetState(dfa::DFAState *previousD, size_t t) override;
-    virtual dfa::DFAState* computeTargetState(dfa::DFA &dfa, dfa::DFAState *previousD, size_t t) override;
-    virtual std::unique_ptr<ATNConfigSet> computeReachSet(ATNConfigSet *closure, size_t t, bool fullCtx) override;
-    virtual bool evalSemanticContext(Ref<const SemanticContext> const& pred, ParserRuleContext *parserCallStack,
+    dfa::DFAState* getExistingTargetState(dfa::DFAState *previousD, size_t t) override;
+    dfa::DFAState* computeTargetState(dfa::DFA &dfa, dfa::DFAState *previousD, size_t t) override;
+    std::unique_ptr<ATNConfigSet> computeReachSet(ATNConfigSet *closure, size_t t, bool fullCtx) override;
+    bool evalSemanticContext(Ref<const SemanticContext> const& pred, ParserRuleContext *parserCallStack,
                                      size_t alt, bool fullCtx) override;
-    virtual void reportAttemptingFullContext(dfa::DFA &dfa, const antlrcpp::BitSet &conflictingAlts, ATNConfigSet *configs,
+    void reportAttemptingFullContext(dfa::DFA &dfa, const antlrcpp::BitSet &conflictingAlts, ATNConfigSet *configs,
                                              size_t startIndex, size_t stopIndex) override;
-    virtual void reportContextSensitivity(dfa::DFA &dfa, size_t prediction, ATNConfigSet *configs,
+    void reportContextSensitivity(dfa::DFA &dfa, size_t prediction, ATNConfigSet *configs,
                                           size_t startIndex, size_t stopIndex) override;
-    virtual void reportAmbiguity(dfa::DFA &dfa, dfa::DFAState *D, size_t startIndex, size_t stopIndex, bool exact,
+    void reportAmbiguity(dfa::DFA &dfa, dfa::DFAState *D, size_t startIndex, size_t stopIndex, bool exact,
                                  const antlrcpp::BitSet &ambigAlts, ATNConfigSet *configs) override;
   };
 

--- a/runtime/Cpp/runtime/src/atn/RangeTransition.h
+++ b/runtime/Cpp/runtime/src/atn/RangeTransition.h
@@ -21,10 +21,10 @@ namespace atn {
 
     RangeTransition(ATNState *target, size_t from, size_t to);
 
-    virtual misc::IntervalSet label() const override;
-    virtual bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
+    misc::IntervalSet label() const override;
+    bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
 
-    virtual std::string toString() const override;
+    std::string toString() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/RuleTransition.h
+++ b/runtime/Cpp/runtime/src/atn/RuleTransition.h
@@ -32,10 +32,10 @@ namespace atn {
     RuleTransition(RuleTransition const&) = delete;
     RuleTransition& operator=(RuleTransition const&) = delete;
 
-    virtual bool isEpsilon() const override;
-    virtual bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
+    bool isEpsilon() const override;
+    bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
 
-    virtual std::string toString() const override;
+    std::string toString() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/SetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/SetTransition.h
@@ -25,10 +25,10 @@ namespace atn {
 
     SetTransition(ATNState *target, misc::IntervalSet set) : SetTransition(TransitionType::SET, target, std::move(set)) {}
 
-    virtual misc::IntervalSet label() const override;
-    virtual bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
+    misc::IntervalSet label() const override;
+    bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
 
-    virtual std::string toString() const override;
+    std::string toString() const override;
 
   protected:
     SetTransition(TransitionType transitionType, ATNState *target, misc::IntervalSet set);

--- a/runtime/Cpp/runtime/src/atn/WildcardTransition.h
+++ b/runtime/Cpp/runtime/src/atn/WildcardTransition.h
@@ -18,9 +18,9 @@ namespace atn {
 
     explicit WildcardTransition(ATNState *target);
 
-    virtual bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
+    bool matches(size_t symbol, size_t minVocabSymbol, size_t maxVocabSymbol) const override;
 
-    virtual std::string toString() const override;
+    std::string toString() const override;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/tree/AbstractParseTreeVisitor.h
+++ b/runtime/Cpp/runtime/src/tree/AbstractParseTreeVisitor.h
@@ -15,7 +15,7 @@ namespace tree {
   public:
     /// The default implementation calls <seealso cref="ParseTree#accept"/> on the
     /// specified tree.
-    virtual std::any visit(ParseTree *tree) override {
+    std::any visit(ParseTree *tree) override {
       return tree->accept(this);
     }
 
@@ -32,7 +32,7 @@ namespace tree {
      * the tree structure. Visitors that modify the tree should override this
      * method to behave properly in respect to the specific algorithm in use.</p>
      */
-    virtual std::any visitChildren(ParseTree *node) override {
+    std::any visitChildren(ParseTree *node) override {
       std::any result = defaultResult();
       size_t n = node->children.size();
       for (size_t i = 0; i < n; i++) {
@@ -49,13 +49,13 @@ namespace tree {
 
     /// The default implementation returns the result of
     /// <seealso cref="#defaultResult defaultResult"/>.
-    virtual std::any visitTerminal(TerminalNode * /*node*/) override {
+    std::any visitTerminal(TerminalNode * /*node*/) override {
       return defaultResult();
     }
 
     /// The default implementation returns the result of
     /// <seealso cref="#defaultResult defaultResult"/>.
-    virtual std::any visitErrorNode(ErrorNode * /*node*/) override {
+    std::any visitErrorNode(ErrorNode * /*node*/) override {
       return defaultResult();
     }
 

--- a/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.h
+++ b/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.h
@@ -27,16 +27,16 @@ namespace tree {
 
     explicit ErrorNodeImpl(Token *symbol) : ErrorNode(ParseTreeType::ERROR), symbol(symbol) {}
 
-    virtual Token* getSymbol() const override;
-    virtual void setParent(RuleContext *parent) override;
-    virtual misc::Interval getSourceInterval() override;
+    Token* getSymbol() const override;
+    void setParent(RuleContext *parent) override;
+    misc::Interval getSourceInterval() override;
 
-    virtual std::any accept(ParseTreeVisitor *visitor) override;
+    std::any accept(ParseTreeVisitor *visitor) override;
 
-    virtual std::string getText() override;
-    virtual std::string toStringTree(Parser *parser, bool pretty = false) override;
-    virtual std::string toString() override;
-    virtual std::string toStringTree(bool pretty = false) override;
+    std::string getText() override;
+    std::string toStringTree(Parser *parser, bool pretty = false) override;
+    std::string toString() override;
+    std::string toStringTree(bool pretty = false) override;
   };
 
 } // namespace tree

--- a/runtime/Cpp/runtime/src/tree/IterativeParseTreeWalker.h
+++ b/runtime/Cpp/runtime/src/tree/IterativeParseTreeWalker.h
@@ -46,7 +46,7 @@ namespace tree {
    */
   class ANTLR4CPP_PUBLIC IterativeParseTreeWalker : public ParseTreeWalker {
   public:
-    virtual void walk(ParseTreeListener *listener, ParseTree *t) const override;
+    void walk(ParseTreeListener *listener, ParseTree *t) const override;
   };
 
 } // namespace tree

--- a/runtime/Cpp/runtime/src/tree/TerminalNodeImpl.h
+++ b/runtime/Cpp/runtime/src/tree/TerminalNodeImpl.h
@@ -16,16 +16,16 @@ namespace tree {
 
     explicit TerminalNodeImpl(Token *symbol) : TerminalNode(ParseTreeType::TERMINAL), symbol(symbol) {}
 
-    virtual Token* getSymbol() const override;
-    virtual void setParent(RuleContext *parent) override;
-    virtual misc::Interval getSourceInterval() override;
+    Token* getSymbol() const override;
+    void setParent(RuleContext *parent) override;
+    misc::Interval getSourceInterval() override;
 
-    virtual std::any accept(ParseTreeVisitor *visitor) override;
+    std::any accept(ParseTreeVisitor *visitor) override;
 
-    virtual std::string getText() override;
-    virtual std::string toStringTree(Parser *parser, bool pretty = false) override;
-    virtual std::string toString() override;
-    virtual std::string toStringTree(bool pretty = false) override;
+    std::string getText() override;
+    std::string toStringTree(Parser *parser, bool pretty = false) override;
+    std::string toString() override;
+    std::string toStringTree(bool pretty = false) override;
   };
 
 } // namespace tree

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.h
@@ -73,7 +73,7 @@ namespace pattern {
     class CannotInvokeStartRule : public RuntimeException {
     public:
       CannotInvokeStartRule(const RuntimeException &e);
-      ~CannotInvokeStartRule();
+      ~CannotInvokeStartRule() override;
     };
 
     // Fixes https://github.com/antlr/antlr4/issues/413
@@ -82,7 +82,7 @@ namespace pattern {
     public:
       StartRuleDoesNotConsumeFullPattern() = default;
       StartRuleDoesNotConsumeFullPattern(StartRuleDoesNotConsumeFullPattern const&) = default;
-      ~StartRuleDoesNotConsumeFullPattern();
+      ~StartRuleDoesNotConsumeFullPattern() override;
 
       StartRuleDoesNotConsumeFullPattern& operator=(StartRuleDoesNotConsumeFullPattern const&) = default;
     };

--- a/runtime/Cpp/runtime/src/tree/pattern/RuleTagToken.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/RuleTagToken.h
@@ -73,7 +73,7 @@ namespace pattern {
     /// <p/>
     /// Rule tag tokens are always placed on the <seealso cref="#DEFAULT_CHANNE"/>.
     /// </summary>
-    virtual size_t getChannel() const override;
+    size_t getChannel() const override;
 
     /// <summary>
     /// {@inheritDoc}
@@ -81,35 +81,35 @@ namespace pattern {
     /// This method returns the rule tag formatted with {@code <} and {@code >}
     /// delimiters.
     /// </summary>
-    virtual std::string getText() const override;
+    std::string getText() const override;
 
     /// Rule tag tokens have types assigned according to the rule bypass
     /// transitions created during ATN deserialization.
-    virtual size_t getType() const override;
+    size_t getType() const override;
 
     /// The implementation for <seealso cref="RuleTagToken"/> always returns 0.
-    virtual size_t getLine() const override;
+    size_t getLine() const override;
 
     /// The implementation for <seealso cref="RuleTagToken"/> always returns INVALID_INDEX.
-    virtual size_t getCharPositionInLine() const override;
+    size_t getCharPositionInLine() const override;
 
     /// The implementation for <seealso cref="RuleTagToken"/> always returns INVALID_INDEX.
-    virtual size_t getTokenIndex() const override;
+    size_t getTokenIndex() const override;
 
     /// The implementation for <seealso cref="RuleTagToken"/> always returns INVALID_INDEX.
-    virtual size_t getStartIndex() const override;
+    size_t getStartIndex() const override;
 
     /// The implementation for <seealso cref="RuleTagToken"/> always returns INVALID_INDEX.
-    virtual size_t getStopIndex() const override;
+    size_t getStopIndex() const override;
 
     /// The implementation for <seealso cref="RuleTagToken"/> always returns {@code null}.
-    virtual TokenSource *getTokenSource() const override;
+    TokenSource *getTokenSource() const override;
 
     /// The implementation for <seealso cref="RuleTagToken"/> always returns {@code null}.
-    virtual CharStream *getInputStream() const override;
+    CharStream *getInputStream() const override;
 
     /// The implementation for <seealso cref="RuleTagToken"/> returns a string of the form {@code ruleName:bypassTokenType}.
-    virtual std::string toString() const override;
+    std::string toString() const override;
   };
 
 } // namespace pattern

--- a/runtime/Cpp/runtime/src/tree/pattern/TagChunk.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/TagChunk.h
@@ -37,7 +37,7 @@ namespace pattern {
     /// <exception cref="IllegalArgumentException"> if {@code tag} is {@code null} or
     /// empty. </exception>
     TagChunk(const std::string &tag);
-    virtual ~TagChunk();
+    ~TagChunk() override;
 
     /// <summary>
     /// Construct a new instance of <seealso cref="TagChunk"/> using the specified label
@@ -70,7 +70,7 @@ namespace pattern {
     /// are returned in the form {@code label:tag}, and unlabeled tags are
     /// returned as just the tag name.
     /// </summary>
-    virtual std::string toString() override;
+    std::string toString() override;
 
   private:
     /// This is the backing field for <seealso cref="#getTag"/>.

--- a/runtime/Cpp/runtime/src/tree/pattern/TextChunk.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/TextChunk.h
@@ -29,7 +29,7 @@ namespace pattern {
     /// <exception cref="IllegalArgumentException"> if {@code text} is {@code null}. </exception>
   public:
     TextChunk(const std::string &text);
-    virtual ~TextChunk();
+    ~TextChunk() override;
 
     /// <summary>
     /// Gets the raw text of this chunk.
@@ -43,7 +43,7 @@ namespace pattern {
     /// The implementation for <seealso cref="TextChunk"/> returns the result of
     /// <seealso cref="#getText()"/> in single quotes.
     /// </summary>
-    virtual std::string toString() override;
+    std::string toString() override;
   };
 
 } // namespace pattern

--- a/runtime/Cpp/runtime/src/tree/pattern/TokenTagToken.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/TokenTagToken.h
@@ -64,7 +64,7 @@ namespace pattern {
     /// The implementation for <seealso cref="TokenTagToken"/> returns the token tag
     /// formatted with {@code <} and {@code >} delimiters.
     /// </summary>
-    virtual std::string getText() const override;
+    std::string getText() const override;
 
     /// <summary>
     /// {@inheritDoc}
@@ -72,7 +72,7 @@ namespace pattern {
     /// The implementation for <seealso cref="TokenTagToken"/> returns a string of the form
     /// {@code tokenName:type}.
     /// </summary>
-    virtual std::string toString() const override;
+    std::string toString() const override;
   };
 
 } // namespace pattern

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexerErrorListener.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexerErrorListener.h
@@ -13,7 +13,7 @@ namespace xpath {
 
   class ANTLR4CPP_PUBLIC XPathLexerErrorListener : public BaseErrorListener {
   public:
-    virtual void syntaxError(Recognizer *recognizer, Token *offendingSymbol, size_t line,
+    void syntaxError(Recognizer *recognizer, Token *offendingSymbol, size_t line,
       size_t charPositionInLine, const std::string &msg, std::exception_ptr e) override;
   };
 

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathRuleAnywhereElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathRuleAnywhereElement.h
@@ -16,7 +16,7 @@ namespace xpath {
   public:
     XPathRuleAnywhereElement(const std::string &ruleName, int ruleIndex);
 
-    virtual std::vector<ParseTree *> evaluate(ParseTree *t) override;
+    std::vector<ParseTree *> evaluate(ParseTree *t) override;
 
   protected:
     int _ruleIndex = 0;

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathRuleElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathRuleElement.h
@@ -15,7 +15,7 @@ namespace xpath {
   public:
     XPathRuleElement(const std::string &ruleName, size_t ruleIndex);
 
-    virtual std::vector<ParseTree *> evaluate(ParseTree *t) override;
+    std::vector<ParseTree *> evaluate(ParseTree *t) override;
 
   protected:
     size_t _ruleIndex = 0;

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathTokenAnywhereElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathTokenAnywhereElement.h
@@ -17,7 +17,7 @@ namespace xpath {
   public:
     XPathTokenAnywhereElement(const std::string &tokenName, int tokenType);
 
-    virtual std::vector<ParseTree *> evaluate(ParseTree *t) override;
+    std::vector<ParseTree *> evaluate(ParseTree *t) override;
   };
 
 } // namespace xpath

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathTokenElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathTokenElement.h
@@ -15,7 +15,7 @@ namespace xpath {
   public:
     XPathTokenElement(const std::string &tokenName, size_t tokenType);
 
-    virtual std::vector<ParseTree *> evaluate(ParseTree *t) override;
+    std::vector<ParseTree *> evaluate(ParseTree *t) override;
 
   protected:
     size_t _tokenType = 0;

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathWildcardAnywhereElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathWildcardAnywhereElement.h
@@ -15,7 +15,7 @@ namespace xpath {
   public:
     XPathWildcardAnywhereElement();
 
-    virtual std::vector<ParseTree *> evaluate(ParseTree *t) override;
+    std::vector<ParseTree *> evaluate(ParseTree *t) override;
   };
 
 } // namespace xpath

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathWildcardElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathWildcardElement.h
@@ -15,7 +15,7 @@ namespace xpath {
   public:
     XPathWildcardElement();
 
-    virtual std::vector<ParseTree *> evaluate(ParseTree *t) override;
+    std::vector<ParseTree *> evaluate(ParseTree *t) override;
   };
 
 } // namespace xpath


### PR DESCRIPTION
... and clean up duplicates where a method is marked `virtual` _and_ `override` (`override` implies `virtual).

Use of `override` informs the developer reading the code and reduces mistakes (e.g. accidentally messing up a signature while overridding).