### PR TITLE
restrict deserialized types when reading maven dependency status

### DIFF
--- a/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/GrammarDependencies.java
+++ b/antlr4-maven-plugin/src/main/java/org/antlr/mojo/antlr4/GrammarDependencies.java
@@ -18,8 +18,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InvalidClassException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -283,7 +286,7 @@ class GrammarDependencies {
             log.debug("Load grammars dependency status: " + statusFile);
 
             try {
-                ObjectInputStream in = new ObjectInputStream(new FileInputStream(
+                ObjectInputStream in = createRestrictedInputStream(new FileInputStream(
                             statusFile));
 
                 try {
@@ -302,6 +305,36 @@ class GrammarDependencies {
         }
 
         return new HashMap<File, Map.Entry<byte[], Collection<String>>>();
+    }
+
+    /** Classes that legitimately appear in a serialized dependency status file. */
+    private static final Set<String> ALLOWED_STATUS_CLASSES = new HashSet<String>(Arrays.asList(
+        "java.util.HashMap",
+        "java.util.HashSet",
+        "java.util.ArrayList",
+        "java.util.AbstractMap$SimpleImmutableEntry",
+        "java.io.File",
+        "java.lang.String",
+        "java.lang.Number",
+        "[B"));
+
+    /**
+     * Reads the dependency status file while refusing any class outside
+     * {@link #ALLOWED_STATUS_CLASSES}. The status file lives in the build output
+     * directory, so a crafted copy would otherwise let arbitrary serializable
+     * classes be instantiated during the build.
+     */
+    static ObjectInputStream createRestrictedInputStream(InputStream in) throws IOException {
+        return new ObjectInputStream(in) {
+            @Override
+            protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+                String name = desc.getName();
+                if (!ALLOWED_STATUS_CLASSES.contains(name)) {
+                    throw new InvalidClassException("Unsupported class in dependency status", name);
+                }
+                return super.resolveClass(desc);
+            }
+        };
     }
 
     private String stripPath(String str) {

--- a/antlr4-maven-plugin/src/test/java/org/antlr/mojo/antlr4/GrammarDependenciesTest.java
+++ b/antlr4-maven-plugin/src/test/java/org/antlr/mojo/antlr4/GrammarDependenciesTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ * Use of this file is governed by the BSD 3-clause license that
+ * can be found in the LICENSE.txt file in the project root.
+ */
+
+package org.antlr.mojo.antlr4;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class GrammarDependenciesTest {
+
+    @Test
+    public void readsLegitimateStatusGraph() throws Exception {
+        Map<File, Map.Entry<byte[], ArrayList<String>>> status =
+            new HashMap<File, Map.Entry<byte[], ArrayList<String>>>();
+        ArrayList<String> usages = new ArrayList<String>();
+        usages.add("A.g4");
+        status.put(new File("Base.g4"),
+            new AbstractMap.SimpleImmutableEntry<byte[], ArrayList<String>>(new byte[]{1, 2, 3}, usages));
+
+        Object result = GrammarDependencies.createRestrictedInputStream(
+            new ByteArrayInputStream(serialize(status))).readObject();
+
+        @SuppressWarnings("unchecked")
+        Map<File, Map.Entry<byte[], ArrayList<String>>> read =
+            (Map<File, Map.Entry<byte[], ArrayList<String>>>) result;
+        assertEquals(usages, read.get(new File("Base.g4")).getValue());
+    }
+
+    @Test
+    public void rejectsUnexpectedClassBeforeItIsInstantiated() throws Exception {
+        Payload.deserialized = false;
+        byte[] bytes = serialize(new Payload());
+
+        try (ObjectInputStream in = GrammarDependencies.createRestrictedInputStream(
+                new ByteArrayInputStream(bytes))) {
+            in.readObject();
+            fail("expected InvalidClassException");
+        } catch (InvalidClassException expected) {
+            // resolveClass rejects the type before readObject can run
+        }
+        assertFalse("payload readObject must not execute", Payload.deserialized);
+    }
+
+    private static byte[] serialize(Object o) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bos)) {
+            out.writeObject(o);
+        }
+        return bos.toByteArray();
+    }
+
+    /** Stands in for a deserialization gadget: its readObject has a side effect. */
+    public static class Payload implements Serializable {
+        static boolean deserialized = false;
+
+        private void readObject(ObjectInputStream in) throws Exception {
+            in.defaultReadObject();
+            deserialized = true;
+        }
+    }
+}


### PR DESCRIPTION
The maven plugin's dependency status cache is deserialized without any type restriction:
- `GrammarDependencies.loadStatus` reads `target/maven-status/antlr4/dependencies.ser` through a bare `ObjectInputStream` and casts the result straight to a `Map`
- that file sits in the build output directory, so a project carrying a crafted `dependencies.ser` can have arbitrary serializable classes instantiated, and their `readObject` side effects executed, while `mvn` runs
- the read now goes through an `ObjectInputStream` whose `resolveClass` permits only the types this cache is built from and raises `InvalidClassException` before any other class is constructed
- `loadStatus` already falls back to an empty cache on failure, so a rejected file simply triggers a normal regeneration

Added a test covering a legitimate status graph round-trip and confirming a stand-in gadget is refused before its `readObject` executes.