### PR TITLE
reject tokenVocab names containing a path separator

### DIFF
--- a/tool-testsuite/test/org/antlr/v4/test/tool/TestCompositeGrammars.java
+++ b/tool-testsuite/test/org/antlr/v4/test/tool/TestCompositeGrammars.java
@@ -383,6 +383,26 @@ public class TestCompositeGrammars {
 		assertEquals(0, equeue.size());
 	}
 
+	@Test public void testTokenVocabWithPathIsRejected(@TempDir Path tempDir) {
+		String tempDirPath = tempDir.toString();
+		FileUtils.mkdir(tempDirPath);
+		String outsideDir = tempDirPath + "/outside";
+		FileUtils.mkdir(outsideDir);
+		writeFile(outsideDir, "secret.tokens", "NOT_A_TOKEN_FILE=hunter2\n");
+
+		String workDir = tempDirPath + "/work";
+		FileUtils.mkdir(workDir);
+		String parser =
+			"parser grammar P;\n" +
+			"options {tokenVocab='../outside/secret';}\n" +
+			"s : A ;\n";
+		writeFile(workDir, "P.g4", parser);
+
+		ErrorQueue equeue = Generator.antlrOnString(workDir, "Java", "P.g4", false);
+		assertEquals(1, equeue.errors.size());
+		assertEquals(ErrorType.INVALID_TOKEN_VOCAB_NAME, equeue.errors.get(0).getErrorType());
+	}
+
 	@Test public void testImportedTokenVocabIgnoredWithWarning(@TempDir Path tempDir) throws RecognitionException {
 		String tempDirPath = tempDir.toString();
 		ErrorQueue equeue = new ErrorQueue();

--- a/tool/src/org/antlr/v4/parse/TokenVocabParser.java
+++ b/tool/src/org/antlr/v4/parse/TokenVocabParser.java
@@ -36,11 +36,24 @@ public class TokenVocabParser {
 	public Map<String,Integer> load() {
 		Map<String,Integer> tokens = new LinkedHashMap<String,Integer>();
 		int maxTokenType = -1;
+		Tool tool = g.tool;
+		String vocabName = g.getOptionString("tokenVocab");
+		if ( !isPlainVocabName(vocabName) ) {
+			GrammarAST inTree = g.ast.getOptionAST("tokenVocab");
+			if ( inTree!=null ) {
+				tool.errMgr.grammarError(ErrorType.INVALID_TOKEN_VOCAB_NAME,
+										 g.fileName,
+										 inTree.getToken(),
+										 vocabName);
+			}
+			else { // must be from -D option on cmd-line not token in tree
+				tool.errMgr.toolError(ErrorType.INVALID_TOKEN_VOCAB_NAME, vocabName);
+			}
+			return tokens;
+		}
 		File fullFile = getImportedVocabFile();
 		FileInputStream fis = null;
 		BufferedReader br = null;
-		Tool tool = g.tool;
-		String vocabName = g.getOptionString("tokenVocab");
 		try {
 			Pattern tokenDefPattern = Pattern.compile("([^\n]+?)[ \\t]*?=[ \\t]*?([0-9]+)");
 			fis = new FileInputStream(fullFile);
@@ -120,6 +133,16 @@ public class TokenVocabParser {
 			}
 		}
 		return tokens;
+	}
+
+	/** A {@code tokenVocab} value names a grammar, and {@link #getImportedVocabFile}
+	 *  resolves it against the lib, output and grammar directories.  A name
+	 *  carrying a path separator escapes all three, so only plain names are
+	 *  accepted here.
+	 */
+	public static boolean isPlainVocabName(String vocabName) {
+		return vocabName!=null && !vocabName.isEmpty() &&
+			   vocabName.indexOf('/')<0 && vocabName.indexOf('\\')<0;
 	}
 
 	/** Return a File descriptor for vocab file.  Look in library or

--- a/tool/src/org/antlr/v4/tool/ErrorType.java
+++ b/tool/src/org/antlr/v4/tool/ErrorType.java
@@ -525,6 +525,12 @@ public enum ErrorType {
 	 */
 	UNSUPPORTED_REFERENCE_IN_LEXER_SET(183, "rule reference <arg> is not currently supported in a set", ErrorSeverity.ERROR),
 	/**
+	 * Compiler Error 188.
+	 *
+	 * <p>tokenVocab option <em>name</em> must not contain a path</p>
+	 */
+	INVALID_TOKEN_VOCAB_NAME(188, "tokenVocab option <arg> must be a grammar name, not a path", ErrorSeverity.ERROR),
+	/**
 	 * Compiler Error 135.
 	 *
 	 * <p>cannot assign a value to list label <em>label</em></p>


### PR DESCRIPTION
The `tokenVocab` option value is used verbatim to build the `.tokens` path in `TokenVocabParser`:
- `getImportedVocabFile` resolves it against `libDirectory`, `outputDirectory` and the grammar directory, none of which constrain the result
- option values may be quoted string literals, so `options { tokenVocab='../../secret/creds'; }` resolves outside all three roots
- lines that fail the token-definition regex are reported via `TOKENS_FILE_SYNTAX_ERROR`, putting the contents of the opened file into tool output

Rejecting names that carry a path separator before anything is opened. `antlr4-maven-plugin` already reduces this same value with `stripPath`, so a bare grammar name is the expected shape.