### PR TITLE
[antlr4] Do not leave EOF in an undefined state after including antlr-runtime.h

### DIFF
--- a/runtime/Cpp/runtime/src/antlr4-runtime.h
+++ b/runtime/Cpp/runtime/src/antlr4-runtime.h
@@ -9,6 +9,12 @@
 
 // IWYU pragma: begin_exports
 
+// antlr4-common.h undef EOF, so we need to save it and recover later.
+#ifdef EOF
+#pragma push_macro("EOF")
+#define ANTLR_SAVED_EOF
+#endif
+
 #include "antlr4-common.h"
 
 #include "ANTLRErrorListener.h"
@@ -168,5 +174,9 @@
 #include "tree/xpath/XPathWildcardAnywhereElement.h"
 #include "tree/xpath/XPathWildcardElement.h"
 #include "internal/Synchronization.h"
+
+#ifdef ANTLR_SAVED_EOF
+#pragma pop_macro("EOF")
+#endif
 
 // IWYU pragma: end_exports


### PR DESCRIPTION
Signed-off-by: Yuxuan Chen <ych@meta.com>

`antlr-common.h` attempts to undefine EOF and leaves it in an undefined state. However, this breaks when you attempt to include header that expects EOF to be there. (e.g. you can't include <strstream> any more after including `antlr-runtime.h`)

This patch proposes using `push_macro` to save the EOF macro before we try to do anything and `pop_macro` right before the end of `antlr-runtime.h`. 