### PR TITLE
Fix Dart/Flutter web integer literals JavaScript overflow error

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Dart/Dart.stg
@@ -519,7 +519,7 @@ testShiftInRange(shiftAmount) ::= <<
 >>
 
 bitsetBitfieldComparison(s, bits) ::= <%
-(<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((1 \<\< <offsetShift(s.varName, bits.shift)>) & <bits.calculated>) != 0)
+(<testShiftInRange({<offsetShift(s.varName, bits.shift)>})> && ((BigInt.one \<\< <offsetShift(s.varName, bits.shift)>) & BigInt.parse('<bits.calculated>')) != BigInt.zero)
 %>
 
 isZero ::= [


### PR DESCRIPTION
Fix for https://github.com/antlr/antlr4/issues/4880
Using BigInt for proper handling integer literals >= 2^53 when building Flutter web
