### PR TITLE
[JavaScript-runtime] Add getInvokingContext to Parser.d.ts

### DIFF
--- a/runtime/JavaScript/src/antlr4/Parser.d.ts
+++ b/runtime/JavaScript/src/antlr4/Parser.d.ts
@@ -46,5 +46,6 @@ export declare class Parser extends Recognizer<Token> {
     setTokenStream(input: TokenStream): void;
     notifyErrorListeners(msg: string, offendingToken: Token, err: RecognitionException | undefined): void;
     getCurrentToken(): Token;
+    getInvokingContext(ruleIndex: number): ParserRuleContext;
     
 }


### PR DESCRIPTION
When using non-local attribute references in the grammar (ex: `{$ruleName::MyAttribute}?`), the target [generates code](https://github.com/dudemaga/antlr4/blob/694898420da04b23de77032ba10befd737e5e21b/tool/resources/org/antlr/v4/tool/templates/codegen/JavaScript/JavaScript.stg#L577) that uses the `getInvokingContext` function in the parser. However, currently the function is not in the Parser type definition. This causes issues when using the runtime in a Typescript project.

This PR just adds the function to the Parser type definition as it is used in the code generation.