### PR TITLE
switch to golang standard library for slices

### DIFF
--- a/runtime/Go/antlr/v4/go.mod
+++ b/runtime/Go/antlr/v4/go.mod
@@ -1,5 +1,3 @@
 module github.com/antlr4-go/antlr/v4
 
-go 1.20
-
-require golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
+go 1.21

--- a/runtime/Go/antlr/v4/lexer_action_executor.go
+++ b/runtime/Go/antlr/v4/lexer_action_executor.go
@@ -4,7 +4,7 @@
 
 package antlr
 
-import "golang.org/x/exp/slices"
+import "slices"
 
 // Represents an executor for a sequence of lexer actions which traversed during
 // the Matching operation of a lexer rule (token).


### PR DESCRIPTION
`slices` package has been available since golang 1.21 [1]. current supported versions of golang is 1.22 and 1.23 [2].

So, Can we please bump
- at least 1.21 in go.mod
- switch the import to drop the experimental `x/exp` package

Context: in kubernetes, we have been trying to remove the usage of `x/exp` for a while now [3] and this is the last bit we need. thanks!

cc @liggitt 

[1] https://tip.golang.org/doc/go1.21#slices
[2] https://endoflife.date/go
[3] https://github.com/kubernetes/kubernetes/issues/128571
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
