### PR TITLE
RuntimeMetaData.java: Improve the usability of the version check

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/RuntimeMetaData.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/RuntimeMetaData.java
@@ -143,27 +143,51 @@ public class RuntimeMetaData {
 	 */
 	public static void checkVersion(String generatingToolVersion, String compileTimeVersion) {
 		String runtimeVersion = VERSION;
-		boolean runtimeConflictsWithGeneratingTool = false;
-		boolean runtimeConflictsWithCompileTimeTool = false;
 
-		if ( generatingToolVersion!=null ) {
-			runtimeConflictsWithGeneratingTool =
-				!runtimeVersion.equals(generatingToolVersion) &&
-				!getMajorMinorVersion(runtimeVersion).equals(getMajorMinorVersion(generatingToolVersion));
-		}
-
-		runtimeConflictsWithCompileTimeTool =
-			!runtimeVersion.equals(compileTimeVersion) &&
-			!getMajorMinorVersion(runtimeVersion).equals(getMajorMinorVersion(compileTimeVersion));
-
-		if ( runtimeConflictsWithGeneratingTool ) {
+		if ( runtimeConflictsWithGeneratingTool(runtimeVersion, generatingToolVersion) ) {
 			System.err.printf("ANTLR Tool version %s used for code generation does not match the current runtime version %s%n",
 							  generatingToolVersion, runtimeVersion);
 		}
-		if ( runtimeConflictsWithCompileTimeTool ) {
+		if ( runtimeConflictsWithCompileTimeTool(runtimeVersion, compileTimeVersion) ) {
 			System.err.printf("ANTLR Runtime version %s used for parser compilation does not match the current runtime version %s%n",
 							  compileTimeVersion, runtimeVersion);
 		}
+	}
+
+	/**
+	 * Asserts that the runtime version matches the generating tool and compile-time versions.
+	 *
+	 * <p>See {@link #checkVersion(String, String)} for behavior and details.</p>
+	 *
+	 * @throws IllegalStateException if the runtime version does not match the generating tool or compile-time versions.
+	 */
+	public static void assertVersionMatches(String generatingToolVersion, String compileTimeVersion) {
+		String runtimeVersion = VERSION;
+
+		StringBuilder errorMessage = new StringBuilder();
+
+		if ( runtimeConflictsWithGeneratingTool(runtimeVersion, generatingToolVersion) ) {
+			errorMessage.append(String.format("ANTLR Tool version %s used for code generation does not match the current runtime version %s",
+					generatingToolVersion, runtimeVersion));
+		}
+		if ( runtimeConflictsWithCompileTimeTool(runtimeVersion, compileTimeVersion) ) {
+			errorMessage.append(String.format("ANTLR Runtime version %s used for parser compilation does not match the current runtime version %s",
+					compileTimeVersion, runtimeVersion));
+		}
+		if ( errorMessage.length() > 0 ) {
+			throw new IllegalStateException(errorMessage.toString());
+		}
+	}
+
+	private static boolean runtimeConflictsWithGeneratingTool(String runtimeVersion, String generatingToolVersion) {
+		return generatingToolVersion != null
+				&& !runtimeVersion.equals(generatingToolVersion)
+				&& !getMajorMinorVersion(runtimeVersion).equals(getMajorMinorVersion(generatingToolVersion));
+	}
+
+	private static boolean runtimeConflictsWithCompileTimeTool(String runtimeVersion, String compileTimeVersion) {
+		return !runtimeVersion.equals(compileTimeVersion)
+				&& !getMajorMinorVersion(runtimeVersion).equals(getMajorMinorVersion(compileTimeVersion));
 	}
 
 	/**


### PR DESCRIPTION
At [PMD](https://github.com/pmd/pmd) we have both
* ANTLR generated parsers in our code and
* ANTLR generated parsers in external dependencies.

Obviously, this causes problems whenever one updates to an incompatible version of ANTLR and the other doesn't. We do have [a test to catch this](https://github.com/pmd/pmd/blob/main/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/AntlrVersionTest.java), but having to check stderr for messages isn't nice.

This PR adds a method `assertVersionMatches` to RuntimeMetaData.java that does basically the same as `checkVersion`. Only difference: Instead of printing to stderr it throws an IllegalStateException.