### PR TITLE
Add include `antlr4-common.h` to files using symbols from it.

### DIFF
--- a/runtime/Cpp/runtime/src/ANTLRErrorListener.h
+++ b/runtime/Cpp/runtime/src/ANTLRErrorListener.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "RecognitionException.h"
 
 namespace antlrcpp {

--- a/runtime/Cpp/runtime/src/ANTLRErrorStrategy.h
+++ b/runtime/Cpp/runtime/src/ANTLRErrorStrategy.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "Token.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/ANTLRFileStream.h
+++ b/runtime/Cpp/runtime/src/ANTLRFileStream.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "ANTLRInputStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/ANTLRInputStream.cpp
+++ b/runtime/Cpp/runtime/src/ANTLRInputStream.cpp
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "Exceptions.h"
+#include "antlr4-common.h"
 #include "misc/Interval.h"
 #include "IntStream.h"
 

--- a/runtime/Cpp/runtime/src/ANTLRInputStream.h
+++ b/runtime/Cpp/runtime/src/ANTLRInputStream.h
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <string_view>
 
+#include "antlr4-common.h"
 #include "CharStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/BailErrorStrategy.h
+++ b/runtime/Cpp/runtime/src/BailErrorStrategy.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "DefaultErrorStrategy.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/BaseErrorListener.h
+++ b/runtime/Cpp/runtime/src/BaseErrorListener.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "ANTLRErrorListener.h"
 
 namespace antlrcpp {

--- a/runtime/Cpp/runtime/src/BufferedTokenStream.cpp
+++ b/runtime/Cpp/runtime/src/BufferedTokenStream.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "WritableToken.h"
+#include "antlr4-common.h"
 #include "Lexer.h"
 #include "RuleContext.h"
 #include "misc/Interval.h"

--- a/runtime/Cpp/runtime/src/BufferedTokenStream.h
+++ b/runtime/Cpp/runtime/src/BufferedTokenStream.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "TokenStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/CharStream.h
+++ b/runtime/Cpp/runtime/src/CharStream.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include "IntStream.h"
+#include "antlr4-common.h"
 #include "misc/Interval.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/CommonToken.cpp
+++ b/runtime/Cpp/runtime/src/CommonToken.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "TokenSource.h"
+#include "antlr4-common.h"
 #include "CharStream.h"
 #include "Recognizer.h"
 #include "Vocabulary.h"

--- a/runtime/Cpp/runtime/src/CommonToken.h
+++ b/runtime/Cpp/runtime/src/CommonToken.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "WritableToken.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/CommonTokenFactory.h
+++ b/runtime/Cpp/runtime/src/CommonTokenFactory.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "TokenFactory.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/CommonTokenStream.cpp
+++ b/runtime/Cpp/runtime/src/CommonTokenStream.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include "Token.h"
 
+#include "antlr4-common.h"
 #include "CommonTokenStream.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/CommonTokenStream.h
+++ b/runtime/Cpp/runtime/src/CommonTokenStream.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include "antlr4-common.h"
 #include "BufferedTokenStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/ConsoleErrorListener.h
+++ b/runtime/Cpp/runtime/src/ConsoleErrorListener.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "BaseErrorListener.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "NoViableAltException.h"
+#include "antlr4-common.h"
 #include "misc/IntervalSet.h"
 #include "atn/ParserATNSimulator.h"
 #include "InputMismatchException.h"

--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.h
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstddef>
 #include "ANTLRErrorStrategy.h"
+#include "antlr4-common.h"
 #include "misc/IntervalSet.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/DiagnosticErrorListener.cpp
+++ b/runtime/Cpp/runtime/src/DiagnosticErrorListener.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/PredictionContext.h"
+#include "antlr4-common.h"
 #include "atn/ATNConfig.h"
 #include "atn/ATNConfigSet.h"
 #include "Parser.h"

--- a/runtime/Cpp/runtime/src/DiagnosticErrorListener.h
+++ b/runtime/Cpp/runtime/src/DiagnosticErrorListener.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "BaseErrorListener.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/FailedPredicateException.h
+++ b/runtime/Cpp/runtime/src/FailedPredicateException.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "RecognitionException.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/InputMismatchException.h
+++ b/runtime/Cpp/runtime/src/InputMismatchException.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "RecognitionException.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/InterpreterRuleContext.h
+++ b/runtime/Cpp/runtime/src/InterpreterRuleContext.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include "antlr4-common.h"
 #include "ParserRuleContext.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/Lexer.cpp
+++ b/runtime/Cpp/runtime/src/Lexer.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/LexerATNSimulator.h"
+#include "antlr4-common.h"
 #include "Exceptions.h"
 #include "misc/Interval.h"
 #include "CommonTokenFactory.h"

--- a/runtime/Cpp/runtime/src/Lexer.h
+++ b/runtime/Cpp/runtime/src/Lexer.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "Recognizer.h"
+#include "antlr4-common.h"
 #include "TokenSource.h"
 #include "CharStream.h"
 #include "Token.h"

--- a/runtime/Cpp/runtime/src/LexerInterpreter.h
+++ b/runtime/Cpp/runtime/src/LexerInterpreter.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include "Lexer.h"
+#include "antlr4-common.h"
 #include "atn/PredictionContext.h"
 #include "atn/PredictionContextCache.h"
 #include "Vocabulary.h"

--- a/runtime/Cpp/runtime/src/LexerNoViableAltException.h
+++ b/runtime/Cpp/runtime/src/LexerNoViableAltException.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "RecognitionException.h"
+#include "antlr4-common.h"
 #include "atn/ATNConfigSet.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/ListTokenSource.cpp
+++ b/runtime/Cpp/runtime/src/ListTokenSource.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstddef>
 #include "Token.h"
+#include "antlr4-common.h"
 #include "CommonToken.h"
 #include "CharStream.h"
 

--- a/runtime/Cpp/runtime/src/ListTokenSource.h
+++ b/runtime/Cpp/runtime/src/ListTokenSource.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstddef>
 #include "TokenSource.h"
+#include "antlr4-common.h"
 #include "CommonTokenFactory.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/NoViableAltException.cpp
+++ b/runtime/Cpp/runtime/src/NoViableAltException.cpp
@@ -5,6 +5,7 @@
 
 #include "Parser.h"
 
+#include "antlr4-common.h"
 #include "NoViableAltException.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/NoViableAltException.h
+++ b/runtime/Cpp/runtime/src/NoViableAltException.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "RecognitionException.h"
+#include "antlr4-common.h"
 #include "Token.h"
 #include "atn/ATNConfigSet.h"
 

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/ATNDeserializationOptions.h"
+#include "antlr4-common.h"
 #include "tree/pattern/ParseTreePatternMatcher.h"
 #include "dfa/DFA.h"
 #include "ParserRuleContext.h"

--- a/runtime/Cpp/runtime/src/Parser.h
+++ b/runtime/Cpp/runtime/src/Parser.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "Recognizer.h"
+#include "antlr4-common.h"
 #include "tree/ParseTreeListener.h"
 #include "tree/ParseTree.h"
 #include "TokenStream.h"

--- a/runtime/Cpp/runtime/src/ParserInterpreter.cpp
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "dfa/DFA.h"
+#include "antlr4-common.h"
 #include "atn/RuleStartState.h"
 #include "InterpreterRuleContext.h"
 #include "atn/ParserATNSimulator.h"

--- a/runtime/Cpp/runtime/src/ParserInterpreter.h
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "Parser.h"
+#include "antlr4-common.h"
 #include "atn/ATN.h"
 #include "support/BitSet.h"
 #include "atn/PredictionContext.h"

--- a/runtime/Cpp/runtime/src/ParserRuleContext.h
+++ b/runtime/Cpp/runtime/src/ParserRuleContext.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "RuleContext.h"
+#include "antlr4-common.h"
 #include "support/CPPUtils.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/ProxyErrorListener.h
+++ b/runtime/Cpp/runtime/src/ProxyErrorListener.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "ANTLRErrorListener.h"
+#include "antlr4-common.h"
 #include "Exceptions.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/RecognitionException.cpp
+++ b/runtime/Cpp/runtime/src/RecognitionException.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include "atn/ATN.h"
+#include "antlr4-common.h"
 #include "Recognizer.h"
 #include "ParserRuleContext.h"
 #include "misc/IntervalSet.h"

--- a/runtime/Cpp/runtime/src/RecognitionException.h
+++ b/runtime/Cpp/runtime/src/RecognitionException.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "Exceptions.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/Recognizer.h
+++ b/runtime/Cpp/runtime/src/Recognizer.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "ProxyErrorListener.h"
+#include "antlr4-common.h"
 #include "support/Casts.h"
 #include "atn/SerializedATNView.h"
 #include "internal/Synchronization.h"

--- a/runtime/Cpp/runtime/src/RuleContext.cpp
+++ b/runtime/Cpp/runtime/src/RuleContext.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "tree/Trees.h"
+#include "antlr4-common.h"
 #include "misc/Interval.h"
 #include "Parser.h"
 #include "atn/ATN.h"

--- a/runtime/Cpp/runtime/src/RuleContext.h
+++ b/runtime/Cpp/runtime/src/RuleContext.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "tree/ParseTree.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/RuleContextWithAltNum.h
+++ b/runtime/Cpp/runtime/src/RuleContextWithAltNum.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include "antlr4-common.h"
 #include "ParserRuleContext.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/Token.h
+++ b/runtime/Cpp/runtime/src/Token.h
@@ -8,6 +8,7 @@
 #include <limits>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "IntStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/TokenSource.h
+++ b/runtime/Cpp/runtime/src/TokenSource.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "TokenFactory.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/TokenStream.h
+++ b/runtime/Cpp/runtime/src/TokenStream.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "IntStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "Exceptions.h"
+#include "antlr4-common.h"
 #include "misc/Interval.h"
 #include "Token.h"
 #include "TokenStream.h"

--- a/runtime/Cpp/runtime/src/UnbufferedCharStream.cpp
+++ b/runtime/Cpp/runtime/src/UnbufferedCharStream.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <cstddef>
 #include "misc/Interval.h"
+#include "antlr4-common.h"
 #include "Exceptions.h"
 #include "support/Utf8.h"
 

--- a/runtime/Cpp/runtime/src/UnbufferedCharStream.h
+++ b/runtime/Cpp/runtime/src/UnbufferedCharStream.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "CharStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/UnbufferedTokenStream.cpp
+++ b/runtime/Cpp/runtime/src/UnbufferedTokenStream.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "Token.h"
+#include "antlr4-common.h"
 #include "Exceptions.h"
 #include "assert.h"
 #include "TokenSource.h"

--- a/runtime/Cpp/runtime/src/UnbufferedTokenStream.h
+++ b/runtime/Cpp/runtime/src/UnbufferedTokenStream.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "TokenStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/WritableToken.h
+++ b/runtime/Cpp/runtime/src/WritableToken.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "Token.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/ATN.h
+++ b/runtime/Cpp/runtime/src/atn/ATN.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "RuleContext.h"
+#include "antlr4-common.h"
 #include "internal/Synchronization.h"
 
 // GCC generates a warning when forward-declaring ATN if ATN has already been

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "antlr4-common.h"
 #include "atn/PredictionContext.h"
 #include "SemanticContext.h"
 

--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/PredictionContext.h"
+#include "antlr4-common.h"
 #include "atn/ATNConfig.h"
 #include "atn/ATNSimulator.h"
 #include "Exceptions.h"

--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
@@ -11,6 +11,7 @@
 #include <cassert>
 
 #include "support/BitSet.h"
+#include "antlr4-common.h"
 #include "atn/PredictionContext.h"
 #include "atn/ATNConfig.h"
 #include "FlatHashSet.h"

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
@@ -5,6 +5,7 @@
 
 #include "atn/ATNDeserializationOptions.h"
 
+#include "antlr4-common.h"
 #include "atn/ATNType.h"
 #include "atn/ATNState.h"
 #include "atn/ATN.h"

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.h
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <cstddef>
 #include "atn/ATNDeserializationOptions.h"
+#include "antlr4-common.h"
 #include "atn/SerializedATNView.h"
 #include "atn/LexerAction.h"
 #include "atn/Transition.h"

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include "atn/ATNSimulator.h"
 
+#include "antlr4-common.h"
 #include "atn/ATNConfigSet.h"
 #include "atn/ATNDeserializer.h"
 #include "atn/ATNType.h"

--- a/runtime/Cpp/runtime/src/atn/ATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ATNSimulator.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "atn/ATN.h"
+#include "antlr4-common.h"
 #include "atn/PredictionContext.h"
 #include "atn/PredictionContextCache.h"
 #include "misc/IntervalSet.h"

--- a/runtime/Cpp/runtime/src/atn/ATNState.h
+++ b/runtime/Cpp/runtime/src/atn/ATNState.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/IntervalSet.h"
+#include "antlr4-common.h"
 #include "atn/Transition.h"
 #include "atn/ATNStateType.h"
 

--- a/runtime/Cpp/runtime/src/atn/ActionTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/ActionTransition.cpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/ActionTransition.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/ActionTransition.h
+++ b/runtime/Cpp/runtime/src/atn/ActionTransition.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/AmbiguityInfo.h
+++ b/runtime/Cpp/runtime/src/atn/AmbiguityInfo.h
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include "atn/DecisionEventInfo.h"
+#include "antlr4-common.h"
 #include "support/BitSet.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstring>
 
+#include "antlr4-common.h"
 #include "atn/SingletonPredictionContext.h"
 #include "atn/HashUtils.h"
 #include "misc/MurmurHash.h"

--- a/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/ArrayPredictionContext.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/PredictionContext.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/AtomTransition.h
+++ b/runtime/Cpp/runtime/src/atn/AtomTransition.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/BasicState.h
+++ b/runtime/Cpp/runtime/src/atn/BasicState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/BlockEndState.h
+++ b/runtime/Cpp/runtime/src/atn/BlockEndState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/BlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/BlockStartState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/DecisionState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/ContextSensitivityInfo.h
+++ b/runtime/Cpp/runtime/src/atn/ContextSensitivityInfo.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/DecisionEventInfo.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/DecisionInfo.h
+++ b/runtime/Cpp/runtime/src/atn/DecisionInfo.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/ContextSensitivityInfo.h"
+#include "antlr4-common.h"
 #include "atn/AmbiguityInfo.h"
 #include "atn/PredicateEvalInfo.h"
 #include "atn/ErrorInfo.h"

--- a/runtime/Cpp/runtime/src/atn/DecisionState.h
+++ b/runtime/Cpp/runtime/src/atn/DecisionState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <string>
+#include "antlr4-common.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/EpsilonTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/EpsilonTransition.cpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/EpsilonTransition.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/EpsilonTransition.h
+++ b/runtime/Cpp/runtime/src/atn/EpsilonTransition.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/ErrorInfo.h
+++ b/runtime/Cpp/runtime/src/atn/ErrorInfo.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/DecisionEventInfo.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/RuleStopState.h"
+#include "antlr4-common.h"
 #include "atn/Transition.h"
 #include "atn/RuleTransition.h"
 #include "atn/SingletonPredictionContext.h"

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.h
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstddef>
 #include "Token.h"
+#include "antlr4-common.h"
 #include "atn/ATNConfig.h"
 #include "atn/PredictionContext.h"
 #include "support/BitSet.h"

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "antlr4-common.h"
 #include "atn/DecisionState.h"
 #include "atn/PredictionContext.h"
 #include "SemanticContext.h"

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/ATNConfig.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "IntStream.h"
+#include "antlr4-common.h"
 #include "atn/OrderedATNConfigSet.h"
 #include "Token.h"
 #include "LexerNoViableAltException.h"

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
@@ -12,6 +12,7 @@
 #include <atomic>
 
 #include "atn/ATNSimulator.h"
+#include "antlr4-common.h"
 #include "atn/LexerATNConfig.h"
 #include "atn/ATNConfigSet.h"
 

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "antlr4-common.h"
 #include "atn/LexerIndexedCustomAction.h"
 #include "atn/HashUtils.h"
 #include "support/CPPUtils.h"

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstddef>
 #include "CharStream.h"
+#include "antlr4-common.h"
 #include "atn/LexerAction.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerChannelAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerChannelAction.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/LexerAction.h"
+#include "antlr4-common.h"
 #include "atn/LexerActionType.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerCustomAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerCustomAction.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/LexerAction.h"
+#include "antlr4-common.h"
 #include "atn/LexerActionType.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/HashUtils.h"
+#include "antlr4-common.h"
 #include "misc/MurmurHash.h"
 #include "Lexer.h"
 #include "support/CPPUtils.h"

--- a/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerIndexedCustomAction.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "RuleContext.h"
+#include "antlr4-common.h"
 #include "atn/LexerAction.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerModeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerModeAction.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/LexerAction.h"
+#include "antlr4-common.h"
 #include "atn/LexerActionType.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerMoreAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerMoreAction.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "antlr4-common.h"
 #include "Lexer.h"
 
 #include "atn/LexerMoreAction.h"

--- a/runtime/Cpp/runtime/src/atn/LexerMoreAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerMoreAction.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/LexerAction.h"
+#include "antlr4-common.h"
 #include "atn/LexerActionType.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerPopModeAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerPopModeAction.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "antlr4-common.h"
 #include "Lexer.h"
 
 #include "atn/LexerPopModeAction.h"

--- a/runtime/Cpp/runtime/src/atn/LexerPopModeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerPopModeAction.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/LexerAction.h"
+#include "antlr4-common.h"
 #include "atn/LexerActionType.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerPushModeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerPushModeAction.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/LexerAction.h"
+#include "antlr4-common.h"
 #include "atn/LexerActionType.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerSkipAction.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerSkipAction.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "antlr4-common.h"
 #include "Lexer.h"
 
 #include "atn/LexerSkipAction.h"

--- a/runtime/Cpp/runtime/src/atn/LexerSkipAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerSkipAction.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/LexerAction.h"
+#include "antlr4-common.h"
 #include "atn/LexerActionType.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerTypeAction.h
+++ b/runtime/Cpp/runtime/src/atn/LexerTypeAction.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/LexerActionType.h"
+#include "antlr4-common.h"
 #include "atn/LexerAction.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LookaheadEventInfo.h
+++ b/runtime/Cpp/runtime/src/atn/LookaheadEventInfo.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/DecisionEventInfo.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LoopEndState.h
+++ b/runtime/Cpp/runtime/src/atn/LoopEndState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/NotSetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/NotSetTransition.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/SetTransition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/OrderedATNConfigSet.h
+++ b/runtime/Cpp/runtime/src/atn/OrderedATNConfigSet.h
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include "atn/ATNConfigSet.h"
+#include "antlr4-common.h"
 #include "atn/ATNConfig.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/ParseInfo.h
+++ b/runtime/Cpp/runtime/src/atn/ParseInfo.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/DecisionInfo.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "dfa/DFA.h"
+#include "antlr4-common.h"
 #include "NoViableAltException.h"
 #include "atn/DecisionState.h"
 #include "ParserRuleContext.h"

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "PredictionMode.h"
+#include "antlr4-common.h"
 #include "dfa/DFAState.h"
 #include "atn/ATNSimulator.h"
 #include "atn/PredictionContext.h"

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulatorOptions.h
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulatorOptions.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <utility>
+#include "antlr4-common.h"
 #include "atn/PredictionContextMergeCacheOptions.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/PlusBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/PlusBlockStartState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/BlockStartState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/PlusLoopbackState.h
+++ b/runtime/Cpp/runtime/src/atn/PlusLoopbackState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/DecisionState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/PrecedencePredicateTransition.h
+++ b/runtime/Cpp/runtime/src/atn/PrecedencePredicateTransition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/Transition.h"
+#include "antlr4-common.h"
 #include "atn/SemanticContext.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include "SemanticContext.h"
 
+#include "antlr4-common.h"
 #include "atn/PredicateEvalInfo.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.h
+++ b/runtime/Cpp/runtime/src/atn/PredicateEvalInfo.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/DecisionEventInfo.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/PredicateTransition.h
+++ b/runtime/Cpp/runtime/src/atn/PredicateTransition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/Transition.h"
+#include "antlr4-common.h"
 #include "atn/SemanticContext.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/SingletonPredictionContext.h"
+#include "antlr4-common.h"
 #include "misc/MurmurHash.h"
 #include "atn/ArrayPredictionContext.h"
 #include "atn/PredictionContextCache.h"

--- a/runtime/Cpp/runtime/src/atn/PredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionContext.h
@@ -12,6 +12,7 @@
 #include <atomic>
 
 #include "Recognizer.h"
+#include "antlr4-common.h"
 #include "atn/ATN.h"
 #include "atn/ATNState.h"
 #include "atn/PredictionContextType.h"

--- a/runtime/Cpp/runtime/src/atn/PredictionContextCache.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionContextCache.cpp
@@ -25,6 +25,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/PredictionContextCache.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/PredictionContextCache.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionContextCache.h
@@ -27,6 +27,7 @@
 
 #include <cstddef>
 #include "atn/PredictionContext.h"
+#include "antlr4-common.h"
 #include "FlatHashSet.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/PredictionContextMergeCache.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionContextMergeCache.cpp
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include "atn/PredictionContextMergeCache.h"
 
+#include "antlr4-common.h"
 #include "misc/MurmurHash.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/PredictionContextMergeCache.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionContextMergeCache.h
@@ -30,6 +30,7 @@
 #include <utility>
 
 #include "atn/PredictionContext.h"
+#include "antlr4-common.h"
 #include "atn/PredictionContextMergeCacheOptions.h"
 #include "FlatHashMap.h"
 

--- a/runtime/Cpp/runtime/src/atn/PredictionMode.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredictionMode.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/RuleStopState.h"
+#include "antlr4-common.h"
 #include "atn/ATNConfigSet.h"
 #include "atn/ATNConfig.h"
 #include "misc/MurmurHash.h"

--- a/runtime/Cpp/runtime/src/atn/PredictionMode.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionMode.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "support/BitSet.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/ParserATNSimulator.h"
+#include "antlr4-common.h"
 #include "atn/DecisionInfo.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/RangeTransition.h
+++ b/runtime/Cpp/runtime/src/atn/RangeTransition.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/RuleStartState.h
+++ b/runtime/Cpp/runtime/src/atn/RuleStartState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/RuleStopState.h
+++ b/runtime/Cpp/runtime/src/atn/RuleStopState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/RuleTransition.h
+++ b/runtime/Cpp/runtime/src/atn/RuleTransition.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
@@ -12,6 +12,7 @@
 #include <unordered_set>
 
 #include "misc/MurmurHash.h"
+#include "antlr4-common.h"
 #include "support/Casts.h"
 #include "support/CPPUtils.h"
 #include "support/Arrays.h"

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.h
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "Recognizer.h"
+#include "antlr4-common.h"
 #include "support/CPPUtils.h"
 #include "atn/SemanticContextType.h"
 

--- a/runtime/Cpp/runtime/src/atn/SetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/SetTransition.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.cpp
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include "atn/SingletonPredictionContext.h"
 
+#include "antlr4-common.h"
 #include "support/Casts.h"
 #include "misc/MurmurHash.h"
 #include "atn/HashUtils.h"

--- a/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.h
+++ b/runtime/Cpp/runtime/src/atn/SingletonPredictionContext.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/PredictionContext.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/StarBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/StarBlockStartState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/BlockStartState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/StarLoopEntryState.h
+++ b/runtime/Cpp/runtime/src/atn/StarLoopEntryState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/DecisionState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/StarLoopbackState.h
+++ b/runtime/Cpp/runtime/src/atn/StarLoopbackState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/TokensStartState.h
+++ b/runtime/Cpp/runtime/src/atn/TokensStartState.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "atn/DecisionState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/Transition.h
+++ b/runtime/Cpp/runtime/src/atn/Transition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/IntervalSet.h"
+#include "antlr4-common.h"
 #include "atn/TransitionType.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/WildcardTransition.h
+++ b/runtime/Cpp/runtime/src/atn/WildcardTransition.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/dfa/DFA.h
+++ b/runtime/Cpp/runtime/src/dfa/DFA.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "dfa/DFAState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/dfa/DFASerializer.h
+++ b/runtime/Cpp/runtime/src/dfa/DFASerializer.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "Vocabulary.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.h
+++ b/runtime/Cpp/runtime/src/dfa/LexerDFASerializer.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "dfa/DFASerializer.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/internal/Synchronization.cpp
+++ b/runtime/Cpp/runtime/src/internal/Synchronization.cpp
@@ -23,6 +23,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
 // WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include "antlr4-common.h"
 #include "internal/Synchronization.h"
 
 using namespace antlr4::internal;

--- a/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "antlr4-common.h"
 #include "Lexer.h"
 #include "Exceptions.h"
 #include "Vocabulary.h"

--- a/runtime/Cpp/runtime/src/misc/IntervalSet.h
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/Interval.h"
+#include "antlr4-common.h"
 #include "Exceptions.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/misc/MurmurHash.cpp
+++ b/runtime/Cpp/runtime/src/misc/MurmurHash.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include "antlr4-common.h"
 #include "misc/MurmurHash.h"
 
 using namespace antlr4::misc;

--- a/runtime/Cpp/runtime/src/tree/AbstractParseTreeVisitor.h
+++ b/runtime/Cpp/runtime/src/tree/AbstractParseTreeVisitor.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <cstddef>
 #include "tree/ParseTree.h"
+#include "antlr4-common.h"
 #include "tree/ParseTreeVisitor.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/ErrorNode.h
+++ b/runtime/Cpp/runtime/src/tree/ErrorNode.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "tree/TerminalNode.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.h
+++ b/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include "tree/ErrorNode.h"
+#include "antlr4-common.h"
 #include "tree/TerminalNodeImpl.h"
 #include "misc/Interval.h"
 

--- a/runtime/Cpp/runtime/src/tree/ParseTree.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTree.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include "support/Any.h"
+#include "antlr4-common.h"
 #include "tree/ParseTreeType.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/ParseTreeVisitor.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTreeVisitor.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "support/Any.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/TerminalNode.h
+++ b/runtime/Cpp/runtime/src/tree/TerminalNode.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "antlr4-common.h"
 #include "tree/ParseTree.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/TerminalNodeImpl.h
+++ b/runtime/Cpp/runtime/src/tree/TerminalNodeImpl.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <string>
+#include "antlr4-common.h"
 #include "tree/TerminalNode.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/Trees.cpp
+++ b/runtime/Cpp/runtime/src/tree/Trees.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "tree/ErrorNode.h"
+#include "antlr4-common.h"
 #include "Parser.h"
 #include "ParserRuleContext.h"
 #include "support/CPPUtils.h"

--- a/runtime/Cpp/runtime/src/tree/Trees.h
+++ b/runtime/Cpp/runtime/src/tree/Trees.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "tree/TerminalNode.h"
+#include "antlr4-common.h"
 #include "ParserRuleContext.h"
 #include "Recognizer.h"
 

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "tree/pattern/ParseTreePattern.h"
+#include "antlr4-common.h"
 #include "tree/pattern/ParseTreeMatch.h"
 #include "tree/TerminalNode.h"
 #include "CommonTokenStream.h"

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include "antlr4-common.h"
 #include "Exceptions.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/pattern/RuleTagToken.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/RuleTagToken.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include "Exceptions.h"
 
+#include "antlr4-common.h"
 #include "tree/pattern/RuleTagToken.h"
 
 using namespace antlr4::tree::pattern;

--- a/runtime/Cpp/runtime/src/tree/pattern/RuleTagToken.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/RuleTagToken.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "Token.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/pattern/TagChunk.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/TagChunk.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <string>
+#include "antlr4-common.h"
 #include "Chunk.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/pattern/TextChunk.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/TextChunk.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <string>
+#include "antlr4-common.h"
 #include "Chunk.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/pattern/TokenTagToken.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/TokenTagToken.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <string>
+#include "antlr4-common.h"
 #include "CommonToken.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "XPathLexer.h"
+#include "antlr4-common.h"
 #include "XPathLexerErrorListener.h"
 #include "XPathElement.h"
 #include "XPathWildcardAnywhereElement.h"

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexerErrorListener.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexerErrorListener.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "BaseErrorListener.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathRuleAnywhereElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathRuleAnywhereElement.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <string>
+#include "antlr4-common.h"
 #include "XPathElement.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathRuleElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathRuleElement.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "XPathElement.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathTokenAnywhereElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathTokenAnywhereElement.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <string>
+#include "antlr4-common.h"
 #include "XPathElement.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathTokenElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathTokenElement.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
+#include "antlr4-common.h"
 #include "XPathElement.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathWildcardAnywhereElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathWildcardAnywhereElement.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <vector>
+#include "antlr4-common.h"
 #include "XPathElement.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathWildcardElement.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathWildcardElement.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <vector>
+#include "antlr4-common.h"
 #include "XPathElement.h"
 
 namespace antlr4 {


### PR DESCRIPTION
All files using

  * `ANTLR4CPP_PUBLIC`
  * `ANTLR4CPP_USING_ABSEIL`
  * `ANTLR4CPP_HAVE_BUILTIN`
  * `INVALID_INDEX`
  * `Ref`
  * `ssize_t`

... and not yet directly including `antlr4-common.h`
