### PR TITLE
carry trailing high surrogate across CodePointBuffer appends

### DIFF
--- a/runtime-testsuite/test/org/antlr/v4/runtime/TestCodePointCharStream.java
+++ b/runtime-testsuite/test/org/antlr/v4/runtime/TestCodePointCharStream.java
@@ -9,6 +9,8 @@ package org.antlr.v4.runtime;
 import org.antlr.v4.runtime.misc.Interval;
 import org.junit.jupiter.api.Test;
 
+import java.nio.CharBuffer;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestCodePointCharStream {
@@ -299,5 +301,28 @@ public class TestCodePointCharStream {
 		CodePointCharStream s = CharStreams.fromString("hello \uD83C\uDF0D");
 		assertTrue(s.getInternalStorage() instanceof int[]);
 		assertEquals(7, s.size());
+	}
+
+	@Test
+	public void splitSurrogatePairAcrossAppendsProducesOneCodePoint() {
+		// An emoji (U+1F4A9) whose UTF-16 surrogate pair is delivered in two
+		// separate append() calls, as happens when CharStreams.fromReader hits a
+		// chunk boundary in the middle of the pair.
+		CodePointBuffer.Builder builder = CodePointBuffer.builder(8);
+		builder.append(CharBuffer.wrap(new char[] { '\uD83D' }));
+		builder.append(CharBuffer.wrap(new char[] { '\uDCA9' }));
+		CodePointCharStream s = CodePointCharStream.fromBuffer(builder.build());
+		assertEquals(1, s.size());
+		assertEquals(0x1F4A9, s.LA(1));
+		assertEquals("\uD83D\uDCA9", s.toString());
+	}
+
+	@Test
+	public void danglingHighSurrogateAtEndOfInputIsPreserved() {
+		CodePointBuffer.Builder builder = CodePointBuffer.builder(8);
+		builder.append(CharBuffer.wrap(new char[] { 'a', '\uD83D' }));
+		CodePointCharStream s = CodePointCharStream.fromBuffer(builder.build());
+		assertEquals(2, s.size());
+		assertEquals(0xD83D, s.LA(2));
 	}
 }

--- a/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/CodePointBuffer.java
@@ -171,6 +171,12 @@ public class CodePointBuffer {
 					charBuffer.flip();
 					break;
 				case INT:
+					if (prevHighSurrogate != -1) {
+						// Flush a high surrogate left dangling at the end of the input.
+						ensureRemaining(1);
+						intBuffer.put(prevHighSurrogate);
+						prevHighSurrogate = -1;
+					}
 					intBuffer.flip();
 					break;
 			}
@@ -340,11 +346,10 @@ public class CodePointBuffer {
 				}
 			}
 
-			if (prevHighSurrogate != -1) {
-				// Dangling high surrogate
-				outInt[outOffset] = prevHighSurrogate & 0xFFFF;
-				outOffset++;
-			}
+			// A high surrogate at the end of this chunk stays pending in
+			// prevHighSurrogate so the next append() can pair it with a low
+			// surrogate split across the chunk boundary. build() flushes it if no
+			// low surrogate ever arrives.
 
 			utf16In.position(inOffset - utf16In.arrayOffset());
 			intBuffer.position(outOffset - intBuffer.arrayOffset());


### PR DESCRIPTION
`appendArrayInt` emitted a chunk-trailing high surrogate immediately instead of holding it in `prevHighSurrogate`, so a surrogate pair split across two `append()` calls (e.g. `CharStreams.fromReader` filling its read buffer mid-emoji) decoded to a spurious lone surrogate before the real code point; found tracing the chunked decode path, the fix keeps it pending for the next `append()` and flushes a still-dangling one in `build()`.