### PR TITLE
fix: Cpp $rule.text fail if $rule is nullptr

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Cpp/Cpp.stg
@@ -979,7 +979,7 @@ RulePropertyRef_stopHeader(r)  ::= "<! Required but unused. !>"
 RulePropertyRef_stop(r)  ::= "(<ctx(r)>-><r.label> != nullptr ? (<ctx(r)>-><r.label>->stop) : nullptr)"
 
 RulePropertyRef_textHeader(r)  ::= "<! Required but unused. !>"
-RulePropertyRef_text(r)  ::= "(<ctx(r)>-><r.label> != nullptr ? _input->getText(<ctx(r)>-><r.label>->start, <ctx(r)>-><r.label>->stop) : nullptr)"
+RulePropertyRef_text(r)  ::= "(<ctx(r)>-><r.label> != nullptr ? _input->getText(<ctx(r)>-><r.label>->start, <ctx(r)>-><r.label>->stop) : \"\")"
 
 RulePropertyRef_ctxHeader(r)   ::= "<! Required but unused. !>"
 RulePropertyRef_ctx(r)   ::= "<ctx(r)>-><r.label>"


### PR DESCRIPTION
With a grammar like this:

```antlr
rule: (VAL | VAR {
        is_constant = false;
    }) name=IDENTIFIER (COLON type {
        type_name = $type.text; <-- we look this line
    })? (EQ value=expression {
        value = $value.tree;
    })?
```

When generating for Cpp target we get this specific result:

```cpp
type_name = (antlrcpp::downCast<Variable_declarationContext *>(_localctx)->typeContext != nullptr ? _input->getText(antlrcpp::downCast<Variable_declarationContext *>(_localctx)->typeContext->start, antlrcpp::downCast<Variable_declarationContext *>(_localctx)->typeContext->stop) : nullptr);
```

If input doesn't match the `type` branch then we fallback on nullptr. As of cpp23 standard this line doesn't compile as it waits for `std::string`.

AS `Token::getText` returns `std::string`, then fallback value should be empty string

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
