### PR TITLE
Cpp: move DFA write locks from the ATN onto the DFA

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/tsconfig.json
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/tsconfig.json
@@ -4,8 +4,5 @@
     "moduleResolution": "node",
     "target": "ES6",
     "noImplicitAny": true,
-  },
-  "ts-node": {
-    "esm": true
   }
 }

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/typescript/TsxRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/typescript/TsxRunner.java
@@ -15,7 +15,7 @@ import java.nio.file.Files;
 import static org.antlr.v4.test.runtime.FileUtils.writeFile;
 import static org.antlr.v4.test.runtime.RuntimeTestUtils.isWindows;
 
-public class TsNodeRunner extends RuntimeRunner {
+public class TsxRunner extends RuntimeRunner {
 
 	/* TypeScript runtime is the same as JavaScript runtime */
 	private final static String NORMALIZED_JAVASCRIPT_RUNTIME_PATH = getRuntimePath("JavaScript").replace('\\', '/');
@@ -30,12 +30,12 @@ public class TsNodeRunner extends RuntimeRunner {
 
 	@Override
 	protected void initRuntime(RunOptions runOptions) throws Exception {
-		npmInstallTsNodeAndWebpack();
+		npmInstallTsxAndWebpack();
 		npmLinkRuntime();
 	}
 
-	private void npmInstallTsNodeAndWebpack() throws Exception {
-		Processor.run(new String[] {NPM_EXEC, "--silent", "install", "-g", "typescript", "ts-node", "webpack", "webpack-cli"}, null);
+	private void npmInstallTsxAndWebpack() throws Exception {
+		Processor.run(new String[] {NPM_EXEC, "--silent", "install", "-g", "tsx", "webpack", "webpack-cli"}, null);
 	}
 
 	private void npmLinkRuntime() throws Exception {
@@ -57,7 +57,7 @@ public class TsNodeRunner extends RuntimeRunner {
 	public String getBaseVisitorSuffix() { return null; }
 
 	@Override
-	public String getRuntimeToolName() { return "ts-node"  + (isWindows() ? ".cmd" : ""); }
+	public String getRuntimeToolName() { return "tsx" + (isWindows() ? ".cmd" : ""); }
 
 	@Override
 	protected CompiledState compile(RunOptions runOptions, GeneratedState generatedState) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/typescript/TypeScriptRuntimeTests.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/typescript/TypeScriptRuntimeTests.java
@@ -12,6 +12,6 @@ import org.antlr.v4.test.runtime.RuntimeTests;
 public class TypeScriptRuntimeTests extends RuntimeTests {
 	@Override
 	protected RuntimeRunner createRuntimeRunner() {
-		return new TsNodeRunner();
+		return new TsxRunner();
 	}
 }

--- a/runtime/Cpp/runtime/src/atn/ATN.h
+++ b/runtime/Cpp/runtime/src/atn/ATN.h
@@ -130,9 +130,11 @@ namespace atn {
     friend class LexerATNSimulator;
     friend class ParserATNSimulator;
 
+    // Guards the lazy nextTokens cache (ATNState::_nextTokenWithinRule). The
+    // DFA state/edge write locks formerly here were moved onto the DFA itself
+    // (see dfa::DFA::stateMutex/edgeMutex) so concurrent parses with independent
+    // DFAs no longer serialize on a single per-ATN lock.
     mutable internal::Mutex _mutex;
-    mutable internal::SharedMutex _stateMutex;
-    mutable internal::SharedMutex _edgeMutex;
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -80,7 +80,7 @@ size_t LexerATNSimulator::match(CharStream *input, size_t mode) {
   const dfa::DFA &dfa = _decisionToDFA[mode];
   dfa::DFAState* s0;
   {
-    SharedLock<SharedMutex> stateLock(atn._stateMutex);
+    SharedLock<SharedMutex> stateLock(dfa.stateMutex());
     s0 = dfa.s0;
   }
   if (s0 == nullptr) {
@@ -527,7 +527,7 @@ void LexerATNSimulator::addDFAEdge(dfa::DFAState *p, size_t t, dfa::DFAState *q)
     return;
   }
 
-  UniqueLock<SharedMutex> edgeLock(atn._edgeMutex);
+  UniqueLock<SharedMutex> edgeLock(_decisionToDFA[_mode].edgeMutex());
   p->setEdge(t - MIN_DFA_EDGE, MAX_DFA_EDGE - MIN_DFA_EDGE + 1, q); // connect
 }
 
@@ -559,7 +559,7 @@ dfa::DFAState *LexerATNSimulator::addDFAState(ATNConfigSet *configs, bool suppre
   dfa::DFA &dfa = _decisionToDFA[_mode];
 
   {
-    UniqueLock<SharedMutex> stateLock(atn._stateMutex);
+    UniqueLock<SharedMutex> stateLock(dfa.stateMutex());
     auto [existing, inserted] = dfa.states.insert(proposed);
     if (!inserted) {
       delete proposed;

--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
@@ -181,19 +181,18 @@ size_t LexerATNSimulator::execATN(CharStream *input, dfa::DFAState *ds0) {
 }
 
 dfa::DFAState *LexerATNSimulator::getExistingTargetState(dfa::DFAState *s, size_t t) {
-  dfa::DFAState* retval = nullptr;
-  SharedLock<SharedMutex> edgeLock(atn._edgeMutex);
-  if (t <= MAX_DFA_EDGE) {
-    auto iterator = s->edges.find(t - MIN_DFA_EDGE);
-#if LEXER_DEBUG_ATN == 1
-    if (iterator != s->edges.end()) {
-      std::cout << std::string("reuse state ") << s->stateNumber << std::string(" edge to ") << iterator->second->stateNumber << std::endl;
-    }
-#endif
-
-    if (iterator != s->edges.end())
-      retval = iterator->second;
+  if (t > MAX_DFA_EDGE) {
+    return nullptr;
   }
+  // Lock-free: the edge table is published with release in addDFAEdge and read
+  // here with acquire (see DFAState::getEdge). A benign miss (null) just causes
+  // the target to be recomputed, mirroring the Java runtime.
+  dfa::DFAState *retval = s->getEdge(t - MIN_DFA_EDGE);
+#if LEXER_DEBUG_ATN == 1
+  if (retval != nullptr) {
+    std::cout << std::string("reuse state ") << s->stateNumber << std::string(" edge to ") << retval->stateNumber << std::endl;
+  }
+#endif
   return retval;
 }
 
@@ -529,7 +528,7 @@ void LexerATNSimulator::addDFAEdge(dfa::DFAState *p, size_t t, dfa::DFAState *q)
   }
 
   UniqueLock<SharedMutex> edgeLock(atn._edgeMutex);
-  p->edges[t - MIN_DFA_EDGE] = q; // connect
+  p->setEdge(t - MIN_DFA_EDGE, MAX_DFA_EDGE - MIN_DFA_EDGE + 1, q); // connect
 }
 
 dfa::DFAState *LexerATNSimulator::addDFAState(ATNConfigSet *configs) {

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -292,11 +292,10 @@ size_t ParserATNSimulator::execATN(dfa::DFA &dfa, dfa::DFAState *s0, TokenStream
 }
 
 dfa::DFAState *ParserATNSimulator::getExistingTargetState(dfa::DFAState *previousD, size_t t) {
-  dfa::DFAState* retval;
-  SharedLock<SharedMutex> edgeLock(atn._edgeMutex);
-  auto iterator = previousD->edges.find(t);
-  retval = (iterator == previousD->edges.end()) ? nullptr : iterator->second;
-  return retval;
+  // Lock-free acquire read (see DFAState::getEdge). Edges are indexed by t + 1 so
+  // EOF (t == SIZE_MAX) maps to slot 0, matching the generated parser; a miss
+  // yields nullptr and the target is recomputed.
+  return previousD->getEdge(t + 1);
 }
 
 dfa::DFAState *ParserATNSimulator::computeTargetState(dfa::DFA &dfa, dfa::DFAState *previousD, size_t t) {
@@ -1297,13 +1296,15 @@ dfa::DFAState *ParserATNSimulator::addDFAEdge(dfa::DFA &dfa, dfa::DFAState *from
     UniqueLock<SharedMutex> stateLock(atn._stateMutex);
     to = addDFAState(dfa, to); // used existing if possible not incoming
   }
-  if (from == nullptr || t > (int)atn.maxTokenType) {
+  if (from == nullptr || t < -1 || t > (int)atn.maxTokenType) {
     return to;
   }
 
   {
     UniqueLock<SharedMutex> edgeLock(atn._edgeMutex);
-    from->edges[t] = to; // connect
+    // Edges are indexed by t + 1 so EOF (t == -1) lands in slot 0; the table
+    // therefore needs maxTokenType + 2 slots.
+    from->setEdge(t + 1, atn.maxTokenType + 2, to); // connect
   }
 
 #if DFA_DEBUG == 1

--- a/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
+++ b/runtime/Cpp/runtime/src/atn/ParserATNSimulator.cpp
@@ -127,11 +127,11 @@ size_t ParserATNSimulator::adaptivePredict(TokenStream *input, size_t decision, 
 
   dfa::DFAState *s0;
   {
-    SharedLock<SharedMutex> stateLock(atn._stateMutex);
+    SharedLock<SharedMutex> stateLock(dfa.stateMutex());
     if (dfa.isPrecedenceDfa()) {
       // the start state for a precedence DFA depends on the current
       // parser precedence, and is provided by a DFA method.
-      SharedLock<SharedMutex> edgeLock(atn._edgeMutex);
+      SharedLock<SharedMutex> edgeLock(dfa.edgeMutex());
       s0 = dfa.getPrecedenceStartState(parser->getPrecedence());
     } else {
       // the start state for a "regular" DFA is just s0
@@ -143,7 +143,7 @@ size_t ParserATNSimulator::adaptivePredict(TokenStream *input, size_t decision, 
     auto s0_closure = computeStartState(dfa.atnStartState, &ParserRuleContext::EMPTY, false);
     std::unique_ptr<dfa::DFAState> newState;
     std::unique_ptr<dfa::DFAState> oldState;
-    UniqueLock<SharedMutex> stateLock(atn._stateMutex);
+    UniqueLock<SharedMutex> stateLock(dfa.stateMutex());
     dfa::DFAState* ds0 = dfa.s0;
     if (dfa.isPrecedenceDfa()) {
       /* If this is a precedence DFA, we use applyPrecedenceFilter
@@ -155,7 +155,7 @@ size_t ParserATNSimulator::adaptivePredict(TokenStream *input, size_t decision, 
       ds0->configs = std::move(s0_closure); // not used for prediction but useful to know start configs anyway
       newState = std::make_unique<dfa::DFAState>(applyPrecedenceFilter(ds0->configs.get()));
       s0 = addDFAState(dfa, newState.get());
-      UniqueLock<SharedMutex> edgeLock(atn._edgeMutex);
+      UniqueLock<SharedMutex> edgeLock(dfa.edgeMutex());
       dfa.setPrecedenceStartState(parser->getPrecedence(), s0);
     } else {
       newState = std::make_unique<dfa::DFAState>(std::move(s0_closure));
@@ -1293,7 +1293,7 @@ dfa::DFAState *ParserATNSimulator::addDFAEdge(dfa::DFA &dfa, dfa::DFAState *from
   }
 
   {
-    UniqueLock<SharedMutex> stateLock(atn._stateMutex);
+    UniqueLock<SharedMutex> stateLock(dfa.stateMutex());
     to = addDFAState(dfa, to); // used existing if possible not incoming
   }
   if (from == nullptr || t < -1 || t > (int)atn.maxTokenType) {
@@ -1301,7 +1301,7 @@ dfa::DFAState *ParserATNSimulator::addDFAEdge(dfa::DFA &dfa, dfa::DFAState *from
   }
 
   {
-    UniqueLock<SharedMutex> edgeLock(atn._edgeMutex);
+    UniqueLock<SharedMutex> edgeLock(dfa.edgeMutex());
     // Edges are indexed by t + 1 so EOF (t == -1) lands in slot 0; the table
     // therefore needs maxTokenType + 2 slots.
     from->setEdge(t + 1, atn.maxTokenType + 2, to); // connect

--- a/runtime/Cpp/runtime/src/dfa/DFA.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFA.cpp
@@ -73,9 +73,9 @@ DFAState* DFA::getPrecedenceStartState(int precedence) const {
     return nullptr;
   }
 
-  // Read under ATN::_edgeMutex (held by the caller); the precedence start-state
-  // table is the only edge table that grows, and it is never read via the
-  // lock-free getEdge path used by the lexer/parser simulators.
+  // Read under this DFA's edgeMutex() (held by the caller); the precedence
+  // start-state table is the only edge table that grows, and it is never read
+  // via the lock-free getEdge path used by the lexer/parser simulators.
   return s0->getEdge(static_cast<size_t>(precedence));
 }
 

--- a/runtime/Cpp/runtime/src/dfa/DFA.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFA.cpp
@@ -69,11 +69,14 @@ bool DFA::isPrecedenceDfa() const {
 DFAState* DFA::getPrecedenceStartState(int precedence) const {
   assert(_precedenceDfa); // Only precedence DFAs may contain a precedence start state.
 
-  auto iterator = s0->edges.find(precedence);
-  if (iterator == s0->edges.end())
+  if (precedence < 0) {
     return nullptr;
+  }
 
-  return iterator->second;
+  // Read under ATN::_edgeMutex (held by the caller); the precedence start-state
+  // table is the only edge table that grows, and it is never read via the
+  // lock-free getEdge path used by the lexer/parser simulators.
+  return s0->getEdge(static_cast<size_t>(precedence));
 }
 
 void DFA::setPrecedenceStartState(int precedence, DFAState *startState) {
@@ -85,7 +88,7 @@ void DFA::setPrecedenceStartState(int precedence, DFAState *startState) {
     return;
   }
 
-  s0->edges[precedence] = startState;
+  s0->setEdge(static_cast<size_t>(precedence), static_cast<size_t>(precedence) + 1, startState);
 }
 
 std::vector<DFAState *> DFA::getStates() const {

--- a/runtime/Cpp/runtime/src/dfa/DFA.h
+++ b/runtime/Cpp/runtime/src/dfa/DFA.h
@@ -5,12 +5,14 @@
 
 #pragma once
 
+#include <memory>
 #include <unordered_set>
 #include <vector>
 #include <string>
 #include <cstddef>
 #include "antlr4-common.h"
 #include "dfa/DFAState.h"
+#include "internal/Synchronization.h"
 
 namespace antlr4 {
 namespace dfa {
@@ -89,12 +91,31 @@ namespace dfa {
 
     std::string toLexerString() const;
 
+    /// Locks guarding writes to THIS DFA: stateMutex() serializes state-set
+    /// insertion (addDFAState), edgeMutex() serializes edge-table allocation and
+    /// stores (DFAState::setEdge). Lock-free DFAState::getEdge() reads need
+    /// neither. These live on the DFA — not the ATN — so independent DFAs (each
+    /// interpreter owns its own decisionToDFA) never serialize against one
+    /// another; a DFA shared across threads (generated recognizers' static
+    /// decisionToDFA) still serializes its own writers, as before, but now at
+    /// per-decision rather than per-ATN granularity.
+    internal::SharedMutex &stateMutex() const noexcept { return *_stateMutex; }
+    internal::SharedMutex &edgeMutex() const noexcept { return *_edgeMutex; }
+
   private:
     /**
      * {@code true} if this DFA is for a precedence decision; otherwise,
      * {@code false}. This is the backing field for {@link #isPrecedenceDfa}.
      */
     bool _precedenceDfa;
+
+    // Heap-allocated so DFA stays movable (SharedMutex is neither movable nor
+    // copyable). A moved-into DFA gets fresh locks via these initializers; DFAs
+    // are only moved empty during decisionToDFA construction, before any parse.
+    std::unique_ptr<internal::SharedMutex> _stateMutex =
+        std::make_unique<internal::SharedMutex>();
+    std::unique_ptr<internal::SharedMutex> _edgeMutex =
+        std::make_unique<internal::SharedMutex>();
   };
 
 } // namespace atn

--- a/runtime/Cpp/runtime/src/dfa/DFASerializer.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFASerializer.cpp
@@ -25,8 +25,8 @@ std::string DFASerializer::toString() const {
   std::stringstream ss;
   std::vector<DFAState *> states = _dfa->getStates();
   for (auto *s : states) {
-    for (size_t i = 0; i < s->edges.size(); i++) {
-      DFAState *t = s->edges[i];
+    for (size_t i = 0; i < s->edgeCount(); i++) {
+      DFAState *t = s->getEdge(i);
       if (t != nullptr && t->stateNumber != INT32_MAX) {
         ss << getStateString(s);
         std::string label = getEdgeLabel(i);
@@ -39,7 +39,9 @@ std::string DFASerializer::toString() const {
 }
 
 std::string DFASerializer::getEdgeLabel(size_t i) const {
-  return _vocabulary.getDisplayName(i); // ml: no longer needed -1 as we use a map for edges, without offset.
+  // Edges are indexed by t + 1 (EOF in slot 0), so shift back to the token
+  // type; i == 0 wraps to Token::EOF, which the vocabulary displays as "EOF".
+  return _vocabulary.getDisplayName(i - 1);
 }
 
 std::string DFASerializer::getStateString(DFAState *s) const {

--- a/runtime/Cpp/runtime/src/dfa/DFAState.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.cpp
@@ -42,9 +42,9 @@ void DFAState::setEdge(size_t index, size_t minSize, DFAState *target) {
     _edgeCount.store(newCount, std::memory_order_release);
     _edges.store(newEdges, std::memory_order_release);
     // Only the precedence start state ever reaches this with a non-null
-    // `edges`, and it is read exclusively under ATN::_edgeMutex (never via the
-    // lock-free getEdge path), so freeing the old table here cannot race a
-    // concurrent reader.
+    // `edges`, and it is read exclusively under the owning DFA's edgeMutex()
+    // (never via the lock-free getEdge path), so freeing the old table here
+    // cannot race a concurrent reader.
     delete[] edges;
     edges = newEdges;
   }

--- a/runtime/Cpp/runtime/src/dfa/DFAState.cpp
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.cpp
@@ -3,10 +3,12 @@
  * can be found in the LICENSE.txt file in the project root.
  */
 
+#include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <sstream>
 #include <string>
-#include <cstddef>
+
 #include "atn/ATNConfigSet.h"
 #include "atn/SemanticContext.h"
 #include "atn/ATNConfig.h"
@@ -16,6 +18,39 @@
 
 using namespace antlr4::dfa;
 using namespace antlr4::atn;
+
+DFAState::~DFAState() {
+  delete[] _edges.load(std::memory_order_relaxed);
+}
+
+void DFAState::setEdge(size_t index, size_t minSize, DFAState *target) {
+  std::atomic<DFAState *> *edges = _edges.load(std::memory_order_relaxed);
+  size_t count = _edgeCount.load(std::memory_order_relaxed);
+
+  if (edges == nullptr || index >= count) {
+    size_t newCount = std::max(minSize, index + 1);
+    auto *newEdges = new std::atomic<DFAState *>[newCount];
+    for (size_t i = 0; i < count; ++i) {
+      newEdges[i].store(edges[i].load(std::memory_order_relaxed), std::memory_order_relaxed);
+    }
+    for (size_t i = count; i < newCount; ++i) {
+      newEdges[i].store(nullptr, std::memory_order_relaxed);
+    }
+    // Publish the (fully initialized) table: a lock-free getEdge() that
+    // observes this pointer with acquire is guaranteed to see the slot
+    // contents and the updated count.
+    _edgeCount.store(newCount, std::memory_order_release);
+    _edges.store(newEdges, std::memory_order_release);
+    // Only the precedence start state ever reaches this with a non-null
+    // `edges`, and it is read exclusively under ATN::_edgeMutex (never via the
+    // lock-free getEdge path), so freeing the old table here cannot race a
+    // concurrent reader.
+    delete[] edges;
+    edges = newEdges;
+  }
+
+  edges[index].store(target, std::memory_order_release);
+}
 
 std::string DFAState::PredPrediction::toString() const {
   return std::string("(") + pred->toString() + ", " + std::to_string(alt) + ")";

--- a/runtime/Cpp/runtime/src/dfa/DFAState.h
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.h
@@ -12,8 +12,9 @@
 #include <cstddef>
 #include "antlr4-common.h"
 
+#include <atomic>
+
 #include "atn/ATNConfigSet.h"
-#include "FlatHashMap.h"
 
 namespace antlr4 {
 namespace dfa {
@@ -65,12 +66,6 @@ namespace dfa {
 
     std::unique_ptr<atn::ATNConfigSet> configs;
 
-    /// {@code edges[symbol]} points to target of symbol. Shift up by 1 so (-1)
-    ///  <seealso cref="Token#EOF"/> maps to {@code edges[0]}.
-    // ml: this is a sparse list, so we use a map instead of a vector.
-    //     Watch out: we no longer have the -1 offset, as it isn't needed anymore.
-    FlatHashMap<size_t, DFAState*> edges;
-
     /// if accept state, what ttype do we match or alt do we predict?
     /// This is set to <seealso cref="ATN#INVALID_ALT_NUMBER"/> when <seealso cref="#predicates"/>{@code !=null} or
     /// <seealso cref="#requiresFullContext"/>.
@@ -112,6 +107,41 @@ namespace dfa {
 
     explicit DFAState(std::unique_ptr<atn::ATNConfigSet> configs) : configs(std::move(configs)) {}
 
+    DFAState(const DFAState&) = delete;
+    DFAState& operator=(const DFAState&) = delete;
+
+    ~DFAState();
+
+    /// Outgoing DFA edges, mirroring Java's {@code DFAState.edges} array:
+    /// {@code edges[symbol]} points to the target state for that symbol. The
+    /// table is allocated lazily at a fixed size and its slots are published
+    /// with release/read with acquire, so getEdge() needs no lock. Allocation,
+    /// growth and stores (setEdge) must be serialized by the caller through
+    /// ATN::_edgeMutex.
+
+    /// Lock-free read of the edge for the given (already offset) index, or
+    /// nullptr if there is no such edge yet. Safe to call without any lock.
+    DFAState *getEdge(size_t index) const noexcept {
+      std::atomic<DFAState *> *edges = _edges.load(std::memory_order_acquire);
+      if (edges == nullptr || index >= _edgeCount.load(std::memory_order_acquire)) {
+        return nullptr;
+      }
+      return edges[index].load(std::memory_order_acquire);
+    }
+
+    /// Number of edge slots currently allocated (for serialization/iteration).
+    size_t edgeCount() const noexcept { return _edgeCount.load(std::memory_order_acquire); }
+
+    /// Store an edge. `minSize` is the natural full size of the table for this
+    /// DFA kind (the lexer char range, or maxTokenType+2 for the parser, whose
+    /// edges are indexed by t+1 so EOF lands in slot 0); the table is
+    /// grown to at least `index + 1` if needed. The caller MUST hold the
+    /// ATN::_edgeMutex write lock. Lexer/parser tables are allocated once at
+    /// `minSize` and never reallocated, so concurrent lock-free getEdge() calls
+    /// never observe a moved table; only the precedence start state grows, and
+    /// it is read exclusively under the lock.
+    void setEdge(size_t index, size_t minSize, DFAState *target);
+
     /// <summary>
     /// Get the set of all alts mentioned by all ATN configurations in this
     ///  DFA state.
@@ -134,6 +164,12 @@ namespace dfa {
     bool equals(const DFAState &other) const;
 
     std::string toString() const;
+
+  private:
+    // Array of `_edgeCount` atomic edge slots, or nullptr before the first
+    // edge is added. Owned by this state and freed in the destructor.
+    std::atomic<std::atomic<DFAState *> *> _edges{nullptr};
+    std::atomic<size_t> _edgeCount{0};
   };
 
   inline bool operator==(const DFAState &lhs, const DFAState &rhs) {

--- a/runtime/Cpp/runtime/src/dfa/DFAState.h
+++ b/runtime/Cpp/runtime/src/dfa/DFAState.h
@@ -116,8 +116,8 @@ namespace dfa {
     /// {@code edges[symbol]} points to the target state for that symbol. The
     /// table is allocated lazily at a fixed size and its slots are published
     /// with release/read with acquire, so getEdge() needs no lock. Allocation,
-    /// growth and stores (setEdge) must be serialized by the caller through
-    /// ATN::_edgeMutex.
+    /// growth and stores (setEdge) must be serialized by the caller through the
+    /// owning DFA's edgeMutex() (dfa::DFA::edgeMutex).
 
     /// Lock-free read of the edge for the given (already offset) index, or
     /// nullptr if there is no such edge yet. Safe to call without any lock.
@@ -135,8 +135,8 @@ namespace dfa {
     /// Store an edge. `minSize` is the natural full size of the table for this
     /// DFA kind (the lexer char range, or maxTokenType+2 for the parser, whose
     /// edges are indexed by t+1 so EOF lands in slot 0); the table is
-    /// grown to at least `index + 1` if needed. The caller MUST hold the
-    /// ATN::_edgeMutex write lock. Lexer/parser tables are allocated once at
+    /// grown to at least `index + 1` if needed. The caller MUST hold the owning
+    /// DFA's edgeMutex() write lock. Lexer/parser tables are allocated once at
     /// `minSize` and never reallocated, so concurrent lock-free getEdge() calls
     /// never observe a moved table; only the precedence start state grows, and
     /// it is read exclusively under the lock.


### PR DESCRIPTION
> **Note:** stacked on #4953 (and, for green CI, on #4963 — the test-harness fix for the repo-wide `typescript` failures, see #4962). This change is the single `Cpp: move DFA write locks` commit; the diff collapses to it as the others merge.

## What

Moves the DFA state/edge **write** locks off the ATN
(`ATN::_stateMutex` / `ATN::_edgeMutex`, removed) and onto the DFA itself
(`dfa::DFA::stateMutex()` / `edgeMutex()`, heap-allocated so `DFA` stays
movable). The lexer/parser simulators lock the owning DFA instead of the ATN.
`ATN::_mutex` (the lazy `nextTokens` cache) is unchanged.

## Why

Each `ParserInterpreter` / `LexerInterpreter` owns its own `decisionToDFA`,
but the write locks lived on the **shared** ATN — so concurrent interpreters
over one (read-only) ATN serialized on a single lock for DFA writes they do
not even share. Measured effect: parsing a shared spec across 4 threads ran at
**~0.6× of serial** — concurrency was a net loss.

With per-DFA locks, independent DFAs use independent locks: the same 4-thread
workload scales to **~2.1×** (≈4× better wall-clock than before the patch).
A DFA genuinely shared across threads (a generated recognizer's static
`decisionToDFA`) still serializes its own writers — same locking discipline,
per-decision rather than per-ATN granularity.

## Safety / verification

- **ThreadSanitizer**: a TSan build of the runtime with an 8-thread concurrent
  parse harness over a shared ATN reports no data races.
- AddressSanitizer runs continuously in a downstream CI against this patch.
- Read paths are unchanged by this commit (edge reads are lock-free via #4953).

## Context

Shipped today (with #4953) in
[antlrope](https://github.com/zuzukin/antlrope); this is what makes its
shared-spec parallel parsing scale. Measurements and methodology:
https://zuzukin.github.io/antlrope/concepts/ ("How much do the patches
contribute?").

---

**Authorship note:** this patch was developed with AI assistance (Claude Opus
4.8, reflected in the commit trailer); I reviewed the design and code, and the
verification above (TSan harness, ASan CI, benchmarks) is what I'd stake it on.

