### PR TITLE
Remove stray debug print from TokenStreamRewriter (Java, C#)

### DIFF
--- a/runtime/CSharp/src/TokenStreamRewriter.cs
+++ b/runtime/CSharp/src/TokenStreamRewriter.cs
@@ -621,7 +621,6 @@ namespace Antlr4.Runtime
                         // kill first delete
                         rop.index = Math.Min(prevRop.index, rop.index);
                         rop.lastIndex = Math.Max(prevRop.lastIndex, rop.lastIndex);
-                        System.Console.Out.WriteLine("new rop " + rop);
                     }
                     else
                     {

--- a/runtime/Java/src/org/antlr/v4/runtime/TokenStreamRewriter.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/TokenStreamRewriter.java
@@ -516,7 +516,6 @@ public class TokenStreamRewriter {
 					rewrites.set(prevRop.instructionIndex, null); // kill first delete
 					rop.index = Math.min(prevRop.index, rop.index);
 					rop.lastIndex = Math.max(prevRop.lastIndex, rop.lastIndex);
-					System.out.println("new rop "+rop);
 				}
 				else if ( !disjoint ) {
 					throw new IllegalArgumentException("replace op boundaries of "+rop+" overlap with previous "+prevRop);


### PR DESCRIPTION
`TokenStreamRewriter.reduceToSingleOperationPerIndex` writes a debug line to
stdout whenever it merges two overlapping deletes:

```java
// Java, TokenStreamRewriter.java
rop.lastIndex = Math.max(prevRop.lastIndex, rop.lastIndex);
System.out.println("new rop "+rop);
```

```csharp
// C#, TokenStreamRewriter.cs
rop.lastIndex = Math.Max(prevRop.lastIndex, rop.lastIndex);
System.Console.Out.WriteLine("new rop " + rop);
```

This is reachable from ordinary supported use — any two overlapping
`delete()` calls on the same program:

```java
rewriter.delete(0, 1);
rewriter.delete(1, 3);
rewriter.getText();
```

produces the correct result but also prints, unbidden, to stdout:

```
new rop <DeleteOp@[@0,0:0='a',<1>,1:0]..[@3,3:3='d',<4>,1:3]>
```

Library code should not write to stdout. It is especially unwelcome here,
because `TokenStreamRewriter` is frequently used in tools that emit their
transformed source to stdout — the debug line lands in the middle of the
output.

The line immediately above it is already commented out for the same reason:

```java
//System.out.println("overlapping deletes: "+prevRop+", "+rop);
```

The C++, JavaScript, Go and Swift runtimes have no equivalent print; Java
and C# are the only two that kept it.

### Testing

- `mvn -Dtest=TestTokenStreamRewriter test` → 43 tests, all pass
- `mvn -Dtest='java.**' test` in `runtime-testsuite` → 438 tests, 0 failures

Rewriter output is unchanged; only the stray stdout line is gone. I could
not build the C# runtime locally (no `dotnet` on this machine), so that half
rests on CI — it is the same single-line deletion as the Java side.
