### PR TITLE
Remove Interval internal cache

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/misc/Interval.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/misc/Interval.java
@@ -7,11 +7,7 @@ package org.antlr.v4.runtime.misc;
 
 /** An immutable inclusive interval a..b */
 public class Interval {
-	public static final int INTERVAL_POOL_MAX_VALUE = 1000;
-
 	public static final Interval INVALID = new Interval(-1,-2);
-
-	static final Interval[] cache = new Interval[INTERVAL_POOL_MAX_VALUE+1];
 
 	public int a;
 	public int b;
@@ -25,14 +21,7 @@ public class Interval {
 	 *  have a..a (set with 1 element).
 	 */
 	public static Interval of(int a, int b) {
-		// cache just a..a
-		if ( a!=b || a<0 || a>INTERVAL_POOL_MAX_VALUE ) {
-			return new Interval(a,b);
-		}
-		if ( cache[a]==null ) {
-			cache[a] = new Interval(a,a);
-		}
-		return cache[a];
+		return new Interval(a,b);
 	}
 
 	/** return number of elements between a and b inclusively. x..x is length 1.


### PR DESCRIPTION
The cache is not thread safe, but it was used in the multithreaded context, making it possible for the `Interval.of` method to return invalid values.

This is a proposed fix for the https://github.com/antlr/antlr4/issues/4901

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
