### PR TITLE
[Go] Use strings.Builder instead of string concat

### DIFF
--- a/runtime/Go/antlr/v4/common_token_stream.go
+++ b/runtime/Go/antlr/v4/common_token_stream.go
@@ -6,6 +6,7 @@ package antlr
 
 import (
 	"strconv"
+	"strings"
 )
 
 // CommonTokenStream is an implementation of TokenStream that loads tokens from
@@ -351,7 +352,7 @@ func (c *CommonTokenStream) GetTextFromInterval(interval Interval) string {
 		stop = len(c.tokens) - 1
 	}
 
-	s := ""
+	var sb strings.Builder
 
 	for i := start; i < stop+1; i++ {
 		t := c.tokens[i]
@@ -360,10 +361,10 @@ func (c *CommonTokenStream) GetTextFromInterval(interval Interval) string {
 			break
 		}
 
-		s += t.GetText()
+		sb.WriteString(t.GetText())
 	}
 
-	return s
+	return sb.String()
 }
 
 // Fill gets all tokens from the lexer until EOF.


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
This commit optimizes the performance of the GetTextFromInterval method when a single SQL text is too large
