### PR TITLE
cast char to unsigned before isupper/islower in xpath and pattern lexers

### DIFF
--- a/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
+++ b/runtime/Cpp/runtime/src/tree/pattern/ParseTreePatternMatcher.cpp
@@ -247,13 +247,13 @@ std::vector<std::unique_ptr<Token>> ParseTreePatternMatcher::tokenize(const std:
     if (is<TagChunk *>(&chunk)) {
       TagChunk &tagChunk = (TagChunk&)chunk;
       // add special rule token or conjure up new token from name
-      if (isupper(tagChunk.getTag()[0])) {
+      if (isupper(static_cast<unsigned char>(tagChunk.getTag()[0]))) {
         size_t ttype = _parser->getTokenType(tagChunk.getTag());
         if (ttype == Token::INVALID_TYPE) {
           throw IllegalArgumentException("Unknown token " + tagChunk.getTag() + " in pattern: " + pattern);
         }
         tokens.emplace_back(new TokenTagToken(tagChunk.getTag(), (int)ttype, tagChunk.getLabel()));
-      } else if (islower(tagChunk.getTag()[0])) {
+      } else if (islower(static_cast<unsigned char>(tagChunk.getTag()[0]))) {
         size_t ruleIndex = _parser->getRuleIndex(tagChunk.getTag());
         if (ruleIndex == INVALID_INDEX) {
           throw IllegalArgumentException("Unknown rule " + tagChunk.getTag() + " in pattern: " + pattern);

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.cpp
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.cpp
@@ -164,7 +164,7 @@ void XPathLexer::action(RuleContext *context, size_t ruleIndex, size_t actionInd
 void XPathLexer::IDAction(antlr4::RuleContext *context, size_t actionIndex) {
   switch (actionIndex) {
     case 0: 
-    				if (isupper(getText()[0]))
+    				if (isupper(static_cast<unsigned char>(getText()[0])))
     				  setType(TOKEN_REF);
     				else
     				  setType(RULE_REF);

--- a/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.g4
+++ b/runtime/Cpp/runtime/src/tree/xpath/XPathLexer.g4
@@ -26,7 +26,7 @@ BANG	 : '!' ;
 
 ID			:	NameStartChar NameChar*
 				{
-				if (isupper(getText()[0]))
+				if (isupper(static_cast<unsigned char>(getText()[0])))
 				  setType(TOKEN_REF);
 				else
 				  setType(RULE_REF);


### PR DESCRIPTION
Two lexing helpers in the C++ runtime hand a raw char to isupper()/islower():
- ParseTreePatternMatcher::tokenize branches on isupper/islower of tagChunk.getTag()[0]
- the XPath ID lexer action does the same on getText()[0] (source in XPathLexer.g4, kept in sync)
- a tag or xpath identifier whose first byte is non-ASCII (a UTF-8 lead byte such as 0xC3) makes that char negative, which is undefined for the ctype functions since the argument must be representable as unsigned char or EOF

Cast each byte to unsigned char before the call, matching the Java runtime's Character.isUpperCase/isLowerCase path.