### PR TITLE
تحديث ContRIUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@
 4. Install and configure [EditorConfig](http://editorconfig.org/) so your text editor or IDE uses the ANTLR 4 coding style
 5. [Build ANTLR 4](doc/building-antlr.md)
 6. [Run the ANTLR project unit tests](doc/antlr-project-testing.md)
-7. Create a [pull request](https://help.github.com/articles/using-pull-requests/) with your changes and make sure you're comparing your `dev`-derived branch in your fork to the `dev` branch from the `antlr/antlr4` repo:
+7.   إنشاء أ.   [طلب السحب.](https://help.github.com/articles/[بدء التشغيل.MD](https://github.com/user-attachments/files/19559938/getting-started.md)
+     استخدام-سحب-طلبات/) مع التغييرات الخاصة بك وتأكد من أنك تقارن الخاص بك. 'dev'-الفرع المشتقة في شوكتك إلى    'ديف.  '    فرع من...    `ANTLR/ANTLR4'ANTLR/ANTLR4.' الريبو:  
 
 <img src="doc/images/PR-on-dev.png" width="600">
 


### PR DESCRIPTION
الفراغ العام الرئيسي (String[] args) {
أداة antlr = أداة جديدة (args) ؛
StringBuilder b = منشئ سلسلة جديد () ؛  إذا (args.length == 0) {
antlr.help () ؛
binding.et.setText (String.valueOf (antlr.errMgr.getNumErrors ())) ؛  }

حاول {

antlr.processGrammarsOnCommandLine () ؛
antlr.addListener (
ANTLRToolListener () {  @override
معلومات الفراغ العام (معلومات الأوتار) {
ب.الملحق (معلومات).الملحق ("\n") ؛  binding.et.setText (b.toString ()) ؛
}

@override
خطأ الفراغ العام (خطأ ANTLRMessage) {  b.append (خطأ.fileName).append ("\n") ؛
binding.et.setText (b.toString ()) ؛  }

@override
تحذير الفراغ العام (حرب ANTLRMessage) {
b.append (war.fileName).append ("\n") ؛  binding.et.setText (b.toString ()) ؛
}
});
} أخيرا {
إذا (AntLr.log) {  حاول {
اسم سجل الأوتار = antlr.logMgr.save ();
System.out.println ("كتب " + اسم السجل) ؛  binding.et.setText ("كتب " + اسم السجل) ؛
} الصيد (IOException ioe) {
antlr.errMgr.toolError (نوع الخطأ. INTERNAL_ERROR، IOE) ؛  }
}
}
}

<!--
شكرا لاقتراح مساهمة في مشروع ANTLR!

(يرجى التأكد من أن علاقاتك العامة في فرع آخر غير dev أو master  وتأكد أيضًا من أنك تستمد هذا الفرع من dev.)

اعتبارًا من 4.10، تستخدم ANTLR مطور مؤسسة Linux Foundation شهادة المنشأ، DCO، الإصدار 1.1. انظر إما.
https://developercertificate.org/ أو ملف
contributors-cert-of-origin.txt في الدليل الرئيسي. 

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.) --> 