### PR TITLE
fix use-after-free of folded insert op in token stream rewriter

### DIFF
--- a/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
+++ b/runtime/Cpp/runtime/src/TokenStreamRewriter.cpp
@@ -393,16 +393,20 @@ std::unordered_map<size_t, TokenStreamRewriter::RewriteOperation*> TokenStreamRe
     }
     // look for replaces where iop.index is in range; error
     std::vector<ReplaceOp*> prevReplaces = getKindOfOps<ReplaceOp>(rewrites, i);
+    bool dropIop = false;
     for (auto *rop : prevReplaces) {
       if (iop->index == rop->index) {
         rop->text = catOpText(&iop->text, &rop->text);
-        delete rewrites[i];
-        rewrites[i] = nullptr; // delete current insert
+        dropIop = true; // delete current insert
         continue;
       }
       if (iop->index >= rop->index && iop->index <= rop->lastIndex) {
         throw IllegalArgumentException("insert op " + iop->toString() + " within boundaries of previous " + rop->toString());
       }
+    }
+    if (dropIop) {
+      delete rewrites[i];
+      rewrites[i] = nullptr;
     }
   }
 


### PR DESCRIPTION
1. In the WALK INSERTS phase of `TokenStreamRewriter::reduceToSingleOperationPerIndex`, the current `InsertBeforeOp` is freed as soon as its index matches one of the earlier `ReplaceOp`s, but the loop over `prevReplaces` keeps going and reads `iop->index` again on the next iteration (and `iop->toString()` on the overlap-error path).
2. Deferred the free until after that loop, so the op stays owned by `rewrites[i]` for the whole comparison and is also not leaked if the overlap check throws.

The Java runtime only nulls the slot and never frees, so this is specific to the C++ port. Reached by any program that queues two or more replaces where the first shares an index with an insert:

```cpp
rewriter.replace(size_t(0), size_t(0), "a");
rewriter.replace(size_t(5), size_t(5), "b");
rewriter.insertBefore(size_t(0), "z");
rewriter.getText();
```

Against an ASan build of the runtime this reports:

```
==9440==ERROR: AddressSanitizer: heap-use-after-free on address 0x6060000002c8
READ of size 8 at 0x6060000002c8 thread T0
    #0 antlr4::TokenStreamRewriter::reduceToSingleOperationPerIndex(...) TokenStreamRewriter.cpp:397
    #1 antlr4::TokenStreamRewriter::getText(...) TokenStreamRewriter.cpp:283
freed by thread T0 here:
    #1 antlr4::TokenStreamRewriter::InsertBeforeOp::~InsertBeforeOp() TokenStreamRewriter.h:189
    #2 antlr4::TokenStreamRewriter::reduceToSingleOperationPerIndex(...) TokenStreamRewriter.cpp:399
```

After the patch the same program runs clean under ASan and `ctest` on the C++ runtime is green (64/64).