### PR TITLE
Go target: rename labeled fields that collide with rule-getter methods

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/LabelCollidingWithEscapedLabel.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/LabelCollidingWithEscapedLabel.txt
@@ -1,0 +1,21 @@
+[notes]
+Regression test for Go: when a label collides with the auto-generated
+rule-getter on its struct AND a separate label already occupies the
+escaped name, the Go target must escape both to keep them distinct
+within the struct's single field+method namespace.
+
+[type]
+Parser
+
+[grammar]
+grammar T;
+a : B=b B_=c ;
+b : 'x' ;
+c : 'y' ;
+
+[start]
+a
+
+[input]
+xy
+

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/LabelCollidingWithRuleGetter.txt
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/descriptors/ParserExec/LabelCollidingWithRuleGetter.txt
@@ -1,0 +1,21 @@
+[notes]
+Regression test for Go: a labeled rule reference whose label name equals the
+auto-generated rule-getter method name (after first-letter capitalization)
+must not produce a struct where field and method share the same identifier.
+This is illegal in Go because method receivers and struct fields share
+a single namespace.
+
+[type]
+Parser
+
+[grammar]
+grammar T;
+a : B=b ;
+b : 'x' ;
+
+[start]
+a
+
+[input]
+x
+

--- a/tool/src/org/antlr/v4/codegen/OutputModelController.java
+++ b/tool/src/org/antlr/v4/codegen/OutputModelController.java
@@ -30,6 +30,7 @@ import org.antlr.v4.codegen.model.SrcOp;
 import org.antlr.v4.codegen.model.StarBlock;
 import org.antlr.v4.codegen.model.VisitorFile;
 import org.antlr.v4.codegen.model.decl.CodeBlock;
+import org.antlr.v4.codegen.model.decl.StructDecl;
 import org.antlr.v4.misc.Utils;
 import org.antlr.v4.parse.ANTLRParser;
 import org.antlr.v4.parse.GrammarASTAdaptor;
@@ -170,6 +171,15 @@ public class OutputModelController {
 		}
 		else {
 			buildNormalRuleFunction(r, function);
+		}
+
+		// All Decls are now in place: give the target a chance to resolve cross-decl name collisions.
+		Target target = delegate.getGenerator().getTarget();
+		target.finalizeStruct(function.ruleCtx);
+		if (function.altToContext != null) {
+			for (StructDecl alt : function.altToContext) {
+				if (alt != null) target.finalizeStruct(alt);
+			}
 		}
 
 		Grammar g = getGrammar();

--- a/tool/src/org/antlr/v4/codegen/Target.java
+++ b/tool/src/org/antlr/v4/codegen/Target.java
@@ -9,6 +9,7 @@ package org.antlr.v4.codegen;
 import org.antlr.v4.Tool;
 import org.antlr.v4.codegen.model.RuleFunction;
 import org.antlr.v4.codegen.model.SerializedATN;
+import org.antlr.v4.codegen.model.decl.StructDecl;
 import org.antlr.v4.misc.CharSupport;
 import org.antlr.v4.misc.Utils;
 import org.antlr.v4.parse.ANTLRParser;
@@ -112,6 +113,14 @@ public abstract class Target {
 
 	protected String escapeWord(String word) {
 		return word + "_";
+	}
+
+	/** Called once per StructDecl after all of its decls are added,
+	 *  giving targets a chance to resolve cross-decl name collisions
+	 *  (e.g., the Go target's field-vs-method namespace overlap on a
+	 *  struct receiver). Default: no-op.
+	 */
+	public void finalizeStruct(StructDecl struct) {
 	}
 
 	protected void genFile(Grammar g, ST outputFileST, String fileName)

--- a/tool/src/org/antlr/v4/codegen/model/decl/Decl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/Decl.java
@@ -12,7 +12,7 @@ import org.antlr.v4.codegen.model.SrcOp;
 /** */
 public class Decl extends SrcOp {
 	public final String name;
-	public final String escapedName;
+	public String escapedName;
 	public final String decl; 	// whole thing if copied from action
 	public boolean isLocal; // if local var (not in RuleContext struct)
 	public StructDecl ctx;  // which context contains us? set by addDecl

--- a/tool/src/org/antlr/v4/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/GoTarget.java
@@ -9,6 +9,9 @@ package org.antlr.v4.codegen.target;
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.SourceType;
 import org.antlr.v4.codegen.Target;
+import org.antlr.v4.codegen.model.decl.Decl;
+import org.antlr.v4.codegen.model.decl.StructDecl;
+import org.antlr.v4.misc.Utils;
 import org.antlr.v4.parse.ANTLRParser;
 import org.antlr.v4.tool.Grammar;
 import org.stringtemplate.v4.ST;
@@ -65,6 +68,41 @@ public class GoTarget extends Target {
 	@Override
 	protected Set<String> getReservedWords() {
 		return reservedWords;
+	}
+
+	/** In Go, struct fields and methods on the same receiver share a single
+	 *  namespace, so a labeled rule reference like {@code Expression=expression}
+	 *  produces a struct field {@code Expression} that collides with the
+	 *  auto-generated rule-getter method {@code Expression()} (the rule name
+	 *  capitalized).
+	 */
+	@Override
+	public void finalizeStruct(StructDecl struct) {
+		if (struct == null) return;
+
+		Set<String> taken = new HashSet<>();
+		for (Decl g : struct.getters) {
+			String n = g.escapedName;
+			if (n != null && !n.isEmpty()) {
+				taken.add(Utils.capitalize(n));
+			}
+		}
+
+		renameCollidingFields(struct.ruleContextDecls,     taken);
+		renameCollidingFields(struct.ruleContextListDecls, taken);
+		renameCollidingFields(struct.tokenDecls,           taken);
+		renameCollidingFields(struct.tokenListDecls,       taken);
+	}
+
+	private void renameCollidingFields(Iterable<Decl> fields, Set<String> taken) {
+		for (Decl f : fields) {
+			String name = f.escapedName;
+			while (taken.contains(name)) {
+				name = escapeWord(name);
+			}
+			f.escapedName = name;
+			taken.add(name);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
