### PR TITLE
Bump deprecated ubuntu

### DIFF
--- a/.github/workflows/hosted.yml
+++ b/.github/workflows/hosted.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [
           macos-15,
-          ubuntu-20.04,
+          ubuntu-22.04,
           windows-2022
         ]
         compiler: [ clang, gcc ]
@@ -161,7 +161,7 @@ jobs:
       matrix:
         os: [
           macos-15,
-          ubuntu-20.04,
+          ubuntu-22.04,
           windows-2022
         ]
         target: [


### PR DESCRIPTION
ubuntu-20.04 is no longer available for running CI on GH
This PR updates the CI tu use ubuntu-22.04 instead
