### PR TITLE
perf(runtime): Optimize thread safety and performance for DFA state management 

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -687,18 +687,17 @@ public class LexerATNSimulator extends ATNSimulator {
 		}
 
 		DFA dfa = decisionToDFA[mode];
-		synchronized (dfa.states) {
-			DFAState existing = dfa.states.get(proposed);
-			if ( existing!=null ) return existing;
 
-			DFAState newState = proposed;
+		DFAState existing = dfa.states.get(proposed);
+		if ( existing!=null ) return existing;
 
-			newState.stateNumber = dfa.states.size();
-			configs.setReadonly(true);
-			newState.configs = configs;
-			dfa.states.put(newState, newState);
-			return newState;
-		}
+		DFAState newState = proposed;
+
+		newState.stateNumber = dfa.states.size();
+		configs.setReadonly(true);
+		newState.configs = configs;
+		dfa.states.put(newState, newState);
+		return newState;
 	}
 
 

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ParserATNSimulator.java
@@ -2101,26 +2101,24 @@ public class ParserATNSimulator extends ATNSimulator {
 			return D;
 		}
 
-		synchronized (dfa.states) {
-			DFAState existing = dfa.states.get(D);
+		DFAState existing = dfa.states.get(D);
 
-			if ( existing!=null ) {
-				if ( trace_atn_sim ) System.out.println("addDFAState " + D + " exists");
-				return existing;
-			}
-
-			D.stateNumber = dfa.states.size();
-
-			if (!D.configs.isReadonly()) {
-				D.configs.optimizeConfigs(this);
-				D.configs.setReadonly(true);
-			}
-
-			if ( trace_atn_sim ) System.out.println("addDFAState new "+D);
-
-			dfa.states.put(D, D);
-			return D;
+		if ( existing!=null ) {
+			if ( trace_atn_sim ) System.out.println("addDFAState " + D + " exists");
+			return existing;
 		}
+
+		D.stateNumber = dfa.states.size();
+
+		if (!D.configs.isReadonly()) {
+			D.configs.optimizeConfigs(this);
+			D.configs.setReadonly(true);
+		}
+
+		if ( trace_atn_sim ) System.out.println("addDFAState new "+D);
+
+		dfa.states.put(D, D);
+		return D;
 	}
 
 	protected void reportAttemptingFullContext(DFA dfa, BitSet conflictingAlts, ATNConfigSet configs, int startIndex, int stopIndex) {

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/DFA.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/DFA.java
@@ -16,17 +16,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class DFA {
 	/** A set of all DFA states. Use {@link Map} so we can get old state back
 	 *  ({@link Set} only allows you to see if it's there).
      */
 
-	public final Map<DFAState, DFAState> states = new HashMap<DFAState, DFAState>();
+	public final Map<DFAState, DFAState> states = new ConcurrentHashMap<>();
 
 	public volatile DFAState s0;
 


### PR DESCRIPTION
Hi, team

As mentioned in issue #2454, I also found a performance bottleneck in ANTLR caused by the lock on the `DFA.states` object. Due to lock contention, the performance degrades significantly under high concurrency.

In my test case — parsing a SQL file with 400,000 characters — a single parse took about 200ms. However, when I increased the concurrency to 32 threads, the per-request latency jumped to 5–10 seconds. While not all SQL statements are this long, and it's expected that longer queries take more time, the current implementation introduces a serious issue: a single long SQL parsing task can block many short ones due to the global lock, causing the latency of short SQL statements to increase dramatically beyond expectations.

This problem can be resolved with a very simple change: replacing the `synchronized` HashMap with a `ConcurrentHashMap`.
