### PR TITLE
Change printf to use System.out instead of System.err

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/RuntimeMetaData.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/RuntimeMetaData.java
@@ -157,11 +157,11 @@ public class RuntimeMetaData {
 			!getMajorMinorVersion(runtimeVersion).equals(getMajorMinorVersion(compileTimeVersion));
 
 		if ( runtimeConflictsWithGeneratingTool ) {
-			System.err.printf("ANTLR Tool version %s used for code generation does not match the current runtime version %s%n",
+			System.out.printf("ANTLR Tool version %s used for code generation does not match the current runtime version %s%n",
 							  generatingToolVersion, runtimeVersion);
 		}
 		if ( runtimeConflictsWithCompileTimeTool ) {
-			System.err.printf("ANTLR Runtime version %s used for parser compilation does not match the current runtime version %s%n",
+			System.out.printf("ANTLR Runtime version %s used for parser compilation does not match the current runtime version %s%n",
 							  compileTimeVersion, runtimeVersion);
 		}
 	}


### PR DESCRIPTION
It seems to be an overkiil to log such problems as errors.

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
