### PR TITLE
Test: fix TypeScript runtime tests in CI by running them with tsx instead of ts-node

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/tsconfig.json
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/helpers/tsconfig.json
@@ -4,8 +4,5 @@
     "moduleResolution": "node",
     "target": "ES6",
     "noImplicitAny": true,
-  },
-  "ts-node": {
-    "esm": true
   }
 }

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/typescript/TsxRunner.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/typescript/TsxRunner.java
@@ -15,7 +15,7 @@ import java.nio.file.Files;
 import static org.antlr.v4.test.runtime.FileUtils.writeFile;
 import static org.antlr.v4.test.runtime.RuntimeTestUtils.isWindows;
 
-public class TsNodeRunner extends RuntimeRunner {
+public class TsxRunner extends RuntimeRunner {
 
 	/* TypeScript runtime is the same as JavaScript runtime */
 	private final static String NORMALIZED_JAVASCRIPT_RUNTIME_PATH = getRuntimePath("JavaScript").replace('\\', '/');
@@ -30,12 +30,12 @@ public class TsNodeRunner extends RuntimeRunner {
 
 	@Override
 	protected void initRuntime(RunOptions runOptions) throws Exception {
-		npmInstallTsNodeAndWebpack();
+		npmInstallTsxAndWebpack();
 		npmLinkRuntime();
 	}
 
-	private void npmInstallTsNodeAndWebpack() throws Exception {
-		Processor.run(new String[] {NPM_EXEC, "--silent", "install", "-g", "typescript", "ts-node", "webpack", "webpack-cli"}, null);
+	private void npmInstallTsxAndWebpack() throws Exception {
+		Processor.run(new String[] {NPM_EXEC, "--silent", "install", "-g", "tsx", "webpack", "webpack-cli"}, null);
 	}
 
 	private void npmLinkRuntime() throws Exception {
@@ -57,7 +57,7 @@ public class TsNodeRunner extends RuntimeRunner {
 	public String getBaseVisitorSuffix() { return null; }
 
 	@Override
-	public String getRuntimeToolName() { return "ts-node"  + (isWindows() ? ".cmd" : ""); }
+	public String getRuntimeToolName() { return "tsx" + (isWindows() ? ".cmd" : ""); }
 
 	@Override
 	protected CompiledState compile(RunOptions runOptions, GeneratedState generatedState) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/typescript/TypeScriptRuntimeTests.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/typescript/TypeScriptRuntimeTests.java
@@ -12,6 +12,6 @@ import org.antlr.v4.test.runtime.RuntimeTests;
 public class TypeScriptRuntimeTests extends RuntimeTests {
 	@Override
 	protected RuntimeRunner createRuntimeRunner() {
-		return new TsNodeRunner();
+		return new TsxRunner();
 	}
 }


### PR DESCRIPTION
Fixes #4962.

## What

The TypeScript runtime tests execute each generated test program with
ts-node. This swaps the executor to [tsx](https://tsx.is) (esbuild-based),
renames `TsNodeRunner` → `TsxRunner` to match, drops the now-unused
`ts-node` section from the helper tsconfig, and stops installing a global
`typescript` (it was only ts-node's peer; the JavaScript runtime's webpack
build installs its own pinned `typescript` locally).

## Why

As detailed in #4962, every `build (*, typescript)` job has failed since
~April: the harness installs its toolchain unpinned, npm's
`typescript@latest` is now the TypeScript 7 (Go-based) rewrite, and
ts-node 10.9.x (unmaintained since 2022) crashes on startup reaching into
the removed `ts.sys` internal API — before any ANTLR code runs. The same
`dev` tree was green in February under TypeScript 5.x.

## Why tsx rather than pinning

Pinning `typescript@5 ts-node@10.9.2` would also go green today, but
ts-node is unmaintained and the pin would freeze the tests to an aging
TypeScript indefinitely. tsx executes TypeScript via esbuild and does not
depend on TypeScript's compiler API at all, so TypeScript's release
cadence cannot break it again.

tsx transpiles without type-checking (as `ts-node --transpile-only`
would); these are execution tests that compare runtime output, so no
coverage is lost.

## Verification

- Reproduced the harness setup locally (ESM package.json + helper
  tsconfig + a test file importing `antlr4`): ts-node under
  `typescript@7.0.2` fails with exactly the CI error; tsx runs the same
  file successfully.
- This PR's own CI runs the typescript jobs on all three OSes — that is
  the definitive validation.

---

**Authorship note:** this change was developed with AI assistance (Claude
Fable 5, reflected in the commit trailer); I reviewed the change and the
diagnosis.
