### PR TITLE
fix(Go) issue in ATNConfig::LEquals

### DIFF
--- a/runtime/Go/antlr/v4/atn_config.go
+++ b/runtime/Go/antlr/v4/atn_config.go
@@ -313,7 +313,7 @@ func (a *ATNConfig) LEquals(other Collectable[*ATNConfig]) bool {
 
 	switch {
 	case a.lexerActionExecutor == nil && otherT.lexerActionExecutor == nil:
-		return true
+		//return true
 	case a.lexerActionExecutor != nil && otherT.lexerActionExecutor != nil:
 		if !a.lexerActionExecutor.Equals(otherT.lexerActionExecutor) {
 			return false


### PR DESCRIPTION
it may cause some token can't match with text (some ATN's target in the token have same hash with other token's)
fix issue about AtnStatesSizeMoreThan65535 test failure. [PR 3842](https://github.com/antlr/antlr4/pull/3842)