### PR TITLE
RuleContext: use correct override.

### DIFF
--- a/runtime/Cpp/runtime/src/RuleContext.h
+++ b/runtime/Cpp/runtime/src/RuleContext.h
@@ -138,8 +138,6 @@ namespace antlr4 {
 
     virtual std::string toString(const std::vector<std::string> &ruleNames, RuleContext *stop);
 
-    bool operator == (const RuleContext &other) { return this == &other; } // Simple address comparison.
-
   private:
     void InitializeInstanceFields();
   };


### PR DESCRIPTION
The operator== in RuleContext only mildly looked like the virtual operator== in the base class: it does take a different parameter and was not const.

This results in warnings by the compiler complaining about a shadowed method:

```
/usr/include/antlr4-runtime/tree/ParseTree.h:50:18: warning: ‘virtual bool antlr4::tree::ParseTree::operator==(const antlr4::tree::ParseTree&) const’ was hidden [-Woverloaded-virtual=]
   50 |     virtual bool operator == (const ParseTree &other) const;
      |                  ^~~~~~~~
/usr/include/antlr4-runtime/RuleContext.h:135:10: note:   by ‘bool antlr4::RuleContext::operator==(const antlr4::RuleContext&)’
  135 |     bool operator == (const RuleContext &other) { return this == &other; } // Simple address comparison.
```

This does not look intentional. Fix by using the correct parameter (which is the base class) and mark it const and override.
