### PR TITLE
chore(deps-dev): Update CI ubuntu image to 22

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [
           macos-15,
-          ubuntu-20.04,
+          ubuntu-22.04,
           windows-2022
         ]
         compiler: [ clang, gcc ]
@@ -161,7 +161,7 @@ jobs:
       matrix:
         os: [
           macos-15,
-          ubuntu-20.04,
+          ubuntu-22.04,
           windows-2022
         ]
         target: [


### PR DESCRIPTION
ubuntu-20.04 runner image is deprecated since 2025-02-01 and fully unsupported since 2025-04-15

See https://github.com/actions/runner-images/issues/11101
