### PR TITLE
fix(java): ATN.getExpectedTokens expects RuleTransition but gets EpsilonTransition (issue #4843)

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/atn/ATN.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/ATN.java
@@ -180,7 +180,12 @@ public class ATN {
 		expected.remove(Token.EPSILON);
 		while (ctx != null && ctx.invokingState >= 0 && following.contains(Token.EPSILON)) {
 			ATNState invokingState = states.get(ctx.invokingState);
-			RuleTransition rt = (RuleTransition)invokingState.transition(0);
+			Transition t = invokingState.transition(0);
+			while (t instanceof EpsilonTransition) {
+				EpsilonTransition et = (EpsilonTransition) t;
+				t = et.target.transition(0);
+			}
+			RuleTransition rt = (RuleTransition) t;
 			following = nextTokens(rt.followState);
 			expected.addAll(following);
 			expected.remove(Token.EPSILON);


### PR DESCRIPTION
Resolved the issue raised in #4843. According to the convention, invokingState.transition(0) should be a RuleTransition, but I found that sometimes it can also be an EpsilonTransition. So I tried following this EpsilonTransition to find the actual RuleTransition.

The method to reproduce this issue can be found in the issue #4843 

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
