### PR TITLE
Fix a CMake v4.0.0 build error (related to `googletest`)

### DIFF
--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -70,7 +70,7 @@ if (ANTLR_BUILD_CPP_TESTS)
 
   FetchContent_Declare(
     googletest
-    URL https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.zip
+    URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
   )
 
   if(WITH_STATIC_CRT)


### PR DESCRIPTION
CMake version 4.0.0 doesn't support the currently used `googletest` CMake project version. As such, updating the project to the latest version makes sense.

(This closes https://github.com/antlr/antlr4/issues/4807)

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
