### PR TITLE
Antlr4 action error position display

### DIFF
--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestAttributeChecks.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestAttributeChecks.java
@@ -9,9 +9,16 @@ package org.antlr.v4.test.tool;
 import org.antlr.runtime.RecognitionException;
 import org.antlr.v4.tool.ErrorType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.misc.ErrorBuffer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.antlr.v4.test.tool.ToolTestUtils.testErrors;
 
@@ -145,7 +152,7 @@ public class TestAttributeChecks {
 		"$S::j = $S::k;",	"error(" + ErrorType.UNDEFINED_RULE_IN_NONLOCAL_REF.code + "): A.g4:5:8: reference to undefined rule S in non-local ref $S::j = $S::k;\n",
 	};
 
-	String[] dynInlineChecks = {
+	static String[] dynInlineChecks = {
 		"$a",			"error(" + ErrorType.ISOLATED_RULE_REF.code + "): A.g4:7:4: missing attribute access on rule reference a in $a\n",
 		"$b",			"error(" + ErrorType.ISOLATED_RULE_REF.code + "): A.g4:7:4: missing attribute access on rule reference b in $b\n",
 		"$lab",			"error(" + ErrorType.ISOLATED_RULE_REF.code + "): A.g4:7:4: missing attribute access on rule reference lab in $lab\n",
@@ -214,8 +221,18 @@ public class TestAttributeChecks {
 		testActions("inline", inlineChecks, attributeTemplate);
 	}
 
-	@Test public void testDynamicInlineActions() throws RecognitionException {
-		testActions("inline", dynInlineChecks, attributeTemplate);
+	public static Stream<Arguments> testDynamicInlineActionsParams() {
+		List<Arguments> arguments = new ArrayList<>();
+		for (int i = 0; i < dynInlineChecks.length; i+=2) {
+			arguments.add(Arguments.of(dynInlineChecks[i], dynInlineChecks[i+1]));
+		}
+		return arguments.stream();
+	}
+
+	@ParameterizedTest
+	@MethodSource("testDynamicInlineActionsParams")
+	public void testDynamicInlineActions(String input, String expected) {
+		testAction("inline", attributeTemplate, input, expected);
 	}
 
 	@Test public void testBadInlineActions() throws RecognitionException {
@@ -244,12 +261,16 @@ public class TestAttributeChecks {
 		for (int i = 0; i < pairs.length; i += 2) {
 			String action = pairs[i];
 			String expected = pairs[i + 1];
-			STGroup g = new STGroup('<', '>');
-			g.setListener(new ErrorBuffer()); // hush warnings
-			ST st = new ST(g, template);
-			st.add(location, action);
-			String grammar = st.render();
-			testErrors(new String[]{grammar, expected}, false);
+			testAction(location, template, action, expected);
 		}
+	}
+
+	private static void testAction(String location, String template, String action, String expected) {
+		STGroup g = new STGroup('<', '>');
+		g.setListener(new ErrorBuffer()); // hush warnings
+		ST st = new ST(g, template);
+		st.add(location, action);
+		String grammar = st.render();
+		testErrors(new String[]{grammar, expected}, false);
 	}
 }

--- a/tool/src/org/antlr/v4/semantics/ActionErrorManager.java
+++ b/tool/src/org/antlr/v4/semantics/ActionErrorManager.java
@@ -1,0 +1,117 @@
+package org.antlr.v4.semantics;
+
+import org.antlr.runtime.CommonToken;
+import org.antlr.runtime.RecognitionException;
+import org.antlr.runtime.Token;
+import org.antlr.v4.tool.*;
+import org.stringtemplate.v4.ST;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class ActionErrorManager extends ErrorManager {
+	private final Token actionToken;
+	private final ErrorManager delegate;
+
+	public ActionErrorManager(Token actionToken, ErrorManager delegate) {
+		super(delegate.tool);
+		this.delegate = Objects.requireNonNull(delegate, "ErrorManager delegate cannot be null");
+		this.actionToken = Objects.requireNonNull(actionToken, "Token actionToken cannot be null");
+	}
+
+	@Override
+	public void grammarError(ErrorType etype, String fileName, Token token, Object... args) {
+		delegate.grammarError(etype, fileName, resolveTokenWithGrammarAbsolutePosition(token), args);
+	}
+
+	private Token resolveTokenWithGrammarAbsolutePosition(Token token) {
+		if (token instanceof CommonToken && actionToken instanceof CommonToken) {
+			CommonToken absolutePositionToken = new CommonToken(token);
+			CommonToken ruleToken = (CommonToken) actionToken;
+			absolutePositionToken.setStartIndex(ruleToken.getStartIndex() + absolutePositionToken.getStartIndex());
+			absolutePositionToken.setStopIndex(ruleToken.getStartIndex() + absolutePositionToken.getStopIndex());
+			return absolutePositionToken;
+		}
+		return token;
+	}
+
+	@Override
+	public void resetErrorState() {
+		delegate.resetErrorState();
+	}
+
+	@Override
+	public ST getMessageTemplate(ANTLRMessage msg) {
+		return delegate.getMessageTemplate(msg);
+	}
+
+	@Override
+	public ST getLocationFormat() {
+		return delegate.getLocationFormat();
+	}
+
+	@Override
+	public ST getReportFormat(ErrorSeverity severity) {
+		return delegate.getReportFormat(severity);
+	}
+
+	@Override
+	public ST getMessageFormat() {
+		return delegate.getMessageFormat();
+	}
+
+	@Override
+	public boolean formatWantsSingleLineMessage() {
+		return delegate.formatWantsSingleLineMessage();
+	}
+
+	@Override
+	public void info(String msg) {
+		delegate.info(msg);
+	}
+
+	@Override
+	public void syntaxError(ErrorType etype, String fileName, Token token, RecognitionException antlrException, Object... args) {
+		delegate.syntaxError(etype, fileName, token, antlrException, args);
+	}
+
+	@Override
+	public void toolError(ErrorType errorType, Object... args) {
+		delegate.toolError(errorType, args);
+	}
+
+	@Override
+	public void toolError(ErrorType errorType, Throwable e, Object... args) {
+		delegate.toolError(errorType, e, args);
+	}
+
+	@Override
+	public void leftRecursionCycles(String fileName, Collection<? extends Collection<Rule>> cycles) {
+		delegate.leftRecursionCycles(fileName, cycles);
+	}
+
+	@Override
+	public int getNumErrors() {
+		return delegate.getNumErrors();
+	}
+
+	@Override
+	public void emit(ErrorType etype, ANTLRMessage msg) {
+		delegate.emit(etype, msg);
+	}
+
+	@Override
+	public void setFormat(String formatName) {
+		delegate.setFormat(formatName);
+	}
+
+	@Override
+	protected boolean verifyFormat() {
+		return super.verifyFormat();
+	}
+
+	@Override
+	public void panic(ErrorType errorType, Object... args) {
+		delegate.panic(errorType, args);
+	}
+}

--- a/tool/src/org/antlr/v4/semantics/AttributeChecks.java
+++ b/tool/src/org/antlr/v4/semantics/AttributeChecks.java
@@ -7,6 +7,7 @@
 package org.antlr.v4.semantics;
 
 import org.antlr.runtime.ANTLRStringStream;
+import org.antlr.runtime.CommonToken;
 import org.antlr.runtime.Token;
 import org.antlr.v4.parse.ActionSplitter;
 import org.antlr.v4.parse.ActionSplitterListener;
@@ -39,8 +40,8 @@ public class AttributeChecks implements ActionSplitterListener {
         this.alt = alt;
         this.node = node;
         this.actionToken = actionToken;
-		this.errMgr = g.tool.errMgr;
-    }
+		this.errMgr = new ActionErrorManager(actionToken, g.tool.errMgr);
+	}
 
     public static void checkAllAttributeExpressions(Grammar g) {
         for (ActionAST act : g.namedActions.values()) {


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->

Fix for invalid displaying errors in actions in intellij plugin. Invalid display was caused by providing action relative position instead of absolute position.
Issue: https://github.com/antlr/antlr4/issues/4879
@parrt can you take a look?
before:
![image](https://github.com/user-attachments/assets/33b0eeaf-7ae2-4461-ba27-be5f5f1e12e6)
after:
![image](https://github.com/user-attachments/assets/862c3b42-36ee-4f30-af41-53a6a7303054)

