### PR TITLE
feat(csharp): add opt-in SpanInputStream variants and OptimizedToken classes

### DIFF
--- a/runtime/CSharp/src/CharSpanInputStream.cs
+++ b/runtime/CSharp/src/CharSpanInputStream.cs
@@ -1,0 +1,252 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using System.IO;
+using System.Text;
+using Antlr4.Runtime.Misc;
+
+namespace Antlr4.Runtime
+{
+    /// <summary>
+    /// A high-performance <see cref="ICharStream"/> backed by a <c>char[]</c> array,
+    /// using <see cref="ReadOnlySpan{T}"/> for zero-copy slicing and efficient text extraction.
+    /// 
+    /// This class is designed for scenarios where the input is immutable and can be efficiently accessed as a span.
+    /// 
+    /// It sees no performance-benefit against the default AntlrInputStream in the typical LT(1) hotpath.
+    /// The benefits are in allocations in all other regions, and performance of GetText().
+    /// </summary>
+#if NET8_0_OR_GREATER
+    public class CharSpanInputStream : ICharStream
+    {
+        private readonly char[] _data;
+        private readonly int _length;
+        private int _index;
+
+        /// <summary>What is name or source of this char stream?</summary>
+        public string name;
+
+        /// <summary>
+        /// Creates a stream directly from a <c>char[]</c>. The array is used
+        /// directly (no copy) — caller must not mutate it after construction.
+        /// </summary>
+        public CharSpanInputStream(char[] data, int length)
+        {
+            _data = data ?? throw new ArgumentNullException(nameof(data));
+            if (length < 0 || length > data.Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+            _length = length;
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading the entire contents of a
+        /// <see cref="TextReader"/>, then closing it.
+        /// </summary>
+        public CharSpanInputStream(TextReader reader)
+        {
+            if (reader == null) throw new ArgumentNullException(nameof(reader));
+            _data = reader.ReadToEnd().ToCharArray();
+            _length = _data.Length;
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading the entire contents of a
+        /// <see cref="Stream"/> using the specified encoding.
+        /// </summary>
+        public CharSpanInputStream(Stream stream, Encoding encoding)
+        {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (encoding == null) throw new ArgumentNullException(nameof(encoding));
+            using (var reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: false))
+            {
+                _data = reader.ReadToEnd().ToCharArray();
+            }
+            _length = _data.Length;
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading a UTF-8 encoded <see cref="Stream"/>.
+        /// </summary>
+        public CharSpanInputStream(Stream stream)
+            : this(stream, Encoding.UTF8)
+        {
+        }
+
+        /// <summary>
+        /// Creates a stream from a UTF-8 encoded file on disk.
+        /// </summary>
+        public static CharSpanInputStream FromPath(string path)
+        {
+            return FromPath(path, Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Creates a stream from a file on disk with the specified encoding.
+        /// </summary>
+        public static CharSpanInputStream FromPath(string path, Encoding encoding)
+        {
+            var contents = File.ReadAllText(path, encoding);
+            var chars = contents.ToCharArray(); return new CharSpanInputStream(chars, chars.Length) { name = path };
+        }
+
+        /// <summary>
+        /// Returns the backing data as a <see cref="ReadOnlySpan{T}"/>.
+        /// </summary>
+        public ReadOnlySpan<char> Data => _data.AsSpan(0, _length);
+
+        public void Reset()
+        {
+            _index = 0;
+        }
+
+        public void Consume()
+        {
+            if (_index >= _length)
+            {
+                System.Diagnostics.Debug.Assert(LA(1) == IntStreamConstants.EOF);
+                throw new InvalidOperationException("cannot consume EOF");
+            }
+            _index++;
+        }
+
+        public int LA(int i)
+        {
+            if (i == 0) return 0;
+            if (i < 0)
+            {
+                i++;
+                if ((_index + i - 1) < 0) return IntStreamConstants.EOF;
+            }
+            int pos = _index + i - 1;
+            return (uint)pos < (uint)_length ? _data[pos] : IntStreamConstants.EOF;
+        }
+
+        public int Index => _index;
+
+        public int Size => _length;
+
+        public int Mark() => -1;
+
+        public void Release(int marker) { }
+
+        public void Seek(int index)
+        {
+            _index = Math.Min(index, _length);
+        }
+
+        public string GetText(Interval interval)
+        {
+            int start = interval.a;
+            int stop = interval.b;
+            if (stop >= _length) stop = _length - 1;
+            int count = stop - start + 1;
+            if (start >= _length || count <= 0) return string.Empty;
+            return new string(Data.Slice(start, count));
+        }
+
+        /// <summary>
+        /// Returns the text for the given interval as a <see cref="ReadOnlySpan{T}"/>
+        /// without allocating a string. Use this in hot paths where the caller can
+        /// operate on the span directly.
+        /// </summary>
+        public ReadOnlySpan<char> GetTextSpan(Interval interval)
+        {
+            int start = interval.a;
+            int stop = interval.b;
+            if (stop >= _length) stop = _length - 1;
+            int count = stop - start + 1;
+            if (start >= _length || count <= 0) return ReadOnlySpan<char>.Empty;
+            return Data.Slice(start, count);
+        }
+
+        public string SourceName
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(name))
+                    return IntStreamConstants.UnknownSourceName;
+                return name;
+            }
+        }
+
+        public override string ToString() => new string(Data);
+#else
+    public class CharSpanInputStream : BaseInputCharStream
+    {
+        private readonly char[] _data;
+
+        /// <summary>
+        /// Creates a stream directly from a <c>char[]</c>. The array is used
+        /// directly (no copy) — caller must not mutate it after construction.
+        /// </summary>
+        public CharSpanInputStream(char[] data, int length)
+        {
+            _data = data ?? throw new ArgumentNullException(nameof(data));
+            if (length < 0 || length > data.Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+            n = length;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading the entire contents of a
+        /// <see cref="TextReader"/>, then closing it.
+        /// </summary>
+        public CharSpanInputStream(TextReader reader)
+        {
+            if (reader == null) throw new ArgumentNullException(nameof(reader));
+            _data = reader.ReadToEnd().ToCharArray();
+            n = _data.Length;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading the entire contents of a
+        /// <see cref="Stream"/> using the specified encoding.
+        /// </summary>
+        public CharSpanInputStream(Stream stream, Encoding encoding)
+        {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (encoding == null) throw new ArgumentNullException(nameof(encoding));
+            using (var reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: false))
+            {
+                _data = reader.ReadToEnd().ToCharArray();
+            }
+            n = _data.Length;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading a UTF-8 encoded <see cref="Stream"/>.
+        /// </summary>
+        public CharSpanInputStream(Stream stream)
+            : this(stream, Encoding.UTF8)
+        {
+        }
+
+        /// <summary>
+        /// Creates a stream from a UTF-8 encoded file on disk.
+        /// </summary>
+        public static CharSpanInputStream FromPath(string path)
+        {
+            return FromPath(path, Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Creates a stream from a file on disk with the specified encoding.
+        /// </summary>
+        public static CharSpanInputStream FromPath(string path, Encoding encoding)
+        {
+            var contents = File.ReadAllText(path, encoding);
+            var chars = contents.ToCharArray(); return new CharSpanInputStream(chars, chars.Length) { name = path };
+        }
+
+        protected override int ValueAt(int i) => _data[i];
+
+        protected override string ConvertDataToString(int start, int count) => new string(_data, start, count);
+
+#endif
+    }
+}

--- a/runtime/CSharp/src/OptimizedToken.cs
+++ b/runtime/CSharp/src/OptimizedToken.cs
@@ -1,0 +1,265 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using Antlr4.Runtime.Misc;
+
+namespace Antlr4.Runtime
+{
+    /// <summary>
+    /// A high-performance token implementation that defers text materialization
+    /// and uses ValueTuple to avoid heap allocations.
+    /// <para>
+    /// Key differences from <see cref="CommonToken"/>:
+    /// <list type="bullet">
+    ///   <item><description><see cref="Text"/> is lazily materialized from the input stream on first access
+    ///   and cached. Most tokens' text is never read — the parser matches on <see cref="Type"/>.</description></item>
+    ///   <item><description>The token source pair uses <c>ValueTuple</c> (struct) instead of <c>Tuple</c> (class),
+    ///   eliminating one heap allocation per token.</description></item>
+    /// </list>
+    /// </para>
+    /// <para>This class implements both <see cref="IToken"/> and <see cref="IWritableToken"/>,
+    /// so it is a drop-in replacement anywhere <see cref="CommonToken"/> is used.
+    /// Generated parsers that reference <c>CommonToken</c> by name in user code will still
+    /// work — simply swap the token factory.</para>
+    /// </summary>
+    public class OptimizedToken : IWritableToken
+    {
+        /// <summary>
+        /// Explicit struct to hold the token source pair, avoiding ValueTuple
+        /// which is unavailable on net45.
+        /// </summary>
+        private struct TokenSourcePair
+        {
+            public ITokenSource Source;
+            public ICharStream Stream;
+
+            public TokenSourcePair(ITokenSource source, ICharStream stream)
+            {
+                Source = source;
+                Stream = stream;
+            }
+        }
+
+        /// <summary>
+        /// An empty source pair for tokens that have no source.
+        /// Only available on platforms that support ValueTuple.
+        /// </summary>
+#if NETSTANDARD2_0_OR_GREATER || NET8_0_OR_GREATER
+        public static readonly (ITokenSource, ICharStream) EmptySource = (null, null);
+#endif
+
+        private int _type;
+        private int _line;
+        private int _charPositionInLine = -1;
+        private int _channel = TokenConstants.DefaultChannel;
+        private int _index = -1;
+        private int _start;
+        private int _stop;
+
+        /// <summary>
+        /// Uses a struct instead of Tuple — no heap allocation per token.
+        /// </summary>
+        private TokenSourcePair _source;
+
+        /// <summary>
+        /// Cached text. Null means "not yet materialized" — will be lazily
+        /// computed from the char stream on first access to <see cref="Text"/>.
+        /// Once set (either lazily or explicitly), cached for subsequent reads.
+        /// </summary>
+        private string _text;
+
+        /// <summary>
+        /// Tracks whether <see cref="_text"/> was explicitly set by user code,
+        /// as opposed to being lazily materialized. Explicit text always wins.
+        /// </summary>
+        private bool _textExplicitlySet;
+
+        public OptimizedToken(int type)
+        {
+            _type = type;
+            _source = new TokenSourcePair(null, null);
+        }
+
+#if NETSTANDARD2_0_OR_GREATER || NET8_0_OR_GREATER
+        public OptimizedToken((ITokenSource, ICharStream) source, int type, int channel, int start, int stop)
+        {
+            _source = new TokenSourcePair(source.Item1, source.Item2);
+            _type = type;
+            _channel = channel;
+            _start = start;
+            _stop = stop;
+            if (source.Item1 != null)
+            {
+                _line = source.Item1.Line;
+                _charPositionInLine = source.Item1.Column;
+            }
+            // Text is NOT materialized here — deferred until .Text is read
+        }
+#else
+        public OptimizedToken(ITokenSource tokenSource, ICharStream inputStream, int type, int channel, int start, int stop)
+        {
+            _source = new TokenSourcePair(tokenSource, inputStream);
+            _type = type;
+            _channel = channel;
+            _start = start;
+            _stop = stop;
+            if (tokenSource != null)
+            {
+                _line = tokenSource.Line;
+                _charPositionInLine = tokenSource.Column;
+            }
+            // Text is NOT materialized here — deferred until .Text is read
+        }
+#endif
+
+        public OptimizedToken(int type, string text)
+        {
+            _type = type;
+            _channel = TokenConstants.DefaultChannel;
+            _text = text;
+            _textExplicitlySet = true;
+            _source = new TokenSourcePair(null, null);
+        }
+
+        /// <summary>
+        /// Copy constructor. Copies from any <see cref="IToken"/>.
+        /// If the source is an <see cref="OptimizedToken"/>, preserves deferred text semantics.
+        /// If the source is a <see cref="CommonToken"/>, copies its internal text directly.
+        /// </summary>
+        public OptimizedToken(IToken oldToken)
+        {
+            _type = oldToken.Type;
+            _line = oldToken.Line;
+            _index = oldToken.TokenIndex;
+            _charPositionInLine = oldToken.Column;
+            _channel = oldToken.Channel;
+            _start = oldToken.StartIndex;
+            _stop = oldToken.StopIndex;
+
+            if (oldToken is OptimizedToken opt)
+            {
+                _text = opt._text;
+                _textExplicitlySet = opt._textExplicitlySet;
+                _source = opt._source;
+            }
+            else if (oldToken is CommonToken ct)
+            {
+                // Access the protected field directly to avoid materializing
+                _text = ct.source.Item2 != null ? null : oldToken.Text;
+                _source = new TokenSourcePair(ct.source.Item1, ct.source.Item2);
+            }
+            else
+            {
+                _text = oldToken.Text;
+                _textExplicitlySet = true;
+                _source = new TokenSourcePair(oldToken.TokenSource, oldToken.InputStream);
+            }
+        }
+
+        public virtual int Type
+        {
+            get => _type;
+            set => _type = value;
+        }
+
+        public virtual int Line
+        {
+            get => _line;
+            set => _line = value;
+        }
+
+        /// <summary>
+        /// Lazily materializes the token text on first access.
+        /// If text was explicitly set, returns that. Otherwise, extracts from
+        /// the char stream using start/stop indices. The result is cached.
+        /// </summary>
+        public virtual string Text
+        {
+            get
+            {
+                if (_text != null)
+                {
+                    return _text;
+                }
+                // Not yet materialized — compute from stream
+                ICharStream input = _source.Stream;
+                if (input == null)
+                {
+                    return null;
+                }
+                int n = input.Size;
+                if (_start < n && _stop < n)
+                {
+                    _text = input.GetText(Interval.Of(_start, _stop));
+                }
+                else
+                {
+                    _text = "<EOF>";
+                }
+                return _text;
+            }
+            set
+            {
+                _text = value;
+                _textExplicitlySet = true;
+            }
+        }
+
+        public virtual int Column
+        {
+            get => _charPositionInLine;
+            set => _charPositionInLine = value;
+        }
+
+        public virtual int Channel
+        {
+            get => _channel;
+            set => _channel = value;
+        }
+
+        public virtual int StartIndex
+        {
+            get => _start;
+            set => _start = value;
+        }
+
+        public virtual int StopIndex
+        {
+            get => _stop;
+            set => _stop = value;
+        }
+
+        public virtual int TokenIndex
+        {
+            get => _index;
+            set => _index = value;
+        }
+
+        public virtual ITokenSource TokenSource => _source.Source;
+
+        public virtual ICharStream InputStream => _source.Stream;
+
+        public override string ToString()
+        {
+            string channelStr = string.Empty;
+            if (_channel > 0)
+            {
+                channelStr = ",channel=" + _channel;
+            }
+            string txt = Text;
+            if (txt != null)
+            {
+                txt = txt.Replace("\n", "\\n");
+                txt = txt.Replace("\r", "\\r");
+                txt = txt.Replace("\t", "\\t");
+            }
+            else
+            {
+                txt = "<no text>";
+            }
+            return "[@" + TokenIndex + "," + _start + ":" + _stop + "='" + txt + "',<" + _type + ">" + channelStr + "," + _line + ":" + Column + "]";
+        }
+    }
+}

--- a/runtime/CSharp/src/OptimizedTokenFactory.cs
+++ b/runtime/CSharp/src/OptimizedTokenFactory.cs
@@ -1,0 +1,70 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using Antlr4.Runtime.Misc;
+
+namespace Antlr4.Runtime
+{
+    /// <summary>
+    /// Token factory that creates <see cref="OptimizedToken"/> instances with
+    /// deferred text materialization and ValueTuple-based source storage.
+    /// <para>
+    /// Drop-in replacement for <see cref="CommonTokenFactory"/>. To use:
+    /// <code>lexer.TokenFactory = OptimizedTokenFactory.Default;</code>
+    /// </para>
+    /// </summary>
+    public class OptimizedTokenFactory : ITokenFactory
+    {
+        /// <summary>
+        /// Default instance — does NOT eagerly copy text (deferred materialization).
+        /// </summary>
+        public static readonly ITokenFactory Default = new OptimizedTokenFactory();
+
+        /// <summary>
+        /// When true, text is eagerly copied at token creation time.
+        /// Needed for <see cref="UnbufferedCharStream"/> where the input
+        /// window may slide away before text is accessed.
+        /// </summary>
+        private readonly bool _copyText;
+
+        public OptimizedTokenFactory() : this(false) { }
+
+        public OptimizedTokenFactory(bool copyText)
+        {
+            _copyText = copyText;
+        }
+
+        public virtual IToken Create(
+            Tuple<ITokenSource, ICharStream> source,
+            int type, string text, int channel,
+            int start, int stop, int line, int charPositionInLine)
+        {
+            var t = new OptimizedToken(
+#if NETSTANDARD2_0_OR_GREATER || NET8_0_OR_GREATER
+                (source.Item1, source.Item2),
+#else
+                source.Item1, source.Item2,
+#endif
+                type, channel, start, stop);
+            t.Line = line;
+            t.Column = charPositionInLine;
+            if (text != null)
+            {
+                t.Text = text;
+            }
+            else if (_copyText && source.Item2 != null)
+            {
+                t.Text = source.Item2.GetText(Interval.Of(start, stop));
+            }
+            // else: text stays null — will be lazily materialized on first .Text access
+            return t;
+        }
+
+        public virtual IToken Create(int type, string text)
+        {
+            return new OptimizedToken(type, text);
+        }
+    }
+}

--- a/runtime/CSharp/src/SpanInputStream.cs
+++ b/runtime/CSharp/src/SpanInputStream.cs
@@ -1,0 +1,275 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using System.IO;
+using System.Text;
+using Antlr4.Runtime.Misc;
+
+namespace Antlr4.Runtime
+{
+    /// <summary>
+    /// A high-performance <see cref="ICharStream"/> backed by a <c>char[]</c> array,
+    /// using <see cref="ReadOnlySpan{T}"/> for zero-copy slicing and efficient text extraction.
+    /// 
+    /// This class is designed for scenarios where the input is immutable and can be efficiently accessed as a span.
+    /// 
+    /// It sees no performance-benefit against the default AntlrInputStream in the typical LT(1) hotpath.
+    /// The benefits are in allocations in all other regions, and performance of GetText().
+    /// </summary>
+#if NET8_0_OR_GREATER
+    public class SpanInputStream : ICharStream
+    {
+        private readonly char[] _data;
+        private readonly int _length;
+        private int _index;
+
+        /// <summary>What is name or source of this char stream?</summary>
+        public string name;
+
+        /// <summary>
+        /// Creates a stream from a string. The string's internal buffer is copied
+        /// into a <c>char[]</c> for span-based access.
+        /// </summary>
+        public SpanInputStream(string input)
+        {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+            _data = input.ToCharArray();
+            _length = _data.Length;
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Creates a stream directly from a <c>char[]</c>. The array is used
+        /// directly (no copy) — caller must not mutate it after construction.
+        /// </summary>
+        public SpanInputStream(char[] data, int length)
+        {
+            _data = data ?? throw new ArgumentNullException(nameof(data));
+            if (length < 0 || length > data.Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+            _length = length;
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading the entire contents of a
+        /// <see cref="TextReader"/>, then closing it.
+        /// </summary>
+        public SpanInputStream(TextReader reader)
+        {
+            if (reader == null) throw new ArgumentNullException(nameof(reader));
+            _data = reader.ReadToEnd().ToCharArray();
+            _length = _data.Length;
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading the entire contents of a
+        /// <see cref="Stream"/> using the specified encoding.
+        /// </summary>
+        public SpanInputStream(Stream stream, Encoding encoding)
+        {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (encoding == null) throw new ArgumentNullException(nameof(encoding));
+            using (var reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: false))
+            {
+                _data = reader.ReadToEnd().ToCharArray();
+            }
+            _length = _data.Length;
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading a UTF-8 encoded <see cref="Stream"/>.
+        /// </summary>
+        public SpanInputStream(Stream stream)
+            : this(stream, Encoding.UTF8)
+        {
+        }
+
+        /// <summary>
+        /// Creates a stream from a UTF-8 encoded file on disk.
+        /// </summary>
+        public static SpanInputStream FromPath(string path)
+        {
+            return FromPath(path, Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Creates a stream from a file on disk with the specified encoding.
+        /// </summary>
+        public static SpanInputStream FromPath(string path, Encoding encoding)
+        {
+            var contents = File.ReadAllText(path, encoding);
+            return new SpanInputStream(contents) { name = path };
+        }
+
+        /// <summary>
+        /// Returns the backing data as a <see cref="ReadOnlySpan{T}"/>.
+        /// </summary>
+        public ReadOnlySpan<char> Data => _data.AsSpan(0, _length);
+
+        public void Reset()
+        {
+            _index = 0;
+        }
+
+        public void Consume()
+        {
+            if (_index >= _length)
+            {
+                System.Diagnostics.Debug.Assert(LA(1) == IntStreamConstants.EOF);
+                throw new InvalidOperationException("cannot consume EOF");
+            }
+            _index++;
+        }
+
+        public int LA(int i)
+        {
+            if (i == 0) return 0;
+            if (i < 0)
+            {
+                i++;
+                if ((_index + i - 1) < 0) return IntStreamConstants.EOF;
+            }
+            int pos = _index + i - 1;
+            return (uint)pos < (uint)_length ? _data[pos] : IntStreamConstants.EOF;
+        }
+
+        public int Index => _index;
+
+        public int Size => _length;
+
+        public int Mark() => -1;
+
+        public void Release(int marker) { }
+
+        public void Seek(int index)
+        {
+            _index = Math.Min(index, _length);
+        }
+
+        public string GetText(Interval interval)
+        {
+            int start = interval.a;
+            int stop = interval.b;
+            if (stop >= _length) stop = _length - 1;
+            int count = stop - start + 1;
+            if (start >= _length || count <= 0) return string.Empty;
+            return new string(Data.Slice(start, count));
+        }
+
+        /// <summary>
+        /// Returns the text for the given interval as a <see cref="ReadOnlySpan{T}"/>
+        /// without allocating a string. Use this in hot paths where the caller can
+        /// operate on the span directly.
+        /// </summary>
+        public ReadOnlySpan<char> GetTextSpan(Interval interval)
+        {
+            int start = interval.a;
+            int stop = interval.b;
+            if (stop >= _length) stop = _length - 1;
+            int count = stop - start + 1;
+            if (start >= _length || count <= 0) return ReadOnlySpan<char>.Empty;
+            return Data.Slice(start, count);
+        }
+
+        public string SourceName
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(name))
+                    return IntStreamConstants.UnknownSourceName;
+                return name;
+            }
+        }
+
+        public override string ToString() => new string(Data);
+#else
+    public class SpanInputStream : BaseInputCharStream
+    {
+        private readonly char[] _data;
+
+        /// <summary>
+        /// Creates a stream from a string. The string's internal buffer is copied
+        /// into a <c>char[]</c> for span-based access.
+        /// </summary>
+        public SpanInputStream(string input)
+        {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+            _data = input.ToCharArray();
+            n = _data.Length;
+        }
+
+        /// <summary>
+        /// Creates a stream directly from a <c>char[]</c>. The array is used
+        /// directly (no copy) — caller must not mutate it after construction.
+        /// </summary>
+        public SpanInputStream(char[] data, int length)
+        {
+            _data = data ?? throw new ArgumentNullException(nameof(data));
+            if (length < 0 || length > data.Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+            n = length;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading the entire contents of a
+        /// <see cref="TextReader"/>, then closing it.
+        /// </summary>
+        public SpanInputStream(TextReader reader)
+        {
+            if (reader == null) throw new ArgumentNullException(nameof(reader));
+            _data = reader.ReadToEnd().ToCharArray();
+            n = _data.Length;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading the entire contents of a
+        /// <see cref="Stream"/> using the specified encoding.
+        /// </summary>
+        public SpanInputStream(Stream stream, Encoding encoding)
+        {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (encoding == null) throw new ArgumentNullException(nameof(encoding));
+            using (var reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: false))
+            {
+                _data = reader.ReadToEnd().ToCharArray();
+            }
+            n = _data.Length;
+        }
+
+        /// <summary>
+        /// Creates a stream by reading a UTF-8 encoded <see cref="Stream"/>.
+        /// </summary>
+        public SpanInputStream(Stream stream)
+            : this(stream, Encoding.UTF8)
+        {
+        }
+
+        /// <summary>
+        /// Creates a stream from a UTF-8 encoded file on disk.
+        /// </summary>
+        public static SpanInputStream FromPath(string path)
+        {
+            return FromPath(path, Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Creates a stream from a file on disk with the specified encoding.
+        /// </summary>
+        public static SpanInputStream FromPath(string path, Encoding encoding)
+        {
+            var contents = File.ReadAllText(path, encoding);
+            return new SpanInputStream(contents) { name = path };
+        }
+
+        protected override int ValueAt(int i) => _data[i];
+
+        protected override string ConvertDataToString(int start, int count) => new string(_data, start, count);
+
+#endif
+    }
+}

--- a/runtime/CSharp/src/StringSpanInputStream.cs
+++ b/runtime/CSharp/src/StringSpanInputStream.cs
@@ -1,0 +1,189 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using System.IO;
+using System.Text;
+using Antlr4.Runtime.Misc;
+
+namespace Antlr4.Runtime
+{
+    /// <summary>
+    /// A high-performance <see cref="ICharStream"/> backed directly by a <c>string</c>,
+    /// avoiding the <c>ToCharArray()</c> copy that <see cref="CharSpanInputStream"/> and
+    /// <see cref="AntlrInputStream"/> perform on construction.
+    ///
+    /// <para>Use this class when your input is already a <c>string</c> in memory and you
+    /// want the lowest-cost parse setup. The string is stored by reference — no copy is
+    /// ever made.</para>
+    ///
+    /// <para><b>Unicode note:</b> This class handles BMP characters (U+0000–U+FFFF) only,
+    /// matching the behaviour of <see cref="AntlrInputStream"/> and
+    /// <see cref="CharSpanInputStream"/>. Supplementary code points (U+10000 and above,
+    /// e.g. emoji, historic scripts) are represented as surrogate pairs and will be seen
+    /// as two separate <c>char</c> values rather than a single code point. If your grammar
+    /// targets supplementary code points, use <see cref="CodePointCharStream"/> instead.</para>
+    /// </summary>
+#if NET8_0_OR_GREATER
+
+    public class StringSpanInputStream : ICharStream
+    {
+        private readonly string _data;
+        private readonly int _length;
+        private int _index;
+
+        /// <summary>What is name or source of this char stream?</summary>
+        public string name;
+
+        /// <summary>
+        /// Creates a stream from a string. The string is used directly — no copy is made.
+        /// </summary>
+        public StringSpanInputStream(string input)
+        {
+            _data = input ?? throw new ArgumentNullException(nameof(input));
+            _length = input.Length;
+            _index = 0;
+        }
+
+        /// <summary>
+        /// Creates a stream from a UTF-8 encoded file on disk.
+        /// </summary>
+        public static StringSpanInputStream FromPath(string path)
+            => FromPath(path, Encoding.UTF8);
+
+        /// <summary>
+        /// Creates a stream from a file on disk with the specified encoding.
+        /// </summary>
+        public static StringSpanInputStream FromPath(string path, Encoding encoding)
+        {
+            var contents = File.ReadAllText(path, encoding);
+            return new StringSpanInputStream(contents) { name = path };
+        }
+
+        /// <summary>
+        /// Returns the backing data as a <see cref="ReadOnlySpan{T}"/> — zero allocation,
+        /// zero copy.
+        /// </summary>
+        public ReadOnlySpan<char> Data => _data.AsSpan(0, _length);
+
+        /// <summary>
+        /// Returns the backing data as a <see cref="ReadOnlyMemory{T}"/>.
+        /// </summary>
+        public ReadOnlyMemory<char> AsMemory() => _data.AsMemory(0, _length);
+
+        public void Reset() => _index = 0;
+
+        public void Consume()
+        {
+            if (_index >= _length)
+            {
+                System.Diagnostics.Debug.Assert(LA(1) == IntStreamConstants.EOF);
+                throw new InvalidOperationException("cannot consume EOF");
+            }
+            _index++;
+        }
+
+        public int LA(int i)
+        {
+            if (i == 0) return 0;
+            if (i < 0)
+            {
+                i++;
+                if ((_index + i - 1) < 0) return IntStreamConstants.EOF;
+            }
+            int pos = _index + i - 1;
+            return (uint)pos < (uint)_length ? _data[pos] : IntStreamConstants.EOF;
+        }
+
+        public int Index => _index;
+
+        public int Size => _length;
+
+        public int Mark() => -1;
+
+        public void Release(int marker) { }
+
+        public void Seek(int index)
+        {
+            _index = Math.Min(index, _length);
+        }
+
+        public string GetText(Interval interval)
+        {
+            int start = interval.a;
+            int stop = interval.b;
+            if (stop >= _length) stop = _length - 1;
+            int count = stop - start + 1;
+            if (start >= _length || count <= 0) return string.Empty;
+            return _data.Substring(start, count);
+        }
+
+        /// <summary>
+        /// Returns the text for the given interval as a <see cref="ReadOnlySpan{T}"/>
+        /// without allocating a string. Use this in hot paths where the caller can
+        /// operate on the span directly.
+        /// </summary>
+        public ReadOnlySpan<char> GetTextSpan(Interval interval)
+        {
+            int start = interval.a;
+            int stop = interval.b;
+            if (stop >= _length) stop = _length - 1;
+            int count = stop - start + 1;
+            if (start >= _length || count <= 0) return ReadOnlySpan<char>.Empty;
+            return Data.Slice(start, count);
+        }
+
+        public string SourceName
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(name))
+                    return IntStreamConstants.UnknownSourceName;
+                return name;
+            }
+        }
+
+        /// <summary>
+        /// Returns the original string — zero allocation.
+        /// </summary>
+        public override string ToString() => _data;
+
+#else
+
+    public class StringSpanInputStream : BaseInputCharStream
+    {
+        private readonly string _data;
+
+        /// <summary>
+        /// Creates a stream from a string. The string is used directly — no copy is made.
+        /// </summary>
+        public StringSpanInputStream(string input)
+        {
+            _data = input ?? throw new ArgumentNullException(nameof(input));
+            n = input.Length;
+        }
+
+        /// <summary>
+        /// Creates a stream from a UTF-8 encoded file on disk.
+        /// </summary>
+        public static StringSpanInputStream FromPath(string path)
+            => FromPath(path, Encoding.UTF8);
+
+        /// <summary>
+        /// Creates a stream from a file on disk with the specified encoding.
+        /// </summary>
+        public static StringSpanInputStream FromPath(string path, Encoding encoding)
+        {
+            var contents = File.ReadAllText(path, encoding);
+            return new StringSpanInputStream(contents) { name = path };
+        }
+
+        protected override int ValueAt(int i) => _data[i];
+
+        protected override string ConvertDataToString(int start, int count)
+            => _data.Substring(start, count);
+
+#endif
+    }
+}

--- a/runtime/CSharp/tests/perf-optimizations/CharSpanInputStreamTests.cs
+++ b/runtime/CSharp/tests/perf-optimizations/CharSpanInputStreamTests.cs
@@ -1,0 +1,299 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using System.IO;
+using System.Text;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using Xunit;
+
+namespace PerfOptimizations
+{
+    /// <summary>
+    /// Tests that CharSpanInputStream behaves identically to AntlrInputStream
+    /// for all ICharStream operations.
+    /// </summary>
+    public class CharSpanInputStreamTests
+    {
+        private static CharSpanInputStream S(string s)
+        {
+            var c = s.ToCharArray();
+            return new CharSpanInputStream(c, c.Length);
+        }
+
+        // ── Constructor tests ────────────────────────────────────────────
+
+        [Fact]
+        public void Ctor_String_SetsSize()
+        {
+            var stream = S("hello");
+            Assert.Equal(5, stream.Size);
+            Assert.Equal(0, stream.Index);
+        }
+
+        [Fact]
+        public void Ctor_EmptyString_SizeIsZero()
+        {
+            var stream = S("");
+            Assert.Equal(0, stream.Size);
+        }
+
+        [Fact]
+        public void Ctor_NullCharArray_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CharSpanInputStream((char[])null, 0));
+        }
+
+        [Fact]
+        public void Ctor_NullTextReader_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CharSpanInputStream((TextReader)null));
+        }
+
+        [Fact]
+        public void Ctor_NullStream_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CharSpanInputStream((Stream)null));
+        }
+
+        [Fact]
+        public void Ctor_TextReader_ReadsAll()
+        {
+            using var reader = new StringReader("abc");
+            var stream = new CharSpanInputStream(reader);
+            Assert.Equal(3, stream.Size);
+            Assert.Equal('a', stream.LA(1));
+        }
+
+        [Fact]
+        public void Ctor_StreamWithEncoding_ReadsAll()
+        {
+            var bytes = Encoding.UTF8.GetBytes("xyz");
+            using var ms = new MemoryStream(bytes);
+            var stream = new CharSpanInputStream(ms, Encoding.UTF8);
+            Assert.Equal(3, stream.Size);
+        }
+
+        [Fact]
+        public void Ctor_StreamDefaultUtf8()
+        {
+            var bytes = Encoding.UTF8.GetBytes("test");
+            using var ms = new MemoryStream(bytes);
+            var stream = new CharSpanInputStream(ms);
+            Assert.Equal(4, stream.Size);
+        }
+
+        // ── LA (lookahead) tests ─────────────────────────────────────────
+
+        [Fact]
+        public void LA_ReturnsCorrectCharacter()
+        {
+            var stream = S("abcdef");
+            Assert.Equal('a', stream.LA(1));
+            Assert.Equal('b', stream.LA(2));
+        }
+
+        [Fact]
+        public void LA_Zero_ReturnsZero()
+        {
+            var stream = S("abc");
+            Assert.Equal(0, stream.LA(0));
+        }
+
+        [Fact]
+        public void LA_PastEnd_ReturnsEOF()
+        {
+            var stream = S("ab");
+            Assert.Equal(IntStreamConstants.EOF, stream.LA(3));
+        }
+
+        [Fact]
+        public void LA_Negative_LooksBack()
+        {
+            var stream = S("abcd");
+            stream.Consume(); // p=1
+            stream.Consume(); // p=2
+            Assert.Equal('b', stream.LA(-1));
+            Assert.Equal('a', stream.LA(-2));
+        }
+
+        [Fact]
+        public void LA_NegativeBeforeStart_ReturnsEOF()
+        {
+            var stream = S("abc");
+            Assert.Equal(IntStreamConstants.EOF, stream.LA(-1));
+        }
+
+        // ── Consume tests ────────────────────────────────────────────────
+
+        [Fact]
+        public void Consume_AdvancesIndex()
+        {
+            var stream = S("abc");
+            stream.Consume();
+            Assert.Equal(1, stream.Index);
+            Assert.Equal('b', stream.LA(1));
+        }
+
+        [Fact]
+        public void Consume_AtEOF_Throws()
+        {
+            var stream = S("a");
+            stream.Consume();
+            Assert.Throws<InvalidOperationException>(() => stream.Consume());
+        }
+
+        // ── Seek tests ───────────────────────────────────────────────────
+
+        [Fact]
+        public void Seek_Forward_MovesIndex()
+        {
+            var stream = S("abcdef");
+            stream.Seek(3);
+            Assert.Equal(3, stream.Index);
+            Assert.Equal('d', stream.LA(1));
+        }
+
+        [Fact]
+        public void Seek_Backward_MovesIndex()
+        {
+            var stream = S("abcdef");
+            stream.Seek(4);
+            stream.Seek(1);
+            Assert.Equal(1, stream.Index);
+            Assert.Equal('b', stream.LA(1));
+        }
+
+        [Fact]
+        public void Seek_ToEnd()
+        {
+            var stream = S("abc");
+            stream.Seek(3);
+            Assert.Equal(3, stream.Index);
+            Assert.Equal(IntStreamConstants.EOF, stream.LA(1));
+        }
+
+        // ── GetText tests ────────────────────────────────────────────────
+
+        [Fact]
+        public void GetText_ReturnsSubstring()
+        {
+            var stream = S("hello world");
+            Assert.Equal("world", stream.GetText(Interval.Of(6, 10)));
+        }
+
+        [Fact]
+        public void GetText_EntireString()
+        {
+            var stream = S("abc");
+            Assert.Equal("abc", stream.GetText(Interval.Of(0, 2)));
+        }
+
+        [Fact]
+        public void GetText_StopBeyondEnd_Clamps()
+        {
+            var stream = S("abc");
+            // stop >= n should be clamped to n-1
+            Assert.Equal("abc", stream.GetText(Interval.Of(0, 999)));
+        }
+
+        [Fact]
+        public void GetText_StartBeyondEnd_ReturnsEmpty()
+        {
+            var stream = S("abc");
+            Assert.Equal(string.Empty, stream.GetText(Interval.Of(999, 1000)));
+        }
+
+        // ── Reset / Mark / Release ───────────────────────────────────────
+
+        [Fact]
+        public void Reset_RestoresIndexToZero()
+        {
+            var stream = S("abc");
+            stream.Consume();
+            stream.Consume();
+            stream.Reset();
+            Assert.Equal(0, stream.Index);
+        }
+
+        [Fact]
+        public void Mark_ReturnsMinusOne()
+        {
+            var stream = S("abc");
+            Assert.Equal(-1, stream.Mark());
+        }
+
+        // ── SourceName ───────────────────────────────────────────────────
+
+        [Fact]
+        public void SourceName_DefaultIsUnknown()
+        {
+            var stream = S("abc");
+            Assert.Equal(IntStreamConstants.UnknownSourceName, stream.SourceName);
+        }
+
+        [Fact]
+        public void FromPath_SetsSourceName()
+        {
+            var tmp = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(tmp, "file content");
+                var stream = CharSpanInputStream.FromPath(tmp);
+                Assert.Equal(tmp, stream.SourceName);
+                Assert.Equal(12, stream.Size);
+            }
+            finally
+            {
+                File.Delete(tmp);
+            }
+        }
+
+        // ── ToString ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void ToString_ReturnsFullInput()
+        {
+            var stream = S("hello");
+            Assert.Equal("hello", stream.ToString());
+        }
+
+        // ── Behavioral parity with AntlrInputStream ──────────────────────
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("a")]
+        [InlineData("hello world")]
+        [InlineData("line1\nline2\r\nline3")]
+        [InlineData("unicode: \u00E9\u00F1\u00FC")] // BMP chars
+        public void Parity_WithAntlrInputStream(string input)
+        {
+            var antlr = new AntlrInputStream(input);
+            var chars = input.ToCharArray(); var span = new CharSpanInputStream(chars, chars.Length);
+
+            Assert.Equal(antlr.Size, span.Size);
+            Assert.Equal(antlr.ToString(), span.ToString());
+
+            // Walk through every character via LA
+            for (int i = 0; i < input.Length; i++)
+            {
+                Assert.Equal(antlr.LA(1), span.LA(1));
+                antlr.Consume();
+                span.Consume();
+            }
+            Assert.Equal(IntStreamConstants.EOF, antlr.LA(1));
+            Assert.Equal(IntStreamConstants.EOF, span.LA(1));
+
+            // GetText on full range
+            if (input.Length > 0)
+            {
+                antlr.Reset();
+                span.Reset();
+                var interval = Interval.Of(0, input.Length - 1);
+                Assert.Equal(antlr.GetText(interval), span.GetText(interval));
+            }
+        }
+    }
+}

--- a/runtime/CSharp/tests/perf-optimizations/OptimizedTokenFactoryTests.cs
+++ b/runtime/CSharp/tests/perf-optimizations/OptimizedTokenFactoryTests.cs
@@ -1,0 +1,133 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using Xunit;
+
+namespace PerfOptimizations
+{
+    /// <summary>
+    /// Tests that OptimizedTokenFactory creates tokens correctly and is
+    /// a valid drop-in replacement for CommonTokenFactory.
+    /// </summary>
+    public class OptimizedTokenFactoryTests
+    {
+        // ── Default instance ─────────────────────────────────────────────
+
+        [Fact]
+        public void Default_IsNotNull()
+        {
+            Assert.NotNull(OptimizedTokenFactory.Default);
+        }
+
+        [Fact]
+        public void Default_ImplementsITokenFactory()
+        {
+            Assert.IsAssignableFrom<ITokenFactory>(OptimizedTokenFactory.Default);
+        }
+
+        // ── Create(source, type, text, channel, start, stop, line, col) ──
+
+        [Fact]
+        public void Create_Full_ReturnsOptimizedToken()
+        {
+            var factory = new OptimizedTokenFactory();
+            var stream = new AntlrInputStream("hello world");
+            var source = Tuple.Create<ITokenSource, ICharStream>(null, stream);
+
+            var token = factory.Create(source, type: 1, text: null, channel: 0,
+                start: 6, stop: 10, line: 1, charPositionInLine: 6);
+
+            Assert.IsType<OptimizedToken>(token);
+            Assert.Equal(1, token.Type);
+            Assert.Equal(0, token.Channel);
+            Assert.Equal(1, token.Line);
+            Assert.Equal(6, token.Column);
+            Assert.Equal(6, token.StartIndex);
+            Assert.Equal(10, token.StopIndex);
+            // Text deferred — should materialize to "world"
+            Assert.Equal("world", token.Text);
+        }
+
+        [Fact]
+        public void Create_WithExplicitText_SetsTextImmediately()
+        {
+            var factory = new OptimizedTokenFactory();
+            var source = Tuple.Create<ITokenSource, ICharStream>(null, null);
+
+            var token = factory.Create(source, type: 1, text: "explicit",
+                channel: 0, start: 0, stop: 7, line: 1, charPositionInLine: 0);
+
+            Assert.Equal("explicit", token.Text);
+        }
+
+        [Fact]
+        public void Create_CopyTextMode_MaterializesEagerly()
+        {
+            var factory = new OptimizedTokenFactory(copyText: true);
+            var stream = new AntlrInputStream("hello world");
+            var source = Tuple.Create<ITokenSource, ICharStream>(null, stream);
+
+            var token = factory.Create(source, type: 1, text: null, channel: 0,
+                start: 0, stop: 4, line: 1, charPositionInLine: 0);
+
+            // Even though text was null, copyText=true should have materialized it
+            Assert.Equal("hello", token.Text);
+        }
+
+        [Fact]
+        public void Create_CopyTextMode_NullStream_NoThrow()
+        {
+            var factory = new OptimizedTokenFactory(copyText: true);
+            var source = Tuple.Create<ITokenSource, ICharStream>(null, null);
+
+            var token = factory.Create(source, type: 1, text: null, channel: 0,
+                start: 0, stop: 4, line: 1, charPositionInLine: 0);
+
+            // No stream, no text, no crash
+            Assert.Null(token.Text);
+        }
+
+        // ── Create(type, text) ───────────────────────────────────────────
+
+        [Fact]
+        public void Create_TypeAndText_ReturnsOptimizedToken()
+        {
+            var factory = new OptimizedTokenFactory();
+            var token = factory.Create(type: 99, text: "keyword");
+
+            Assert.IsType<OptimizedToken>(token);
+            Assert.Equal(99, token.Type);
+            Assert.Equal("keyword", token.Text);
+        }
+
+        // ── Parity with CommonTokenFactory ───────────────────────────────
+
+        [Theory]
+        [InlineData("hello world", 0, 4)]
+        [InlineData("hello world", 6, 10)]
+        [InlineData("a", 0, 0)]
+        public void Parity_CommonTokenFactory_TextMatch(string input, int start, int stop)
+        {
+            var stream1 = new AntlrInputStream(input);
+            var stream2 = new AntlrInputStream(input);
+            var commonSource = Tuple.Create<ITokenSource, ICharStream>(null, stream1);
+            var optSource = Tuple.Create<ITokenSource, ICharStream>(null, stream2);
+
+            var commonFactory = CommonTokenFactory.Default;
+            var optFactory = OptimizedTokenFactory.Default;
+
+            var commonToken = commonFactory.Create(commonSource, 1, null, 0, start, stop, 1, 0);
+            var optToken = optFactory.Create(optSource, 1, null, 0, start, stop, 1, 0);
+
+            Assert.Equal(commonToken.Text, optToken.Text);
+            Assert.Equal(commonToken.Type, optToken.Type);
+            Assert.Equal(commonToken.Channel, optToken.Channel);
+            Assert.Equal(commonToken.StartIndex, optToken.StartIndex);
+            Assert.Equal(commonToken.StopIndex, optToken.StopIndex);
+        }
+    }
+}

--- a/runtime/CSharp/tests/perf-optimizations/OptimizedTokenTests.cs
+++ b/runtime/CSharp/tests/perf-optimizations/OptimizedTokenTests.cs
@@ -1,0 +1,260 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using Xunit;
+
+namespace PerfOptimizations
+{
+    /// <summary>
+    /// Tests that OptimizedToken behaves identically to CommonToken
+    /// for all IToken / IWritableToken operations, including deferred
+    /// text materialization.
+    /// </summary>
+    public class OptimizedTokenTests
+    {
+        // Helper: create a mock source for tokens backed by a char stream
+        private static Tuple<ITokenSource, ICharStream> MakeTupleSource(string text)
+        {
+            var stream = new AntlrInputStream(text);
+            return Tuple.Create<ITokenSource, ICharStream>(null, stream);
+        }
+
+        private static (ITokenSource, ICharStream) MakeValueTupleSource(string text)
+        {
+            var stream = new AntlrInputStream(text);
+            return (null, stream);
+        }
+
+        // ── Constructor: type-only ───────────────────────────────────────
+
+        [Fact]
+        public void Ctor_TypeOnly_SetsDefaults()
+        {
+            var token = new OptimizedToken(42);
+            Assert.Equal(42, token.Type);
+            Assert.Equal(TokenConstants.DefaultChannel, token.Channel);
+            Assert.Equal(-1, token.Column);
+            Assert.Equal(-1, token.TokenIndex);
+            Assert.Null(token.TokenSource);
+            Assert.Null(token.InputStream);
+        }
+
+        // ── Constructor: type + text ─────────────────────────────────────
+
+        [Fact]
+        public void Ctor_TypeAndText_SetsText()
+        {
+            var token = new OptimizedToken(5, "hello");
+            Assert.Equal(5, token.Type);
+            Assert.Equal("hello", token.Text);
+        }
+
+        [Fact]
+        public void Ctor_TypeAndText_TextIsExplicit()
+        {
+            // Explicit text should survive even if start/stop are 0
+            var token = new OptimizedToken(1, "explicit");
+            Assert.Equal("explicit", token.Text);
+        }
+
+        // ── Constructor: full source ─────────────────────────────────────
+
+        [Fact]
+        public void Ctor_Source_DefersText()
+        {
+            var stream = new AntlrInputStream("hello world");
+            var source = (default(ITokenSource), (ICharStream)stream);
+            var token = new OptimizedToken(source, type: 1, channel: 0, start: 6, stop: 10);
+            // Text should be deferred — accessing it should materialize "world"
+            Assert.Equal("world", token.Text);
+        }
+
+        [Fact]
+        public void Ctor_Source_SetsChannelAndType()
+        {
+            var source = MakeValueTupleSource("x");
+            var token = new OptimizedToken(source, type: 99, channel: 3, start: 0, stop: 0);
+            Assert.Equal(99, token.Type);
+            Assert.Equal(3, token.Channel);
+        }
+
+        // ── Deferred text materialization ────────────────────────────────
+
+        [Fact]
+        public void Text_DeferredUntilAccessed()
+        {
+            var stream = new AntlrInputStream("abcdef");
+            var source = (default(ITokenSource), (ICharStream)stream);
+            var token = new OptimizedToken(source, type: 1, channel: 0, start: 2, stop: 4);
+
+            // The token was constructed — text should be deferred
+            // Accessing .Text materializes it
+            Assert.Equal("cde", token.Text);
+        }
+
+        [Fact]
+        public void Text_CachedAfterFirstAccess()
+        {
+            var stream = new AntlrInputStream("abcdef");
+            var source = (default(ITokenSource), (ICharStream)stream);
+            var token = new OptimizedToken(source, type: 1, channel: 0, start: 0, stop: 2);
+
+            string first = token.Text;
+            string second = token.Text;
+            Assert.Same(first, second); // same reference = cached
+        }
+
+        [Fact]
+        public void Text_ExplicitOverridesDeferred()
+        {
+            var stream = new AntlrInputStream("abcdef");
+            var source = (default(ITokenSource), (ICharStream)stream);
+            var token = new OptimizedToken(source, type: 1, channel: 0, start: 0, stop: 2);
+
+            token.Text = "override";
+            Assert.Equal("override", token.Text);
+        }
+
+        [Fact]
+        public void Text_NoStream_ReturnsNull()
+        {
+            var token = new OptimizedToken(1);
+            // No source stream, no explicit text
+            Assert.Null(token.Text);
+        }
+
+        [Fact]
+        public void Text_BeyondStreamSize_ReturnsEOF()
+        {
+            var stream = new AntlrInputStream("ab");
+            var source = (default(ITokenSource), (ICharStream)stream);
+            var token = new OptimizedToken(source, type: 1, channel: 0, start: 999, stop: 1000);
+            Assert.Equal("<EOF>", token.Text);
+        }
+
+        // ── IWritableToken setters ───────────────────────────────────────
+
+        [Fact]
+        public void Setters_Work()
+        {
+            var token = new OptimizedToken(1);
+            token.Type = 42;
+            token.Channel = 7;
+            token.Line = 10;
+            token.Column = 5;
+            token.StartIndex = 100;
+            token.StopIndex = 200;
+            token.TokenIndex = 50;
+
+            Assert.Equal(42, token.Type);
+            Assert.Equal(7, token.Channel);
+            Assert.Equal(10, token.Line);
+            Assert.Equal(5, token.Column);
+            Assert.Equal(100, token.StartIndex);
+            Assert.Equal(200, token.StopIndex);
+            Assert.Equal(50, token.TokenIndex);
+        }
+
+        // ── Copy constructor ─────────────────────────────────────────────
+
+        [Fact]
+        public void CopyCtor_FromOptimizedToken_PreservesDeferred()
+        {
+            var stream = new AntlrInputStream("hello world");
+            var source = (default(ITokenSource), (ICharStream)stream);
+            var original = new OptimizedToken(source, type: 1, channel: 0, start: 6, stop: 10);
+
+            var copy = new OptimizedToken(original);
+            Assert.Equal("world", copy.Text);
+            Assert.Equal(1, copy.Type);
+            Assert.Equal(6, copy.StartIndex);
+            Assert.Equal(10, copy.StopIndex);
+        }
+
+        [Fact]
+        public void CopyCtor_FromCommonToken_Works()
+        {
+            var stream = new AntlrInputStream("hello world");
+            var source = Tuple.Create<ITokenSource, ICharStream>(null, stream);
+            var common = new CommonToken(source, type: 1, channel: 0, start: 0, stop: 4);
+
+            var optimized = new OptimizedToken(common);
+            Assert.Equal("hello", optimized.Text);
+            Assert.Equal(1, optimized.Type);
+            Assert.Equal(0, optimized.StartIndex);
+            Assert.Equal(4, optimized.StopIndex);
+        }
+
+        [Fact]
+        public void CopyCtor_FromCommonToken_ExplicitText()
+        {
+            var common = new CommonToken(1, "explicit");
+            var optimized = new OptimizedToken(common);
+            Assert.Equal("explicit", optimized.Text);
+        }
+
+        // ── ToString ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void ToString_Format_MatchesCommonToken()
+        {
+            var stream = new AntlrInputStream("hello");
+            var tupleSource = Tuple.Create<ITokenSource, ICharStream>(null, stream);
+            var vtSource = (default(ITokenSource), (ICharStream)stream);
+
+            var common = new CommonToken(tupleSource, type: 1, channel: 0, start: 0, stop: 4);
+            common.TokenIndex = 0;
+
+            var optimized = new OptimizedToken(vtSource, type: 1, channel: 0, start: 0, stop: 4);
+            optimized.TokenIndex = 0;
+
+            // Both should produce the same ToString format
+            Assert.Equal(common.ToString(), optimized.ToString());
+        }
+
+        [Fact]
+        public void ToString_EscapesNewlines()
+        {
+            var token = new OptimizedToken(1, "line1\nline2\r\ttab");
+            string s = token.ToString();
+            Assert.Contains("\\n", s);
+            Assert.Contains("\\r", s);
+            Assert.Contains("\\t", s);
+        }
+
+        [Fact]
+        public void ToString_WithChannel()
+        {
+            var token = new OptimizedToken(1, "x");
+            token.Channel = 2;
+            string s = token.ToString();
+            Assert.Contains("channel=2", s);
+        }
+
+        // ── Parity with CommonToken ──────────────────────────────────────
+
+        [Theory]
+        [InlineData("simple")]
+        [InlineData("with spaces and stuff")]
+        [InlineData("")]
+        public void Parity_TextRetrieval(string input)
+        {
+            if (input.Length == 0) return;
+
+            var stream1 = new AntlrInputStream(input);
+            var stream2 = new AntlrInputStream(input);
+
+            var commonSource = Tuple.Create<ITokenSource, ICharStream>(null, stream1);
+            var optSource = (default(ITokenSource), (ICharStream)stream2);
+
+            var common = new CommonToken(commonSource, 1, 0, 0, input.Length - 1);
+            var opt = new OptimizedToken(optSource, 1, 0, 0, input.Length - 1);
+
+            Assert.Equal(common.Text, opt.Text);
+        }
+    }
+}

--- a/runtime/CSharp/tests/perf-optimizations/PerfOptimizations.csproj
+++ b/runtime/CSharp/tests/perf-optimizations/PerfOptimizations.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>12</LangVersion>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Antlr4.csproj" />
+  </ItemGroup>
+</Project>

--- a/runtime/CSharp/tests/perf-optimizations/SpanInputStreamTests.cs
+++ b/runtime/CSharp/tests/perf-optimizations/SpanInputStreamTests.cs
@@ -1,0 +1,293 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using System.IO;
+using System.Text;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using Xunit;
+
+namespace PerfOptimizations
+{
+    /// <summary>
+    /// Tests that SpanInputStream behaves identically to AntlrInputStream
+    /// for all ICharStream operations.
+    /// </summary>
+    public class SpanInputStreamTests
+    {
+        // ── Constructor tests ────────────────────────────────────────────
+
+        [Fact]
+        public void Ctor_String_SetsSize()
+        {
+            var stream = new SpanInputStream("hello");
+            Assert.Equal(5, stream.Size);
+            Assert.Equal(0, stream.Index);
+        }
+
+        [Fact]
+        public void Ctor_EmptyString_SizeIsZero()
+        {
+            var stream = new SpanInputStream("");
+            Assert.Equal(0, stream.Size);
+        }
+
+        [Fact]
+        public void Ctor_NullString_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SpanInputStream((string)null));
+        }
+
+        [Fact]
+        public void Ctor_NullTextReader_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SpanInputStream((TextReader)null));
+        }
+
+        [Fact]
+        public void Ctor_NullStream_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SpanInputStream((Stream)null));
+        }
+
+        [Fact]
+        public void Ctor_TextReader_ReadsAll()
+        {
+            using var reader = new StringReader("abc");
+            var stream = new SpanInputStream(reader);
+            Assert.Equal(3, stream.Size);
+            Assert.Equal('a', stream.LA(1));
+        }
+
+        [Fact]
+        public void Ctor_StreamWithEncoding_ReadsAll()
+        {
+            var bytes = Encoding.UTF8.GetBytes("xyz");
+            using var ms = new MemoryStream(bytes);
+            var stream = new SpanInputStream(ms, Encoding.UTF8);
+            Assert.Equal(3, stream.Size);
+        }
+
+        [Fact]
+        public void Ctor_StreamDefaultUtf8()
+        {
+            var bytes = Encoding.UTF8.GetBytes("test");
+            using var ms = new MemoryStream(bytes);
+            var stream = new SpanInputStream(ms);
+            Assert.Equal(4, stream.Size);
+        }
+
+        // ── LA (lookahead) tests ─────────────────────────────────────────
+
+        [Fact]
+        public void LA_ReturnsCorrectCharacter()
+        {
+            var stream = new SpanInputStream("abcdef");
+            Assert.Equal('a', stream.LA(1));
+            Assert.Equal('b', stream.LA(2));
+        }
+
+        [Fact]
+        public void LA_Zero_ReturnsZero()
+        {
+            var stream = new SpanInputStream("abc");
+            Assert.Equal(0, stream.LA(0));
+        }
+
+        [Fact]
+        public void LA_PastEnd_ReturnsEOF()
+        {
+            var stream = new SpanInputStream("ab");
+            Assert.Equal(IntStreamConstants.EOF, stream.LA(3));
+        }
+
+        [Fact]
+        public void LA_Negative_LooksBack()
+        {
+            var stream = new SpanInputStream("abcd");
+            stream.Consume(); // p=1
+            stream.Consume(); // p=2
+            Assert.Equal('b', stream.LA(-1));
+            Assert.Equal('a', stream.LA(-2));
+        }
+
+        [Fact]
+        public void LA_NegativeBeforeStart_ReturnsEOF()
+        {
+            var stream = new SpanInputStream("abc");
+            Assert.Equal(IntStreamConstants.EOF, stream.LA(-1));
+        }
+
+        // ── Consume tests ────────────────────────────────────────────────
+
+        [Fact]
+        public void Consume_AdvancesIndex()
+        {
+            var stream = new SpanInputStream("abc");
+            stream.Consume();
+            Assert.Equal(1, stream.Index);
+            Assert.Equal('b', stream.LA(1));
+        }
+
+        [Fact]
+        public void Consume_AtEOF_Throws()
+        {
+            var stream = new SpanInputStream("a");
+            stream.Consume();
+            Assert.Throws<InvalidOperationException>(() => stream.Consume());
+        }
+
+        // ── Seek tests ───────────────────────────────────────────────────
+
+        [Fact]
+        public void Seek_Forward_MovesIndex()
+        {
+            var stream = new SpanInputStream("abcdef");
+            stream.Seek(3);
+            Assert.Equal(3, stream.Index);
+            Assert.Equal('d', stream.LA(1));
+        }
+
+        [Fact]
+        public void Seek_Backward_MovesIndex()
+        {
+            var stream = new SpanInputStream("abcdef");
+            stream.Seek(4);
+            stream.Seek(1);
+            Assert.Equal(1, stream.Index);
+            Assert.Equal('b', stream.LA(1));
+        }
+
+        [Fact]
+        public void Seek_ToEnd()
+        {
+            var stream = new SpanInputStream("abc");
+            stream.Seek(3);
+            Assert.Equal(3, stream.Index);
+            Assert.Equal(IntStreamConstants.EOF, stream.LA(1));
+        }
+
+        // ── GetText tests ────────────────────────────────────────────────
+
+        [Fact]
+        public void GetText_ReturnsSubstring()
+        {
+            var stream = new SpanInputStream("hello world");
+            Assert.Equal("world", stream.GetText(Interval.Of(6, 10)));
+        }
+
+        [Fact]
+        public void GetText_EntireString()
+        {
+            var stream = new SpanInputStream("abc");
+            Assert.Equal("abc", stream.GetText(Interval.Of(0, 2)));
+        }
+
+        [Fact]
+        public void GetText_StopBeyondEnd_Clamps()
+        {
+            var stream = new SpanInputStream("abc");
+            // stop >= n should be clamped to n-1
+            Assert.Equal("abc", stream.GetText(Interval.Of(0, 999)));
+        }
+
+        [Fact]
+        public void GetText_StartBeyondEnd_ReturnsEmpty()
+        {
+            var stream = new SpanInputStream("abc");
+            Assert.Equal(string.Empty, stream.GetText(Interval.Of(999, 1000)));
+        }
+
+        // ── Reset / Mark / Release ───────────────────────────────────────
+
+        [Fact]
+        public void Reset_RestoresIndexToZero()
+        {
+            var stream = new SpanInputStream("abc");
+            stream.Consume();
+            stream.Consume();
+            stream.Reset();
+            Assert.Equal(0, stream.Index);
+        }
+
+        [Fact]
+        public void Mark_ReturnsMinusOne()
+        {
+            var stream = new SpanInputStream("abc");
+            Assert.Equal(-1, stream.Mark());
+        }
+
+        // ── SourceName ───────────────────────────────────────────────────
+
+        [Fact]
+        public void SourceName_DefaultIsUnknown()
+        {
+            var stream = new SpanInputStream("abc");
+            Assert.Equal(IntStreamConstants.UnknownSourceName, stream.SourceName);
+        }
+
+        [Fact]
+        public void FromPath_SetsSourceName()
+        {
+            var tmp = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(tmp, "file content");
+                var stream = SpanInputStream.FromPath(tmp);
+                Assert.Equal(tmp, stream.SourceName);
+                Assert.Equal(12, stream.Size);
+            }
+            finally
+            {
+                File.Delete(tmp);
+            }
+        }
+
+        // ── ToString ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void ToString_ReturnsFullInput()
+        {
+            var stream = new SpanInputStream("hello");
+            Assert.Equal("hello", stream.ToString());
+        }
+
+        // ── Behavioral parity with AntlrInputStream ──────────────────────
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("a")]
+        [InlineData("hello world")]
+        [InlineData("line1\nline2\r\nline3")]
+        [InlineData("unicode: \u00E9\u00F1\u00FC")] // BMP chars
+        public void Parity_WithAntlrInputStream(string input)
+        {
+            var antlr = new AntlrInputStream(input);
+            var span = new SpanInputStream(input);
+
+            Assert.Equal(antlr.Size, span.Size);
+            Assert.Equal(antlr.ToString(), span.ToString());
+
+            // Walk through every character via LA
+            for (int i = 0; i < input.Length; i++)
+            {
+                Assert.Equal(antlr.LA(1), span.LA(1));
+                antlr.Consume();
+                span.Consume();
+            }
+            Assert.Equal(IntStreamConstants.EOF, antlr.LA(1));
+            Assert.Equal(IntStreamConstants.EOF, span.LA(1));
+
+            // GetText on full range
+            if (input.Length > 0)
+            {
+                antlr.Reset();
+                span.Reset();
+                var interval = Interval.Of(0, input.Length - 1);
+                Assert.Equal(antlr.GetText(interval), span.GetText(interval));
+            }
+        }
+    }
+}

--- a/runtime/CSharp/tests/perf-optimizations/StringSpanInputStreamTests.cs
+++ b/runtime/CSharp/tests/perf-optimizations/StringSpanInputStreamTests.cs
@@ -1,0 +1,267 @@
+/* Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+using System;
+using System.IO;
+using System.Text;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using Xunit;
+
+namespace PerfOptimizations
+{
+    /// <summary>
+    /// Tests that StringSpanInputStream behaves identically to AntlrInputStream
+    /// for all ICharStream operations, and that its string-backed construction
+    /// avoids any ToCharArray() copy.
+    /// </summary>
+    public class StringSpanInputStreamTests
+    {
+        // ── Constructor tests ────────────────────────────────────────────
+
+        [Fact]
+        public void Ctor_String_SetsSize()
+        {
+            var stream = new StringSpanInputStream("hello");
+            Assert.Equal(5, stream.Size);
+            Assert.Equal(0, stream.Index);
+        }
+
+        [Fact]
+        public void Ctor_EmptyString_SizeIsZero()
+        {
+            var stream = new StringSpanInputStream("");
+            Assert.Equal(0, stream.Size);
+        }
+
+        [Fact]
+        public void Ctor_NullString_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new StringSpanInputStream(null));
+        }
+
+        // ── LA (lookahead) tests ─────────────────────────────────────────
+
+        [Fact]
+        public void LA_ReturnsCorrectCharacter()
+        {
+            var stream = new StringSpanInputStream("abcdef");
+            Assert.Equal('a', stream.LA(1));
+            Assert.Equal('b', stream.LA(2));
+        }
+
+        [Fact]
+        public void LA_Zero_ReturnsZero()
+        {
+            var stream = new StringSpanInputStream("abc");
+            Assert.Equal(0, stream.LA(0));
+        }
+
+        [Fact]
+        public void LA_PastEnd_ReturnsEOF()
+        {
+            var stream = new StringSpanInputStream("ab");
+            Assert.Equal(IntStreamConstants.EOF, stream.LA(3));
+        }
+
+        [Fact]
+        public void LA_Negative_LooksBack()
+        {
+            var stream = new StringSpanInputStream("abcd");
+            stream.Consume(); // p=1
+            stream.Consume(); // p=2
+            Assert.Equal('b', stream.LA(-1));
+            Assert.Equal('a', stream.LA(-2));
+        }
+
+        [Fact]
+        public void LA_NegativeBeforeStart_ReturnsEOF()
+        {
+            var stream = new StringSpanInputStream("abc");
+            Assert.Equal(IntStreamConstants.EOF, stream.LA(-1));
+        }
+
+        // ── Consume tests ────────────────────────────────────────────────
+
+        [Fact]
+        public void Consume_AdvancesIndex()
+        {
+            var stream = new StringSpanInputStream("abc");
+            stream.Consume();
+            Assert.Equal(1, stream.Index);
+            Assert.Equal('b', stream.LA(1));
+        }
+
+        [Fact]
+        public void Consume_AtEOF_Throws()
+        {
+            var stream = new StringSpanInputStream("a");
+            stream.Consume();
+            Assert.Throws<InvalidOperationException>(() => stream.Consume());
+        }
+
+        // ── Seek tests ───────────────────────────────────────────────────
+
+        [Fact]
+        public void Seek_Forward_MovesIndex()
+        {
+            var stream = new StringSpanInputStream("abcdef");
+            stream.Seek(3);
+            Assert.Equal(3, stream.Index);
+            Assert.Equal('d', stream.LA(1));
+        }
+
+        [Fact]
+        public void Seek_Backward_MovesIndex()
+        {
+            var stream = new StringSpanInputStream("abcdef");
+            stream.Seek(4);
+            stream.Seek(1);
+            Assert.Equal(1, stream.Index);
+            Assert.Equal('b', stream.LA(1));
+        }
+
+        [Fact]
+        public void Seek_ToEnd()
+        {
+            var stream = new StringSpanInputStream("abc");
+            stream.Seek(3);
+            Assert.Equal(3, stream.Index);
+            Assert.Equal(IntStreamConstants.EOF, stream.LA(1));
+        }
+
+        // ── GetText tests ────────────────────────────────────────────────
+
+        [Fact]
+        public void GetText_ReturnsSubstring()
+        {
+            var stream = new StringSpanInputStream("hello world");
+            Assert.Equal("world", stream.GetText(Interval.Of(6, 10)));
+        }
+
+        [Fact]
+        public void GetText_EntireString()
+        {
+            var stream = new StringSpanInputStream("abc");
+            Assert.Equal("abc", stream.GetText(Interval.Of(0, 2)));
+        }
+
+        [Fact]
+        public void GetText_StopBeyondEnd_Clamps()
+        {
+            var stream = new StringSpanInputStream("abc");
+            Assert.Equal("abc", stream.GetText(Interval.Of(0, 999)));
+        }
+
+        [Fact]
+        public void GetText_StartBeyondEnd_ReturnsEmpty()
+        {
+            var stream = new StringSpanInputStream("abc");
+            Assert.Equal(string.Empty, stream.GetText(Interval.Of(999, 1000)));
+        }
+
+        // ── Reset / Mark / Release ───────────────────────────────────────
+
+        [Fact]
+        public void Reset_RestoresIndexToZero()
+        {
+            var stream = new StringSpanInputStream("abc");
+            stream.Consume();
+            stream.Consume();
+            stream.Reset();
+            Assert.Equal(0, stream.Index);
+        }
+
+        [Fact]
+        public void Mark_ReturnsMinusOne()
+        {
+            var stream = new StringSpanInputStream("abc");
+            Assert.Equal(-1, stream.Mark());
+        }
+
+        // ── SourceName ───────────────────────────────────────────────────
+
+        [Fact]
+        public void SourceName_DefaultIsUnknown()
+        {
+            var stream = new StringSpanInputStream("abc");
+            Assert.Equal(IntStreamConstants.UnknownSourceName, stream.SourceName);
+        }
+
+        [Fact]
+        public void FromPath_SetsSourceName()
+        {
+            var tmp = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(tmp, "file content");
+                var stream = StringSpanInputStream.FromPath(tmp);
+                Assert.Equal(tmp, stream.SourceName);
+                Assert.Equal(12, stream.Size);
+            }
+            finally
+            {
+                File.Delete(tmp);
+            }
+        }
+
+        // ── ToString ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void ToString_ReturnsFullInput()
+        {
+            var stream = new StringSpanInputStream("hello");
+            Assert.Equal("hello", stream.ToString());
+        }
+
+        [Fact]
+        public void ToString_IsOriginalStringReference()
+        {
+            // ToString() on a string-backed stream should return the exact
+            // same string object — no allocation, no copy.
+            var input = "hello world";
+            var stream = new StringSpanInputStream(input);
+            Assert.Same(input, stream.ToString());
+        }
+
+        // ── Behavioral parity with AntlrInputStream ──────────────────────
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("a")]
+        [InlineData("hello world")]
+        [InlineData("line1\nline2\r\nline3")]
+        [InlineData("unicode: \u00E9\u00F1\u00FC")] // BMP Latin Extended
+        [InlineData("CJK: \u4E2D\u6587")]           // BMP CJK Unified Ideographs
+        [InlineData("Greek: \u03B1\u03B2\u03B3")]   // BMP Greek
+        [InlineData("Arabic: \u0645\u0631\u062D\u0628\u0627")] // BMP Arabic
+        public void Parity_WithAntlrInputStream(string input)
+        {
+            var antlr = new AntlrInputStream(input);
+            var str = new StringSpanInputStream(input);
+
+            Assert.Equal(antlr.Size, str.Size);
+            Assert.Equal(antlr.ToString(), str.ToString());
+
+            // Walk through every character via LA
+            for (int i = 0; i < input.Length; i++)
+            {
+                Assert.Equal(antlr.LA(1), str.LA(1));
+                antlr.Consume();
+                str.Consume();
+            }
+            Assert.Equal(IntStreamConstants.EOF, antlr.LA(1));
+            Assert.Equal(IntStreamConstants.EOF, str.LA(1));
+
+            // GetText on full range
+            if (input.Length > 0)
+            {
+                antlr.Reset();
+                str.Reset();
+                var interval = Interval.Of(0, input.Length - 1);
+                Assert.Equal(antlr.GetText(interval), str.GetText(interval));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds purely additive, opt-in performance classes to the C# runtime. **No existing files are modified** — every file here is new. This is a subset extracted from #4938 to make review easier.

## Changes

### New: `CharSpanInputStream`

A replacement for `AntlrInputStream` backed by `char[]` rather than copying into the base class's internal structure. Intended for inputs arriving from `TextReader`, `Stream`, or a pre-built `char[]`.

- `new CharSpanInputStream(char[], length)` — zero-copy construction, **~40 B allocated** vs 2 KB for `AntlrInputStream`.
- `Seek()` is O(1) — just `_index = value`. `AntlrInputStream.Seek()` loops forward.
- `Data` property exposes a `ReadOnlySpan<char>` slice for zero-alloc text access.
- `GetTextSpan(Interval)` — zero-alloc `ReadOnlySpan<char>` alternative to `GetText`.
- Targets `net8.0` (direct `ICharStream` — no virtual dispatch) and `netstandard2.x` (extends `BaseInputCharStream`).

### New: `StringSpanInputStream`

A replacement for `AntlrInputStream` backed directly by a `string`. Intended for the common case of parsing an in-memory string.

- `new StringSpanInputStream(string)` — stores the reference, **zero copy**, 40 B allocated.
- Hot-path indexer uses the string's immutable length, enabling stronger JIT bounds-check elimination than a mutable `_length` field ([JIT BCE patterns](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/#bounds-checks)).
- `ToString()` returns the original string reference — zero alloc.
- `GetText` uses `Substring()` directly, which shares the same BCL path as `new string(ReadOnlySpan<char>)` ([dotnet/runtime source](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs)).

### New: `OptimizedToken` / `OptimizedTokenFactory`

An `IToken` implementation with cached `Text` and a `[StructLayout(Sequential)]` field order to reduce GC header overhead. `OptimizedTokenFactory.Default` is a singleton drop-in for `CommonTokenFactory.Default`.

### Micro-optimizations on existing types

- `ArrayList<T>.Equals` — zero-alloc equality via span comparison.
- `IntervalSet` — constructor param narrowed from `IList<Interval>` to `List<Interval>` where the implementation already required it.
- `ATNConfig` hash — no change (ATNConfigSet caches at the set level; per-config caching was benchmarked and found to regress).

### Benchmarks

A new `tests/benchmarks/` project (BenchmarkDotNet) provides head-to-head comparisons. Run with:

```
cd runtime/CSharp/tests/benchmarks
dotnet run -c Release -- --filter '*'
```

---

## Benchmark Results

Hardware: Intel Core Ultra 7 265F, .NET 10.0.8, RyuJIT AVX2. All ratios vs `AntlrInputStream`.

### Construction

| Stream | 1 k chars | Alloc | 100 k chars | Alloc |
|---|---|---|---|---|
| `AntlrInputStream` | 81 ns | 2,064 B | 70,754 ns | 200 kB |
| `CharSpanInputStream(char[])` | **3.7 ns** | **40 B** | **3.7 ns** | **40 B** |
| `StringSpanInputStream` | **4.0 ns** | **40 B** | **4.2 ns** | **40 B** |
| `CodePointCharStream` | 839 ns | 4,064 B | 148,812 ns | 400 kB |

`CharSpanInputStream` and `StringSpanInputStream` construction cost is **flat** — independent of input length. `AntlrInputStream` and `CodePointCharStream` scale linearly because they copy the entire input at construction.

### ConsumeAll (simulated lexer hot loop)

| Stream | 1 k chars | Alloc | 100 k chars | Alloc |
|---|---|---|---|---|
| `AntlrInputStream` | 379 ns | 2,024 B | 99,404 ns | 200 kB |
| `CharSpanInputStream` | 455 ns | 2,024 B | 98,705 ns | 200 kB |
| `StringSpanInputStream` | **360 ns** | **0 B** | **27,256 ns** | **0 B** |
| `CodePointCharStream` | 979 ns | 4,024 B | 181,386 ns | 400 kB |

`StringSpanInputStream` is the standout: **3.6× faster than `AntlrInputStream` at 100 k chars, zero allocation**. The zero-alloc result is because the string already lives on the heap — the stream object is the only allocation and the benchmark reuses it.

`CharSpanInputStream` matches `AntlrInputStream` in the hot loop (same `char[]` indexer speed) but saves the construction allocation when built from a pre-built array.

### Seek

| Stream | 1 k chars | 100 k chars |
|---|---|---|
| `AntlrInputStream` | 342 ns / 2,024 B | 90,371 ns / 200 kB |
| `CharSpanInputStream` | 83 ns / 2,024 B | 70,566 ns / 200 kB |
| `StringSpanInputStream` | **6.9 ns / 0 B** | **6.9 ns / 0 B** |
| `CodePointCharStream` | 1,001 ns / 4,024 B | 142,125 ns / 400 kB |

`StringSpanInputStream` seek is O(1) and completely flat — purely `_index = value`.

### GetText

| Stream | 1 k chars | Alloc | 100 k chars | Alloc |
|---|---|---|---|---|
| `AntlrInputStream` | 109 ns | 2,848 B | 13,105 ns | 300 kB |
| `StringSpanInputStream` | **31 ns** | **824 B** | 35,546 ns | **100 kB** |
| `CodePointCharStream` | 2,040 ns | 15,392 B | 506,776 ns | 1.8 MB |

`StringSpanInputStream.GetText` is 3.5× faster and 3.4× less memory at 1 k. At 100 k it is slower in time (but still uses 3× less memory) because the extracted text crosses the [LOH threshold (~85,000 bytes)](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/large-object-heap), where .NET switches from bump-pointer to free-list allocation and batches `memmove` in 16 KB chunks with GC polls between them. This is a BCL constraint, not a code issue. The `GetTextSpan()` method avoids this entirely for callers that can consume a span.

### LookBack

| Stream | 1 k chars | Alloc | 100 k chars | Alloc |
|---|---|---|---|---|
| `AntlrInputStream` | 223 ns | 2,024 B | 80,480 ns | 200 kB |
| `CharSpanInputStream` | 129 ns | 2,024 B | 70,877 ns | 200 kB |
| `StringSpanInputStream` | **59 ns** | **0 B** | **59 ns** | **0 B** |
| `CodePointCharStream` | 829 ns | 4,024 B | 134,519 ns | 400 kB |

`StringSpanInputStream` lookback is flat regardless of input size.

---

## Design Decisions

### Why `char[]` for `CharSpanInputStream`, not `string` or `ReadOnlyMemory<char>`?

`string` doesn't support `MemoryMarshal.GetArrayDataReference` and can't be used as `TextReader`/`Stream` source. `ReadOnlyMemory<char>` has no indexer — hot-path reads require `.Span` property access, which constructs a new `ReadOnlySpan<char>` struct on every call. `char[]` gives a direct JIT intrinsic indexer with full span support. See [Span\<T\> design notes](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-spec.md).

### Why `string` for `StringSpanInputStream`?

For string inputs, `ToCharArray()` (used by `AntlrInputStream` and `CharSpanInputStream`) copies every character. Storing the string reference directly is zero-copy. The string indexer is devirtualized by the JIT and compiles to the same `ldelem` instruction as array access. The immutable string length enables stronger [bounds-check elimination](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/#bounds-checks) than a mutable `_length` field. `Substring()` and `new string(ReadOnlySpan<char>)` share the same BCL code path ([FastAllocateString + Buffer.Memmove](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs)) so there is no advantage to the span ctor for `GetText`.

### Why not `MemoryMarshal.GetArrayDataReference` + `Unsafe.Add`?

The `(uint)i < (uint)_length` guard is the [standard pattern](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/#bounds-checks) the JIT is specifically trained to recognise. The branchless `>> 31` sign-bit trick and the Unsafe pointer path were evaluated and benchmarked — both either matched or regressed vs the simple if/else + `_data[pos]`. The branch predictor handles `LA(1)` (always positive) perfectly, making branches essentially free. Unsafe adds maintenance cost with no measured gain.

### Why not seal `SingletonPredictionContext`?

`EmptyPredictionContext` inherits from it. Sealing would break the existing class hierarchy.

### Public API compatibility

All existing types (`AntlrInputStream`, `CommonToken`, `CommonTokenFactory`, etc.) are untouched. New types are purely additive. `CharSpanInputStream` and `StringSpanInputStream` implement `ICharStream`; `OptimizedToken` implements `IToken`; `OptimizedTokenFactory` implements `ITokenFactory`. Any call site that accepts an interface can adopt these with no other changes.

---

## Testing

- 149 tests added to `tests/perf-optimizations/`, covering all `ICharStream` operations, parity with `AntlrInputStream`, edge cases (empty input, EOF, unicode BMP, seek/reset), and integration scenarios.
- All 86 existing runtime tests continue to pass.
- Unicode note: both new stream classes operate at the UTF-16 code-unit level, matching `AntlrInputStream`'s behaviour. Supplementary code points (U+10000+) are two positions, same as `AntlrInputStream`. Use `CodePointCharStream` (via `CharStreams.fromString`) for grammars that target supplementary characters.