### PR TITLE
Fix typo and clarify input file argument in Interpreter help message

### DIFF
--- a/tool/src/org/antlr/v4/gui/Interpreter.java
+++ b/tool/src/org/antlr/v4/gui/Interpreter.java
@@ -62,10 +62,10 @@ public class Interpreter {
 
 	public Interpreter(String[] args) throws Exception {
 		if ( args.length < 2 ) {
-			System.err.println("java org.antlr.v4.gui.Intrepreter [X.g4|XParser.g4 XLexer.g4] startRuleName\n" +
-					"  [-tokens] [-tree] [-gui] [-encoding encodingname]\n" +
-					"  [-trace] [-profile filename.csv] [input-filename(s)]");
-			System.err.println("Omitting input-filename makes rig read from stdin.");
+			System.err.println("java org.antlr.v4.gui.Interpreter [X.g4|XParser.g4 XLexer.g4] startRuleName\n" +
+				"  [-tokens] [-tree] [-gui] [-encoding encodingname]\n" +
+				"  [-trace] [-profile filename.csv] [source-code-file(s)]");
+			System.err.println("Omitting source-code-file makes the tool read from stdin.");
 			return;
 		}
 		int i=0;


### PR DESCRIPTION
## Problem
The help message for `org.antlr.v4.gui.Interpreter` (invoked via `antlr4-parse` or directly via `java -cp`) contains a typo in the class name (`Intrepreter`) and uses the abstract term `input-filename(s)`, which can be confusing for users trying to understand what kind of files the tool expects.

Additionally, the fallback message uses the word "rig", which is ambiguous in this context.

## Solution
This PR updates the help message printed to `stderr` when the tool is invoked with insufficient arguments:
1. Fixes the typo: `Intrepreter` → `Interpreter`.
2. Replaces `input-filename(s)` with `source-code-file(s)` to explicitly indicate that the tool expects plain text source code files in the target language.
3. Updates the stdin fallback message to use the new terminology and replaces "rig" with "the tool".

### Before
```text
java org.antlr.v4.gui.Intrepreter [X.g4|XParser.g4 XLexer.g4] startRuleName
  [-tokens] [-tree] [-gui] [-encoding encodingname]
  [-trace] [-profile filename.csv] [input-filename(s)]
Omitting input-filename makes rig read from stdin.
```

### After
```text
java org.antlr.v4.gui.Interpreter [X.g4|XParser.g4 XLexer.g4] startRuleName
  [-tokens] [-tree] [-gui] [-encoding encodingname]
  [-trace] [-profile filename.csv] [source-code-file(s)]
Omitting source-code-file makes the tool read from stdin.
```

## Verification
Run the interpreter with insufficient arguments to trigger the help message:
```bash
java -cp ~/projects/antlr4/tool/target/antlr4-4.13.3-SNAPSHOT-complete.jar org.antlr.v4.gui.Interpreter
# or
antlr4-parse
```
The output should match the "After" block above.
```