### PR TITLE
Fix TokenStreamRewriter bugs in the Python3 runtime

### DIFF
--- a/runtime/Python3/src/antlr4/TokenStreamRewriter.py
+++ b/runtime/Python3/src/antlr4/TokenStreamRewriter.py
@@ -158,11 +158,12 @@ class TokenStreamRewriter(object):
                     rewrites[prevRop.instructionIndex] = None
                     continue
                 isDisjoint = any((prevRop.last_index<rop.index, prevRop.index>rop.last_index))
-                if all((prevRop.text is None, rop.text is None, not isDisjoint)):
+                # Delete special case of replace (text is empty):
+                # D.i-j.u D.x-y.v | boundaries overlap    combine to max(min)..max(right)
+                if all((not prevRop.text, not rop.text, not isDisjoint)):
                     rewrites[prevRop.instructionIndex] = None
                     rop.index = min(prevRop.index, rop.index)
-                    rop.last_index = min(prevRop.last_index, rop.last_index)
-                    print('New rop {}'.format(rop))
+                    rop.last_index = max(prevRop.last_index, rop.last_index)
                 elif (not(isDisjoint)):
                     raise ValueError("replace op boundaries of {} overlap with previous {}".format(rop, prevRop))
 
@@ -171,13 +172,13 @@ class TokenStreamRewriter(object):
             if any((iop is None, not isinstance(iop, TokenStreamRewriter.InsertBeforeOp))):
                 continue
             prevInserts = [op for op in rewrites[:i] if isinstance(op, TokenStreamRewriter.InsertBeforeOp)]
-            for prev_index, prevIop in enumerate(prevInserts):
+            for prevIop in prevInserts:
                 if prevIop.index == iop.index and type(prevIop) is TokenStreamRewriter.InsertBeforeOp:
                     iop.text += prevIop.text
-                    rewrites[prev_index] = None
+                    rewrites[prevIop.instructionIndex] = None
                 elif prevIop.index == iop.index and type(prevIop) is TokenStreamRewriter.InsertAfterOp:
                     iop.text = prevIop.text + iop.text
-                    rewrites[prev_index] = None
+                    rewrites[prevIop.instructionIndex] = None
             # look for replaces where iop.index is in range; error
             prevReplaces = [op for op in rewrites[:i] if isinstance(op, TokenStreamRewriter.ReplaceOp)]
             for rop in prevReplaces:
@@ -253,3 +254,4 @@ class TokenStreamRewriter(object):
             if self.text:
                 return '<ReplaceOp@{}..{}:"{}">'.format(self.tokens.get(self.index), self.tokens.get(self.last_index),
                                                         self.text)
+            return '<DeleteOp@{}..{}>'.format(self.tokens.get(self.index), self.tokens.get(self.last_index))

--- a/runtime/Python3/tests/TestTokenStreamRewriter.py
+++ b/runtime/Python3/tests/TestTokenStreamRewriter.py
@@ -5,7 +5,8 @@
 import unittest
 
 
-from mocks.TestLexer import TestLexer, TestLexer2
+from mocks.TestLexer import TestLexer
+from mocks.TestLexer2 import TestLexer2
 from antlr4.TokenStreamRewriter import TokenStreamRewriter
 from antlr4.InputStream import InputStream
 from antlr4.CommonTokenStream import CommonTokenStream
@@ -519,6 +520,64 @@ class TestTokenStreamRewriter(unittest.TestCase):
         rewriter.insertAfter(1, '</b>')
 
         self.assertEqual('<b>a</b><b>a</b>', rewriter.getDefaultText())
+
+    def testCombineInsertsAfterUnrelatedReplace(self):
+        """
+        Test for fix for: https://github.com/antlr/antlr4/issues/4818
+
+        Combining the two inserts must not disturb the unrelated ReplaceOp
+        that precedes them in the instruction list.
+        """
+        input = InputStream('abc')
+        lexer = TestLexer(input)
+        stream = CommonTokenStream(lexer=lexer)
+        stream.fill()
+        rewriter = TokenStreamRewriter(tokens=stream)
+
+        rewriter.replaceIndex(2, 'R')
+        rewriter.insertBeforeIndex(0, 'x')
+        rewriter.insertBeforeIndex(0, 'y')
+
+        self.assertEqual('yxabR', rewriter.getDefaultText())
+
+    def testCombineOverlappingDeletes(self):
+        input = InputStream('abcc')
+        lexer = TestLexer(input)
+        stream = CommonTokenStream(lexer=lexer)
+        stream.fill()
+        rewriter = TokenStreamRewriter(tokens=stream)
+
+        rewriter.delete(TokenStreamRewriter.DEFAULT_PROGRAM_NAME, 0, 1)
+        rewriter.delete(TokenStreamRewriter.DEFAULT_PROGRAM_NAME, 1, 3)
+
+        self.assertEqual('', rewriter.getDefaultText())
+
+    def testCombineOverlappingDeletesReversed(self):
+        input = InputStream('abcc')
+        lexer = TestLexer(input)
+        stream = CommonTokenStream(lexer=lexer)
+        stream.fill()
+        rewriter = TokenStreamRewriter(tokens=stream)
+
+        rewriter.delete(TokenStreamRewriter.DEFAULT_PROGRAM_NAME, 1, 3)
+        rewriter.delete(TokenStreamRewriter.DEFAULT_PROGRAM_NAME, 0, 2)
+
+        self.assertEqual('', rewriter.getDefaultText())
+
+    def testDeleteOpToString(self):
+        input = InputStream('abc')
+        lexer = TestLexer(input)
+        stream = CommonTokenStream(lexer=lexer)
+        stream.fill()
+        rewriter = TokenStreamRewriter(tokens=stream)
+
+        rewriter.deleteIndex(1)
+
+        op = rewriter.getProgram(TokenStreamRewriter.DEFAULT_PROGRAM_NAME)[0]
+        self.assertEqual(
+            '<DeleteOp@[@1,1:1=\'b\',<2>,1:1]..[@1,1:1=\'b\',<2>,1:1]>',
+            str(op)
+        )
 
 
 if __name__ == '__main__':

--- a/runtime/Python3/tests/mocks/TestLexer.g4
+++ b/runtime/Python3/tests/mocks/TestLexer.g4
@@ -1,0 +1,5 @@
+lexer grammar TestLexer;
+
+A : 'a';
+B : 'b';
+C : 'c';

--- a/runtime/Python3/tests/mocks/TestLexer.py
+++ b/runtime/Python3/tests/mocks/TestLexer.py
@@ -1,101 +1,50 @@
-# Generated from /Users/lyga/Dropbox/code/python/antlr4-learn/test_grammar/T.g4 by ANTLR 4.5.3
-# encoding: utf-8
-from __future__ import print_function
+# Generated from TestLexer.g4 by ANTLR 4.13.2
 from antlr4 import *
 from io import StringIO
+import sys
+if sys.version_info >= (3, 6):
+    from typing import TextIO
+else:
+    from typing.io import TextIO
 
 
 def serializedATN():
-    with StringIO() as buf:
-        buf.write(u"\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\2")
-        buf.write(u"\5\17\b\1\4\2\t\2\4\3\t\3\4\4\t\4\3\2\3\2\3\3\3\3\3\4")
-        buf.write(u"\3\4\2\2\5\3\3\5\4\7\5\3\2\2\16\2\3\3\2\2\2\2\5\3\2\2")
-        buf.write(u"\2\2\7\3\2\2\2\3\t\3\2\2\2\5\13\3\2\2\2\7\r\3\2\2\2\t")
-        buf.write(u"\n\7c\2\2\n\4\3\2\2\2\13\f\7d\2\2\f\6\3\2\2\2\r\16\7")
-        buf.write(u"e\2\2\16\b\3\2\2\2\3\2\2")
-        return buf.getvalue()
-
+    return [
+        4,0,3,13,6,-1,2,0,7,0,2,1,7,1,2,2,7,2,1,0,1,0,1,1,1,1,1,2,1,2,0,
+        0,3,1,1,3,2,5,3,1,0,0,12,0,1,1,0,0,0,0,3,1,0,0,0,0,5,1,0,0,0,1,7,
+        1,0,0,0,3,9,1,0,0,0,5,11,1,0,0,0,7,8,5,97,0,0,8,2,1,0,0,0,9,10,5,
+        98,0,0,10,4,1,0,0,0,11,12,5,99,0,0,12,6,1,0,0,0,1,0,0
+    ]
 
 class TestLexer(Lexer):
+
     atn = ATNDeserializer().deserialize(serializedATN())
 
-    decisionsToDFA = [DFA(ds, i) for i, ds in enumerate(atn.decisionToState)]
+    decisionsToDFA = [ DFA(ds, i) for i, ds in enumerate(atn.decisionToState) ]
 
     A = 1
     B = 2
     C = 3
 
-    modeNames = [u"DEFAULT_MODE"]
+    channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN" ]
 
-    literalNames = [u"<INVALID>",
-                    u"'a'", u"'b'", u"'c'"]
+    modeNames = [ "DEFAULT_MODE" ]
 
-    symbolicNames = [u"<INVALID>",
-                     u"A", u"B", u"C"]
+    literalNames = [ "<INVALID>",
+            "'a'", "'b'", "'c'" ]
 
-    ruleNames = [u"A", u"B", u"C"]
+    symbolicNames = [ "<INVALID>",
+            "A", "B", "C" ]
 
-    grammarFileName = u"T.g4"
+    ruleNames = [ "A", "B", "C" ]
 
-    def __init__(self, input=None):
-        super(TestLexer, self).__init__(input)
-        self.checkVersion("4.9")
+    grammarFileName = "TestLexer.g4"
+
+    def __init__(self, input=None, output:TextIO = sys.stdout):
+        super().__init__(input, output)
+        self.checkVersion("4.13.2")
         self._interp = LexerATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
         self._actions = None
         self._predicates = None
 
 
-
-def serializedATN2():
-    with StringIO() as buf:
-        buf.write(u"\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\2")
-        buf.write(u"\t(\b\1\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t")
-        buf.write(u"\7\4\b\t\b\3\2\6\2\23\n\2\r\2\16\2\24\3\3\6\3\30\n\3")
-        buf.write(u"\r\3\16\3\31\3\4\3\4\3\5\3\5\3\6\3\6\3\7\3\7\3\b\6\b")
-        buf.write(u"%\n\b\r\b\16\b&\2\2\t\3\3\5\4\7\5\t\6\13\7\r\b\17\t\3")
-        buf.write(u"\2\2*\2\3\3\2\2\2\2\5\3\2\2\2\2\7\3\2\2\2\2\t\3\2\2\2")
-        buf.write(u"\2\13\3\2\2\2\2\r\3\2\2\2\2\17\3\2\2\2\3\22\3\2\2\2\5")
-        buf.write(u"\27\3\2\2\2\7\33\3\2\2\2\t\35\3\2\2\2\13\37\3\2\2\2\r")
-        buf.write(u"!\3\2\2\2\17$\3\2\2\2\21\23\4c|\2\22\21\3\2\2\2\23\24")
-        buf.write(u"\3\2\2\2\24\22\3\2\2\2\24\25\3\2\2\2\25\4\3\2\2\2\26")
-        buf.write(u"\30\4\62;\2\27\26\3\2\2\2\30\31\3\2\2\2\31\27\3\2\2\2")
-        buf.write(u"\31\32\3\2\2\2\32\6\3\2\2\2\33\34\7=\2\2\34\b\3\2\2\2")
-        buf.write(u"\35\36\7?\2\2\36\n\3\2\2\2\37 \7-\2\2 \f\3\2\2\2!\"\7")
-        buf.write(u",\2\2\"\16\3\2\2\2#%\7\"\2\2$#\3\2\2\2%&\3\2\2\2&$\3")
-        buf.write(u"\2\2\2&\'\3\2\2\2\'\20\3\2\2\2\6\2\24\31&\2")
-        return buf.getvalue()
-
-
-class TestLexer2(Lexer):
-
-    atn = ATNDeserializer().deserialize(serializedATN2())
-
-    decisionsToDFA = [ DFA(ds, i) for i, ds in enumerate(atn.decisionToState) ]
-
-
-    ID = 1
-    INT = 2
-    SEMI = 3
-    ASSIGN = 4
-    PLUS = 5
-    MULT = 6
-    WS = 7
-
-    modeNames = [ u"DEFAULT_MODE" ]
-
-    literalNames = [ u"<INVALID>",
-            u"';'", u"'='", u"'+'", u"'*'" ]
-
-    symbolicNames = [ u"<INVALID>",
-            u"ID", u"INT", u"SEMI", u"ASSIGN", u"PLUS", u"MULT", u"WS" ]
-
-    ruleNames = [ u"ID", u"INT", u"SEMI", u"ASSIGN", u"PLUS", u"MULT", u"WS" ]
-
-    grammarFileName = u"T2.g4"
-
-    def __init__(self, input=None):
-        super(TestLexer2, self).__init__(input)
-        self.checkVersion("4.9.1")
-        self._interp = LexerATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
-        self._actions = None
-        self._predicates = None

--- a/runtime/Python3/tests/mocks/TestLexer2.g4
+++ b/runtime/Python3/tests/mocks/TestLexer2.g4
@@ -1,0 +1,9 @@
+lexer grammar TestLexer2;
+
+ID : 'a'..'z'+;
+INT : '0'..'9'+;
+SEMI : ';';
+ASSIGN : '=';
+PLUS : '+';
+MULT : '*';
+WS : ' '+;

--- a/runtime/Python3/tests/mocks/TestLexer2.py
+++ b/runtime/Python3/tests/mocks/TestLexer2.py
@@ -1,0 +1,63 @@
+# Generated from TestLexer2.g4 by ANTLR 4.13.2
+from antlr4 import *
+from io import StringIO
+import sys
+if sys.version_info >= (3, 6):
+    from typing import TextIO
+else:
+    from typing.io import TextIO
+
+
+def serializedATN():
+    return [
+        4,0,7,38,6,-1,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,
+        6,7,6,1,0,4,0,17,8,0,11,0,12,0,18,1,1,4,1,22,8,1,11,1,12,1,23,1,
+        2,1,2,1,3,1,3,1,4,1,4,1,5,1,5,1,6,4,6,35,8,6,11,6,12,6,36,0,0,7,
+        1,1,3,2,5,3,7,4,9,5,11,6,13,7,1,0,0,40,0,1,1,0,0,0,0,3,1,0,0,0,0,
+        5,1,0,0,0,0,7,1,0,0,0,0,9,1,0,0,0,0,11,1,0,0,0,0,13,1,0,0,0,1,16,
+        1,0,0,0,3,21,1,0,0,0,5,25,1,0,0,0,7,27,1,0,0,0,9,29,1,0,0,0,11,31,
+        1,0,0,0,13,34,1,0,0,0,15,17,2,97,122,0,16,15,1,0,0,0,17,18,1,0,0,
+        0,18,16,1,0,0,0,18,19,1,0,0,0,19,2,1,0,0,0,20,22,2,48,57,0,21,20,
+        1,0,0,0,22,23,1,0,0,0,23,21,1,0,0,0,23,24,1,0,0,0,24,4,1,0,0,0,25,
+        26,5,59,0,0,26,6,1,0,0,0,27,28,5,61,0,0,28,8,1,0,0,0,29,30,5,43,
+        0,0,30,10,1,0,0,0,31,32,5,42,0,0,32,12,1,0,0,0,33,35,5,32,0,0,34,
+        33,1,0,0,0,35,36,1,0,0,0,36,34,1,0,0,0,36,37,1,0,0,0,37,14,1,0,0,
+        0,4,0,18,23,36,0
+    ]
+
+class TestLexer2(Lexer):
+
+    atn = ATNDeserializer().deserialize(serializedATN())
+
+    decisionsToDFA = [ DFA(ds, i) for i, ds in enumerate(atn.decisionToState) ]
+
+    ID = 1
+    INT = 2
+    SEMI = 3
+    ASSIGN = 4
+    PLUS = 5
+    MULT = 6
+    WS = 7
+
+    channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN" ]
+
+    modeNames = [ "DEFAULT_MODE" ]
+
+    literalNames = [ "<INVALID>",
+            "';'", "'='", "'+'", "'*'" ]
+
+    symbolicNames = [ "<INVALID>",
+            "ID", "INT", "SEMI", "ASSIGN", "PLUS", "MULT", "WS" ]
+
+    ruleNames = [ "ID", "INT", "SEMI", "ASSIGN", "PLUS", "MULT", "WS" ]
+
+    grammarFileName = "TestLexer2.g4"
+
+    def __init__(self, input=None, output:TextIO = sys.stdout):
+        super().__init__(input, output)
+        self.checkVersion("4.13.2")
+        self._interp = LexerATNSimulator(self, self.atn, self.decisionsToDFA, PredictionContextCache())
+        self._actions = None
+        self._predicates = None
+
+

--- a/runtime/Python3/tests/run.py
+++ b/runtime/Python3/tests/run.py
@@ -3,7 +3,7 @@ import os
 src_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src')
 sys.path.insert(0,src_path)
 from xpathtest import XPathTest
-#from TestTokenStreamRewriter import TestTokenStreamRewriter
+from TestTokenStreamRewriter import TestTokenStreamRewriter
 from TestFileStream import TestFileStream
 from TestInputStream import TestInputStream
 from TestIntervalSet import TestIntervalSet


### PR DESCRIPTION
Fixes #4818.

The Python3 `TokenStreamRewriter` diverges from every other runtime in
`_reduceToSingleOperationPerIndex` and `ReplaceOp`. I checked all seven
runtimes that ship a rewriter (Java, C++, C#, JavaScript, Go, Swift,
Python3 — Dart has none): the other six are correct on each point below,
Python3 is the only outlier. Expected values in this PR were taken by
running the Java runtime, not assumed.

### 1. Wrong index when combining inserts (#4818)

`rewrites[prev_index] = None` used the index into the filtered
`prevInserts` list instead of `prevIop.instructionIndex`, so combining two
inserts nulls out an unrelated operation.

```python
rewriter.replaceIndex(2, 'R')
rewriter.insertBeforeIndex(0, 'x')
rewriter.insertBeforeIndex(0, 'y')
rewriter.getDefaultText()
```

Java returns `'yxabR'`. Python3 raised `ValueError: should be only one op per index`,
because the `ReplaceOp` was destroyed and both inserts survived at index 0.

### 2. Overlapping deletes

Two problems in the same branch:

- the merged right boundary used `min()` where Java, C++, C#, JavaScript,
  Go and Swift all use `max()`;
- the branch was unreachable regardless, because `delete()` stores `""` as
  the text while the guard tested `text is None`.

So overlapping deletes took the error path instead of merging:

```python
rewriter.delete('default', 0, 1)
rewriter.delete('default', 1, 3)
```

Java returns `''`. Python3 raised.

### 3. `ReplaceOp.__str__` returns `None` for deletes

The method has no `return` when `text` is empty, so `str(op)` raised
`TypeError: __str__ returned non-string (type NoneType)`. Every other
runtime emits `<DeleteOp@...>`.

This compounded #2: the `ValueError` message for an overlapping replace
could not be constructed, so the real diagnostic was replaced by a
confusing `TypeError` from deep inside string formatting.

I also dropped a stray `print('New rop ...')` left on the merge path — it
wrote to stdout from library code. (The equivalent prints in the Java and
C# runtimes are left for a separate PR, to keep this one to one runtime.)

### Why this went unnoticed

`runtime/Python3/tests/` is not run by CI, and the rewriter tests could not
run at all: `mocks/TestLexer.py` was generated by ANTLR 4.5.3 (serialized
ATN v3, runtime requires v4), and the import was commented out in `run.py`.

I regenerated the mocks with the current tool, checked in the `.g4` sources
so they can be regenerated in future, and re-enabled the suite.

### Testing

- `python3 runtime/Python3/tests/run.py` → **59 tests, all pass**
- `mvn -Dtest='python3.**' test` in `runtime-testsuite` → **362 tests, 0 failures**

The 39 pre-existing rewriter tests pass both before and after this change —
they never exercised these paths, which is how the bugs survived. The 4 new
regression tests fail 4/4 against the unfixed runtime.
