### PR TITLE
Add filename tracking on Token, TokenSource, and Lexer (Java runtime)

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/TestTokenFile.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/TestTokenFile.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+package org.antlr.v4.test.runtime.java.api;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.IntStream;
+import org.antlr.v4.runtime.ListTokenSource;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenSource;
+import org.antlr.v4.runtime.TokenFactory;
+import org.antlr.v4.runtime.WritableToken;
+import org.antlr.v4.runtime.misc.Pair;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for the optional {@code file} property on {@link Token},
+ * {@link TokenSource}, and {@link WritableToken}.
+ *
+ * <p>These tests cover the new public API (default interface methods on
+ * {@code Token}/{@code TokenSource}/{@code WritableToken}, the
+ * {@code file} field on {@link CommonToken}, the propagation through
+ * {@link CommonToken}'s {@code (Pair, ...)} and copy constructors, and
+ * {@link ListTokenSource#getFile()} behavior).</p>
+ */
+public class TestTokenFile {
+
+	private static final String FILE_A = "alpha.g4";
+	private static final String FILE_B = "beta.g4";
+
+	// 1. Lexer.setFile propagates to tokens emitted afterward.
+	@Test
+	public void testLexerSetFilePropagatesToTokens() {
+		CharStream input = new ANTLRInputStream("AAA");
+		VisitorBasicLexer lexer = new VisitorBasicLexer(input);
+		lexer.setFile(FILE_A);
+
+		Token first = lexer.nextToken();
+		Token second = lexer.nextToken();
+		assertEquals(VisitorBasicLexer.A, first.getType());
+		assertEquals(VisitorBasicLexer.A, second.getType());
+		assertEquals(FILE_A, first.getFile());
+		assertEquals(FILE_A, second.getFile());
+		assertEquals(FILE_A, lexer.getFile());
+	}
+
+	// 2. CommonToken copy constructor preserves file.
+	@Test
+	public void testCommonTokenCopyConstructorPropagatesFile() {
+		CommonToken orig = new CommonToken(1, "x");
+		orig.setFile(FILE_A);
+		orig.setLine(7);
+
+		CommonToken copy = new CommonToken(orig);
+		assertEquals(FILE_A, copy.getFile());
+		assertEquals(7, copy.getLine());
+	}
+
+	// 3. CommonToken (Pair, ...) ctor pulls file from the source TokenSource.
+	@Test
+	public void testCommonTokenFromPairCarriesSourceFile() {
+		CharStream input = new ANTLRInputStream("AAA");
+		VisitorBasicLexer src = new VisitorBasicLexer(input);
+		src.setFile(FILE_B);
+
+		Pair<TokenSource, CharStream> pair = new Pair<TokenSource, CharStream>(src, input);
+		CommonToken t = new CommonToken(pair, 1, Token.DEFAULT_CHANNEL, 0, 0);
+		assertEquals(FILE_B, t.getFile());
+	}
+
+	// 4. ListTokenSource.getFile reflects the current position's file.
+	@Test
+	public void testListTokenSourceGetFileWithTokens() {
+		CommonToken t1 = new CommonToken(1, "a");
+		t1.setFile(FILE_A);
+		CommonToken t2 = new CommonToken(1, "b");
+		t2.setFile(FILE_A);
+
+		ListTokenSource src = new ListTokenSource(Arrays.<Token>asList(t1, t2));
+		assertEquals(FILE_A, src.getFile());
+		src.nextToken();
+		assertEquals(FILE_A, src.getFile());
+	}
+
+	// 5. Empty ListTokenSource returns "" (never null).
+	@Test
+	public void testListTokenSourceGetFileEmpty() {
+		ListTokenSource src = new ListTokenSource(Collections.<Token>emptyList());
+		assertNotNull(src.getFile());
+		assertEquals("", src.getFile());
+	}
+
+	// 6. setFile/getFile round-trips on a WritableToken.
+	@Test
+	public void testWritableTokenSetFileRoundTrip() {
+		WritableToken t = new CommonToken(1, "x");
+		t.setFile(FILE_A);
+		assertEquals(FILE_A, t.getFile());
+		t.setFile(FILE_B);
+		assertEquals(FILE_B, t.getFile());
+	}
+
+	// 7. A Token implementation that does NOT override getFile() picks up
+	// the interface default and returns "". This is the binary-compatibility
+	// guarantee for third-party Token implementations.
+	@Test
+	public void testTokenInterfaceDefaultGetFile() {
+		Token t = new MinimalToken();
+		assertEquals("", t.getFile());
+	}
+
+	// 8. A WritableToken implementation that does NOT override setFile()
+	// picks up the no-op default. Pre-existing third-party implementations
+	// keep compiling and calling setFile is a harmless no-op.
+	@Test
+	public void testWritableTokenInterfaceDefaultSetFile() {
+		MinimalWritableToken t = new MinimalWritableToken();
+		t.setFile(FILE_A);          // default no-op
+		assertEquals("", t.getFile()); // still default ""
+	}
+
+	/** Minimal Token impl that does not override the new default methods. */
+	private static class MinimalToken implements Token {
+		@Override public String getText() { return ""; }
+		@Override public int getType() { return 0; }
+		@Override public int getLine() { return 0; }
+		@Override public int getCharPositionInLine() { return 0; }
+		@Override public int getChannel() { return DEFAULT_CHANNEL; }
+		@Override public int getTokenIndex() { return -1; }
+		@Override public int getStartIndex() { return 0; }
+		@Override public int getStopIndex() { return 0; }
+		@Override public TokenSource getTokenSource() { return null; }
+		@Override public CharStream getInputStream() { return null; }
+		// getFile() intentionally omitted — exercises the default method.
+	}
+
+	/** Minimal WritableToken impl that does not override the new defaults. */
+	private static class MinimalWritableToken extends MinimalToken implements WritableToken {
+		@Override public void setText(String text) { }
+		@Override public void setType(int ttype) { }
+		@Override public void setLine(int line) { }
+		@Override public void setCharPositionInLine(int pos) { }
+		@Override public void setChannel(int channel) { }
+		@Override public void setTokenIndex(int index) { }
+		// setFile(String) intentionally omitted — exercises the default no-op.
+	}
+}

--- a/runtime/Java/src/org/antlr/v4/runtime/CommonToken.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CommonToken.java
@@ -24,6 +24,11 @@ public class CommonToken implements WritableToken, Serializable {
 	protected int type;
 
 	/**
+	 * This is the backing field for {@link #getFile} and {@link #setFile}.
+	 */
+	protected String file;
+
+	/**
 	 * This is the backing field for {@link #getLine} and {@link #setLine}.
 	 */
 	protected int line;
@@ -96,6 +101,7 @@ public class CommonToken implements WritableToken, Serializable {
 		this.start = start;
 		this.stop = stop;
 		if (source.a != null) {
+			this.file = source.a.getFile();
 			this.line = source.a.getLine();
 			this.charPositionInLine = source.a.getCharPositionInLine();
 		}
@@ -130,6 +136,7 @@ public class CommonToken implements WritableToken, Serializable {
 	 */
 	public CommonToken(Token oldToken) {
 		type = oldToken.getType();
+		file = oldToken.getFile();
 		line = oldToken.getLine();
 		index = oldToken.getTokenIndex();
 		charPositionInLine = oldToken.getCharPositionInLine();
@@ -150,6 +157,11 @@ public class CommonToken implements WritableToken, Serializable {
 	@Override
 	public int getType() {
 		return type;
+	}
+
+	@Override
+	public void setFile(String file) {
+		this.file = file;
 	}
 
 	@Override
@@ -186,6 +198,11 @@ public class CommonToken implements WritableToken, Serializable {
 	@Override
 	public void setText(String text) {
 		this.text = text;
+	}
+
+	@Override
+	public String getFile() {
+		return file;
 	}
 
 	@Override

--- a/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Lexer.java
@@ -258,6 +258,11 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 	}
 
 	@Override
+	public String getFile() {
+		return getInterpreter().getFile();
+	}
+
+	@Override
 	public int getLine() {
 		return getInterpreter().getLine();
 	}
@@ -265,6 +270,10 @@ public abstract class Lexer extends Recognizer<Integer, LexerATNSimulator>
 	@Override
 	public int getCharPositionInLine() {
 		return getInterpreter().getCharPositionInLine();
+	}
+
+	public void setFile(String file) {
+		getInterpreter().setFile(file);
 	}
 
 	public void setLine(int line) {

--- a/runtime/Java/src/org/antlr/v4/runtime/ListTokenSource.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/ListTokenSource.java
@@ -150,6 +150,29 @@ public class ListTokenSource implements TokenSource {
 	 * {@inheritDoc}
 	 */
 	@Override
+	public String getFile() {
+		if (i < tokens.size()) {
+			return tokens.get(i).getFile();
+		}
+		else if (eofToken != null) {
+			return eofToken.getFile();
+		}
+		else if (tokens.size() > 0) {
+			// have to calculate the result from the line/column of the previous
+			// token, along with the text of the token.
+			Token lastToken = tokens.get(tokens.size() - 1);
+			return lastToken.getFile();
+		}
+
+		// only reach this if tokens is empty, meaning EOF occurs at the first
+		// position in the input
+		return "";
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public int getLine() {
 		if (i < tokens.size()) {
 			return tokens.get(i).getLine();

--- a/runtime/Java/src/org/antlr/v4/runtime/Token.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/Token.java
@@ -59,6 +59,12 @@ public interface Token {
 	 */
 	int getLine();
 
+	/** The file (or other source name) this token came from. The default
+	 *  implementation returns the empty string for backwards compatibility
+	 *  with implementations that predate this method.
+	 */
+	default String getFile() { return ""; }
+
 	/** The index of the first character of this token relative to the
 	 *  beginning of the line at which it occurs, 0..n-1
 	 */

--- a/runtime/Java/src/org/antlr/v4/runtime/TokenSource.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/TokenSource.java
@@ -39,6 +39,13 @@ public interface TokenSource {
 	public int getLine();
 
 	/**
+	 * Get the file (or other source name) currently being tokenized.
+	 * Returns the empty string by default for backwards compatibility
+	 * with implementations that predate this method.
+	 */
+	default String getFile() { return ""; }
+
+	/**
 	 * Get the index into the current line for the current position in the input
 	 * stream. The first character on a line has position 0.
 	 *

--- a/runtime/Java/src/org/antlr/v4/runtime/WritableToken.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/WritableToken.java
@@ -11,6 +11,13 @@ public interface WritableToken extends Token {
 
 	public void setType(int ttype);
 
+	/**
+	 * Set the file (or other source name) this token came from.
+	 * The default implementation is a no-op for backwards compatibility
+	 * with implementations that predate this method.
+	 */
+	default void setFile(String file) { /* no-op */ }
+
 	public void setLine(int line);
 
 	public void setCharPositionInLine(int pos);

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -42,12 +42,14 @@ public class LexerATNSimulator extends ATNSimulator {
 	 */
 	protected static class SimState {
 		protected int index = -1;
+		protected String file = "";
 		protected int line = 0;
 		protected int charPos = -1;
 		protected DFAState dfaState;
 
 		protected void reset() {
 			index = -1;
+			file = "";
 			line = 0;
 			charPos = -1;
 			dfaState = null;
@@ -66,6 +68,11 @@ public class LexerATNSimulator extends ATNSimulator {
 
 	/** line number 1..n within the input */
 	protected int line = 1;
+
+	/** Optional file (or other source name) currently being lexed. Empty
+	 *  string when not set; surfaced through {@link Lexer#getFile()} and
+	 *  copied into each token via {@link org.antlr.v4.runtime.CommonToken}. */
+	protected String file = "";
 
 	/** The index of the character relative to the beginning of the line 0..n-1 */
 	protected int charPositionInLine = 0;
@@ -95,6 +102,7 @@ public class LexerATNSimulator extends ATNSimulator {
 
 	public void copyState(LexerATNSimulator simulator) {
 		this.charPositionInLine = simulator.charPositionInLine;
+		this.file = simulator.file;
 		this.line = simulator.line;
 		this.mode = simulator.mode;
 		this.startIndex = simulator.startIndex;
@@ -123,6 +131,7 @@ public class LexerATNSimulator extends ATNSimulator {
 	public void reset() {
 		prevAccept.reset();
 		startIndex = -1;
+		file = "";
 		line = 1;
 		charPositionInLine = 0;
 		mode = Lexer.DEFAULT_MODE;
@@ -296,6 +305,10 @@ public class LexerATNSimulator extends ATNSimulator {
 	{
 		if (prevAccept.dfaState != null) {
 			LexerActionExecutor lexerActionExecutor = prevAccept.dfaState.lexerActionExecutor;
+			// Restore the saved file before invoking accept so subclass overrides
+			// of the original 6-arg accept signature continue to see the right
+			// value through the simulator's `file` field.
+			this.file = prevAccept.file;
 			accept(input, lexerActionExecutor, startIndex,
 				prevAccept.index, prevAccept.line, prevAccept.charPos);
 			return prevAccept.dfaState.prediction;
@@ -585,6 +598,7 @@ public class LexerATNSimulator extends ATNSimulator {
 		}
 
 		int savedCharPositionInLine = charPositionInLine;
+		String savedFile = file;
 		int savedLine = line;
 		int index = input.index();
 		int marker = input.mark();
@@ -594,6 +608,7 @@ public class LexerATNSimulator extends ATNSimulator {
 		}
 		finally {
 			charPositionInLine = savedCharPositionInLine;
+			file = savedFile;
 			line = savedLine;
 			input.seek(index);
 			input.release(marker);
@@ -605,6 +620,7 @@ public class LexerATNSimulator extends ATNSimulator {
 								   DFAState dfaState)
 	{
 		settings.index = input.index();
+		settings.file = file;
 		settings.line = line;
 		settings.charPos = charPositionInLine;
 		settings.dfaState = dfaState;
@@ -712,6 +728,14 @@ public class LexerATNSimulator extends ATNSimulator {
 	public String getText(CharStream input) {
 		// index is first lookahead char, don't include.
 		return input.getText(Interval.of(startIndex, input.index()-1));
+	}
+
+	public String getFile() {
+		return file;
+	}
+
+	public void setFile(String file) {
+		this.file = file;
 	}
 
 	public int getLine() {


### PR DESCRIPTION
## What

Adds an optional filename property to the Java runtime so tokens can carry the source file they originated from.

- `Token.getFile()` — new **default method** returning `""` (backwards-compatible for third-party `Token` implementations).
- `TokenSource.getFile()` — new default method returning `""`.
- `WritableToken.setFile(String)` — new default no-op method.
- `CommonToken`: `file` field, getter/setter, propagated through the `(Pair, ...)` and copy constructors.
- `Lexer`: `getFile`/`setFile` delegating to the interpreter.
- `LexerATNSimulator`: `file` field saved/restored across speculative predicate evaluation; threaded through `SimState`. **The protected `accept(...)` signature is unchanged** — subclasses overriding it read `file` via the simulator's field.
- `ListTokenSource.getFile()`: mirrors the existing line/column logic.

## Why

Grammars that preprocess multiple input files (Verilog `` `include ``, SystemVerilog package files, C-style `#include`-style preludes, etc.) want to surface the originating filename in diagnostics without maintaining a parallel stream-to-filename map. We've been carrying this delta on a fork since 2018 and would like to upstream it.

## Compatibility

- **No source/binary break.** New methods on `Token`, `TokenSource`, `WritableToken` are `default`. Any third-party implementor of these interfaces continues to compile and link unchanged.
- **No subclass break.** `LexerATNSimulator.accept(CharStream, LexerActionExecutor, int, int, int, int)` keeps its existing signature. The previous (saved) `file` is written to `this.file` immediately before `accept` is invoked, so subclass overrides see the right value through the field.
- **No allocation regression on the hot path.** One extra reference field on `CommonToken` and one on the simulator. `LexerATNSimulator` initialises `file` to the interned literal `\"\"` (not `new String(\"\")`).

## Tests

`runtime-testsuite/test/org/antlr/v4/test/runtime/java/api/TestTokenFile.java` adds 8 cases:

1. `Lexer.setFile` propagates to tokens emitted afterward.
2. `CommonToken` copy constructor preserves `file`.
3. `CommonToken(Pair, ...)` carries `file` from the source `TokenSource`.
4. `ListTokenSource.getFile()` reflects the current position's file.
5. `ListTokenSource.getFile()` returns `\"\"` (not null) when empty.
6. `WritableToken.setFile`/`getFile` round-trip on `CommonToken`.
7. A minimal `Token` impl with no `getFile` override returns `\"\"` via the default method.
8. A minimal `WritableToken` impl with no `setFile` override accepts the call as a no-op.

`mvn -pl runtime-testsuite test -Dtest='TestTokenStream,TestTokenStreamRewriter,TestExpectedTokens,TestVisitors,TestTokenFile'` → 61/61 pass locally.

## Cross-runtime

Scoped to the Java runtime intentionally. Happy to land follow-ups for C++/C#/Python/JS/Go/Swift/PHP/Dart once the API shape is approved here, or to pivot to a marker sub-interface (`SourcedToken extends Token`) if that's more palatable than adding default methods to the existing interfaces.

## Out of scope (intentionally not included)

- A no-arg `ParserRuleContext.getTokens()` overload — separate concern, will file separately if useful.
- A `Cpp.stg` tweak — unrelated to filename support; current upstream Cpp work likely supersedes it.