### PR TITLE
build: fix location of installed c++ headers

### DIFF
--- a/runtime/Cpp/runtime/CMakeLists.txt
+++ b/runtime/Cpp/runtime/CMakeLists.txt
@@ -7,7 +7,7 @@ if (NOT ANTLR_BUILD_SHARED AND NOT ANTLR_BUILD_STATIC)
   message(FATAL_ERROR "Options ANTLR_BUILD_SHARED and ANTLR_BUILD_STATIC can't both be OFF")
 endif()
 
-set(libantlrcpp_INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/antlr4-runtime")
+set(libantlrcpp_INCLUDE_INSTALL_DIR "include/antlr4-runtime")
 
 set(libantlrcpp_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/runtime/src


### PR DESCRIPTION
Prior to this fix, include files would be installed in the wrong location.  For example, if the install prefix was /usr/local, the headers would be installed in /usr/local/antlr4-runtime instead of /usr/local/include/antlr4-runtime.

This resolves issue #4924 