### PR TITLE
Add top missing antlr4 headers inside impl.

### DIFF
--- a/runtime/Cpp/runtime/src/ANTLRErrorListener.h
+++ b/runtime/Cpp/runtime/src/ANTLRErrorListener.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "RecognitionException.h"
 
 namespace antlrcpp {

--- a/runtime/Cpp/runtime/src/ANTLRErrorStrategy.h
+++ b/runtime/Cpp/runtime/src/ANTLRErrorStrategy.h
@@ -9,6 +9,7 @@
 #include "Token.h"
 
 namespace antlr4 {
+  class Parser;
 
   /// <summary>
   /// The interface for defining strategies to deal with syntax errors encountered

--- a/runtime/Cpp/runtime/src/ANTLRFileStream.cpp
+++ b/runtime/Cpp/runtime/src/ANTLRFileStream.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <string>
+#include "ANTLRInputStream.h"
 #include "ANTLRFileStream.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/ANTLRInputStream.h
+++ b/runtime/Cpp/runtime/src/ANTLRInputStream.h
@@ -10,6 +10,7 @@
 #include <string_view>
 
 #include "antlr4-common.h"
+#include "misc/Interval.h"
 #include "CharStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/BailErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/BailErrorStrategy.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "Exceptions.h"
+#include "Token.h"
 #include "ParserRuleContext.h"
 #include "InputMismatchException.h"
 #include "Parser.h"

--- a/runtime/Cpp/runtime/src/BailErrorStrategy.h
+++ b/runtime/Cpp/runtime/src/BailErrorStrategy.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "Token.h"
 #include "DefaultErrorStrategy.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/BaseErrorListener.cpp
+++ b/runtime/Cpp/runtime/src/BaseErrorListener.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "BaseErrorListener.h"
+#include "Token.h"
 #include "RecognitionException.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/BaseErrorListener.h
+++ b/runtime/Cpp/runtime/src/BaseErrorListener.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "ANTLRErrorListener.h"
 
 namespace antlrcpp {

--- a/runtime/Cpp/runtime/src/BufferedTokenStream.cpp
+++ b/runtime/Cpp/runtime/src/BufferedTokenStream.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "WritableToken.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "Lexer.h"
 #include "RuleContext.h"

--- a/runtime/Cpp/runtime/src/BufferedTokenStream.h
+++ b/runtime/Cpp/runtime/src/BufferedTokenStream.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "TokenStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/BufferedTokenStream.h
+++ b/runtime/Cpp/runtime/src/BufferedTokenStream.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "misc/Interval.h"
 #include "Token.h"
 #include "TokenStream.h"
 

--- a/runtime/Cpp/runtime/src/CommonToken.cpp
+++ b/runtime/Cpp/runtime/src/CommonToken.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "TokenSource.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "CharStream.h"
 #include "Recognizer.h"

--- a/runtime/Cpp/runtime/src/CommonToken.h
+++ b/runtime/Cpp/runtime/src/CommonToken.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "WritableToken.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/CommonTokenStream.h
+++ b/runtime/Cpp/runtime/src/CommonTokenStream.h
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "BufferedTokenStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/ConsoleErrorListener.cpp
+++ b/runtime/Cpp/runtime/src/ConsoleErrorListener.cpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <cstddef>
+#include "Token.h"
 #include "ConsoleErrorListener.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/ConsoleErrorListener.h
+++ b/runtime/Cpp/runtime/src/ConsoleErrorListener.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "BaseErrorListener.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "NoViableAltException.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "misc/IntervalSet.h"
 #include "atn/ParserATNSimulator.h"

--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "NoViableAltException.h"
+#include "atn/ATNStateType.h"
 #include "Token.h"
 #include "antlr4-common.h"
 #include "misc/IntervalSet.h"

--- a/runtime/Cpp/runtime/src/DefaultErrorStrategy.h
+++ b/runtime/Cpp/runtime/src/DefaultErrorStrategy.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstddef>
 #include "ANTLRErrorStrategy.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "misc/IntervalSet.h"
 

--- a/runtime/Cpp/runtime/src/FailedPredicateException.cpp
+++ b/runtime/Cpp/runtime/src/FailedPredicateException.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include "atn/ParserATNSimulator.h"
+#include "atn/TransitionType.h"
 #include "Parser.h"
 #include "atn/PredicateTransition.h"
 #include "atn/ATN.h"

--- a/runtime/Cpp/runtime/src/Lexer.cpp
+++ b/runtime/Cpp/runtime/src/Lexer.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/LexerATNSimulator.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "Exceptions.h"
 #include "misc/Interval.h"

--- a/runtime/Cpp/runtime/src/ListTokenSource.h
+++ b/runtime/Cpp/runtime/src/ListTokenSource.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstddef>
 #include "TokenSource.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "CommonTokenFactory.h"
 

--- a/runtime/Cpp/runtime/src/NoViableAltException.cpp
+++ b/runtime/Cpp/runtime/src/NoViableAltException.cpp
@@ -5,6 +5,7 @@
 
 #include "Parser.h"
 
+#include "Token.h"
 #include "antlr4-common.h"
 #include "NoViableAltException.h"
 

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/ATNDeserializationOptions.h"
+#include "ANTLRErrorStrategy.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "tree/pattern/ParseTreePatternMatcher.h"

--- a/runtime/Cpp/runtime/src/Parser.cpp
+++ b/runtime/Cpp/runtime/src/Parser.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/ATNDeserializationOptions.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "tree/pattern/ParseTreePatternMatcher.h"
 #include "dfa/DFA.h"

--- a/runtime/Cpp/runtime/src/Parser.h
+++ b/runtime/Cpp/runtime/src/Parser.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "Recognizer.h"
+#include "misc/IntervalSet.h"
 #include "ANTLRErrorStrategy.h"
 #include "Token.h"
 #include "antlr4-common.h"

--- a/runtime/Cpp/runtime/src/Parser.h
+++ b/runtime/Cpp/runtime/src/Parser.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "Recognizer.h"
+#include "ANTLRErrorStrategy.h"
 #include "Token.h"
 #include "antlr4-common.h"
 #include "tree/ParseTreeListener.h"

--- a/runtime/Cpp/runtime/src/Parser.h
+++ b/runtime/Cpp/runtime/src/Parser.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "Recognizer.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "tree/ParseTreeListener.h"
 #include "tree/ParseTree.h"

--- a/runtime/Cpp/runtime/src/ParserInterpreter.cpp
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "dfa/DFA.h"
+#include "atn/ATNStateType.h"
 #include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"

--- a/runtime/Cpp/runtime/src/ParserInterpreter.cpp
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "dfa/DFA.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/RuleStartState.h"
 #include "InterpreterRuleContext.h"

--- a/runtime/Cpp/runtime/src/ParserInterpreter.cpp
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "dfa/DFA.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/RuleStartState.h"

--- a/runtime/Cpp/runtime/src/ParserInterpreter.h
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "Parser.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/ATN.h"
 #include "support/BitSet.h"

--- a/runtime/Cpp/runtime/src/ParserInterpreter.h
+++ b/runtime/Cpp/runtime/src/ParserInterpreter.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "Parser.h"
+#include "Token.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/ATN.h"

--- a/runtime/Cpp/runtime/src/ParserRuleContext.h
+++ b/runtime/Cpp/runtime/src/ParserRuleContext.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "RuleContext.h"
+#include "misc/Interval.h"
 #include "Token.h"
 #include "antlr4-common.h"
 #include "support/CPPUtils.h"

--- a/runtime/Cpp/runtime/src/ParserRuleContext.h
+++ b/runtime/Cpp/runtime/src/ParserRuleContext.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "RuleContext.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "support/CPPUtils.h"
 

--- a/runtime/Cpp/runtime/src/ProxyErrorListener.cpp
+++ b/runtime/Cpp/runtime/src/ProxyErrorListener.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "Token.h"
+#include "ANTLRErrorListener.h"
 #include "ProxyErrorListener.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/ProxyErrorListener.cpp
+++ b/runtime/Cpp/runtime/src/ProxyErrorListener.cpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <cstddef>
+#include "Token.h"
 #include "ProxyErrorListener.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/ProxyErrorListener.h
+++ b/runtime/Cpp/runtime/src/ProxyErrorListener.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "ANTLRErrorListener.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "Exceptions.h"
 

--- a/runtime/Cpp/runtime/src/RecognitionException.cpp
+++ b/runtime/Cpp/runtime/src/RecognitionException.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include "atn/ATN.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "Recognizer.h"
 #include "ParserRuleContext.h"

--- a/runtime/Cpp/runtime/src/RecognitionException.h
+++ b/runtime/Cpp/runtime/src/RecognitionException.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "Exceptions.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/RecognitionException.h
+++ b/runtime/Cpp/runtime/src/RecognitionException.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "misc/IntervalSet.h"
 #include "Token.h"
 #include "Exceptions.h"
 

--- a/runtime/Cpp/runtime/src/Recognizer.cpp
+++ b/runtime/Cpp/runtime/src/Recognizer.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "ConsoleErrorListener.h"
+#include "atn/ATNState.h"
 #include "RecognitionException.h"
 #include "support/CPPUtils.h"
 #include "Token.h"

--- a/runtime/Cpp/runtime/src/Recognizer.cpp
+++ b/runtime/Cpp/runtime/src/Recognizer.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "ConsoleErrorListener.h"
+#include "ANTLRErrorListener.h"
 #include "atn/ATNState.h"
 #include "RecognitionException.h"
 #include "support/CPPUtils.h"

--- a/runtime/Cpp/runtime/src/Recognizer.h
+++ b/runtime/Cpp/runtime/src/Recognizer.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "ProxyErrorListener.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "support/Casts.h"
 #include "atn/SerializedATNView.h"

--- a/runtime/Cpp/runtime/src/Recognizer.h
+++ b/runtime/Cpp/runtime/src/Recognizer.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "ProxyErrorListener.h"
+#include "ANTLRErrorListener.h"
 #include "Token.h"
 #include "antlr4-common.h"
 #include "support/Casts.h"

--- a/runtime/Cpp/runtime/src/RuleContext.cpp
+++ b/runtime/Cpp/runtime/src/RuleContext.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "tree/Trees.h"
+#include "tree/ParseTreeType.h"
 #include "antlr4-common.h"
 #include "misc/Interval.h"
 #include "Parser.h"

--- a/runtime/Cpp/runtime/src/RuleContext.h
+++ b/runtime/Cpp/runtime/src/RuleContext.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "misc/Interval.h"
 #include "tree/ParseTree.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/RuleContext.h
+++ b/runtime/Cpp/runtime/src/RuleContext.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "tree/ParseTreeType.h"
 #include "misc/Interval.h"
 #include "tree/ParseTree.h"
 

--- a/runtime/Cpp/runtime/src/TokenSource.h
+++ b/runtime/Cpp/runtime/src/TokenSource.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "TokenFactory.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/TokenStream.h
+++ b/runtime/Cpp/runtime/src/TokenStream.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "IntStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/TokenStream.h
+++ b/runtime/Cpp/runtime/src/TokenStream.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "misc/Interval.h"
 #include "Token.h"
 #include "IntStream.h"
 

--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.h
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
+#include "Token.h"
 #include "antlr4-common.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.h
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstddef>
 #include "Token.h"
+#include "misc/Interval.h"
 #include "antlr4-common.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/UnbufferedCharStream.h
+++ b/runtime/Cpp/runtime/src/UnbufferedCharStream.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "misc/Interval.h"
 #include "CharStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/UnbufferedTokenStream.h
+++ b/runtime/Cpp/runtime/src/UnbufferedTokenStream.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "TokenStream.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/UnbufferedTokenStream.h
+++ b/runtime/Cpp/runtime/src/UnbufferedTokenStream.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "misc/Interval.h"
 #include "Token.h"
 #include "TokenStream.h"
 

--- a/runtime/Cpp/runtime/src/atn/ATN.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATN.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include "atn/LL1Analyzer.h"
+#include "atn/ATNState.h"
 #include "Token.h"
 #include "atn/RuleTransition.h"
 #include "misc/IntervalSet.h"

--- a/runtime/Cpp/runtime/src/atn/ATN.h
+++ b/runtime/Cpp/runtime/src/atn/ATN.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "RuleContext.h"
+#include "misc/IntervalSet.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "internal/Synchronization.h"

--- a/runtime/Cpp/runtime/src/atn/ATN.h
+++ b/runtime/Cpp/runtime/src/atn/ATN.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "RuleContext.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "internal/Synchronization.h"
 

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/PredictionContext.h"
 #include "SemanticContext.h"

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.h
@@ -11,6 +11,7 @@
 #include <cassert>
 
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/SemanticContext.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/PredictionContext.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/ATNConfig.h"
 #include "atn/ATNSimulator.h"

--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.h
@@ -11,6 +11,7 @@
 #include <cassert>
 
 #include "support/BitSet.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/PredictionContext.h"
 #include "atn/ATNConfig.h"

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
@@ -5,6 +5,7 @@
 
 #include "atn/ATNDeserializationOptions.h"
 
+#include "atn/ATNStateType.h"
 #include "antlr4-common.h"
 #include "atn/ATNType.h"
 #include "atn/ATNState.h"

--- a/runtime/Cpp/runtime/src/atn/ActionTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/ActionTransition.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/ActionTransition.h"
 

--- a/runtime/Cpp/runtime/src/atn/ActionTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/ActionTransition.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/ActionTransition.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/ActionTransition.h
+++ b/runtime/Cpp/runtime/src/atn/ActionTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/ActionTransition.h
+++ b/runtime/Cpp/runtime/src/atn/ActionTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"
 

--- a/runtime/Cpp/runtime/src/atn/AtomTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/AtomTransition.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/IntervalSet.h"
+#include "atn/ATNState.h"
 #include "atn/Transition.h"
 
 #include "atn/AtomTransition.h"

--- a/runtime/Cpp/runtime/src/atn/AtomTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/AtomTransition.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/IntervalSet.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"
 

--- a/runtime/Cpp/runtime/src/atn/AtomTransition.h
+++ b/runtime/Cpp/runtime/src/atn/AtomTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/AtomTransition.h
+++ b/runtime/Cpp/runtime/src/atn/AtomTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "misc/IntervalSet.h"
 #include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"

--- a/runtime/Cpp/runtime/src/atn/AtomTransition.h
+++ b/runtime/Cpp/runtime/src/atn/AtomTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"
 

--- a/runtime/Cpp/runtime/src/atn/BasicBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/BasicBlockStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/BlockStartState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/BasicBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/BasicBlockStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 #include "atn/BlockStartState.h"
 

--- a/runtime/Cpp/runtime/src/atn/BasicState.h
+++ b/runtime/Cpp/runtime/src/atn/BasicState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/BlockEndState.h
+++ b/runtime/Cpp/runtime/src/atn/BlockEndState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/BlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/BlockStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 #include "atn/DecisionState.h"
 

--- a/runtime/Cpp/runtime/src/atn/BlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/BlockStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/DecisionState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/DecisionState.cpp
+++ b/runtime/Cpp/runtime/src/atn/DecisionState.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <string>
+#include "atn/ATNState.h"
 #include "atn/DecisionState.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/DecisionState.h
+++ b/runtime/Cpp/runtime/src/atn/DecisionState.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/EpsilonTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/EpsilonTransition.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/EpsilonTransition.h"
 

--- a/runtime/Cpp/runtime/src/atn/EpsilonTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/EpsilonTransition.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/EpsilonTransition.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/EpsilonTransition.h
+++ b/runtime/Cpp/runtime/src/atn/EpsilonTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/EpsilonTransition.h
+++ b/runtime/Cpp/runtime/src/atn/EpsilonTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"
 

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/RuleStopState.h"
+#include "atn/TransitionType.h"
 #include "Token.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/RuleStopState.h"
+#include "Token.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/Transition.h"

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/RuleStopState.h"
+#include "atn/ATNStateType.h"
 #include "atn/TransitionType.h"
 #include "Token.h"
 #include "atn/ATNState.h"

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <cstddef>
 #include "atn/RuleStopState.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/Transition.h"
 #include "atn/RuleTransition.h"

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.h
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstddef>
 #include "Token.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/ATNConfig.h"
 #include "atn/PredictionContext.h"

--- a/runtime/Cpp/runtime/src/atn/LL1Analyzer.h
+++ b/runtime/Cpp/runtime/src/atn/LL1Analyzer.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstddef>
 #include "Token.h"
+#include "misc/IntervalSet.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/ATNConfig.h"

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/DecisionState.h"
 #include "atn/PredictionContext.h"

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.h
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/ATNConfig.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "IntStream.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/OrderedATNConfigSet.h"
 #include "Token.h"

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "IntStream.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/OrderedATNConfigSet.h"

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "IntStream.h"
+#include "atn/ATNStateType.h"
 #include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.h
@@ -12,6 +12,7 @@
 #include <atomic>
 
 #include "atn/ATNSimulator.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/LexerATNConfig.h"
 #include "atn/ATNConfigSet.h"

--- a/runtime/Cpp/runtime/src/atn/LoopEndState.h
+++ b/runtime/Cpp/runtime/src/atn/LoopEndState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/NotSetTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/NotSetTransition.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/NotSetTransition.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "misc/IntervalSet.h"
 

--- a/runtime/Cpp/runtime/src/atn/NotSetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/NotSetTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "misc/IntervalSet.h"
 #include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/SetTransition.h"

--- a/runtime/Cpp/runtime/src/atn/NotSetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/NotSetTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/SetTransition.h"
 

--- a/runtime/Cpp/runtime/src/atn/NotSetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/NotSetTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/SetTransition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "dfa/DFA.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "NoViableAltException.h"
 #include "atn/DecisionState.h"

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "dfa/DFA.h"
+#include "atn/TransitionType.h"
 #include "Token.h"
 #include "antlr4-common.h"
 #include "NoViableAltException.h"

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "dfa/DFA.h"
+#include "atn/ATNStateType.h"
 #include "atn/TransitionType.h"
 #include "Token.h"
 #include "antlr4-common.h"

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include "PredictionMode.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "dfa/DFAState.h"
 #include "atn/ATNSimulator.h"

--- a/runtime/Cpp/runtime/src/atn/PlusBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/PlusBlockStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/BlockStartState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/PlusBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/PlusBlockStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 #include "atn/BlockStartState.h"
 

--- a/runtime/Cpp/runtime/src/atn/PlusLoopbackState.h
+++ b/runtime/Cpp/runtime/src/atn/PlusLoopbackState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 #include "atn/DecisionState.h"
 

--- a/runtime/Cpp/runtime/src/atn/PlusLoopbackState.h
+++ b/runtime/Cpp/runtime/src/atn/PlusLoopbackState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/DecisionState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/PrecedencePredicateTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/PrecedencePredicateTransition.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <cstddef>
+#include "atn/ATNState.h"
 #include "atn/PrecedencePredicateTransition.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/PrecedencePredicateTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/PrecedencePredicateTransition.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/ATNState.h"
+#include "atn/TransitionType.h"
 #include "atn/PrecedencePredicateTransition.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/PrecedencePredicateTransition.h
+++ b/runtime/Cpp/runtime/src/atn/PrecedencePredicateTransition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/Transition.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/SemanticContext.h"

--- a/runtime/Cpp/runtime/src/atn/PrecedencePredicateTransition.h
+++ b/runtime/Cpp/runtime/src/atn/PrecedencePredicateTransition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/Transition.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/SemanticContext.h"
 

--- a/runtime/Cpp/runtime/src/atn/PredicateTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredicateTransition.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <cstddef>
+#include "atn/ATNState.h"
 #include "atn/PredicateTransition.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/PredicateTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/PredicateTransition.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/ATNState.h"
+#include "atn/TransitionType.h"
 #include "atn/PredicateTransition.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/PredicateTransition.h
+++ b/runtime/Cpp/runtime/src/atn/PredicateTransition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/Transition.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/SemanticContext.h"

--- a/runtime/Cpp/runtime/src/atn/PredicateTransition.h
+++ b/runtime/Cpp/runtime/src/atn/PredicateTransition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/Transition.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/SemanticContext.h"
 

--- a/runtime/Cpp/runtime/src/atn/PredictionMode.h
+++ b/runtime/Cpp/runtime/src/atn/PredictionMode.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "support/BitSet.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/RangeTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/RangeTransition.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include "misc/IntervalSet.h"
 
+#include "atn/ATNState.h"
 #include "atn/RangeTransition.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/atn/RangeTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/RangeTransition.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include "misc/IntervalSet.h"
 
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/RangeTransition.h"
 

--- a/runtime/Cpp/runtime/src/atn/RangeTransition.h
+++ b/runtime/Cpp/runtime/src/atn/RangeTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/RangeTransition.h
+++ b/runtime/Cpp/runtime/src/atn/RangeTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "misc/IntervalSet.h"
 #include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"

--- a/runtime/Cpp/runtime/src/atn/RangeTransition.h
+++ b/runtime/Cpp/runtime/src/atn/RangeTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"
 

--- a/runtime/Cpp/runtime/src/atn/RuleStartState.h
+++ b/runtime/Cpp/runtime/src/atn/RuleStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/RuleStopState.h
+++ b/runtime/Cpp/runtime/src/atn/RuleStopState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/RuleTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/RuleTransition.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/RuleStartState.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/RuleTransition.h"
 

--- a/runtime/Cpp/runtime/src/atn/RuleTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/RuleTransition.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <cstddef>
 #include "atn/RuleStartState.h"
+#include "atn/ATNState.h"
 #include "atn/RuleTransition.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/RuleTransition.h
+++ b/runtime/Cpp/runtime/src/atn/RuleTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/RuleTransition.h
+++ b/runtime/Cpp/runtime/src/atn/RuleTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"
 

--- a/runtime/Cpp/runtime/src/atn/SetTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/SetTransition.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "Token.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "misc/IntervalSet.h"
 

--- a/runtime/Cpp/runtime/src/atn/SetTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/SetTransition.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstddef>
 #include "Token.h"
+#include "atn/ATNState.h"
 #include "misc/IntervalSet.h"
 
 #include "atn/SetTransition.h"

--- a/runtime/Cpp/runtime/src/atn/SetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/SetTransition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "misc/IntervalSet.h"
 #include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"

--- a/runtime/Cpp/runtime/src/atn/SetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/SetTransition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/SetTransition.h
+++ b/runtime/Cpp/runtime/src/atn/SetTransition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"
 

--- a/runtime/Cpp/runtime/src/atn/StarBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/StarBlockStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/BlockStartState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/StarBlockStartState.h
+++ b/runtime/Cpp/runtime/src/atn/StarBlockStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 #include "atn/BlockStartState.h"
 

--- a/runtime/Cpp/runtime/src/atn/StarLoopEntryState.h
+++ b/runtime/Cpp/runtime/src/atn/StarLoopEntryState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 #include "atn/DecisionState.h"
 

--- a/runtime/Cpp/runtime/src/atn/StarLoopEntryState.h
+++ b/runtime/Cpp/runtime/src/atn/StarLoopEntryState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/DecisionState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/StarLoopbackState.cpp
+++ b/runtime/Cpp/runtime/src/atn/StarLoopbackState.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "atn/StarLoopEntryState.h"
+#include "atn/ATNStateType.h"
 #include "atn/Transition.h"
 #include "support/Casts.h"
 

--- a/runtime/Cpp/runtime/src/atn/StarLoopbackState.h
+++ b/runtime/Cpp/runtime/src/atn/StarLoopbackState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/TokensStartState.h
+++ b/runtime/Cpp/runtime/src/atn/TokensStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNStateType.h"
 #include "atn/ATNState.h"
 #include "atn/DecisionState.h"
 

--- a/runtime/Cpp/runtime/src/atn/TokensStartState.h
+++ b/runtime/Cpp/runtime/src/atn/TokensStartState.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/DecisionState.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/Transition.cpp
+++ b/runtime/Cpp/runtime/src/atn/Transition.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "Exceptions.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "support/Arrays.h"
 

--- a/runtime/Cpp/runtime/src/atn/Transition.cpp
+++ b/runtime/Cpp/runtime/src/atn/Transition.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "Exceptions.h"
+#include "atn/ATNState.h"
 #include "support/Arrays.h"
 
 #include "atn/Transition.h"

--- a/runtime/Cpp/runtime/src/atn/Transition.cpp
+++ b/runtime/Cpp/runtime/src/atn/Transition.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "Exceptions.h"
+#include "misc/IntervalSet.h"
 #include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "support/Arrays.h"

--- a/runtime/Cpp/runtime/src/atn/Transition.h
+++ b/runtime/Cpp/runtime/src/atn/Transition.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/IntervalSet.h"
+#include "atn/ATNState.h"
 #include "antlr4-common.h"
 #include "atn/TransitionType.h"
 

--- a/runtime/Cpp/runtime/src/atn/WildcardTransition.cpp
+++ b/runtime/Cpp/runtime/src/atn/WildcardTransition.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include "atn/ATNState.h"
 
+#include "atn/TransitionType.h"
 #include "atn/WildcardTransition.h"
 
 using namespace antlr4::atn;

--- a/runtime/Cpp/runtime/src/atn/WildcardTransition.h
+++ b/runtime/Cpp/runtime/src/atn/WildcardTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/ATNState.h"
 #include "atn/Transition.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/atn/WildcardTransition.h
+++ b/runtime/Cpp/runtime/src/atn/WildcardTransition.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "atn/TransitionType.h"
 #include "atn/ATNState.h"
 #include "atn/Transition.h"
 

--- a/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "misc/Interval.h"
 #include "Token.h"
 #include "antlr4-common.h"
 #include "Lexer.h"

--- a/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "misc/MurmurHash.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "Lexer.h"
 #include "Exceptions.h"

--- a/runtime/Cpp/runtime/src/tree/ErrorNode.h
+++ b/runtime/Cpp/runtime/src/tree/ErrorNode.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "tree/ParseTreeType.h"
 #include "tree/TerminalNode.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.h
+++ b/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include "tree/ErrorNode.h"
+#include "tree/ParseTreeType.h"
 #include "Token.h"
 #include "antlr4-common.h"
 #include "tree/TerminalNodeImpl.h"

--- a/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.h
+++ b/runtime/Cpp/runtime/src/tree/ErrorNodeImpl.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include "tree/ErrorNode.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "tree/TerminalNodeImpl.h"
 #include "misc/Interval.h"

--- a/runtime/Cpp/runtime/src/tree/ParseTree.h
+++ b/runtime/Cpp/runtime/src/tree/ParseTree.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include "support/Any.h"
+#include "misc/Interval.h"
 #include "antlr4-common.h"
 #include "tree/ParseTreeType.h"
 

--- a/runtime/Cpp/runtime/src/tree/TerminalNode.h
+++ b/runtime/Cpp/runtime/src/tree/TerminalNode.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "Token.h"
 #include "tree/ParseTree.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/TerminalNode.h
+++ b/runtime/Cpp/runtime/src/tree/TerminalNode.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "antlr4-common.h"
+#include "tree/ParseTreeType.h"
 #include "Token.h"
 #include "tree/ParseTree.h"
 

--- a/runtime/Cpp/runtime/src/tree/TerminalNodeImpl.h
+++ b/runtime/Cpp/runtime/src/tree/TerminalNodeImpl.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "tree/TerminalNode.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/TerminalNodeImpl.h
+++ b/runtime/Cpp/runtime/src/tree/TerminalNodeImpl.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include "antlr4-common.h"
+#include "misc/Interval.h"
 #include "Token.h"
 #include "tree/TerminalNode.h"
 

--- a/runtime/Cpp/runtime/src/tree/TerminalNodeImpl.h
+++ b/runtime/Cpp/runtime/src/tree/TerminalNodeImpl.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include "antlr4-common.h"
+#include "tree/ParseTreeType.h"
 #include "misc/Interval.h"
 #include "Token.h"
 #include "tree/TerminalNode.h"

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstddef>
 #include "tree/pattern/ParseTreePattern.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "tree/pattern/ParseTreeMatch.h"
 #include "tree/TerminalNode.h"

--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.h
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <string>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "Exceptions.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "XPathLexer.h"
+#include "ANTLRInputStream.h"
 #include "Token.h"
 #include "antlr4-common.h"
 #include "XPathLexerErrorListener.h"

--- a/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPath.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstddef>
 #include "XPathLexer.h"
+#include "Token.h"
 #include "antlr4-common.h"
 #include "XPathLexerErrorListener.h"
 #include "XPathElement.h"

--- a/runtime/Cpp/runtime/src/tree/xpath/XPath.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPath.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include "Token.h"
 #include "antlr4-common.h"
 
 namespace antlr4 {

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexerErrorListener.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexerErrorListener.cpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <cstddef>
+#include "Token.h"
 #include "XPathLexerErrorListener.h"
 
 using namespace antlr4;

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexerErrorListener.h
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexerErrorListener.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
+#include "Token.h"
 #include "BaseErrorListener.h"
 
 namespace antlr4 {


### PR DESCRIPTION
One commit per header for easier review.

Done semi-automatically by taking the output of `clang-tidy`'s `misc-include-cleaner` reports and inserting them where needed.

```
~/src/henner-tools/dev-tools/insert-header.cc 'tree/ParseTreeType.h' $(grep "no header providing.*misc-include-cleaner" Cpp_clang-tidy.out | awk -F: '/^runtime\/.*"antlr4::tree::ParseTreeType"/ { print $1}' | sort -u)
```

This is not done for all missing headers yet, some of the remaining reports point to cyclic dependencies that now work because everyone sees the forward declarations `support/Declarations.h`. My goal is minimize the reliance on these forward declarations and reach a good `IWYU` situation for a clear view of the internal dependencies.

Anyway, here a first round.